### PR TITLE
Refactor are_valid_prices to use StrategyLegs

### DIFF
--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -264,8 +264,13 @@ pub trait Optimizable: Validable + Strategies {
         }
     }
 
-    fn are_valid_prices(&self, _call: &OptionData, _put: &OptionData) -> bool {
-        panic!("Are valid prices is not applicable for this strategy");
+    fn are_valid_prices(&self, legs: &StrategyLegs) -> bool {
+        // by default, we assume Options are one long call and one short call
+        let (long, short) = match legs {
+            StrategyLegs::TwoLegs { first, second } => (first, second),
+            _ => panic!("Invalid number of legs for this strategy"),
+        };
+        long.call_ask.unwrap_or(PZERO) > PZERO && short.call_bid.unwrap_or(PZERO) > PZERO
     }
 
     fn create_strategy(&self, _chain: &OptionChain, _legs: &StrategyLegs) -> Self::Strategy {

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -278,7 +278,12 @@ impl Optimizable for BearCallSpread {
                     continue;
                 }
 
-                if !self.are_valid_prices(short_option, long_option) {
+                let legs = StrategyLegs::TwoLegs {
+                    first: short_option,
+                    second: long_option,
+                };
+
+                if !self.are_valid_prices(&legs) {
                     debug!(
                         "Invalid prices - Short({}): {:?} Long({}): {:?}",
                         short_option.strike_price,
@@ -288,11 +293,6 @@ impl Optimizable for BearCallSpread {
                     );
                     continue;
                 }
-
-                let legs = StrategyLegs::TwoLegs {
-                    first: short_option,
-                    second: long_option,
-                };
 
                 let strategy = self.create_strategy(option_chain, &legs);
 
@@ -321,10 +321,6 @@ impl Optimizable for BearCallSpread {
                 }
             }
         }
-    }
-
-    fn are_valid_prices(&self, short: &OptionData, long: &OptionData) -> bool {
-        short.call_bid.unwrap_or(PZERO) > PZERO && long.call_ask.unwrap_or(PZERO) > PZERO
     }
 
     fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -262,7 +262,12 @@ impl Optimizable for BullCallSpread {
                     continue;
                 }
 
-                if !self.are_valid_prices(long_option, short_option) {
+                let legs = StrategyLegs::TwoLegs {
+                    first: long_option,
+                    second: short_option,
+                };
+
+                if !self.are_valid_prices(&legs) {
                     debug!(
                         "Invalid prices - Long({}): {:?} Short({}): {:?}",
                         long_option.strike_price,
@@ -273,10 +278,6 @@ impl Optimizable for BullCallSpread {
                     continue;
                 }
 
-                let legs = StrategyLegs::TwoLegs {
-                    first: long_option,
-                    second: short_option,
-                };
                 let strategy = self.create_strategy(option_chain, &legs);
 
                 if !strategy.validate() {
@@ -304,10 +305,6 @@ impl Optimizable for BullCallSpread {
                 }
             }
         }
-    }
-
-    fn are_valid_prices(&self, long: &OptionData, short: &OptionData) -> bool {
-        long.call_ask.unwrap_or(PZERO) > PZERO && short.call_bid.unwrap_or(PZERO) > PZERO
     }
 
     fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
@@ -1065,7 +1062,11 @@ mod tests_bull_call_spread_optimization {
             Some(50),
         );
 
-        assert!(spread.are_valid_prices(&long_option, &short_option));
+        let legs = StrategyLegs::TwoLegs {
+            first: &long_option,
+            second: &short_option,
+        };
+        assert!(spread.are_valid_prices(&legs));
     }
 
     #[test]
@@ -1094,7 +1095,11 @@ mod tests_bull_call_spread_optimization {
             Some(50),
         );
 
-        assert!(!spread.are_valid_prices(&long_option, &short_option));
+        let legs = StrategyLegs::TwoLegs {
+            first: &long_option,
+            second: &short_option,
+        };
+        assert!(!spread.are_valid_prices(&legs));
     }
 
     #[test]


### PR DESCRIPTION
Refactored the `are_valid_prices` function across various strategies to accept a `StrategyLegs` object instead of separate option parameters. This change improves the code's consistency and encourages better structuring for strategies using two legs, enhancing readability and maintainability. (fix #48)