### PR TITLE
Feature/positive f64

### DIFF
--- a/examples/option_graph.rs
+++ b/examples/option_graph.rs
@@ -5,7 +5,9 @@
 ******************************************************************************/
 use optionstratlib::greeks::equations::Greeks;
 use optionstratlib::model::option::Options;
+use optionstratlib::model::types::PositiveF64;
 use optionstratlib::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use optionstratlib::pos;
 use optionstratlib::utils::logger::setup_logger;
 use optionstratlib::visualization::utils::Graph;
 use std::error::Error;
@@ -19,7 +21,7 @@ fn create_sample_option() -> Options {
         100.0,
         ExpirationDate::Days(30.0),
         0.2,
-        1,
+        pos!(1.0),
         105.0,
         0.05,
         OptionStyle::Call,

--- a/examples/position_graph.rs
+++ b/examples/position_graph.rs
@@ -6,7 +6,9 @@
 use chrono::Utc;
 use optionstratlib::model::option::Options;
 use optionstratlib::model::position::Position;
+use optionstratlib::model::types::PositiveF64;
 use optionstratlib::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use optionstratlib::pos;
 use optionstratlib::visualization::utils::Graph;
 use std::error::Error;
 
@@ -18,7 +20,7 @@ fn create_sample_option() -> Options {
         100.0,
         ExpirationDate::Days(30.0),
         0.2,
-        10,
+        pos!(10.0),
         105.0,
         0.05,
         OptionStyle::Call,

--- a/examples/strategy_bull_call_spread.rs
+++ b/examples/strategy_bull_call_spread.rs
@@ -4,6 +4,8 @@
    Date: 25/9/24
 ******************************************************************************/
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::bull_call_spread::BullCallSpread;
 use optionstratlib::utils::logger::setup_logger;
@@ -22,16 +24,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         5750.0,           // long_strike_itm
         5820.0,           // short_strike
         ExpirationDate::Days(2.0),
-        0.18,  // implied_volatility
-        0.05,  // risk_free_rate
-        0.0,   // dividend_yield
-        2,     // long quantity
-        85.04, // premium_long
-        29.85, // premium_short
-        0.78,  // open_fee_long
-        0.78,  // open_fee_long
-        0.73,  // close_fee_long
-        0.73,  // close_fee_short
+        0.18,      // implied_volatility
+        0.05,      // risk_free_rate
+        0.0,       // dividend_yield
+        pos!(2.0), // long quantity
+        85.04,     // premium_long
+        29.85,     // premium_short
+        0.78,      // open_fee_long
+        0.78,      // open_fee_long
+        0.73,      // close_fee_long
+        0.73,      // close_fee_short
     );
 
     let price_range = strategy.best_range_to_show(1.0).unwrap();

--- a/examples/strategy_call_butterfly.rs
+++ b/examples/strategy_call_butterfly.rs
@@ -4,6 +4,8 @@
    Date: 25/9/24
 ******************************************************************************/
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::call_butterfly::CallButterfly;
 use optionstratlib::utils::logger::setup_logger;
@@ -23,18 +25,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         5850.0,           // long_strike_otm
         5800.0,           // short_strike
         ExpirationDate::Days(2.0),
-        0.18,  // implied_volatility
-        0.05,  // risk_free_rate
-        0.0,   // dividend_yield
-        1,     // long quantity
-        2,     // short_quantity
-        85.04, // premium_long
-        31.65, // premium_short
-        53.04, // open_fee_long
-        0.78,  // open_fee_long
-        0.78,  // close_fee_long
-        0.73,  // close_fee_short
-        0.73,  // close_fee_short
+        0.18,      // implied_volatility
+        0.05,      // risk_free_rate
+        0.0,       // dividend_yield
+        pos!(1.0), // long quantity
+        pos!(2.0), // short_quantity
+        85.04,     // premium_long
+        31.65,     // premium_short
+        53.04,     // open_fee_long
+        0.78,      // open_fee_long
+        0.78,      // close_fee_long
+        0.73,      // close_fee_short
+        0.73,      // close_fee_short
     );
 
     let price_range: Vec<f64> = (5681..=5881).map(|x| x as f64).collect();

--- a/examples/strategy_call_butterfly_best_area.rs
+++ b/examples/strategy_call_butterfly_best_area.rs
@@ -6,6 +6,8 @@
 use optionstratlib::constants::ZERO;
 use optionstratlib::model::chain::OptionChain;
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::call_butterfly::CallButterfly;
 use optionstratlib::strategies::utils::FindOptimalSide;
@@ -26,18 +28,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         ZERO,             // long_strike_otm
         ZERO,             // short_strike
         ExpirationDate::Days(2.0),
-        ZERO, // implied_volatility
-        0.05, // risk_free_rate
-        ZERO, // dividend_yield
-        2,    // long quantity
-        4,    // short_quantity
-        ZERO, // premium_long_itm
-        ZERO, // premium_long_otm
-        ZERO, // premium_short
-        0.78, // open_fee_long
-        0.78, // close_fee_long
-        0.73, // close_fee_short
-        0.73, // close_fee_short
+        ZERO,      // implied_volatility
+        0.05,      // risk_free_rate
+        ZERO,      // dividend_yield
+        pos!(2.0), // long quantity
+        pos!(4.0), // short_quantity
+        ZERO,      // premium_long_itm
+        ZERO,      // premium_long_otm
+        ZERO,      // premium_short
+        0.78,      // open_fee_long
+        0.78,      // close_fee_long
+        0.73,      // close_fee_short
+        0.73,      // close_fee_short
     );
 
     strategy.best_area(&option_chain, FindOptimalSide::Upper);

--- a/examples/strategy_call_butterfly_best_ratio.rs
+++ b/examples/strategy_call_butterfly_best_ratio.rs
@@ -6,6 +6,8 @@
 use optionstratlib::constants::ZERO;
 use optionstratlib::model::chain::OptionChain;
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::call_butterfly::CallButterfly;
 use optionstratlib::strategies::utils::FindOptimalSide;
@@ -26,18 +28,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         ZERO,             // long_strike_otm
         ZERO,             // short_strike
         ExpirationDate::Days(2.0),
-        ZERO, // implied_volatility
-        0.05, // risk_free_rate
-        ZERO, // dividend_yield
-        2,    // long quantity
-        4,    // short_quantity
-        ZERO, // premium_long_itm
-        ZERO, // premium_long_otm
-        ZERO, // premium_short
-        0.78, // open_fee_long
-        0.78, // close_fee_long
-        0.73, // close_fee_short
-        0.73, // close_fee_short
+        ZERO,      // implied_volatility
+        0.05,      // risk_free_rate
+        ZERO,      // dividend_yield
+        pos!(2.0), // long quantity
+        pos!(4.0), // short_quantity
+        ZERO,      // premium_long_itm
+        ZERO,      // premium_long_otm
+        ZERO,      // premium_short
+        0.78,      // open_fee_long
+        0.78,      // close_fee_long
+        0.73,      // close_fee_short
+        0.73,      // close_fee_short
     );
 
     strategy.best_ratio(&option_chain, FindOptimalSide::Range(5700.0, 5900.0));

--- a/examples/strategy_graph.rs
+++ b/examples/strategy_graph.rs
@@ -4,6 +4,8 @@
    Date: 20/8/24
 ******************************************************************************/
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::bull_call_spread::BullCallSpread;
 use optionstratlib::utils::logger::setup_logger;
@@ -22,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         0.2,
         0.05,
         0.0,
-        1,
+        pos!(1.0),
         27.26,
         5.33,
         0.58,

--- a/examples/strategy_iron_condor.rs
+++ b/examples/strategy_iron_condor.rs
@@ -1,4 +1,6 @@
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::iron_condor::IronCondor;
 use optionstratlib::utils::logger::setup_logger;
@@ -19,16 +21,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         2800.0,           // long_call_strike
         2500.0,           // long_put_strike
         ExpirationDate::Days(30.0),
-        0.1548, // implied_volatility
-        0.05,   // risk_free_rate
-        0.0,    // dividend_yield
-        2,      // quantity
-        38.8,   // premium_short_call
-        30.4,   // premium_short_put
-        23.3,   // premium_long_call
-        16.8,   // premium_long_put
-        0.96,   // open_fee
-        0.96,   // close_fee
+        0.1548,    // implied_volatility
+        0.05,      // risk_free_rate
+        0.0,       // dividend_yield
+        pos!(2.0), // quantity
+        38.8,      // premium_short_call
+        30.4,      // premium_short_put
+        23.3,      // premium_long_call
+        16.8,      // premium_long_put
+        0.96,      // open_fee
+        0.96,      // close_fee
     );
 
     let price_range: Vec<f64> = (2450..=2950).map(|x| x as f64).collect();

--- a/examples/strategy_long_strangle.rs
+++ b/examples/strategy_long_strangle.rs
@@ -1,4 +1,6 @@
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::strangle::LongStrangle;
 use optionstratlib::utils::logger::setup_logger;
@@ -17,16 +19,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         2725.0,           // call_strike
         2560.0,           // put_strike
         ExpirationDate::Days(60.0),
-        0.1548, // implied_volatility
-        0.05,   // risk_free_rate
-        0.0,    // dividend_yield
-        2,      // quantity
-        38.8,   // premium_short_call
-        30.4,   // premium_short_put
-        0.96,   // open_fee_short_call
-        0.96,   // close_fee_short_call
-        0.96,   // open_fee_short_put
-        0.96,   // close_fee_short_put
+        0.1548,    // implied_volatility
+        0.05,      // risk_free_rate
+        0.0,       // dividend_yield
+        pos!(2.0), // quantity
+        38.8,      // premium_short_call
+        30.4,      // premium_short_put
+        0.96,      // open_fee_short_call
+        0.96,      // close_fee_short_call
+        0.96,      // open_fee_short_put
+        0.96,      // close_fee_short_put
     );
 
     let price_range: Vec<f64> = (2450..=2850).map(|x| x as f64).collect();

--- a/examples/strategy_poor_mans_covered_call.rs
+++ b/examples/strategy_poor_mans_covered_call.rs
@@ -5,6 +5,8 @@
 ******************************************************************************/
 
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::poor_mans_covered_call::PoorMansCoveredCall;
 use optionstratlib::utils::logger::setup_logger;
@@ -27,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         0.17,                        // implied_volatility
         0.05,                        // risk_free_rate
         0.0,                         // dividend_yield
-        2,                           // quantity
+        pos!(2.0),                   // quantity
         154.7,                       // premium_short_call
         30.8,                        // premium_short_put
         1.74,                        // open_fee_short_call

--- a/examples/strategy_short_strangle.rs
+++ b/examples/strategy_short_strangle.rs
@@ -1,4 +1,6 @@
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::strangle::ShortStrangle;
 use optionstratlib::utils::logger::setup_logger;
@@ -17,16 +19,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         7450.0,           // call_strike
         7050.0,           // put_strike
         ExpirationDate::Days(45.0),
-        0.3745, // implied_volatility
-        0.05,   // risk_free_rate
-        0.0,    // dividend_yield
-        1,      // quantity
-        84.2,   // premium_short_call
-        353.2,  // premium_short_put
-        7.01,   // open_fee_short_call
-        7.01,   // close_fee_short_call
-        7.01,   // open_fee_short_put
-        7.01,   // close_fee_short_put
+        0.3745,    // implied_volatility
+        0.05,      // risk_free_rate
+        0.0,       // dividend_yield
+        pos!(1.0), // quantity
+        84.2,      // premium_short_call
+        353.2,     // premium_short_put
+        7.01,      // open_fee_short_call
+        7.01,      // close_fee_short_call
+        7.01,      // open_fee_short_put
+        7.01,      // close_fee_short_put
     );
 
     let price_range: Vec<f64> = (6400..=8100).map(|x| x as f64).collect();

--- a/examples/strategy_short_strangle_delta.rs
+++ b/examples/strategy_short_strangle_delta.rs
@@ -1,4 +1,6 @@
 use optionstratlib::model::types::ExpirationDate;
+use optionstratlib::model::types::PositiveF64;
+use optionstratlib::pos;
 use optionstratlib::strategies::base::Strategies;
 use optionstratlib::strategies::strangle::ShortStrangle;
 use optionstratlib::utils::logger::setup_logger;
@@ -17,16 +19,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         2480.0,           // call_strike
         2650.0,           // put_strike
         ExpirationDate::Days(3.0),
-        0.1548, // implied_volatility
-        0.05,   // risk_free_rate
-        0.0,    // dividend_yield
-        2,      // quantity
-        46.3,   // premium_short_call
-        4.6,    // premium_short_put
-        0.96,   // open_fee_short_call
-        0.96,   // close_fee_short_call
-        0.96,   // open_fee_short_put
-        0.96,   // close_fee_short_put
+        0.1548,    // implied_volatility
+        0.05,      // risk_free_rate
+        0.0,       // dividend_yield
+        pos!(2.0), // quantity
+        46.3,      // premium_short_call
+        4.6,       // premium_short_put
+        0.96,      // open_fee_short_call
+        0.96,      // close_fee_short_call
+        0.96,      // open_fee_short_put
+        0.96,      // close_fee_short_put
     );
 
     let price_range: Vec<f64> = (2450..=2850).map(|x| x as f64).collect();

--- a/examples/time-and-rate.rs
+++ b/examples/time-and-rate.rs
@@ -6,7 +6,9 @@
 
 use optionstratlib::greeks::utils::big_n;
 use optionstratlib::model::option::Options;
+use optionstratlib::model::types::PositiveF64;
 use optionstratlib::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use optionstratlib::pos;
 use optionstratlib::pricing::black_scholes_model::black_scholes;
 use optionstratlib::utils::logger::setup_logger;
 use rayon::prelude::*;
@@ -137,7 +139,7 @@ fn main() {
             opt.strike,
             ExpirationDate::Days(best_t * 365.0),
             opt.implied_volatility,
-            1,
+            pos!(1.0),
             s,
             best_r,
             OptionStyle::Call,

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -419,15 +419,18 @@ pub fn rho_d(option: &Options) -> f64 {
 mod tests_delta_equations {
     use super::*;
     use crate::constants::ZERO;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{ExpirationDate, OptionStyle, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
     use crate::utils::logger::setup_logger;
     use approx::assert_relative_eq;
 
     #[test]
     fn test_delta_no_volatility_itm() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 150.0, 1, 150.0, ZERO);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 150.0, pos!(1.0), 150.0, ZERO);
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, 1.0, epsilon = 1e-8);
@@ -436,7 +439,8 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_no_volatility_otm() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 110.0, 1, 150.0, ZERO);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 110.0, pos!(1.0), 150.0, ZERO);
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, ZERO, epsilon = 1e-8);
@@ -445,7 +449,8 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_no_volatility_itm_put() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Put, Side::Long, 150.0, 1, 150.0, ZERO);
+        let option =
+            create_sample_option(OptionStyle::Put, Side::Long, 150.0, pos!(1.0), 150.0, ZERO);
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, -1.0, epsilon = 1e-8);
@@ -454,7 +459,8 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_no_volatility_otm_put() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Put, Side::Long, 160.0, 1, 150.0, ZERO);
+        let option =
+            create_sample_option(OptionStyle::Put, Side::Long, 160.0, pos!(1.0), 150.0, ZERO);
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, ZERO, epsilon = 1e-8);
@@ -463,7 +469,14 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_no_volatility_itm_short() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Call, Side::Short, 150.0, 1, 150.0, ZERO);
+        let option = create_sample_option(
+            OptionStyle::Call,
+            Side::Short,
+            150.0,
+            pos!(1.0),
+            150.0,
+            ZERO,
+        );
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, -1.0, epsilon = 1e-8);
@@ -472,7 +485,14 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_no_volatility_otm_short() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Call, Side::Short, 110.0, 1, 150.0, ZERO);
+        let option = create_sample_option(
+            OptionStyle::Call,
+            Side::Short,
+            110.0,
+            pos!(1.0),
+            150.0,
+            ZERO,
+        );
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, ZERO, epsilon = 1e-8);
@@ -481,7 +501,8 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_no_volatility_itm_put_short() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Put, Side::Short, 150.0, 1, 150.0, ZERO);
+        let option =
+            create_sample_option(OptionStyle::Put, Side::Short, 150.0, pos!(1.0), 150.0, ZERO);
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, 1.0, epsilon = 1e-8);
@@ -490,7 +511,8 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_no_volatility_otm_put_short() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Put, Side::Short, 160.0, 1, 150.0, ZERO);
+        let option =
+            create_sample_option(OptionStyle::Put, Side::Short, 160.0, pos!(1.0), 150.0, ZERO);
         let delta_value = delta(&option);
         info!("Zero Volatility: {}", delta_value);
         assert_relative_eq!(delta_value, ZERO, epsilon = 1e-8);
@@ -499,7 +521,8 @@ mod tests_delta_equations {
     #[test]
     fn test_delta_deep_in_the_money_call() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 150.0, 1, 100.0, 0.20);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 150.0, pos!(1.0), 100.0, 0.20);
         let delta_value = delta(&option);
         info!("Deep ITM Call Delta: {}", delta_value);
         assert_relative_eq!(delta_value, 0.9991784198733309, epsilon = 1e-8);
@@ -507,7 +530,8 @@ mod tests_delta_equations {
 
     #[test]
     fn test_delta_deep_out_of_the_money_call() {
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 50.0, 1, 100.0, 0.20);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 50.0, pos!(1.0), 100.0, 0.20);
         let delta_value = delta(&option);
         info!("Deep OTM Call Delta: {}", delta_value);
         assert_relative_eq!(delta_value, 2.0418256951423236e-33, epsilon = 1e-4);
@@ -515,7 +539,8 @@ mod tests_delta_equations {
 
     #[test]
     fn test_delta_at_the_money_put() {
-        let option = create_sample_option(OptionStyle::Put, Side::Long, 100.0, 1, 100.0, 0.20);
+        let option =
+            create_sample_option(OptionStyle::Put, Side::Long, 100.0, pos!(1.0), 100.0, 0.20);
         let delta_value = delta(&option);
         info!("ATM Put Delta: {}", delta_value);
         assert_relative_eq!(delta_value, -0.4596584975686261, epsilon = 1e-8);
@@ -523,7 +548,8 @@ mod tests_delta_equations {
 
     #[test]
     fn test_delta_short_term_high_volatility() {
-        let mut option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.50);
+        let mut option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.50);
         option.expiration_date = ExpirationDate::Days(7.0);
         let delta_value = delta(&option);
         info!("Short-term High Vol Call Delta: {}", delta_value);
@@ -532,7 +558,8 @@ mod tests_delta_equations {
 
     #[test]
     fn test_delta_long_term_low_volatility() {
-        let mut option = create_sample_option(OptionStyle::Put, Side::Long, 100.0, 1, 100.0, 0.10);
+        let mut option =
+            create_sample_option(OptionStyle::Put, Side::Long, 100.0, pos!(1.0), 100.0, 0.10);
         option.expiration_date = ExpirationDate::Days(365.0);
         let delta_value = delta(&option);
         info!("Long-term Low Vol Put Delta: {}", delta_value);
@@ -543,15 +570,18 @@ mod tests_delta_equations {
 #[cfg(test)]
 mod tests_gamma_equations {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{ExpirationDate, OptionStyle, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
     use crate::utils::logger::setup_logger;
     use approx::assert_relative_eq;
 
     #[test]
     fn test_gamma_deep_in_the_money_call() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 150.0, 1, 120.0, 0.2);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 150.0, pos!(1.0), 120.0, 0.2);
         let gamma_value = gamma(&option);
         info!("Deep ITM Call Gamma: {}", gamma_value);
         assert_relative_eq!(gamma_value, 0.000016049457791525, epsilon = 1e-8);
@@ -559,7 +589,8 @@ mod tests_gamma_equations {
 
     #[test]
     fn test_gamma_deep_out_of_the_money_call() {
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 50.0, 1, 100.0, 0.20);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 50.0, pos!(1.0), 100.0, 0.20);
         let gamma_value = gamma(&option);
         info!("Deep OTM Call Gamma: {}", gamma_value);
         assert_relative_eq!(gamma_value, 8.596799333253201e-33, epsilon = 1e-34);
@@ -567,7 +598,8 @@ mod tests_gamma_equations {
 
     #[test]
     fn test_gamma_at_the_money_put() {
-        let option = create_sample_option(OptionStyle::Put, Side::Long, 100.0, 1, 100.0, 0.20);
+        let option =
+            create_sample_option(OptionStyle::Put, Side::Long, 100.0, pos!(1.0), 100.0, 0.20);
         let gamma_value = gamma(&option);
         info!("ATM Put Gamma: {}", gamma_value);
         assert_relative_eq!(gamma_value, 0.06917076441486919, epsilon = 1e-8);
@@ -575,7 +607,8 @@ mod tests_gamma_equations {
 
     #[test]
     fn test_gamma_short_term_high_volatility() {
-        let mut option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.50);
+        let mut option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.50);
         option.expiration_date = ExpirationDate::Days(7.0);
         let gamma_value = gamma(&option);
         info!("Short-term High Vol Call Gamma: {}", gamma_value);
@@ -584,7 +617,8 @@ mod tests_gamma_equations {
 
     #[test]
     fn test_gamma_long_term_low_volatility() {
-        let mut option = create_sample_option(OptionStyle::Put, Side::Long, 100.0, 1, 100.0, 0.10);
+        let mut option =
+            create_sample_option(OptionStyle::Put, Side::Long, 100.0, pos!(1.0), 100.0, 0.10);
         option.expiration_date = ExpirationDate::Days(365.0);
         let gamma_value = gamma(&option);
         info!("Long-term Low Vol Put Gamma: {}", gamma_value);
@@ -593,7 +627,8 @@ mod tests_gamma_equations {
 
     #[test]
     fn test_gamma_zero_volatility() {
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.0);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.0);
         let gamma_value = gamma(&option);
         info!("Zero Volatility Call Gamma: {}", gamma_value);
         assert_relative_eq!(gamma_value, 0.0, epsilon = 1e-8);
@@ -601,7 +636,8 @@ mod tests_gamma_equations {
 
     #[test]
     fn test_gamma_extreme_high_volatility() {
-        let option = create_sample_option(OptionStyle::Put, Side::Short, 100.0, 1, 100.0, 5.0);
+        let option =
+            create_sample_option(OptionStyle::Put, Side::Short, 100.0, pos!(1.0), 100.0, 5.0);
         let gamma_value = gamma(&option);
         info!("Extreme High Volatility Put Gamma: {}", gamma_value);
         assert_relative_eq!(gamma_value, 0.002146478293943308, epsilon = 1e-8);
@@ -611,7 +647,9 @@ mod tests_gamma_equations {
 #[cfg(test)]
 mod tests_vega_equation {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{ExpirationDate, OptionType, Side};
+    use crate::pos;
 
     fn create_test_option(
         underlying_price: f64,
@@ -627,7 +665,7 @@ mod tests_vega_equation {
             strike_price,
             ExpirationDate::Days(expiration_in_days),
             implied_volatility,
-            1, // Quantity
+            pos!(1.0), // Quantity
             underlying_price,
             0.05, // Risk-free rate
             OptionStyle::Call,
@@ -706,7 +744,9 @@ mod tests_vega_equation {
 mod tests_rho_equations {
     use super::*;
     use crate::constants::ZERO;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+    use crate::pos;
     use approx::assert_relative_eq;
 
     fn create_test_option(style: OptionStyle) -> Options {
@@ -717,7 +757,7 @@ mod tests_rho_equations {
             strike_price: 100.0,
             expiration_date: ExpirationDate::Days(365.0),
             implied_volatility: 0.2,
-            quantity: 1,
+            quantity: pos!(1.0),
             underlying_price: 100.0,
             risk_free_rate: 0.05,
             option_style: style,
@@ -784,8 +824,10 @@ mod tests_rho_equations {
 #[cfg(test)]
 mod tests_theta_long_equations {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{ExpirationDate, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
     use approx::assert_relative_eq;
 
     #[test]
@@ -794,10 +836,10 @@ mod tests_theta_long_equations {
         let option = create_sample_option(
             OptionStyle::Call,
             Side::Long,
-            150.0, // underlying price
-            1,     // quantity
-            155.0, // strike price
-            0.20,  // implied volatility
+            150.0,     // underlying price
+            pos!(1.0), // quantity
+            155.0,     // strike price
+            0.20,      // implied volatility
         );
 
         // Expected theta value for a call option (precomputed or from known source)
@@ -816,10 +858,10 @@ mod tests_theta_long_equations {
         let option = create_sample_option(
             OptionStyle::Put,
             Side::Long,
-            150.0, // underlying price
-            1,     // quantity
-            145.0, // strike price
-            0.25,  // implied volatility
+            150.0,     // underlying price
+            pos!(1.0), // quantity
+            145.0,     // strike price
+            0.25,      // implied volatility
         );
 
         // Expected theta value for a put option (precomputed or from known source)
@@ -838,10 +880,10 @@ mod tests_theta_long_equations {
         let mut option = create_sample_option(
             OptionStyle::Call,
             Side::Long,
-            150.0, // underlying price
-            1,     // quantity
-            150.0, // strike price
-            0.15,  // implied volatility
+            150.0,     // underlying price
+            pos!(1.0), // quantity
+            150.0,     // strike price
+            0.15,      // implied volatility
         );
         option.expiration_date = ExpirationDate::Days(1.0); // Option close to expiry
 
@@ -861,10 +903,10 @@ mod tests_theta_long_equations {
         let mut option = create_sample_option(
             OptionStyle::Put,
             Side::Long,
-            140.0, // underlying price
-            1,     // quantity
-            130.0, // strike price
-            0.30,  // implied volatility
+            140.0,     // underlying price
+            pos!(1.0), // quantity
+            130.0,     // strike price
+            0.30,      // implied volatility
         );
         option.expiration_date = ExpirationDate::Days(365.0); // Option far from expiry
 
@@ -882,8 +924,10 @@ mod tests_theta_long_equations {
 #[cfg(test)]
 mod tests_theta_short_equations {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{ExpirationDate, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
     use approx::assert_relative_eq;
 
     #[test]
@@ -892,10 +936,10 @@ mod tests_theta_short_equations {
         let option = create_sample_option(
             OptionStyle::Call,
             Side::Short,
-            150.0, // underlying price
-            1,     // quantity
-            155.0, // strike price
-            0.20,  // implied volatility
+            150.0,     // underlying price
+            pos!(1.0), // quantity
+            155.0,     // strike price
+            0.20,      // implied volatility
         );
 
         // Expected theta value for a short call option (precomputed or from known source)
@@ -914,10 +958,10 @@ mod tests_theta_short_equations {
         let option = create_sample_option(
             OptionStyle::Put,
             Side::Short,
-            150.0, // underlying price
-            1,     // quantity
-            145.0, // strike price
-            0.25,  // implied volatility
+            150.0,     // underlying price
+            pos!(1.0), // quantity
+            145.0,     // strike price
+            0.25,      // implied volatility
         );
 
         // Expected theta value for a short put option (precomputed or from known source)
@@ -936,10 +980,10 @@ mod tests_theta_short_equations {
         let mut option = create_sample_option(
             OptionStyle::Call,
             Side::Short,
-            150.0, // underlying price
-            1,     // quantity
-            150.0, // strike price
-            0.15,  // implied volatility
+            150.0,     // underlying price
+            pos!(1.0), // quantity
+            150.0,     // strike price
+            0.15,      // implied volatility
         );
         option.expiration_date = ExpirationDate::Days(1.0); // Option close to expiry
 
@@ -959,10 +1003,10 @@ mod tests_theta_short_equations {
         let mut option = create_sample_option(
             OptionStyle::Put,
             Side::Short,
-            140.0, // underlying price
-            1,     // quantity
-            130.0, // strike price
-            0.30,  // implied volatility
+            140.0,     // underlying price
+            pos!(1.0), // quantity
+            130.0,     // strike price
+            0.30,      // implied volatility
         );
         option.expiration_date = ExpirationDate::Days(365.0); // Option far from expiry
 

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -375,7 +375,9 @@ mod tests_handle_zero {
 mod tests_calculate_d_values {
     use super::*;
     use crate::constants::ZERO;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{OptionStyle, OptionType, Side};
+    use crate::pos;
     use approx::assert_relative_eq;
 
     #[test]
@@ -389,7 +391,7 @@ mod tests_calculate_d_values {
             risk_free_rate: 0.05,
             implied_volatility: 10.12,
             expiration_date: Default::default(),
-            quantity: 0,
+            quantity: pos!(ZERO),
             option_style: OptionStyle::Call,
             dividend_yield: ZERO,
             exotic_params: None,

--- a/src/model/format.rs
+++ b/src/model/format.rs
@@ -295,7 +295,8 @@ impl fmt::Debug for Strategy {
 #[cfg(test)]
 mod tests_options {
     use super::*;
-    use crate::model::types::BarrierType;
+    use crate::model::types::{BarrierType, PositiveF64};
+    use crate::pos;
     use chrono::{NaiveDate, TimeZone, Utc};
 
     #[test]
@@ -312,7 +313,7 @@ mod tests_options {
             strike_price: 150.0,
             expiration_date: ExpirationDate::DateTime(Utc.from_utc_datetime(&naive_date)),
             implied_volatility: 0.25,
-            quantity: 10,
+            quantity: pos!(10.0),
             underlying_price: 155.0,
             risk_free_rate: 0.01,
             option_style: OptionStyle::Call,
@@ -353,7 +354,7 @@ mod tests_options {
             strike_price: 150.0,
             expiration_date: ExpirationDate::DateTime(Utc.from_utc_datetime(&naive_date)),
             implied_volatility: 0.25,
-            quantity: 10,
+            quantity: pos!(10.0),
             underlying_price: 155.0,
             risk_free_rate: 0.01,
             option_style: OptionStyle::Call,
@@ -397,7 +398,7 @@ mod tests_options {
             strike_price: 2000.0,
             expiration_date: ExpirationDate::DateTime(Utc.from_utc_datetime(&naive_date)),
             implied_volatility: 0.30,
-            quantity: 5,
+            quantity: pos!(5.0),
             underlying_price: 1900.0,
             risk_free_rate: 0.015,
             option_style: OptionStyle::Call,
@@ -784,6 +785,8 @@ mod tests_option_type_display_debug {
 #[cfg(test)]
 mod tests_position_type_display_debug {
     use super::*;
+    use crate::model::types::PositiveF64;
+    use crate::pos;
     use chrono::{DateTime, NaiveDate, TimeZone};
 
     fn get_option() -> (Options, DateTime<Utc>) {
@@ -800,7 +803,7 @@ mod tests_position_type_display_debug {
                 strike_price: 150.0,
                 expiration_date: ExpirationDate::DateTime(Utc.from_utc_datetime(&naive_date)),
                 implied_volatility: 0.25,
-                quantity: 10,
+                quantity: pos!(10.0),
                 underlying_price: 155.0,
                 risk_free_rate: 0.01,
                 option_style: OptionStyle::Call,
@@ -879,7 +882,9 @@ mod tests_position_type_display_debug {
 #[cfg(test)]
 mod tests_strategy_type_display_debug {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::utils::create_sample_option_with_date;
+    use crate::pos;
     use crate::strategies::base::StrategyType;
     use chrono::{NaiveDate, TimeZone};
 
@@ -899,7 +904,7 @@ mod tests_strategy_type_display_debug {
                         OptionStyle::Call,
                         Side::Long,
                         100.0,
-                        1,
+                        pos!(1.0),
                         100.0,
                         0.02,
                         naive_date,
@@ -914,7 +919,7 @@ mod tests_strategy_type_display_debug {
                         OptionStyle::Call,
                         Side::Short,
                         100.0,
-                        1,
+                        pos!(1.0),
                         100.0,
                         0.02,
                         naive_date,
@@ -952,7 +957,7 @@ mod tests_strategy_type_display_debug {
                         OptionStyle::Call,
                         Side::Long,
                         100.0,
-                        1,
+                        pos!(1.0),
                         110.0,
                         0.02,
                         naive_date,
@@ -967,7 +972,7 @@ mod tests_strategy_type_display_debug {
                         OptionStyle::Call,
                         Side::Short,
                         100.0,
-                        1,
+                        pos!(1.0),
                         110.0,
                         0.02,
                         naive_date,

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -22,7 +22,7 @@ impl PositiveF64 {
         if value >= ZERO {
             Ok(PositiveF64(value))
         } else {
-            Err(format!("Value must be positive, got {}", value))
+            Err(format!("PositiveF64 value must be positive, got {}", value))
         }
     }
 
@@ -775,4 +775,112 @@ mod tests_calculate_floating_strike_payoff {
     }
 }
 
+#[cfg(test)]
+mod tests_positive_f64 {
+    use super::*;
+    use std::panic;
 
+    #[test]
+    fn test_positive_f64_creation() {
+        assert!(PositiveF64::new(0.0).is_ok());
+        assert!(PositiveF64::new(1.0).is_ok());
+        assert!(PositiveF64::new(-1.0).is_err());
+    }
+
+    #[test]
+    fn test_positive_f64_value() {
+        let pos = PositiveF64::new(5.0).unwrap();
+        assert_eq!(pos.value(), 5.0);
+    }
+
+    #[test]
+    fn test_positive_f64_from() {
+        let pos = PositiveF64::new(3.0).unwrap();
+        let f: f64 = pos.into();
+        assert_eq!(f, 3.0);
+    }
+
+    #[test]
+    fn test_positive_f64_eq() {
+        let pos = PositiveF64::new(2.0).unwrap();
+        assert_eq!(pos, 2.0);
+        assert_ne!(pos, 3.0);
+    }
+
+    #[test]
+    fn test_positive_f64_display() {
+        let pos = PositiveF64::new(4.5).unwrap();
+        assert_eq!(format!("{}", pos), "4.5");
+    }
+
+    #[test]
+    fn test_positive_f64_debug() {
+        let pos = PositiveF64::new(4.5).unwrap();
+        assert_eq!(format!("{:?}", pos), "4.5");
+    }
+
+    #[test]
+    fn test_positive_f64_add() {
+        let a = PositiveF64::new(2.0).unwrap();
+        let b = PositiveF64::new(3.0).unwrap();
+        assert_eq!((a + b).value(), 5.0);
+    }
+
+    #[test]
+    fn test_positive_f64_div() {
+        let a = PositiveF64::new(6.0).unwrap();
+        let b = PositiveF64::new(2.0).unwrap();
+        assert_eq!((a / b).value(), 3.0);
+    }
+
+    #[test]
+    fn test_positive_f64_div_f64() {
+        let a = PositiveF64::new(6.0).unwrap();
+        assert_eq!((a / 2.0).value(), 3.0);
+    }
+
+    #[test]
+    fn test_f64_mul_positive_f64() {
+        let a = 2.0;
+        let b = PositiveF64::new(3.0).unwrap();
+        assert_eq!(a * b, 6.0);
+    }
+
+    #[test]
+    fn test_positive_f64_mul() {
+        let a = PositiveF64::new(2.0).unwrap();
+        let b = PositiveF64::new(3.0).unwrap();
+        assert_eq!((a * b).value(), 6.0);
+    }
+
+    #[test]
+    fn test_positive_f64_mul_f64() {
+        let a = PositiveF64::new(2.0).unwrap();
+        assert_eq!((a * 3.0).value(), 6.0);
+    }
+
+    #[test]
+    fn test_positive_f64_default() {
+        assert_eq!(PositiveF64::default().value(), 0.0);
+    }
+
+    #[test]
+    fn test_f64_div_positive_f64() {
+        let a = 6.0;
+        let b = PositiveF64::new(2.0).unwrap();
+        assert_eq!(a / b, 3.0);
+    }
+
+    #[test]
+    fn test_pos_macro() {
+        assert_eq!(pos!(5.0).value(), 5.0);
+        let result = panic::catch_unwind(|| pos!(-1.0));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(PZERO.value(), 0.0);
+        assert_eq!(SIZE_ONE.value(), 1.0);
+    }
+}

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -774,3 +774,5 @@ mod tests_calculate_floating_strike_payoff {
         assert_eq!(calculate_floating_strike_payoff(&info), 0.0);
     }
 }
+
+

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -1,6 +1,121 @@
 use crate::constants::ZERO;
 use crate::pricing::payoff::{standard_payoff, Payoff, PayoffInfo};
 use chrono::{DateTime, Duration, Utc};
+use std::fmt;
+use std::ops::{Add, Div, Mul};
+
+pub const PZERO: PositiveF64 = PositiveF64(ZERO);
+pub const SIZE_ONE: PositiveF64 = PositiveF64(1.0);
+
+#[derive(PartialEq, Clone, Copy)]
+pub struct PositiveF64(f64);
+
+#[macro_export]
+macro_rules! pos {
+    ($val:expr) => {
+        PositiveF64::new($val).unwrap()
+    };
+}
+
+impl PositiveF64 {
+    pub fn new(value: f64) -> Result<Self, String> {
+        if value >= ZERO {
+            Ok(PositiveF64(value))
+        } else {
+            Err(format!("Value must be positive, got {}", value))
+        }
+    }
+
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+impl From<PositiveF64> for f64 {
+    fn from(pos_f64: PositiveF64) -> Self {
+        pos_f64.0
+    }
+}
+
+impl PartialEq<f64> for PositiveF64 {
+    fn eq(&self, other: &f64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl fmt::Display for PositiveF64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for PositiveF64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Add for PositiveF64 {
+    type Output = PositiveF64;
+
+    fn add(self, other: PositiveF64) -> PositiveF64 {
+        PositiveF64(self.0 + other.0)
+    }
+}
+
+impl Div for PositiveF64 {
+    type Output = PositiveF64;
+
+    fn div(self, other: PositiveF64) -> PositiveF64 {
+        PositiveF64(self.0 / other.0)
+    }
+}
+
+impl Div<f64> for PositiveF64 {
+    type Output = PositiveF64;
+
+    fn div(self, rhs: f64) -> PositiveF64 {
+        PositiveF64(self.0 / rhs)
+    }
+}
+
+impl Mul<PositiveF64> for f64 {
+    type Output = f64;
+
+    fn mul(self, rhs: PositiveF64) -> f64 {
+        self * rhs.0
+    }
+}
+
+impl Mul for PositiveF64 {
+    type Output = PositiveF64;
+
+    fn mul(self, other: PositiveF64) -> PositiveF64 {
+        PositiveF64(self.0 * other.0)
+    }
+}
+
+impl Mul<f64> for PositiveF64 {
+    type Output = PositiveF64;
+
+    fn mul(self, rhs: f64) -> PositiveF64 {
+        PositiveF64(self.0 * rhs)
+    }
+}
+
+impl Default for PositiveF64 {
+    fn default() -> Self {
+        PositiveF64(ZERO)
+    }
+}
+
+impl Div<PositiveF64> for f64 {
+    type Output = f64;
+
+    fn div(self, rhs: PositiveF64) -> f64 {
+        self / rhs.0
+    }
+}
 
 #[allow(dead_code)]
 #[derive(Clone)]

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -4,7 +4,8 @@
    Date: 21/8/24
 ******************************************************************************/
 use crate::model::option::Options;
-use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use crate::model::types::{ExpirationDate, OptionStyle, OptionType, PositiveF64, Side};
+use crate::pos;
 use chrono::{NaiveDateTime, TimeZone, Utc};
 
 #[allow(dead_code)]
@@ -12,7 +13,7 @@ pub(crate) fn create_sample_option(
     option_style: OptionStyle,
     side: Side,
     underlying_price: f64,
-    quantity: u32,
+    quantity: PositiveF64,
     strike_price: f64,
     volatility: f64,
 ) -> Options {
@@ -37,7 +38,7 @@ pub(crate) fn create_sample_option_with_date(
     option_style: OptionStyle,
     side: Side,
     underlying_price: f64,
-    quantity: u32,
+    quantity: PositiveF64,
     strike_price: f64,
     volatility: f64,
     naive_date: NaiveDateTime,
@@ -67,7 +68,7 @@ pub(crate) fn create_sample_option_simplest(option_style: OptionStyle, side: Sid
         100.0,
         ExpirationDate::Days(30.0),
         0.2,
-        1,
+        pos!(1.0),
         100.0,
         0.05,
         option_style,

--- a/src/pricing/black_scholes_model.rs
+++ b/src/pricing/black_scholes_model.rs
@@ -174,7 +174,7 @@ mod tests_black_scholes {
     use super::*;
     use crate::greeks::utils::{d1, d2};
     use crate::model::option::Options;
-    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side, PZERO, SIZE_ONE};
     use approx::assert_relative_eq;
 
     fn mock_options_call() -> Options {
@@ -188,7 +188,7 @@ mod tests_black_scholes {
             expiration_date: ExpirationDate::Days(3.0),
             option_style: OptionStyle::Call,
             underlying_symbol: "GOLD".to_string(),
-            quantity: 1,
+            quantity: SIZE_ONE,
             dividend_yield: ZERO,
             exotic_params: None,
         }
@@ -205,7 +205,7 @@ mod tests_black_scholes {
             expiration_date: ExpirationDate::Days(365.0),
             option_style: OptionStyle::Call,
             underlying_symbol: "GOLD".to_string(),
-            quantity: 1,
+            quantity: SIZE_ONE,
             dividend_yield: ZERO,
 
             exotic_params: None,
@@ -223,9 +223,8 @@ mod tests_black_scholes {
             expiration_date: ExpirationDate::Days(365.0), // 1 year from now
             option_style: OptionStyle::Put,
             underlying_symbol: "".to_string(),
-            quantity: 0,
+            quantity: PZERO,
             dividend_yield: ZERO,
-
             exotic_params: None,
         }
     }
@@ -293,7 +292,7 @@ mod tests_black_scholes {
             expiration_date: ExpirationDate::Days(365.0),
             option_style: OptionStyle::Call,
             underlying_symbol: "GOLD".to_string(),
-            quantity: 1,
+            quantity: SIZE_ONE,
             dividend_yield: ZERO,
 
             exotic_params: None,
@@ -345,7 +344,7 @@ mod tests_black_scholes {
             expiration_date: ExpirationDate::Days(365.0 / 4.0),
             option_style: OptionStyle::Call,
             underlying_symbol: "GOLD".to_string(),
-            quantity: 1,
+            quantity: SIZE_ONE,
             dividend_yield: ZERO,
 
             exotic_params: None,

--- a/src/pricing/monte_carlo.rs
+++ b/src/pricing/monte_carlo.rs
@@ -54,7 +54,9 @@ fn monte_carlo_option_pricing(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+    use crate::pos;
     use approx::assert_relative_eq;
 
     fn create_test_option() -> Options {
@@ -65,7 +67,7 @@ mod tests {
             strike_price: 100.0,
             expiration_date: ExpirationDate::Days(365.0), // 1 year
             implied_volatility: 0.2,
-            quantity: 1,
+            quantity: pos!(1.0),
             underlying_price: 100.0,
             risk_free_rate: 0.05,
             option_style: OptionStyle::Call,

--- a/src/pricing/telegraph.rs
+++ b/src/pricing/telegraph.rs
@@ -237,7 +237,7 @@ pub fn telegraph(
 #[cfg(test)]
 mod tests_telegraph_process_basis {
     use super::*;
-    use crate::model::types::{OptionStyle, OptionType, Side};
+    use crate::model::types::{OptionStyle, OptionType, Side, PZERO, SIZE_ONE};
 
     #[test]
     fn test_telegraph_process_new() {
@@ -286,7 +286,7 @@ mod tests_telegraph_process_basis {
             implied_volatility: 0.2,
             underlying_symbol: "".to_string(),
             expiration_date: Default::default(),
-            quantity: 1,
+            quantity: SIZE_ONE,
             exotic_params: None,
         };
 
@@ -309,12 +309,12 @@ mod tests_telegraph_process_basis {
             implied_volatility: 0.2,
             underlying_symbol: "".to_string(),
             expiration_date: Default::default(),
-            quantity: 0,
+            quantity: PZERO,
             exotic_params: None,
         };
 
         let _price = telegraph(&option, 100, None, None);
-        // price is stochastic
+        // price is stochastic // TODO: Fix this
         // assert_relative_eq!(price, 0.0, epsilon = 0.0001);
     }
 
@@ -332,13 +332,13 @@ mod tests_telegraph_process_basis {
             implied_volatility: 0.2,
             underlying_symbol: "".to_string(),
             expiration_date: Default::default(),
-            quantity: 0,
+            quantity: PZERO,
             exotic_params: None,
         };
 
         let _price_up = telegraph(&option, 100, Some(0.5), None);
         let _price_down = telegraph(&option, 100, None, Some(0.5));
-        // price is stochastic
+        // price is stochastic // TODO: Fix this
         // assert_relative_eq!(price_up, 0.0, epsilon = 0.0001);
         // assert_relative_eq!(price_down, 0.0, epsilon = 0.0001);
     }
@@ -347,7 +347,7 @@ mod tests_telegraph_process_basis {
 #[cfg(test)]
 mod tests_telegraph_process_extended {
     use super::*;
-    use crate::model::types::{OptionStyle, OptionType, Side};
+    use crate::model::types::{OptionStyle, OptionType, Side, PZERO};
 
     // Helper function to create a mock Options struct
     fn create_mock_option() -> Options {
@@ -362,7 +362,7 @@ mod tests_telegraph_process_extended {
             implied_volatility: 0.2,
             underlying_symbol: "".to_string(),
             expiration_date: Default::default(),
-            quantity: 0,
+            quantity: PZERO,
             exotic_params: None,
         }
     }

--- a/src/pricing/utils.rs
+++ b/src/pricing/utils.rs
@@ -404,7 +404,7 @@ mod tests_utils {
 mod tests_probability_keep_under_strike {
     use super::*;
     use crate::constants::ZERO;
-    use crate::model::types::{ExpirationDate, OptionStyle, OptionType};
+    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, PZERO, SIZE_ONE};
     use approx::assert_relative_eq;
     use tracing::info;
 
@@ -421,7 +421,7 @@ mod tests_probability_keep_under_strike {
             expiration_date: ExpirationDate::Days(365.0),
             implied_volatility: ZERO,
             underlying_symbol: "".to_string(),
-            quantity: 1,
+            quantity: SIZE_ONE,
             exotic_params: None,
         };
         let strike = Some(100.0);
@@ -447,7 +447,7 @@ mod tests_probability_keep_under_strike {
             expiration_date: ExpirationDate::Days(365.0),
             implied_volatility: 0.2,
             underlying_symbol: "".to_string(),
-            quantity: 0,
+            quantity: PZERO,
             exotic_params: None,
         };
         let strike = None;
@@ -469,9 +469,9 @@ mod tests_probability_keep_under_strike {
             option_style: OptionStyle::Call,
             dividend_yield: ZERO,
             expiration_date: ExpirationDate::Days(365.0),
-            implied_volatility: ZERO, // Sin volatilidad
+            implied_volatility: ZERO,
             underlying_symbol: "".to_string(),
-            quantity: 0,
+            quantity: PZERO,
             exotic_params: None,
         };
         let strike = None;
@@ -495,7 +495,7 @@ mod tests_probability_keep_under_strike {
             expiration_date: ExpirationDate::Days(365.0),
             implied_volatility: 5.0, // Alta volatilidad
             underlying_symbol: "".to_string(),
-            quantity: 0,
+            quantity: PZERO,
             exotic_params: None,
         };
         let strike = None;
@@ -519,7 +519,7 @@ mod tests_probability_keep_under_strike {
             expiration_date: ExpirationDate::Days(ZERO),
             implied_volatility: 0.2,
             underlying_symbol: "".to_string(),
-            quantity: 0,
+            quantity: PZERO,
             exotic_params: None,
         };
         let strike = None;

--- a/src/risk/span.rs
+++ b/src/risk/span.rs
@@ -90,14 +90,14 @@ impl SPANMargin {
         let scenario_price = scenario_option.calculate_price_black_scholes();
 
         (scenario_price - current_price)
-            * option.quantity as f64
+            * option.quantity
             * if option.is_short() { -1.0 } else { 1.0 }
     }
 
     fn calculate_short_option_minimum(&self, position: &Position) -> f64 {
         let option = &position.option;
         if option.is_short() {
-            self.short_option_minimum * option.underlying_price * option.quantity as f64
+            self.short_option_minimum * option.underlying_price * option.quantity
         } else {
             0.0
         }
@@ -107,8 +107,10 @@ impl SPANMargin {
 #[cfg(test)]
 mod tests_span {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{OptionStyle, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
     use crate::utils::logger::setup_logger;
     use chrono::Utc;
     use tracing::info;
@@ -116,7 +118,8 @@ mod tests_span {
     #[test]
     fn test_span_margin() {
         setup_logger();
-        let option = create_sample_option(OptionStyle::Call, Side::Short, 155.0, 1, 150.0, 0.2);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Short, 155.0, pos!(1.0), 150.0, 0.2);
 
         let position = Position {
             option,

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -102,7 +102,7 @@ impl Strategy {
                     .unwrap();
                 long_call.option.strike_price
                     + (long_call.total_cost() - short_call.net_premium_received())
-                        / long_call.option.quantity as f64
+                        / long_call.option.quantity
             }
             StrategyType::BearCallSpread => ZERO,
             StrategyType::BullPutSpread => ZERO,
@@ -128,8 +128,8 @@ impl Strategy {
                     .iter()
                     .find(|leg| leg.option.side == Side::Short)
                     .unwrap();
-                let net_debit = (long_call.max_loss() - short_call.max_profit())
-                    / long_call.option.quantity as f64;
+                let net_debit =
+                    (long_call.max_loss() - short_call.max_profit()) / long_call.option.quantity;
                 long_call.option.strike_price + net_debit
             }
             StrategyType::CallButterfly => ZERO,

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -16,7 +16,7 @@ use crate::constants::{
 use crate::model::chain::{OptionChain, OptionData};
 use crate::model::option::Options;
 use crate::model::position::Position;
-use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use crate::model::types::{ExpirationDate, OptionStyle, OptionType, PositiveF64, Side};
 use crate::strategies::utils::{calculate_price_range, FindOptimalSide, OptimizationCriteria};
 use crate::visualization::model::ChartVerticalLine;
 use crate::visualization::utils::Graph;
@@ -49,7 +49,7 @@ impl BullCallSpread {
         implied_volatility: f64,
         risk_free_rate: f64,
         dividend_yield: f64,
-        quantity: u32,
+        quantity: PositiveF64,
         premium_long_call: f64,
         premium_short_call: f64,
         open_fee_long_call: f64,
@@ -234,7 +234,7 @@ impl Strategies for BullCallSpread {
     fn break_even(&self) -> f64 {
         self.short_call.option.strike_price
             - self.calculate_profit_at(self.short_call.option.strike_price)
-                / self.long_call.option.quantity as f64
+                / self.long_call.option.quantity
     }
 
     fn calculate_profit_at(&self, price: f64) -> f64 {
@@ -357,6 +357,7 @@ impl Graph for BullCallSpread {
 mod tests_create_bull_call_spread {
     use super::*;
     use crate::model::types::ExpirationDate;
+    use crate::pos;
     use approx::assert_relative_eq;
 
     fn create_sample_bull_call_spread() -> BullCallSpread {
@@ -369,7 +370,7 @@ mod tests_create_bull_call_spread {
             0.2,
             0.0,
             0.0,
-            1,
+            pos!(1.0),
             5.71,
             5.71,
             1.0,
@@ -448,6 +449,7 @@ mod tests_create_bull_call_spread {
 mod tests_create_bull_call_spread_gold {
     use super::*;
     use crate::model::types::ExpirationDate;
+    use crate::pos;
     use approx::assert_relative_eq;
 
     fn create_sample_bull_call_spread() -> BullCallSpread {
@@ -460,7 +462,7 @@ mod tests_create_bull_call_spread_gold {
             0.2,
             0.05,
             0.0,
-            2,
+            pos!(2.0),
             27.26,
             5.33,
             0.58,

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -312,8 +312,10 @@ impl Graph for CustomStrategy {
 #[cfg(test)]
 mod tests_custom_strategy {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{OptionStyle, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
     use crate::utils::logger::setup_logger;
     use approx::assert_relative_eq;
 
@@ -348,10 +350,10 @@ mod tests_custom_strategy {
         let option = create_sample_option(
             OptionStyle::Call,
             Side::Long,
-            100.0, // underlying_price
-            1,     // quantity
-            100.0, // strike_price
-            0.2,   // volatility
+            100.0,     // underlying_price
+            pos!(1.0), // quantity
+            100.0,     // strike_price
+            0.2,       // volatility
         );
         let position = Position::new(option, 5.0, Default::default(), 0.0, 0.0); // premium
         strategy.add_leg(position);
@@ -369,10 +371,10 @@ mod tests_custom_strategy {
         let option = create_sample_option(
             OptionStyle::Put,
             Side::Long,
-            100.0, // underlying_price
-            1,     // quantity
-            100.0, // strike_price
-            0.2,   // volatility
+            100.0,     // underlying_price
+            pos!(1.0), // quantity
+            100.0,     // strike_price
+            0.2,       // volatility
         );
         let position = Position::new(option, 5.0, Default::default(), 0.0, 0.0); // premium
         strategy.add_leg(position);
@@ -391,18 +393,18 @@ mod tests_custom_strategy {
         let call = create_sample_option(
             OptionStyle::Call,
             Side::Long,
-            100.0, // underlying_price
-            1,     // quantity
-            100.0, // strike_price
-            0.2,   // volatility
+            100.0,     // underlying_price
+            pos!(1.0), // quantity
+            100.0,     // strike_price
+            0.2,       // volatility
         );
         let put = create_sample_option(
             OptionStyle::Put,
             Side::Long,
-            100.0, // underlying_price
-            1,     // quantity
-            100.0, // strike_price
-            0.2,   // volatility
+            100.0,     // underlying_price
+            pos!(1.0), // quantity
+            100.0,     // strike_price
+            0.2,       // volatility
         );
         let position_call = Position::new(call, 5.0, Default::default(), 0.0, 0.0);
         let position_put = Position::new(put, 5.0, Default::default(), 0.0, 0.0);
@@ -429,10 +431,10 @@ mod tests_custom_strategy {
         let option = create_sample_option(
             OptionStyle::Call,
             Side::Short,
-            100.0, // underlying_price
-            1,     // quantity
-            100.0, // strike_price
-            0.2,   // volatility
+            100.0,     // underlying_price
+            pos!(1.0), // quantity
+            100.0,     // strike_price
+            0.2,       // volatility
         );
         strategy
             .positions
@@ -446,8 +448,10 @@ mod tests_custom_strategy {
 #[cfg(test)]
 mod tests_strategy_trait {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{OptionStyle, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
     use crate::utils::logger::setup_logger;
     use approx::assert_relative_eq;
 
@@ -466,7 +470,8 @@ mod tests_strategy_trait {
     #[test]
     fn test_add_leg() {
         let mut strategy = create_test_strategy();
-        let option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         let position = Position::new(option, 1.0, Default::default(), 0.0, 0.0);
 
         strategy.add_leg(position.clone());
@@ -481,7 +486,8 @@ mod tests_strategy_trait {
         let mut strategy = create_test_strategy();
 
         // Add a long call
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -513,7 +519,8 @@ mod tests_strategy_trait {
         let mut strategy = create_test_strategy();
 
         // Add a long call
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -522,7 +529,8 @@ mod tests_strategy_trait {
             0.0,
         ));
 
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 90.0, 1, 90.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 90.0, pos!(1.0), 90.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -560,7 +568,8 @@ mod tests_strategy_trait {
         let mut strategy = create_test_strategy();
 
         // Add a long call
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 80.0, 1, 80.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 80.0, pos!(1.0), 80.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             11.0,
@@ -570,7 +579,8 @@ mod tests_strategy_trait {
         ));
 
         // Add a short put
-        let put_option = create_sample_option(OptionStyle::Put, Side::Long, 100.0, 1, 100.0, 0.2);
+        let put_option =
+            create_sample_option(OptionStyle::Put, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             put_option,
             11.0,
@@ -623,21 +633,21 @@ mod tests_strategy_trait {
 
         // Add multiple legs
         strategy.add_leg(Position::new(
-            create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2),
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2),
             1.0,
             Default::default(),
             0.0,
             0.0,
         ));
         strategy.add_leg(Position::new(
-            create_sample_option(OptionStyle::Call, Side::Short, 100.0, 1, 110.0, 0.2),
+            create_sample_option(OptionStyle::Call, Side::Short, 100.0, pos!(1.0), 110.0, 0.2),
             1.0,
             Default::default(),
             0.0,
             0.0,
         ));
         strategy.add_leg(Position::new(
-            create_sample_option(OptionStyle::Put, Side::Long, 90.0, 1, 90.0, 0.2),
+            create_sample_option(OptionStyle::Put, Side::Long, 90.0, pos!(1.0), 90.0, 0.2),
             1.0,
             Default::default(),
             0.0,
@@ -655,8 +665,10 @@ mod tests_strategy_trait {
 #[cfg(test)]
 mod tests_max_profit {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{OptionStyle, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
 
     fn create_test_strategy() -> CustomStrategy {
         CustomStrategy::new(
@@ -674,7 +686,8 @@ mod tests_max_profit {
     fn test_max_profit_single_long_call() {
         let mut strategy = create_test_strategy();
 
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -691,7 +704,8 @@ mod tests_max_profit {
     fn test_max_profit_single_short_put() {
         let mut strategy = create_test_strategy();
 
-        let put_option = create_sample_option(OptionStyle::Put, Side::Short, 90.0, 1, 90.0, 0.2);
+        let put_option =
+            create_sample_option(OptionStyle::Put, Side::Short, 90.0, pos!(1.0), 90.0, 0.2);
         strategy.add_leg(Position::new(put_option, 1.0, Default::default(), 0.0, 0.0));
 
         let max_profit = strategy.max_profit();
@@ -702,7 +716,8 @@ mod tests_max_profit {
     fn test_max_profit_multi_leg_strategy() {
         let mut strategy = create_test_strategy();
 
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -711,7 +726,8 @@ mod tests_max_profit {
             0.0,
         ));
 
-        let put_option = create_sample_option(OptionStyle::Put, Side::Short, 90.0, 1, 90.0, 0.2);
+        let put_option =
+            create_sample_option(OptionStyle::Put, Side::Short, 90.0, pos!(1.0), 90.0, 0.2);
         strategy.add_leg(Position::new(put_option, 1.0, Default::default(), 0.0, 0.0));
 
         let max_profit = strategy.max_profit();
@@ -731,7 +747,8 @@ mod tests_max_profit {
         let mut strategy = create_test_strategy();
         strategy.step_by = 0.01;
 
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -748,9 +765,10 @@ mod tests_max_profit {
     fn test_max_profit_large_range() {
         let mut strategy = create_test_strategy();
 
-        let call_option_1 = create_sample_option(OptionStyle::Call, Side::Long, 50.0, 1, 50.0, 0.2);
+        let call_option_1 =
+            create_sample_option(OptionStyle::Call, Side::Long, 50.0, pos!(1.0), 50.0, 0.2);
         let call_option_2 =
-            create_sample_option(OptionStyle::Call, Side::Short, 50.0, 1, 150.0, 0.2);
+            create_sample_option(OptionStyle::Call, Side::Short, 50.0, pos!(1.0), 150.0, 0.2);
         strategy.add_leg(Position::new(
             call_option_1,
             1.0,
@@ -774,8 +792,10 @@ mod tests_max_profit {
 #[cfg(test)]
 mod tests_max_loss {
     use super::*;
+    use crate::model::types::PositiveF64;
     use crate::model::types::{OptionStyle, Side};
     use crate::model::utils::create_sample_option;
+    use crate::pos;
 
     fn create_test_strategy() -> CustomStrategy {
         CustomStrategy::new(
@@ -793,7 +813,8 @@ mod tests_max_loss {
     fn test_max_loss_single_long_call() {
         let mut strategy = create_test_strategy();
 
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -810,7 +831,8 @@ mod tests_max_loss {
     fn test_max_loss_single_short_put() {
         let mut strategy = create_test_strategy();
 
-        let put_option = create_sample_option(OptionStyle::Put, Side::Short, 90.0, 1, 90.0, 0.2);
+        let put_option =
+            create_sample_option(OptionStyle::Put, Side::Short, 90.0, pos!(1.0), 90.0, 0.2);
         strategy.add_leg(Position::new(put_option, 1.0, Default::default(), 0.0, 0.0));
 
         let max_loss = strategy.max_loss();
@@ -821,7 +843,8 @@ mod tests_max_loss {
     fn test_max_loss_multi_leg_strategy() {
         let mut strategy = create_test_strategy();
 
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -830,7 +853,8 @@ mod tests_max_loss {
             0.0,
         ));
 
-        let put_option = create_sample_option(OptionStyle::Put, Side::Short, 90.0, 1, 90.0, 0.2);
+        let put_option =
+            create_sample_option(OptionStyle::Put, Side::Short, 90.0, pos!(1.0), 90.0, 0.2);
         strategy.add_leg(Position::new(put_option, 1.0, Default::default(), 0.0, 0.0));
 
         let max_loss = strategy.max_loss();
@@ -850,7 +874,8 @@ mod tests_max_loss {
         let mut strategy = create_test_strategy();
         strategy.step_by = 0.01;
 
-        let call_option = create_sample_option(OptionStyle::Call, Side::Long, 100.0, 1, 100.0, 0.2);
+        let call_option =
+            create_sample_option(OptionStyle::Call, Side::Long, 100.0, pos!(1.0), 100.0, 0.2);
         strategy.add_leg(Position::new(
             call_option,
             1.0,
@@ -867,9 +892,10 @@ mod tests_max_loss {
     fn test_max_loss_large_range() {
         let mut strategy = create_test_strategy();
 
-        let call_option_1 = create_sample_option(OptionStyle::Call, Side::Long, 50.0, 1, 50.0, 0.2);
+        let call_option_1 =
+            create_sample_option(OptionStyle::Call, Side::Long, 50.0, pos!(1.0), 50.0, 0.2);
         let call_option_2 =
-            create_sample_option(OptionStyle::Call, Side::Short, 50.0, 1, 150.0, 0.2);
+            create_sample_option(OptionStyle::Call, Side::Short, 50.0, pos!(1.0), 150.0, 0.2);
         strategy.add_leg(Position::new(
             call_option_1,
             1.0,

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -12,7 +12,7 @@ Key characteristics:
 use super::base::{Strategies, StrategyType};
 use crate::model::option::Options;
 use crate::model::position::Position;
-use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use crate::model::types::{ExpirationDate, OptionStyle, OptionType, PositiveF64, Side};
 use crate::visualization::model::ChartVerticalLine;
 use crate::visualization::utils::Graph;
 use chrono::Utc;
@@ -48,7 +48,7 @@ impl IronCondor {
         implied_volatility: f64,
         risk_free_rate: f64,
         dividend_yield: f64,
-        quantity: u32,
+        quantity: PositiveF64,
         premium_short_call: f64,
         premium_short_put: f64,
         premium_long_call: f64,
@@ -209,11 +209,11 @@ impl Strategies for IronCondor {
     fn max_loss(&self) -> f64 {
         let call_wing_width = (self.long_call.option.strike_price
             - self.short_call.option.strike_price)
-            * (self.long_call.option.quantity as f64)
+            * self.long_call.option.quantity
             - self.net_premium_received();
         let put_wing_width = (self.short_put.option.strike_price
             - self.long_put.option.strike_price)
-            * (self.short_put.option.quantity as f64)
+            * self.short_put.option.quantity
             - self.net_premium_received();
 
         call_wing_width.max(put_wing_width)
@@ -306,33 +306,8 @@ impl Graph for IronCondor {
 #[cfg(test)]
 mod tests_iron_condor {
     use super::*;
+    use crate::model::types::SIZE_ONE;
     use chrono::{TimeZone, Utc};
-
-    // fn create_mock_position(strike: f64, style: OptionStyle, side: Side) -> Position {
-    //     let date = Utc.with_ymd_and_hms(2024, 12, 1, 0, 0, 0).unwrap();
-    //     let option = Options {
-    //         option_type: OptionType::European,
-    //         side,
-    //         underlying_symbol: "AAPL".to_string(),
-    //         strike_price: strike,
-    //         expiration_date: ExpirationDate::DateTime(date),
-    //         implied_volatility: 0.2,
-    //         quantity: 1,
-    //         underlying_price: 150.0,
-    //         risk_free_rate: 0.01,
-    //         option_style: style,
-    //         dividend_yield: 0.02,
-    //         exotic_params: None,
-    //     };
-    //
-    //     Position {
-    //         option,
-    //         premium: strike * 0.01,
-    //         date: Utc::now(),
-    //         open_fee: 2.0,
-    //         close_fee: 2.0,
-    //     }
-    // }
 
     #[test]
     fn test_iron_condor_creation() {
@@ -348,7 +323,7 @@ mod tests_iron_condor {
             0.2,
             0.01,
             0.02,
-            1,
+            SIZE_ONE,
             1.5,
             1.0,
             2.0,
@@ -381,7 +356,7 @@ mod tests_iron_condor {
             0.2,
             0.01,
             0.02,
-            1,
+            SIZE_ONE,
             1.5,
             1.0,
             2.0,
@@ -407,7 +382,7 @@ mod tests_iron_condor {
             0.2,
             0.01,
             0.02,
-            1,
+            SIZE_ONE,
             1.5,
             1.0,
             2.0,
@@ -434,7 +409,7 @@ mod tests_iron_condor {
             0.2,
             0.01,
             0.02,
-            1,
+            SIZE_ONE,
             1.5,
             1.0,
             2.0,
@@ -460,7 +435,7 @@ mod tests_iron_condor {
             0.2,
             0.01,
             0.02,
-            1,
+            SIZE_ONE,
             1.5,
             1.0,
             2.0,
@@ -494,7 +469,7 @@ mod tests_iron_condor {
             0.2,
             0.01,
             0.02,
-            1,
+            SIZE_ONE,
             1.5,
             1.0,
             2.0,

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -27,10 +27,11 @@
     This strategy is often used by investors who are moderately bullish on an asset but wish to reduce the cost
     and risk associated with traditional covered call strategies.
 */
+
 use super::base::{Strategies, StrategyType};
 use crate::model::option::Options;
 use crate::model::position::Position;
-use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use crate::model::types::{ExpirationDate, OptionStyle, OptionType, PositiveF64, Side};
 use crate::visualization::model::ChartVerticalLine;
 use crate::visualization::utils::Graph;
 use chrono::Utc;
@@ -63,7 +64,7 @@ impl PoorMansCoveredCall {
         implied_volatility: f64,
         risk_free_rate: f64,
         dividend_yield: f64,
-        quantity: u32,
+        quantity: PositiveF64,
         premium_long_call: f64,
         premium_short_call: f64,
         open_fee_long_call: f64,
@@ -130,7 +131,7 @@ impl PoorMansCoveredCall {
 
         // Calculate break-even point
         let net_debit =
-            (strategy.long_call.max_loss() - strategy.short_call.max_profit()) / quantity as f64;
+            (strategy.long_call.max_loss() - strategy.short_call.max_profit()) / quantity;
         strategy
             .break_even_points
             .push(long_call_strike + net_debit);
@@ -177,9 +178,9 @@ impl Strategies for PoorMansCoveredCall {
     }
 
     fn fees(&self) -> f64 {
-        (self.long_call.open_fee + self.long_call.close_fee) * self.long_call.option.quantity as f64
+        (self.long_call.open_fee + self.long_call.close_fee) * self.long_call.option.quantity
             + (self.short_call.open_fee + self.short_call.close_fee)
-                * self.short_call.option.quantity as f64
+                * self.short_call.option.quantity
     }
 
     fn profit_area(&self) -> f64 {

--- a/src/strategies/strangle.rs
+++ b/src/strategies/strangle.rs
@@ -14,7 +14,8 @@ use super::base::{Strategies, StrategyType};
 use crate::constants::{DARK_BLUE, DARK_GREEN};
 use crate::model::option::Options;
 use crate::model::position::Position;
-use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use crate::model::types::{ExpirationDate, OptionStyle, OptionType, PositiveF64, Side};
+use crate::pos;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine};
 use crate::visualization::utils::Graph;
 use chrono::Utc;
@@ -46,7 +47,7 @@ impl ShortStrangle {
         implied_volatility: f64,
         risk_free_rate: f64,
         dividend_yield: f64,
-        quantity: u32,
+        quantity: PositiveF64,
         premium_short_call: f64,
         premium_short_put: f64,
         open_fee_short_call: f64,
@@ -109,8 +110,7 @@ impl ShortStrangle {
         );
         strategy.add_leg(short_put.clone());
 
-        let net_quantity =
-            (short_call.option.quantity as f64 + short_put.option.quantity as f64) / 2.0;
+        let net_quantity = (short_call.option.quantity + short_put.option.quantity) / 2.0;
         strategy
             .break_even_points
             .push(put_strike - strategy.net_premium_received() / net_quantity);
@@ -304,7 +304,7 @@ impl LongStrangle {
         implied_volatility: f64,
         risk_free_rate: f64,
         dividend_yield: f64,
-        quantity: u32,
+        quantity: PositiveF64,
         premium_long_call: f64,
         premium_long_put: f64,
         open_fee_long_call: f64,
@@ -367,8 +367,7 @@ impl LongStrangle {
         );
         strategy.add_leg(long_put.clone());
 
-        let net_quantity =
-            (long_call.option.quantity as f64 + long_put.option.quantity as f64) / 2.0;
+        let net_quantity = (long_call.option.quantity + long_put.option.quantity) / pos!(2.0);
 
         strategy
             .break_even_points
@@ -522,6 +521,7 @@ impl Graph for LongStrangle {
 #[cfg(test)]
 mod tests_short_strangle {
     use super::*;
+    use crate::pos;
 
     fn setup() -> ShortStrangle {
         ShortStrangle::new(
@@ -533,7 +533,7 @@ mod tests_short_strangle {
             0.2,
             0.01,
             0.02,
-            100,
+            pos!(100.0),
             2.0,
             1.5,
             0.1,
@@ -636,6 +636,7 @@ is expected and the underlying asset's price is anticipated to remain stable."
 #[cfg(test)]
 mod tests_long_strangle {
     use super::*;
+    use crate::pos;
 
     #[test]
     fn test_long_strangle_new() {
@@ -647,7 +648,7 @@ mod tests_long_strangle {
         let implied_volatility = 0.25;
         let risk_free_rate = 0.01;
         let dividend_yield = 0.02;
-        let quantity = 10;
+        let quantity = pos!(10.0);
         let premium_long_call = 5.0;
         let premium_long_put = 5.0;
         let open_fee_long_call = 0.5;
@@ -717,7 +718,7 @@ mod tests_long_strangle {
         let implied_volatility = 0.25;
         let risk_free_rate = 0.01;
         let dividend_yield = 0.02;
-        let quantity = 10;
+        let quantity = pos!(10.0);
         let premium_long_call = 5.0;
         let premium_long_put = 5.0;
         let open_fee_long_call = 0.5;

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -556,7 +556,7 @@ mod tests_ewma_volatility {
 #[cfg(test)]
 mod tests_implied_volatility {
     use super::*;
-    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side, SIZE_ONE};
     use crate::utils::logger::setup_logger;
     use approx::assert_relative_eq;
     use tracing::info;
@@ -569,7 +569,7 @@ mod tests_implied_volatility {
             100.0,
             ExpirationDate::Days(30.0),
             0.02, // initial implied volatility
-            1,
+            SIZE_ONE,
             100.0,
             0.05,
             OptionStyle::Call,
@@ -1041,8 +1041,9 @@ mod tests_interpolate_volatility_surface {
 
 #[cfg(test)]
 mod tests_uncertain_volatility_bounds {
+
     use super::*;
-    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side, SIZE_ONE};
 
     fn create_test_option() -> Options {
         Options::new(
@@ -1051,10 +1052,10 @@ mod tests_uncertain_volatility_bounds {
             "TEST".to_string(),
             100.0, // strike price
             ExpirationDate::Days(30.0),
-            0.2,   // implied volatility
-            1,     // quantity
-            100.0, // underlying price
-            0.05,  // risk-free rate
+            0.2,      // implied volatility
+            SIZE_ONE, // quantity
+            100.0,    // underlying price
+            0.05,     // risk-free rate
             OptionStyle::Call,
             ZERO, // dividend yield
             None, // exotic params
@@ -1142,7 +1143,7 @@ mod tests_uncertain_volatility_bounds {
 #[cfg(test)]
 mod tests_uncertain_volatility_bounds_side {
     use super::*;
-    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+    use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side, SIZE_ONE};
     use approx::assert_relative_eq;
     use tracing::info;
 
@@ -1153,10 +1154,10 @@ mod tests_uncertain_volatility_bounds_side {
             "TEST".to_string(),
             100.0, // strike price
             ExpirationDate::Days(30.0),
-            0.2,   // implied volatility
-            1,     // quantity
-            100.0, // underlying price
-            0.05,  // risk-free rate
+            0.2,      // implied volatility
+            SIZE_ONE, // quantity
+            100.0,    // underlying price
+            0.05,     // risk-free rate
             option_style,
             ZERO, // dividend yield
             None, // exotic params


### PR DESCRIPTION
**Change quantity type to PositiveF64**

Replaced u32 with PositiveF64 for option quantity to ensure positive float values throughout the pricing and strategies modules. Updated related unit tests and visualization components to use the new type properly, enhancing the accuracy and flexibility in representing quantities.