### PR TITLE
Fix/GitHub work flows

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -2,9 +2,17 @@ name: Code Coverage Report.
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'feature/**'
+      - 'fix/**'
+      - 'release/**'
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'feature/**'
+      - 'fix/**'
+      - 'release/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/Makefile
+++ b/Makefile
@@ -166,13 +166,11 @@ workflow-build:
        
 .PHONY: workflow-lint
 workflow-lint:
-	DOCKER_HOST="$${DOCKER_HOST}" act push --job lint \
-       -P ubuntu-latest=catthehacker/ubuntu:latest
+	DOCKER_HOST="$${DOCKER_HOST}" act push --job lint 
 
 .PHONY: workflow-test
 workflow-test:
-	DOCKER_HOST="$${DOCKER_HOST}" act push --job run_tests \
-       -P ubuntu-latest=catthehacker/ubuntu:latest
+	DOCKER_HOST="$${DOCKER_HOST}" act push --job run_tests
        
 .PHONY: workflow
 workflow: workflow-build workflow-lint workflow-test workflow-coverage     


### PR DESCRIPTION
Expand code coverage workflow to additional branch patterns.

The workflow now triggers on 'feature/**', 'fix/**', and 'release/**' branches alongside 'main'. This ensures code coverage checks are applied consistently across relevant workflows.