### PR TITLE
Feature/#119 get position and modify position in the positionable trait for all strategies

### DIFF
--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -32,7 +32,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::GreeksError;
@@ -188,6 +188,93 @@ impl Positionable for BearCallSpread {
 
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.short_call, &self.long_call])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (_, OptionStyle::Put, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Put is not valid for PoorMansCoveredCall".to_string(),
+            )),
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_call])
+                }
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_call])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        match (
+            &position.option.side,
+            &position.option.option_style,
+            &position.option.strike_price,
+        ) {
+            (_, OptionStyle::Put, _) => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Put is not valid for PoorMansCoveredCall".to_string(),
+                ))
+            }
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price =>
+                {
+                    self.long_call = position.clone();
+                }
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price =>
+                {
+                    self.short_call = position.clone();
+                }
+            _ => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Strike not found in positions".to_string(),
+                ))
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -2195,5 +2282,113 @@ mod tests_delta_size {
         assert!(strategy.is_delta_neutral());
         let suggestion = strategy.suggest_delta_adjustments();
         assert_eq!(suggestion[0], DeltaAdjustment::NoAdjustmentNeeded);
+    }
+}
+
+#[cfg(test)]
+mod tests_bear_call_spread_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_short_bear_call_spread() -> BearCallSpread {
+        BearCallSpread::new(
+            "SP500".to_string(),
+            pos!(5781.88), // underlying_price
+            pos!(5750.0),     // short_call_strike
+            pos!(5820.0),     // long_call_strike
+            ExpirationDate::Days(pos!(2.0)),
+            pos!(0.18),     // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(3.0),      // long quantity
+            pos!(85.04),    // premium_long
+            pos!(29.85),    // premium_short
+            pos!(0.78),     // open_fee_long
+            pos!(0.78),     // open_fee_long
+            pos!(0.73),     // close_fee_long
+            pos!(0.73),     // close_fee_short
+        )
+    }
+
+    #[test]
+    fn test_short_bear_call_spread_get_position() {
+        let mut bear_call_spread = create_test_short_bear_call_spread();
+
+        // Test getting short call position
+        let call_position = bear_call_spread.get_position(&OptionStyle::Call, &Side::Long, &pos!(5820.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5820.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = bear_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5750.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5750.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            bear_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5821.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_bear_call_spread_modify_position() {
+        let mut bear_call_spread = create_test_short_bear_call_spread();
+
+        // Modify short call position
+        let mut modified_call = bear_call_spread.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = bear_call_spread.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(bear_call_spread.short_call.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = bear_call_spread.long_call.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = bear_call_spread.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(bear_call_spread.long_call.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = bear_call_spread.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = bear_call_spread.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
     }
 }

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -209,7 +209,7 @@ impl Positionable for BearCallSpread {
         match (side, option_style, strike) {
             (_, OptionStyle::Put, _) => Err(PositionError::invalid_position_type(
                 side.clone(),
-                "Put is not valid for PoorMansCoveredCall".to_string(),
+                "Put is not valid for BearCallSpread".to_string(),
             )),
             (Side::Long, OptionStyle::Call, strike)
             if *strike == self.long_call.option.strike_price =>

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -212,15 +212,15 @@ impl Positionable for BearCallSpread {
                 "Put is not valid for BearCallSpread".to_string(),
             )),
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call])
-                }
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call])
-                }
+                if *strike == self.short_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -257,15 +257,15 @@ impl Positionable for BearCallSpread {
                 ))
             }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    self.long_call = position.clone();
-                }
+                if *strike == self.long_call.option.strike_price =>
+            {
+                self.long_call = position.clone();
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price =>
-                {
-                    self.short_call = position.clone();
-                }
+                if *strike == self.short_call.option.strike_price =>
+            {
+                self.short_call = position.clone();
+            }
             _ => {
                 return Err(PositionError::invalid_position_type(
                     position.option.side.clone(),
@@ -2297,8 +2297,8 @@ mod tests_bear_call_spread_position_management {
         BearCallSpread::new(
             "SP500".to_string(),
             pos!(5781.88), // underlying_price
-            pos!(5750.0),     // short_call_strike
-            pos!(5820.0),     // long_call_strike
+            pos!(5750.0),  // short_call_strike
+            pos!(5820.0),  // long_call_strike
             ExpirationDate::Days(pos!(2.0)),
             pos!(0.18),     // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -2318,7 +2318,8 @@ mod tests_bear_call_spread_position_management {
         let mut bear_call_spread = create_test_short_bear_call_spread();
 
         // Test getting short call position
-        let call_position = bear_call_spread.get_position(&OptionStyle::Call, &Side::Long, &pos!(5820.0));
+        let call_position =
+            bear_call_spread.get_position(&OptionStyle::Call, &Side::Long, &pos!(5820.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2327,7 +2328,8 @@ mod tests_bear_call_spread_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting short put position
-        let put_position = bear_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5750.0));
+        let put_position =
+            bear_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5750.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2341,11 +2343,11 @@ mod tests_bear_call_spread_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -17,7 +17,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::GreeksError;
@@ -170,6 +170,93 @@ impl Positionable for BearPutSpread {
 
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.long_put, &self.short_put])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (_, OptionStyle::Call, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Call is not valid for BearPutSpread".to_string(),
+            )),
+            (Side::Long, OptionStyle::Put, strike)
+            if *strike == self.long_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_put])
+                }
+            (Side::Short, OptionStyle::Put, strike)
+            if *strike == self.short_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_put])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        match (
+            &position.option.side,
+            &position.option.option_style,
+            &position.option.strike_price,
+        ) {
+            (_, OptionStyle::Call, _) => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Call is not valid for BearPutSpread".to_string(),
+                ))
+            }
+            (Side::Long, OptionStyle::Put, strike)
+            if *strike == self.long_put.option.strike_price =>
+                {
+                    self.long_put = position.clone();
+                }
+            (Side::Short, OptionStyle::Put, strike)
+            if *strike == self.short_put.option.strike_price =>
+                {
+                    self.short_put = position.clone();
+                }
+            _ => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Strike not found in positions".to_string(),
+                ))
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -2238,3 +2325,112 @@ mod tests_delta_size {
         assert_eq!(suggestion[0], DeltaAdjustment::NoAdjustmentNeeded);
     }
 }
+
+#[cfg(test)]
+mod tests_bear_call_spread_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_short_bear_put_spread() -> BearPutSpread {
+        BearPutSpread::new(
+            "SP500".to_string(),
+            pos!(5781.88), // underlying_price
+            pos!(5850.0),     // long_strike
+            pos!(5720.0),     // short_strike
+            ExpirationDate::Days(pos!(2.0)),
+            pos!(0.18),     // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(4.0),      // long quantity
+            pos!(85.04),    // premium_long
+            pos!(29.85),    // premium_short
+            pos!(0.78),     // open_fee_long
+            pos!(0.78),     // open_fee_long
+            pos!(0.73),     // close_fee_long
+            pos!(0.73),     // close_fee_short
+        )
+    }
+
+    #[test]
+    fn test_short_bear_put_spread_get_position() {
+        let mut bear_put_spread = create_test_short_bear_put_spread();
+
+        // Test getting short put position
+        let put_position = bear_put_spread.get_position(&OptionStyle::Put, &Side::Long, &pos!(5850.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5850.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = bear_put_spread.get_position(&OptionStyle::Put, &Side::Short, &pos!(5720.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5720.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            bear_put_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5821.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Call is not valid for BearPutSpread");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_bear_put_spread_modify_position() {
+        let mut bear_put_spread = create_test_short_bear_put_spread();
+
+        // Modify short put position
+        let mut modified_put = bear_put_spread.short_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = bear_put_spread.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(bear_put_spread.short_put.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = bear_put_spread.long_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = bear_put_spread.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(bear_put_spread.long_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = bear_put_spread.short_put.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = bear_put_spread.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+}
+

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -194,15 +194,15 @@ impl Positionable for BearPutSpread {
                 "Call is not valid for BearPutSpread".to_string(),
             )),
             (Side::Long, OptionStyle::Put, strike)
-            if *strike == self.long_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_put])
-                }
+                if *strike == self.long_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_put])
+            }
             (Side::Short, OptionStyle::Put, strike)
-            if *strike == self.short_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_put])
-                }
+                if *strike == self.short_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_put])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -239,15 +239,15 @@ impl Positionable for BearPutSpread {
                 ))
             }
             (Side::Long, OptionStyle::Put, strike)
-            if *strike == self.long_put.option.strike_price =>
-                {
-                    self.long_put = position.clone();
-                }
+                if *strike == self.long_put.option.strike_price =>
+            {
+                self.long_put = position.clone();
+            }
             (Side::Short, OptionStyle::Put, strike)
-            if *strike == self.short_put.option.strike_price =>
-                {
-                    self.short_put = position.clone();
-                }
+                if *strike == self.short_put.option.strike_price =>
+            {
+                self.short_put = position.clone();
+            }
             _ => {
                 return Err(PositionError::invalid_position_type(
                     position.option.side.clone(),
@@ -2338,8 +2338,8 @@ mod tests_bear_call_spread_position_management {
         BearPutSpread::new(
             "SP500".to_string(),
             pos!(5781.88), // underlying_price
-            pos!(5850.0),     // long_strike
-            pos!(5720.0),     // short_strike
+            pos!(5850.0),  // long_strike
+            pos!(5720.0),  // short_strike
             ExpirationDate::Days(pos!(2.0)),
             pos!(0.18),     // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -2359,7 +2359,8 @@ mod tests_bear_call_spread_position_management {
         let mut bear_put_spread = create_test_short_bear_put_spread();
 
         // Test getting short put position
-        let put_position = bear_put_spread.get_position(&OptionStyle::Put, &Side::Long, &pos!(5850.0));
+        let put_position =
+            bear_put_spread.get_position(&OptionStyle::Put, &Side::Long, &pos!(5850.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2368,7 +2369,8 @@ mod tests_bear_call_spread_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting short put position
-        let put_position = bear_put_spread.get_position(&OptionStyle::Put, &Side::Short, &pos!(5720.0));
+        let put_position =
+            bear_put_spread.get_position(&OptionStyle::Put, &Side::Short, &pos!(5720.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2382,11 +2384,11 @@ mod tests_bear_call_spread_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Call is not valid for BearPutSpread");
             }
             _ => {
@@ -2433,4 +2435,3 @@ mod tests_bear_call_spread_position_management {
         }
     }
 }
-

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -19,7 +19,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::GreeksError;
@@ -174,6 +174,93 @@ impl Positionable for BullCallSpread {
 
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.long_call, &self.short_call])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (_, OptionStyle::Put, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Put is not valid for BearCallSpread".to_string(),
+            )),
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_call])
+                }
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_call])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        match (
+            &position.option.side,
+            &position.option.option_style,
+            &position.option.strike_price,
+        ) {
+            (_, OptionStyle::Put, _) => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Put is not valid for PoorMansCoveredCall".to_string(),
+                ))
+            }
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price =>
+                {
+                    self.long_call = position.clone();
+                }
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price =>
+                {
+                    self.short_call = position.clone();
+                }
+            _ => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Strike not found in positions".to_string(),
+                ))
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -2080,5 +2167,113 @@ mod tests_delta_size {
         assert!(strategy.is_delta_neutral());
         let suggestion = strategy.suggest_delta_adjustments();
         assert_eq!(suggestion[0], DeltaAdjustment::NoAdjustmentNeeded);
+    }
+}
+
+#[cfg(test)]
+mod tests_bull_call_spread_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_bull_call_spread() -> BullCallSpread {
+        BullCallSpread::new(
+            "SP500".to_string(),
+            pos!(5781.88), // underlying_price
+            pos!(5750.0),     // long_strike_itm
+            pos!(5820.0),     // short_strike
+            ExpirationDate::Days(pos!(2.0)),
+            pos!(0.18),     // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(2.0),      // long quantity
+            pos!(85.04),    // premium_long
+            pos!(29.85),    // premium_short
+            pos!(0.78),     // open_fee_long
+            pos!(0.78),     // open_fee_long
+            pos!(0.73),     // close_fee_long
+            pos!(0.73),     // close_fee_short
+        )
+    }
+
+    #[test]
+    fn test_short_bull_call_spread_get_position() {
+        let mut bull_call_spread = create_test_bull_call_spread();
+
+        // Test getting short call position
+        let call_position = bull_call_spread.get_position(&OptionStyle::Call, &Side::Long, &pos!(5750.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5750.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = bull_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5820.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5820.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            bull_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5821.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_bull_call_spread_modify_position() {
+        let mut bull_call_spread = create_test_bull_call_spread();
+
+        // Modify short call position
+        let mut modified_call = bull_call_spread.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = bull_call_spread.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(bull_call_spread.short_call.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = bull_call_spread.long_call.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = bull_call_spread.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(bull_call_spread.long_call.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = bull_call_spread.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = bull_call_spread.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
     }
 }

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -198,15 +198,15 @@ impl Positionable for BullCallSpread {
                 "Put is not valid for BearCallSpread".to_string(),
             )),
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call])
-                }
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call])
-                }
+                if *strike == self.short_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -243,15 +243,15 @@ impl Positionable for BullCallSpread {
                 ))
             }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    self.long_call = position.clone();
-                }
+                if *strike == self.long_call.option.strike_price =>
+            {
+                self.long_call = position.clone();
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price =>
-                {
-                    self.short_call = position.clone();
-                }
+                if *strike == self.short_call.option.strike_price =>
+            {
+                self.short_call = position.clone();
+            }
             _ => {
                 return Err(PositionError::invalid_position_type(
                     position.option.side.clone(),
@@ -2182,8 +2182,8 @@ mod tests_bull_call_spread_position_management {
         BullCallSpread::new(
             "SP500".to_string(),
             pos!(5781.88), // underlying_price
-            pos!(5750.0),     // long_strike_itm
-            pos!(5820.0),     // short_strike
+            pos!(5750.0),  // long_strike_itm
+            pos!(5820.0),  // short_strike
             ExpirationDate::Days(pos!(2.0)),
             pos!(0.18),     // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -2203,7 +2203,8 @@ mod tests_bull_call_spread_position_management {
         let mut bull_call_spread = create_test_bull_call_spread();
 
         // Test getting short call position
-        let call_position = bull_call_spread.get_position(&OptionStyle::Call, &Side::Long, &pos!(5750.0));
+        let call_position =
+            bull_call_spread.get_position(&OptionStyle::Call, &Side::Long, &pos!(5750.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2212,7 +2213,8 @@ mod tests_bull_call_spread_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting short put position
-        let put_position = bull_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5820.0));
+        let put_position =
+            bull_call_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5820.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2226,11 +2228,11 @@ mod tests_bull_call_spread_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -200,15 +200,15 @@ impl Positionable for BullPutSpread {
                 "Call is not valid for BullPutSpread".to_string(),
             )),
             (Side::Long, OptionStyle::Put, strike)
-            if *strike == self.long_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_put])
-                }
+                if *strike == self.long_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_put])
+            }
             (Side::Short, OptionStyle::Put, strike)
-            if *strike == self.short_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_put])
-                }
+                if *strike == self.short_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_put])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -245,15 +245,15 @@ impl Positionable for BullPutSpread {
                 ))
             }
             (Side::Long, OptionStyle::Put, strike)
-            if *strike == self.long_put.option.strike_price =>
-                {
-                    self.long_put = position.clone();
-                }
+                if *strike == self.long_put.option.strike_price =>
+            {
+                self.long_put = position.clone();
+            }
             (Side::Short, OptionStyle::Put, strike)
-            if *strike == self.short_put.option.strike_price =>
-                {
-                    self.short_put = position.clone();
-                }
+                if *strike == self.short_put.option.strike_price =>
+            {
+                self.short_put = position.clone();
+            }
             _ => {
                 return Err(PositionError::invalid_position_type(
                     position.option.side.clone(),
@@ -2097,8 +2097,8 @@ mod tests_bear_call_spread_position_management {
         BullPutSpread::new(
             "SP500".to_string(),
             pos!(5781.88), // underlying_price
-            pos!(5850.0),     // long_strike
-            pos!(5720.0),     // short_strike
+            pos!(5850.0),  // long_strike
+            pos!(5720.0),  // short_strike
             ExpirationDate::Days(pos!(2.0)),
             pos!(0.18),     // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -2118,7 +2118,8 @@ mod tests_bear_call_spread_position_management {
         let mut bull_put_spread = create_test_short_bull_put_spread();
 
         // Test getting short put position
-        let put_position = bull_put_spread.get_position(&OptionStyle::Put, &Side::Long, &pos!(5850.0));
+        let put_position =
+            bull_put_spread.get_position(&OptionStyle::Put, &Side::Long, &pos!(5850.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2127,7 +2128,8 @@ mod tests_bear_call_spread_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting short put position
-        let put_position = bull_put_spread.get_position(&OptionStyle::Put, &Side::Short, &pos!(5720.0));
+        let put_position =
+            bull_put_spread.get_position(&OptionStyle::Put, &Side::Short, &pos!(5720.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2141,11 +2143,11 @@ mod tests_bear_call_spread_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Call is not valid for BullPutSpread");
             }
             _ => {

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -19,7 +19,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN, ZERO};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::greeks::Greeks;
@@ -176,6 +176,93 @@ impl Positionable for BullPutSpread {
 
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.long_put, &self.short_put])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (_, OptionStyle::Call, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Call is not valid for BullPutSpread".to_string(),
+            )),
+            (Side::Long, OptionStyle::Put, strike)
+            if *strike == self.long_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_put])
+                }
+            (Side::Short, OptionStyle::Put, strike)
+            if *strike == self.short_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_put])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        match (
+            &position.option.side,
+            &position.option.option_style,
+            &position.option.strike_price,
+        ) {
+            (_, OptionStyle::Call, _) => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Call is not valid for BullPutSpread".to_string(),
+                ))
+            }
+            (Side::Long, OptionStyle::Put, strike)
+            if *strike == self.long_put.option.strike_price =>
+                {
+                    self.long_put = position.clone();
+                }
+            (Side::Short, OptionStyle::Put, strike)
+            if *strike == self.short_put.option.strike_price =>
+                {
+                    self.short_put = position.clone();
+                }
+            _ => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Strike not found in positions".to_string(),
+                ))
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -1995,5 +2082,113 @@ mod tests_delta_size {
         assert!(strategy.is_delta_neutral());
         let suggestion = strategy.suggest_delta_adjustments();
         assert_eq!(suggestion[0], DeltaAdjustment::NoAdjustmentNeeded);
+    }
+}
+
+#[cfg(test)]
+mod tests_bear_call_spread_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_short_bull_put_spread() -> BullPutSpread {
+        BullPutSpread::new(
+            "SP500".to_string(),
+            pos!(5781.88), // underlying_price
+            pos!(5850.0),     // long_strike
+            pos!(5720.0),     // short_strike
+            ExpirationDate::Days(pos!(2.0)),
+            pos!(0.18),     // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(4.0),      // long quantity
+            pos!(85.04),    // premium_long
+            pos!(29.85),    // premium_short
+            pos!(0.78),     // open_fee_long
+            pos!(0.78),     // open_fee_long
+            pos!(0.73),     // close_fee_long
+            pos!(0.73),     // close_fee_short
+        )
+    }
+
+    #[test]
+    fn test_short_bull_put_spread_get_position() {
+        let mut bull_put_spread = create_test_short_bull_put_spread();
+
+        // Test getting short put position
+        let put_position = bull_put_spread.get_position(&OptionStyle::Put, &Side::Long, &pos!(5850.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5850.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = bull_put_spread.get_position(&OptionStyle::Put, &Side::Short, &pos!(5720.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5720.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            bull_put_spread.get_position(&OptionStyle::Call, &Side::Short, &pos!(5821.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Call is not valid for BullPutSpread");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_bull_put_spread_modify_position() {
+        let mut bull_put_spread = create_test_short_bull_put_spread();
+
+        // Modify short put position
+        let mut modified_put = bull_put_spread.short_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = bull_put_spread.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(bull_put_spread.short_put.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = bull_put_spread.long_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = bull_put_spread.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(bull_put_spread.long_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = bull_put_spread.short_put.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = bull_put_spread.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
     }
 }

--- a/src/strategies/butterfly_spread.rs
+++ b/src/strategies/butterfly_spread.rs
@@ -20,7 +20,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN, ZERO};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::GreeksError;
@@ -59,8 +59,8 @@ pub struct LongButterflySpread {
     pub kind: StrategyType,
     pub description: String,
     pub break_even_points: Vec<Positive>,
+    short_call: Position,
     long_call_low: Position,
-    short_calls: Position,
     long_call_high: Position,
 }
 
@@ -93,7 +93,7 @@ impl LongButterflySpread {
             description: LONG_BUTTERFLY_DESCRIPTION.to_string(),
             break_even_points: Vec::new(),
             long_call_low: Position::default(),
-            short_calls: Position::default(),
+            short_call: Position::default(),
             long_call_high: Position::default(),
         };
 
@@ -112,7 +112,7 @@ impl LongButterflySpread {
             dividend_yield,
             None,
         );
-        strategy.short_calls = Position::new(
+        strategy.short_call = Position::new(
             short_calls,
             premium_middle,
             Utc::now(),
@@ -199,7 +199,7 @@ impl Validable for LongButterflySpread {
             debug!("Long call (low strike) is invalid");
             return false;
         }
-        if !self.short_calls.validate() {
+        if !self.short_call.validate() {
             debug!("Short calls (middle strike) are invalid");
             return false;
         }
@@ -208,16 +208,16 @@ impl Validable for LongButterflySpread {
             return false;
         }
 
-        if self.long_call_low.option.strike_price >= self.short_calls.option.strike_price {
+        if self.long_call_low.option.strike_price >= self.short_call.option.strike_price {
             debug!("Low strike must be lower than middle strike");
             return false;
         }
-        if self.short_calls.option.strike_price >= self.long_call_high.option.strike_price {
+        if self.short_call.option.strike_price >= self.long_call_high.option.strike_price {
             debug!("Middle strike must be lower than high strike");
             return false;
         }
 
-        if self.short_calls.option.quantity != self.long_call_low.option.quantity * 2.0 {
+        if self.short_call.option.quantity != self.long_call_low.option.quantity * 2.0 {
             debug!("Middle strike quantity must be double the wing quantities");
             return false;
         }
@@ -235,7 +235,7 @@ impl Positionable for LongButterflySpread {
         match &position.option.side {
             Side::Long => {
                 // short_calls should be inserted first
-                if position.option.strike_price < self.short_calls.option.strike_price {
+                if position.option.strike_price < self.short_call.option.strike_price {
                     self.long_call_low = position.clone();
                     Ok(())
                 } else {
@@ -244,7 +244,7 @@ impl Positionable for LongButterflySpread {
                 }
             }
             Side::Short => {
-                self.short_calls = position.clone();
+                self.short_call = position.clone();
                 Ok(())
             }
         }
@@ -253,9 +253,96 @@ impl Positionable for LongButterflySpread {
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![
             &self.long_call_low,
-            &self.short_calls,
+            &self.short_call,
             &self.long_call_high,
         ])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price => Ok(vec![&mut self.short_call]),
+                
+            (_, OptionStyle::Put, _)=> Err(PositionError::invalid_position_type(
+                        side.clone(),
+                        "Put not found in positions".to_string(),
+                    )),
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call_low.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_call_low])
+                }
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call_high.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_call_high])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+        
+        match (&position.option.side, &position.option.option_style, &position.option.strike_price) {
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price => {
+                self.short_call = position.clone();
+            },
+
+            (_, OptionStyle::Put, _)=> return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Put not found in positions".to_string(),
+            )),
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call_low.option.strike_price =>
+                {
+                    self.long_call_low = position.clone();
+                }
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call_high.option.strike_price =>
+                {
+                    self.long_call_high = position.clone();
+                }
+            _ => return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+
+        Ok(())
     }
 }
 
@@ -265,7 +352,7 @@ impl Strategies for LongButterflySpread {
     }
 
     fn max_profit(&self) -> Result<Positive, StrategyError> {
-        let profit = self.calculate_profit_at(self.short_calls.option.strike_price)?;
+        let profit = self.calculate_profit_at(self.short_call.option.strike_price)?;
         if profit > Decimal::ZERO {
             Ok(profit.into())
         } else {
@@ -301,7 +388,7 @@ impl Strategies for LongButterflySpread {
         } else {
             let break_even_point = break_even_points[0];
 
-            if break_even_point < self.short_calls.option.strike_price {
+            if break_even_point < self.short_call.option.strike_price {
                 self.calculate_profit_at(self.long_call_high.option.strike_price)?
                     .into()
             } else {
@@ -429,8 +516,8 @@ impl Optimizable for LongButterflySpread {
                 low_strike.call_ask.unwrap(),
                 middle_strike.call_bid.unwrap(),
                 high_strike.call_ask.unwrap(),
-                self.short_calls.open_fee,
-                self.short_calls.close_fee,
+                self.short_call.open_fee,
+                self.short_call.close_fee,
                 self.long_call_low.open_fee,
                 self.long_call_low.close_fee,
                 self.long_call_high.open_fee,
@@ -445,7 +532,7 @@ impl Profit for LongButterflySpread {
     fn calculate_profit_at(&self, price: Positive) -> Result<Decimal, Box<dyn Error>> {
         let price = Some(&price);
         Ok(self.long_call_low.pnl_at_expiration(&price)?
-            + self.short_calls.pnl_at_expiration(&price)?
+            + self.short_call.pnl_at_expiration(&price)?
             + self.long_call_high.pnl_at_expiration(&price)?)
     }
 }
@@ -466,7 +553,7 @@ impl Graph for LongButterflySpread {
             ),
             format!(
                 "Short Calls Middle Strike: ${}",
-                self.short_calls.option.strike_price
+                self.short_call.option.strike_price
             ),
             format!(
                 "Long Call High Strike: ${}",
@@ -540,7 +627,7 @@ impl Graph for LongButterflySpread {
         // Maximum profit point (at middle strike)
         points.push(ChartPoint {
             coordinates: (
-                self.short_calls.option.strike_price.to_f64(),
+                self.short_call.option.strike_price.to_f64(),
                 max_profit.to_f64(),
             ),
             label: format!("Max Profit {:.2}", max_profit),
@@ -597,7 +684,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
 
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.long_call_low.option.implied_volatility,
-            self.short_calls.option.implied_volatility,
+            self.short_call.option.implied_volatility,
             self.long_call_high.option.implied_volatility,
         ]);
 
@@ -627,7 +714,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
 
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.long_call_low.option.implied_volatility,
-            self.short_calls.option.implied_volatility,
+            self.short_call.option.implied_volatility,
             self.long_call_high.option.implied_volatility,
         ]);
 
@@ -676,7 +763,7 @@ impl Greeks for LongButterflySpread {
     fn get_options(&self) -> Result<Vec<&Options>, GreeksError> {
         Ok(vec![
             &self.long_call_low.option,
-            &self.short_calls.option,
+            &self.short_call.option,
             &self.long_call_high.option,
         ])
     }
@@ -686,7 +773,7 @@ impl DeltaNeutrality for LongButterflySpread {
     fn calculate_net_delta(&self) -> DeltaInfo {
         let long_call_low_delta = self.long_call_low.option.delta();
         let long_call_high_delta = self.long_call_high.option.delta();
-        let short_calls_delta = self.short_calls.option.delta();
+        let short_calls_delta = self.short_call.option.delta();
         let threshold = DELTA_THRESHOLD;
         let l_cl_delta = long_call_low_delta.unwrap();
         let l_ch_delta = long_call_high_delta.unwrap();
@@ -708,12 +795,12 @@ impl DeltaNeutrality for LongButterflySpread {
 
     fn generate_delta_reducing_adjustments(&self) -> Vec<DeltaAdjustment> {
         let net_delta = self.calculate_net_delta().net_delta;
-        let delta = self.short_calls.option.delta().unwrap();
+        let delta = self.short_call.option.delta().unwrap();
         let qty = Positive((net_delta.abs() / delta).abs());
 
         vec![DeltaAdjustment::SellOptions {
-            quantity: qty * self.short_calls.option.quantity,
-            strike: self.short_calls.option.strike_price,
+            quantity: qty * self.short_call.option.quantity,
+            strike: self.short_call.option.strike_price,
             option_type: OptionStyle::Call,
         }]
     }
@@ -770,8 +857,8 @@ pub struct ShortButterflySpread {
     pub kind: StrategyType,
     pub description: String,
     pub break_even_points: Vec<Positive>,
+    long_call: Position,
     short_call_low: Position,
-    long_calls: Position,
     short_call_high: Position,
 }
 
@@ -804,7 +891,7 @@ impl ShortButterflySpread {
             description: SHORT_BUTTERFLY_DESCRIPTION.to_string(),
             break_even_points: Vec::new(),
             short_call_low: Position::default(),
-            long_calls: Position::default(),
+            long_call: Position::default(),
             short_call_high: Position::default(),
         };
 
@@ -823,7 +910,7 @@ impl ShortButterflySpread {
             dividend_yield,
             None,
         );
-        strategy.long_calls = Position::new(
+        strategy.long_call = Position::new(
             long_calls,
             premium_middle,
             Utc::now(),
@@ -910,7 +997,7 @@ impl Validable for ShortButterflySpread {
             debug!("Short call (low strike) is invalid");
             return false;
         }
-        if !self.long_calls.validate() {
+        if !self.long_call.validate() {
             debug!("Long calls (middle strike) are invalid");
             return false;
         }
@@ -919,16 +1006,16 @@ impl Validable for ShortButterflySpread {
             return false;
         }
 
-        if self.short_call_low.option.strike_price >= self.long_calls.option.strike_price {
+        if self.short_call_low.option.strike_price >= self.long_call.option.strike_price {
             debug!("Low strike must be lower than middle strike");
             return false;
         }
-        if self.long_calls.option.strike_price >= self.short_call_high.option.strike_price {
+        if self.long_call.option.strike_price >= self.short_call_high.option.strike_price {
             debug!("Middle strike must be lower than high strike");
             return false;
         }
 
-        if self.long_calls.option.quantity != self.short_call_low.option.quantity * 2.0 {
+        if self.long_call.option.quantity != self.short_call_low.option.quantity * 2.0 {
             debug!("Middle strike quantity must be double the wing quantities");
             return false;
         }
@@ -946,7 +1033,7 @@ impl Positionable for ShortButterflySpread {
         match &position.option.side {
             Side::Short => {
                 // long_calls should be inserted first
-                if position.option.strike_price < self.long_calls.option.strike_price {
+                if position.option.strike_price < self.long_call.option.strike_price {
                     self.short_call_low = position.clone();
                     Ok(())
                 } else {
@@ -955,7 +1042,7 @@ impl Positionable for ShortButterflySpread {
                 }
             }
             Side::Long => {
-                self.long_calls = position.clone();
+                self.long_call = position.clone();
                 Ok(())
             }
         }
@@ -964,9 +1051,96 @@ impl Positionable for ShortButterflySpread {
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![
             &self.short_call_low,
-            &self.long_calls,
+            &self.long_call,
             &self.short_call_high,
         ])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price => Ok(vec![&mut self.long_call]),
+
+            (_, OptionStyle::Put, _)=> Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Put not found in positions".to_string(),
+            )),
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call_low.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_call_low])
+                }
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call_high.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_call_high])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        match (&position.option.side, &position.option.option_style, &position.option.strike_price) {
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price => {
+                self.long_call = position.clone();
+            },
+
+            (_, OptionStyle::Put, _)=> return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Put not found in positions".to_string(),
+            )),
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call_low.option.strike_price =>
+                {
+                    self.short_call_low = position.clone();
+                }
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call_high.option.strike_price =>
+                {
+                    self.short_call_high = position.clone();
+                }
+            _ => return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+
+        Ok(())
     }
 }
 
@@ -991,7 +1165,7 @@ impl Strategies for ShortButterflySpread {
     }
 
     fn max_loss(&self) -> Result<Positive, StrategyError> {
-        let loss = self.calculate_profit_at(self.long_calls.option.strike_price)?;
+        let loss = self.calculate_profit_at(self.long_call.option.strike_price)?;
         if loss > Decimal::ZERO {
             Err(StrategyError::ProfitLossError(
                 ProfitLossErrorKind::MaxLossError {
@@ -1133,8 +1307,8 @@ impl Optimizable for ShortButterflySpread {
                 low_strike.call_bid.unwrap(),
                 middle_strike.call_ask.unwrap(),
                 high_strike.call_bid.unwrap(),
-                self.long_calls.open_fee,
-                self.long_calls.close_fee,
+                self.long_call.open_fee,
+                self.long_call.close_fee,
                 self.short_call_low.open_fee,
                 self.short_call_low.close_fee,
                 self.short_call_high.open_fee,
@@ -1149,7 +1323,7 @@ impl Profit for ShortButterflySpread {
     fn calculate_profit_at(&self, price: Positive) -> Result<Decimal, Box<dyn Error>> {
         let price = Some(&price);
         Ok(self.short_call_low.pnl_at_expiration(&price)?
-            + self.long_calls.pnl_at_expiration(&price)?
+            + self.long_call.pnl_at_expiration(&price)?
             + self.short_call_high.pnl_at_expiration(&price)?)
     }
 }
@@ -1170,7 +1344,7 @@ impl Graph for ShortButterflySpread {
             ),
             format!(
                 "Long Calls Middle Strike: ${}",
-                self.long_calls.option.strike_price
+                self.long_call.option.strike_price
             ),
             format!(
                 "Short Call High Strike: ${}",
@@ -1236,7 +1410,7 @@ impl Graph for ShortButterflySpread {
         // Maximum loss point (at middle strike)
         points.push(ChartPoint {
             coordinates: (
-                self.long_calls.option.strike_price.to_f64(),
+                self.long_call.option.strike_price.to_f64(),
                 -max_loss.to_f64(),
             ),
             label: format!("Max Loss {:.2}", -max_loss.to_f64()),
@@ -1300,7 +1474,7 @@ impl ProbabilityAnalysis for ShortButterflySpread {
 
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.short_call_low.option.implied_volatility,
-            self.long_calls.option.implied_volatility,
+            self.long_call.option.implied_volatility,
             self.short_call_high.option.implied_volatility,
         ]);
 
@@ -1349,7 +1523,7 @@ impl ProbabilityAnalysis for ShortButterflySpread {
 
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.short_call_low.option.implied_volatility,
-            self.long_calls.option.implied_volatility,
+            self.long_call.option.implied_volatility,
             self.short_call_high.option.implied_volatility,
         ]);
 
@@ -1378,7 +1552,7 @@ impl Greeks for ShortButterflySpread {
     fn get_options(&self) -> Result<Vec<&Options>, GreeksError> {
         Ok(vec![
             &self.short_call_low.option,
-            &self.long_calls.option,
+            &self.long_call.option,
             &self.short_call_high.option,
         ])
     }
@@ -1388,7 +1562,7 @@ impl DeltaNeutrality for ShortButterflySpread {
     fn calculate_net_delta(&self) -> DeltaInfo {
         let short_call_low_delta = self.short_call_low.option.delta();
         let short_call_high_delta = self.short_call_high.option.delta();
-        let long_calls_delta = self.long_calls.option.delta();
+        let long_calls_delta = self.long_call.option.delta();
         let threshold = DELTA_THRESHOLD;
         let s_cl_delta = short_call_low_delta.unwrap();
         let s_ch_delta = short_call_high_delta.unwrap();
@@ -1430,12 +1604,12 @@ impl DeltaNeutrality for ShortButterflySpread {
 
     fn generate_delta_increasing_adjustments(&self) -> Vec<DeltaAdjustment> {
         let net_delta = self.calculate_net_delta().net_delta;
-        let delta = self.long_calls.option.delta().unwrap();
+        let delta = self.long_call.option.delta().unwrap();
         let qty = Positive((net_delta.abs() / delta).abs());
 
         vec![DeltaAdjustment::BuyOptions {
-            quantity: qty * self.long_calls.option.quantity,
-            strike: self.long_calls.option.strike_price,
+            quantity: qty * self.long_call.option.quantity,
+            strike: self.long_call.option.strike_price,
             option_type: OptionStyle::Call,
         }]
     }
@@ -1489,7 +1663,7 @@ mod tests_long_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         assert_eq!(butterfly.long_call_low.option.strike_price, pos!(90.0));
-        assert_eq!(butterfly.short_calls.option.strike_price, pos!(100.0));
+        assert_eq!(butterfly.short_call.option.strike_price, pos!(100.0));
         assert_eq!(butterfly.long_call_high.option.strike_price, pos!(110.0));
     }
 
@@ -1499,7 +1673,7 @@ mod tests_long_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         assert_eq!(butterfly.long_call_low.option.quantity, pos!(1.0));
-        assert_eq!(butterfly.short_calls.option.quantity, pos!(2.0)); // Double quantity
+        assert_eq!(butterfly.short_call.option.quantity, pos!(2.0)); // Double quantity
         assert_eq!(butterfly.long_call_high.option.quantity, pos!(1.0));
     }
 
@@ -1509,7 +1683,7 @@ mod tests_long_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         assert_eq!(butterfly.long_call_low.option.side, Side::Long);
-        assert_eq!(butterfly.short_calls.option.side, Side::Short);
+        assert_eq!(butterfly.short_call.option.side, Side::Short);
         assert_eq!(butterfly.long_call_high.option.side, Side::Long);
     }
 
@@ -1522,7 +1696,7 @@ mod tests_long_butterfly_spread {
             butterfly.long_call_low.option.option_style,
             OptionStyle::Call
         );
-        assert_eq!(butterfly.short_calls.option.option_style, OptionStyle::Call);
+        assert_eq!(butterfly.short_call.option.option_style, OptionStyle::Call);
         assert_eq!(
             butterfly.long_call_high.option.option_style,
             OptionStyle::Call
@@ -1540,7 +1714,7 @@ mod tests_long_butterfly_spread {
             format!("{:?}", expiration)
         );
         assert_eq!(
-            format!("{:?}", butterfly.short_calls.option.expiration_date),
+            format!("{:?}", butterfly.short_call.option.expiration_date),
             format!("{:?}", expiration)
         );
         assert_eq!(
@@ -1575,7 +1749,7 @@ mod tests_long_butterfly_spread {
         );
 
         assert_eq!(butterfly.long_call_low.open_fee, 0.05); // fees / 3
-        assert_eq!(butterfly.short_calls.open_fee, 1.0); // fees / 3
+        assert_eq!(butterfly.short_call.open_fee, 1.0); // fees / 3
         assert_eq!(butterfly.long_call_high.open_fee, 1.0); // fees / 3
     }
 
@@ -1587,8 +1761,8 @@ mod tests_long_butterfly_spread {
 
         assert_eq!(break_even_points.len(), 2);
         assert!(break_even_points[0] > butterfly.long_call_low.option.strike_price);
-        assert!(break_even_points[0] < butterfly.short_calls.option.strike_price);
-        assert!(break_even_points[1] > butterfly.short_calls.option.strike_price);
+        assert!(break_even_points[0] < butterfly.short_call.option.strike_price);
+        assert!(break_even_points[1] > butterfly.short_call.option.strike_price);
         assert!(break_even_points[1] < butterfly.long_call_high.option.strike_price);
     }
 
@@ -1618,7 +1792,7 @@ mod tests_long_butterfly_spread {
         );
 
         assert_eq!(butterfly.long_call_low.option.quantity, pos!(2.0));
-        assert_eq!(butterfly.short_calls.option.quantity, pos!(4.0)); // 2 * 2
+        assert_eq!(butterfly.short_call.option.quantity, pos!(4.0)); // 2 * 2
         assert_eq!(butterfly.long_call_high.option.quantity, pos!(2.0));
     }
 
@@ -1628,9 +1802,9 @@ mod tests_long_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         let lower_width =
-            butterfly.short_calls.option.strike_price - butterfly.long_call_low.option.strike_price;
+            butterfly.short_call.option.strike_price - butterfly.long_call_low.option.strike_price;
         let upper_width = butterfly.long_call_high.option.strike_price
-            - butterfly.short_calls.option.strike_price;
+            - butterfly.short_call.option.strike_price;
 
         assert_eq!(lower_width, upper_width);
     }
@@ -1642,10 +1816,10 @@ mod tests_long_butterfly_spread {
 
         assert_eq!(
             butterfly.long_call_low.option.implied_volatility,
-            butterfly.short_calls.option.implied_volatility
+            butterfly.short_call.option.implied_volatility
         );
         assert_eq!(
-            butterfly.short_calls.option.implied_volatility,
+            butterfly.short_call.option.implied_volatility,
             butterfly.long_call_high.option.implied_volatility
         );
     }
@@ -1726,7 +1900,7 @@ mod tests_short_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         assert_eq!(butterfly.short_call_low.option.strike_price, pos!(90.0));
-        assert_eq!(butterfly.long_calls.option.strike_price, pos!(100.0));
+        assert_eq!(butterfly.long_call.option.strike_price, pos!(100.0));
         assert_eq!(butterfly.short_call_high.option.strike_price, pos!(110.0));
     }
 
@@ -1736,7 +1910,7 @@ mod tests_short_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         assert_eq!(butterfly.short_call_low.option.quantity, pos!(1.0));
-        assert_eq!(butterfly.long_calls.option.quantity, pos!(2.0)); // Double quantity
+        assert_eq!(butterfly.long_call.option.quantity, pos!(2.0)); // Double quantity
         assert_eq!(butterfly.short_call_high.option.quantity, pos!(1.0));
     }
 
@@ -1746,7 +1920,7 @@ mod tests_short_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         assert_eq!(butterfly.short_call_low.option.side, Side::Short);
-        assert_eq!(butterfly.long_calls.option.side, Side::Long);
+        assert_eq!(butterfly.long_call.option.side, Side::Long);
         assert_eq!(butterfly.short_call_high.option.side, Side::Short);
     }
 
@@ -1759,7 +1933,7 @@ mod tests_short_butterfly_spread {
             butterfly.short_call_low.option.option_style,
             OptionStyle::Call
         );
-        assert_eq!(butterfly.long_calls.option.option_style, OptionStyle::Call);
+        assert_eq!(butterfly.long_call.option.option_style, OptionStyle::Call);
         assert_eq!(
             butterfly.short_call_high.option.option_style,
             OptionStyle::Call
@@ -1777,7 +1951,7 @@ mod tests_short_butterfly_spread {
             format!("{:?}", expiration)
         );
         assert_eq!(
-            format!("{:?}", butterfly.long_calls.option.expiration_date),
+            format!("{:?}", butterfly.long_call.option.expiration_date),
             format!("{:?}", expiration)
         );
         assert_eq!(
@@ -1812,7 +1986,7 @@ mod tests_short_butterfly_spread {
         );
 
         assert_eq!(butterfly.short_call_low.open_fee, 1.0); // fees / 3
-        assert_eq!(butterfly.long_calls.open_fee, 1.0); // fees / 3
+        assert_eq!(butterfly.long_call.open_fee, 1.0); // fees / 3
         assert_eq!(butterfly.short_call_high.open_fee, 1.0); // fees / 3
     }
 
@@ -1824,8 +1998,8 @@ mod tests_short_butterfly_spread {
 
         assert_eq!(break_even_points.len(), 2);
         assert!(break_even_points[0] > butterfly.short_call_low.option.strike_price);
-        assert!(break_even_points[0] < butterfly.long_calls.option.strike_price);
-        assert!(break_even_points[1] > butterfly.long_calls.option.strike_price);
+        assert!(break_even_points[0] < butterfly.long_call.option.strike_price);
+        assert!(break_even_points[1] > butterfly.long_call.option.strike_price);
         assert!(break_even_points[1] < butterfly.short_call_high.option.strike_price);
     }
 
@@ -1855,7 +2029,7 @@ mod tests_short_butterfly_spread {
         );
 
         assert_eq!(butterfly.short_call_low.option.quantity, pos!(2.0));
-        assert_eq!(butterfly.long_calls.option.quantity, pos!(4.0)); // 2 * 2
+        assert_eq!(butterfly.long_call.option.quantity, pos!(4.0)); // 2 * 2
         assert_eq!(butterfly.short_call_high.option.quantity, pos!(2.0));
     }
 
@@ -1865,9 +2039,9 @@ mod tests_short_butterfly_spread {
         let butterfly = create_test_butterfly();
 
         let lower_width =
-            butterfly.long_calls.option.strike_price - butterfly.short_call_low.option.strike_price;
+            butterfly.long_call.option.strike_price - butterfly.short_call_low.option.strike_price;
         let upper_width = butterfly.short_call_high.option.strike_price
-            - butterfly.long_calls.option.strike_price;
+            - butterfly.long_call.option.strike_price;
 
         assert_eq!(lower_width, upper_width);
     }
@@ -1879,10 +2053,10 @@ mod tests_short_butterfly_spread {
 
         assert_eq!(
             butterfly.short_call_low.option.implied_volatility,
-            butterfly.long_calls.option.implied_volatility
+            butterfly.long_call.option.implied_volatility
         );
         assert_eq!(
-            butterfly.long_calls.option.implied_volatility,
+            butterfly.long_call.option.implied_volatility,
             butterfly.short_call_high.option.implied_volatility
         );
     }
@@ -1898,7 +2072,7 @@ mod tests_short_butterfly_spread {
             underlying_price
         );
         assert_eq!(
-            butterfly.long_calls.option.underlying_price,
+            butterfly.long_call.option.underlying_price,
             underlying_price
         );
         assert_eq!(
@@ -1945,7 +2119,7 @@ mod tests_short_butterfly_spread {
             butterfly.short_call_low.option.risk_free_rate,
             risk_free_rate
         );
-        assert_eq!(butterfly.long_calls.option.risk_free_rate, risk_free_rate);
+        assert_eq!(butterfly.long_call.option.risk_free_rate, risk_free_rate);
         assert_eq!(
             butterfly.short_call_high.option.risk_free_rate,
             risk_free_rate
@@ -2087,7 +2261,7 @@ mod tests_long_butterfly_validation {
             pos!(0.05), // open_fee_long_call_high
             pos!(0.05), // close_fee_long_call_high
         );
-        butterfly.short_calls = create_valid_position(Side::Short, pos!(100.0), pos!(1.0));
+        butterfly.short_call = create_valid_position(Side::Short, pos!(100.0), pos!(1.0));
         assert!(!butterfly.validate());
     }
 
@@ -2254,7 +2428,7 @@ mod tests_short_butterfly_validation {
             pos!(0.05), // open_fee_long_call_high
             pos!(0.05), // close_fee_long_call_high
         );
-        butterfly.long_calls = create_valid_position(Side::Long, pos!(100.0), pos!(1.0));
+        butterfly.long_call = create_valid_position(Side::Long, pos!(100.0), pos!(1.0));
         assert!(!butterfly.validate());
     }
 
@@ -2687,10 +2861,10 @@ mod tests_butterfly_optimizable {
         butterfly.find_optimal(&chain, FindOptimalSide::All, OptimizationCriteria::Ratio);
 
         assert!(
-            butterfly.long_call_low.option.strike_price < butterfly.short_calls.option.strike_price
+            butterfly.long_call_low.option.strike_price < butterfly.short_call.option.strike_price
         );
         assert!(
-            butterfly.short_calls.option.strike_price
+            butterfly.short_call.option.strike_price
                 < butterfly.long_call_high.option.strike_price
         );
     }
@@ -2730,10 +2904,10 @@ mod tests_butterfly_optimizable {
         butterfly.find_optimal(&chain, FindOptimalSide::All, OptimizationCriteria::Ratio);
 
         assert!(
-            butterfly.short_call_low.option.strike_price < butterfly.long_calls.option.strike_price
+            butterfly.short_call_low.option.strike_price < butterfly.long_call.option.strike_price
         );
         assert!(
-            butterfly.long_calls.option.strike_price
+            butterfly.long_call.option.strike_price
                 < butterfly.short_call_high.option.strike_price
         );
     }
@@ -2756,10 +2930,10 @@ mod tests_butterfly_optimizable {
             OptimizationCriteria::Ratio,
         );
 
-        assert!(long_butterfly.short_calls.option.strike_price >= pos!(95.0));
-        assert!(long_butterfly.short_calls.option.strike_price <= pos!(105.0));
-        assert!(short_butterfly.long_calls.option.strike_price >= pos!(95.0));
-        assert!(short_butterfly.long_calls.option.strike_price <= pos!(105.0));
+        assert!(long_butterfly.short_call.option.strike_price >= pos!(95.0));
+        assert!(long_butterfly.short_call.option.strike_price <= pos!(105.0));
+        assert!(short_butterfly.long_call.option.strike_price >= pos!(95.0));
+        assert!(short_butterfly.long_call.option.strike_price <= pos!(105.0));
     }
 }
 
@@ -3621,7 +3795,7 @@ mod tests_long_butterfly_delta {
             _ => panic!("Invalid suggestion"),
         }
 
-        let mut option = strategy.short_calls.option.clone();
+        let mut option = strategy.short_call.option.clone();
         option.quantity = delta;
         let delta = option.delta().unwrap();
         assert_decimal_eq!(delta, -size, DELTA_THRESHOLD);
@@ -3768,7 +3942,7 @@ mod tests_long_butterfly_delta_size {
             _ => panic!("Invalid suggestion"),
         }
 
-        let mut option = strategy.short_calls.option.clone();
+        let mut option = strategy.short_call.option.clone();
         option.quantity = delta;
         let delta = option.delta().unwrap();
         assert_decimal_eq!(delta, -size, DELTA_THRESHOLD);
@@ -3860,7 +4034,7 @@ mod tests_short_butterfly_delta {
             _ => panic!("Invalid suggestion"),
         }
 
-        let mut option = strategy.long_calls.option.clone();
+        let mut option = strategy.long_call.option.clone();
         option.quantity = delta;
         let delta = option.delta().unwrap();
         assert_decimal_eq!(delta, -size, DELTA_THRESHOLD);
@@ -4005,7 +4179,7 @@ mod tests_short_butterfly_delta_size {
             _ => panic!("Invalid suggestion"),
         }
 
-        let mut option = strategy.long_calls.option.clone();
+        let mut option = strategy.long_call.option.clone();
         option.quantity = delta;
         let delta = option.delta().unwrap();
         assert_decimal_eq!(delta, -size, DELTA_THRESHOLD);
@@ -4085,4 +4259,349 @@ mod tests_short_butterfly_delta_size {
         let suggestion = strategy.suggest_delta_adjustments();
         assert_eq!(suggestion[0], DeltaAdjustment::NoAdjustmentNeeded);
     }
+}
+
+#[cfg(test)]
+mod tests_long_butterfly_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_butterfly() -> ShortButterflySpread {
+        ShortButterflySpread::new(
+            "SP500".to_string(),
+            pos!(5781.88), // underlying_price
+            pos!(5700.0),     // short_strike_itm
+            pos!(5780.0),     // long_strike
+            pos!(5850.0),     // short_strike_otm
+            ExpirationDate::Days(pos!(2.0)),
+            pos!(0.18),     // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(1.0),      // long quantity
+            pos!(119.01),   // premium_long
+            pos!(66.0),     // premium_short
+            pos!(29.85),    // open_fee_long
+            pos!(0.05),
+            pos!(0.05),
+            pos!(0.05),
+            pos!(0.05),
+            pos!(0.05),
+            pos!(0.05),
+        )
+    }
+
+    #[test]
+    fn test_long_butterfly_get_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Test getting short call position
+        let call_position = butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(5780.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5780.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = butterfly.get_position(&OptionStyle::Put, &Side::Short, &pos!(2560.0));
+        assert!(put_position.is_err());
+
+        // Test getting non-existent position
+        let invalid_position =
+            butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_butterfly_get_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Test getting short call position
+        let call_position = butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(5700.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5700.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting short put position
+        let put_position = butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(5850.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5850.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_long_butterfly_modify_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Modify short call position
+        let mut modified_call = butterfly.long_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = butterfly.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(butterfly.long_call.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = butterfly.long_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = butterfly.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
+    #[test]
+    fn test_short_butterfly_modify_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Modify long call position
+        let mut modified_call = butterfly.short_call_low.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = butterfly.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(butterfly.short_call_low.option.quantity, pos!(2.0));
+
+        // Modify long put position
+        let mut modified_put = butterfly.short_call_high.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = butterfly.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(butterfly.short_call_high.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = butterfly.short_call_low.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = butterfly.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod tests_short_butterfly_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_butterfly() -> LongButterflySpread {
+        LongButterflySpread::new(
+            "SP500".to_string(),
+            pos!(5795.88), // underlying_price
+            pos!(5710.0),     // long_strike_itm
+            pos!(5780.0),     // short_strike
+            pos!(5850.0),     // long_strike_otm
+            ExpirationDate::Days(pos!(2.0)),
+            pos!(0.18),     // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(2.0),      // long quantity
+            pos!(113.3),    // premium_long_low
+            pos!(64.20),    // premium_short
+            pos!(31.65),    // premium_long_high
+            pos!(0.05),     // open_fee_short_call
+            pos!(0.05),     // close_fee_short_call
+            pos!(0.05),     // open_fee_long_call_low
+            pos!(0.05),     // close_fee_long_call_low
+            pos!(0.05),     // open_fee_long_call_high
+            pos!(0.05),     // close_fee_long_call_high
+        )
+    }
+
+    #[test]
+    fn test_short_butterfly_get_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Test getting short call position
+        let call_position = butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(5780.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5780.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+        
+
+        // Test getting non-existent position
+        let invalid_position =
+            butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_long_butterfly_get_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Test getting short call position
+        let call_position = butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(5710.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5710.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(5850.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(5850.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting non-existent position
+        let invalid_position =
+            butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_butterfly_modify_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Modify short call position
+        let mut modified_call = butterfly.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = butterfly.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(butterfly.short_call.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = butterfly.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = butterfly.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
+    #[test]
+    fn test_long_butterfly_modify_position() {
+        let mut butterfly = create_test_butterfly();
+
+        // Modify long call position
+        let mut modified_call = butterfly.long_call_low.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = butterfly.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(butterfly.long_call_low.option.quantity, pos!(2.0));
+
+        // Modify long put position
+        let mut modified_put = butterfly.long_call_high.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = butterfly.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(butterfly.long_call_high.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = butterfly.long_call_high.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = butterfly.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
 }

--- a/src/strategies/butterfly_spread.rs
+++ b/src/strategies/butterfly_spread.rs
@@ -276,22 +276,25 @@ impl Positionable for LongButterflySpread {
     ) -> Result<Vec<&mut Position>, PositionError> {
         match (side, option_style, strike) {
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price => Ok(vec![&mut self.short_call]),
-                
-            (_, OptionStyle::Put, _)=> Err(PositionError::invalid_position_type(
-                        side.clone(),
-                        "Put not found in positions".to_string(),
-                    )),
+                if *strike == self.short_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call])
+            }
+
+            (_, OptionStyle::Put, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Put not found in positions".to_string(),
+            )),
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call_low.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call_low])
-                }
+                if *strike == self.long_call_low.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call_low])
+            }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call_high.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call_high])
-                }
+                if *strike == self.long_call_high.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call_high])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -315,31 +318,40 @@ impl Positionable for LongButterflySpread {
                 },
             ));
         }
-        
-        match (&position.option.side, &position.option.option_style, &position.option.strike_price) {
-            (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price => {
-                self.short_call = position.clone();
-            },
 
-            (_, OptionStyle::Put, _)=> return Err(PositionError::invalid_position_type(
-                position.option.side.clone(),
-                "Put not found in positions".to_string(),
-            )),
+        match (
+            &position.option.side,
+            &position.option.option_style,
+            &position.option.strike_price,
+        ) {
+            (Side::Short, OptionStyle::Call, strike)
+                if *strike == self.short_call.option.strike_price =>
+            {
+                self.short_call = position.clone();
+            }
+
+            (_, OptionStyle::Put, _) => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Put not found in positions".to_string(),
+                ))
+            }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call_low.option.strike_price =>
-                {
-                    self.long_call_low = position.clone();
-                }
+                if *strike == self.long_call_low.option.strike_price =>
+            {
+                self.long_call_low = position.clone();
+            }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call_high.option.strike_price =>
-                {
-                    self.long_call_high = position.clone();
-                }
-            _ => return Err(PositionError::invalid_position_type(
-                position.option.side.clone(),
-                "Strike not found in positions".to_string(),
-            )),
+                if *strike == self.long_call_high.option.strike_price =>
+            {
+                self.long_call_high = position.clone();
+            }
+            _ => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Strike not found in positions".to_string(),
+                ))
+            }
         }
 
         Ok(())
@@ -1074,22 +1086,25 @@ impl Positionable for ShortButterflySpread {
     ) -> Result<Vec<&mut Position>, PositionError> {
         match (side, option_style, strike) {
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price => Ok(vec![&mut self.long_call]),
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
 
-            (_, OptionStyle::Put, _)=> Err(PositionError::invalid_position_type(
+            (_, OptionStyle::Put, _) => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Put not found in positions".to_string(),
             )),
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call_low.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call_low])
-                }
+                if *strike == self.short_call_low.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call_low])
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call_high.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call_high])
-                }
+                if *strike == self.short_call_high.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call_high])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -1114,30 +1129,39 @@ impl Positionable for ShortButterflySpread {
             ));
         }
 
-        match (&position.option.side, &position.option.option_style, &position.option.strike_price) {
+        match (
+            &position.option.side,
+            &position.option.option_style,
+            &position.option.strike_price,
+        ) {
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price => {
+                if *strike == self.long_call.option.strike_price =>
+            {
                 self.long_call = position.clone();
-            },
+            }
 
-            (_, OptionStyle::Put, _)=> return Err(PositionError::invalid_position_type(
-                position.option.side.clone(),
-                "Put not found in positions".to_string(),
-            )),
+            (_, OptionStyle::Put, _) => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Put not found in positions".to_string(),
+                ))
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call_low.option.strike_price =>
-                {
-                    self.short_call_low = position.clone();
-                }
+                if *strike == self.short_call_low.option.strike_price =>
+            {
+                self.short_call_low = position.clone();
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call_high.option.strike_price =>
-                {
-                    self.short_call_high = position.clone();
-                }
-            _ => return Err(PositionError::invalid_position_type(
-                position.option.side.clone(),
-                "Strike not found in positions".to_string(),
-            )),
+                if *strike == self.short_call_high.option.strike_price =>
+            {
+                self.short_call_high = position.clone();
+            }
+            _ => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Strike not found in positions".to_string(),
+                ))
+            }
         }
 
         Ok(())
@@ -1803,8 +1827,8 @@ mod tests_long_butterfly_spread {
 
         let lower_width =
             butterfly.short_call.option.strike_price - butterfly.long_call_low.option.strike_price;
-        let upper_width = butterfly.long_call_high.option.strike_price
-            - butterfly.short_call.option.strike_price;
+        let upper_width =
+            butterfly.long_call_high.option.strike_price - butterfly.short_call.option.strike_price;
 
         assert_eq!(lower_width, upper_width);
     }
@@ -2040,8 +2064,8 @@ mod tests_short_butterfly_spread {
 
         let lower_width =
             butterfly.long_call.option.strike_price - butterfly.short_call_low.option.strike_price;
-        let upper_width = butterfly.short_call_high.option.strike_price
-            - butterfly.long_call.option.strike_price;
+        let upper_width =
+            butterfly.short_call_high.option.strike_price - butterfly.long_call.option.strike_price;
 
         assert_eq!(lower_width, upper_width);
     }
@@ -2864,8 +2888,7 @@ mod tests_butterfly_optimizable {
             butterfly.long_call_low.option.strike_price < butterfly.short_call.option.strike_price
         );
         assert!(
-            butterfly.short_call.option.strike_price
-                < butterfly.long_call_high.option.strike_price
+            butterfly.short_call.option.strike_price < butterfly.long_call_high.option.strike_price
         );
     }
 
@@ -2907,8 +2930,7 @@ mod tests_butterfly_optimizable {
             butterfly.short_call_low.option.strike_price < butterfly.long_call.option.strike_price
         );
         assert!(
-            butterfly.long_call.option.strike_price
-                < butterfly.short_call_high.option.strike_price
+            butterfly.long_call.option.strike_price < butterfly.short_call_high.option.strike_price
         );
     }
 
@@ -4273,9 +4295,9 @@ mod tests_long_butterfly_position_management {
         ShortButterflySpread::new(
             "SP500".to_string(),
             pos!(5781.88), // underlying_price
-            pos!(5700.0),     // short_strike_itm
-            pos!(5780.0),     // long_strike
-            pos!(5850.0),     // short_strike_otm
+            pos!(5700.0),  // short_strike_itm
+            pos!(5780.0),  // long_strike
+            pos!(5850.0),  // short_strike_otm
             ExpirationDate::Days(pos!(2.0)),
             pos!(0.18),     // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -4316,11 +4338,11 @@ mod tests_long_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -4358,11 +4380,11 @@ mod tests_long_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -4390,7 +4412,10 @@ mod tests_long_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -4424,7 +4449,10 @@ mod tests_long_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -4432,7 +4460,6 @@ mod tests_long_butterfly_position_management {
             _ => panic!("Expected ValidationError"),
         }
     }
-
 }
 
 #[cfg(test)]
@@ -4447,9 +4474,9 @@ mod tests_short_butterfly_position_management {
         LongButterflySpread::new(
             "SP500".to_string(),
             pos!(5795.88), // underlying_price
-            pos!(5710.0),     // long_strike_itm
-            pos!(5780.0),     // short_strike
-            pos!(5850.0),     // long_strike_otm
+            pos!(5710.0),  // long_strike_itm
+            pos!(5780.0),  // short_strike
+            pos!(5850.0),  // long_strike_otm
             ExpirationDate::Days(pos!(2.0)),
             pos!(0.18),     // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -4479,7 +4506,6 @@ mod tests_short_butterfly_position_management {
         assert_eq!(positions[0].option.strike_price, pos!(5780.0));
         assert_eq!(positions[0].option.option_style, OptionStyle::Call);
         assert_eq!(positions[0].option.side, Side::Short);
-        
 
         // Test getting non-existent position
         let invalid_position =
@@ -4487,11 +4513,11 @@ mod tests_short_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -4529,11 +4555,11 @@ mod tests_short_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -4561,7 +4587,10 @@ mod tests_short_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -4595,7 +4624,10 @@ mod tests_short_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -4603,5 +4635,4 @@ mod tests_short_butterfly_position_management {
             _ => panic!("Expected ValidationError"),
         }
     }
-
 }

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -255,25 +255,24 @@ impl Positionable for CallButterfly {
     ) -> Result<Vec<&mut Position>, PositionError> {
         match (side, option_style, strike) {
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call_low.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call_low])
-                }
+                if *strike == self.short_call_low.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call_low])
+            }
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call_high.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call_high])
-                }
+                if *strike == self.short_call_high.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call_high])
+            }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call])
-                }
-            (_, OptionStyle::Put, _) =>
-                Err(PositionError::invalid_position_type(
-                    side.clone(),
-                    "Put not found in positions".to_string(),
-                )),
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
+            (_, OptionStyle::Put, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Put not found in positions".to_string(),
+            )),
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -297,7 +296,7 @@ impl Positionable for CallButterfly {
                 },
             ));
         }
-        
+
         if position.option.strike_price != self.long_call.option.strike_price
             && position.option.strike_price != self.short_call_low.option.strike_price
             && position.option.strike_price != self.short_call_high.option.strike_price
@@ -315,18 +314,16 @@ impl Positionable for CallButterfly {
             ));
         }
 
-        if position.option.option_style == OptionStyle::Call 
-            && position.option.side == Side::Long {
+        if position.option.option_style == OptionStyle::Call && position.option.side == Side::Long {
             self.long_call = position.clone();
         }
-        
+
         if position.option.strike_price == self.short_call_low.option.strike_price {
             self.short_call_low = position.clone();
         }
         if position.option.strike_price == self.short_call_high.option.strike_price {
             self.short_call_high = position.clone();
         }
-        
 
         Ok(())
     }
@@ -1866,9 +1863,9 @@ mod tests_call_butterfly_position_management {
         CallButterfly::new(
             "SP500".to_string(),
             pos!(5781.88), // underlying_price
-            pos!(5750.0),     // long_call_strike
-            pos!(5800.0),     // short_call_low_strike
-            pos!(5850.0),     // short_call_high_strike
+            pos!(5750.0),  // long_call_strike
+            pos!(5800.0),  // short_call_low_strike
+            pos!(5850.0),  // short_call_high_strike
             ExpirationDate::Days(pos!(2.0)),
             pos!(0.18),     // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -1891,7 +1888,8 @@ mod tests_call_butterfly_position_management {
         let mut call_butterfly = create_test_call_butterfly();
 
         // Test getting short call position
-        let call_position = call_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(5800.0));
+        let call_position =
+            call_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(5800.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -1900,7 +1898,8 @@ mod tests_call_butterfly_position_management {
         assert_eq!(positions[0].option.side, Side::Short);
 
         // Test getting short put position
-        let put_position = call_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(5850.0));
+        let put_position =
+            call_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(5850.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -1914,11 +1913,11 @@ mod tests_call_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -1933,14 +1932,14 @@ mod tests_call_butterfly_position_management {
         let mut call_butterfly = create_test_call_butterfly();
 
         // Test getting short call position
-        let call_position = call_butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(5750.0));
+        let call_position =
+            call_butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(5750.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
         assert_eq!(positions[0].option.strike_price, pos!(5750.0));
         assert_eq!(positions[0].option.option_style, OptionStyle::Call);
         assert_eq!(positions[0].option.side, Side::Long);
-        
 
         // Test getting non-existent position
         let invalid_position =
@@ -1948,11 +1947,11 @@ mod tests_call_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -1987,7 +1986,10 @@ mod tests_call_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -2007,7 +2009,6 @@ mod tests_call_butterfly_position_management {
         assert!(result.is_ok());
         assert_eq!(call_butterfly.long_call.option.quantity, pos!(2.0));
 
-
         // Test modifying with invalid position
         let mut invalid_position = call_butterfly.long_call.clone();
         invalid_position.option.strike_price = pos!(95.0);
@@ -2015,7 +2016,10 @@ mod tests_call_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -2023,5 +2027,4 @@ mod tests_call_butterfly_position_management {
             _ => panic!("Expected ValidationError"),
         }
     }
-
 }

--- a/src/strategies/delta_neutral/model.rs
+++ b/src/strategies/delta_neutral/model.rs
@@ -531,14 +531,13 @@ mod tests {
     }
 }
 
-
 #[cfg(test)]
 mod additional_tests {
     use super::*;
-    use std::cell::RefCell;
-    use crate::{pos, Options};
     use crate::error::GreeksError;
     use crate::greeks::Greek;
+    use crate::{pos, Options};
+    use std::cell::RefCell;
 
     // Enhanced mock to track adjustments
     struct MockStrategyWithAdjustments {
@@ -584,8 +583,14 @@ mod additional_tests {
             self.underlying_price
         }
 
-        fn adjust_underlying_position(&mut self, quantity: Positive, side: Side) -> Result<(), Box<dyn Error>> {
-            self.underlying_adjustments.borrow_mut().push((quantity, side));
+        fn adjust_underlying_position(
+            &mut self,
+            quantity: Positive,
+            side: Side,
+        ) -> Result<(), Box<dyn Error>> {
+            self.underlying_adjustments
+                .borrow_mut()
+                .push((quantity, side));
             Ok(())
         }
 
@@ -596,9 +601,12 @@ mod additional_tests {
             option_type: &OptionStyle,
             side: &Side,
         ) -> Result<(), Box<dyn Error>> {
-            self.option_adjustments
-                .borrow_mut()
-                .push((quantity, *strike, option_type.clone(), side.clone()));
+            self.option_adjustments.borrow_mut().push((
+                quantity,
+                *strike,
+                option_type.clone(),
+                side.clone(),
+            ));
             Ok(())
         }
     }
@@ -647,7 +655,9 @@ mod additional_tests {
 
         // Only Long adjustments should be applied
         let option_adjustments = strategy.option_adjustments.borrow();
-        assert!(option_adjustments.iter().all(|(_, _, _, side)| matches!(side, Side::Long)));
+        assert!(option_adjustments
+            .iter()
+            .all(|(_, _, _, side)| matches!(side, Side::Long)));
 
         Ok(())
     }
@@ -706,10 +716,10 @@ mod additional_tests {
 #[cfg(test)]
 mod delta_adjustment_tests {
     use super::*;
-    use std::cell::RefCell;
     use crate::error::GreeksError;
     use crate::greeks::Greek;
     use crate::{pos, Options};
+    use std::cell::RefCell;
 
     // Enhanced mock strategy for testing specific adjustment scenarios
     struct TestMockStrategy {
@@ -754,8 +764,14 @@ mod delta_adjustment_tests {
             self.underlying_price
         }
 
-        fn adjust_underlying_position(&mut self, quantity: Positive, side: Side) -> Result<(), Box<dyn Error>> {
-            self.underlying_adjustments.borrow_mut().push((quantity, side));
+        fn adjust_underlying_position(
+            &mut self,
+            quantity: Positive,
+            side: Side,
+        ) -> Result<(), Box<dyn Error>> {
+            self.underlying_adjustments
+                .borrow_mut()
+                .push((quantity, side));
             Ok(())
         }
 
@@ -766,7 +782,12 @@ mod delta_adjustment_tests {
             option_type: &OptionStyle,
             side: &Side,
         ) -> Result<(), Box<dyn Error>> {
-            self.option_adjustments.borrow_mut().push((quantity, *strike, option_type.clone(), side.clone()));
+            self.option_adjustments.borrow_mut().push((
+                quantity,
+                *strike,
+                option_type.clone(),
+                side.clone(),
+            ));
             Ok(())
         }
     }
@@ -790,7 +811,9 @@ mod delta_adjustment_tests {
         strategy.apply_delta_adjustments(None, None)?;
 
         let adjustments = strategy.underlying_adjustments.borrow();
-        assert!(adjustments.iter().any(|(_, side)| matches!(side, Side::Long)));
+        assert!(adjustments
+            .iter()
+            .any(|(_, side)| matches!(side, Side::Long)));
         assert!(adjustments.iter().any(|(qty, _)| *qty == pos!(0.5)));
 
         Ok(())
@@ -806,8 +829,9 @@ mod delta_adjustment_tests {
         let adjustments = strategy.option_adjustments.borrow();
         let call_adjustments: Vec<_> = adjustments
             .iter()
-            .filter(|(_, _, style, side)|
-                matches!(style, OptionStyle::Call) && matches!(side, Side::Long))
+            .filter(|(_, _, style, side)| {
+                matches!(style, OptionStyle::Call) && matches!(side, Side::Long)
+            })
             .collect();
 
         assert!(!call_adjustments.is_empty());
@@ -827,8 +851,9 @@ mod delta_adjustment_tests {
         let adjustments = strategy.option_adjustments.borrow();
         let call_adjustments: Vec<_> = adjustments
             .iter()
-            .filter(|(_, _, style, side)|
-                matches!(style, OptionStyle::Call) && matches!(side, Side::Short))
+            .filter(|(_, _, style, side)| {
+                matches!(style, OptionStyle::Call) && matches!(side, Side::Short)
+            })
             .collect();
 
         assert!(!call_adjustments.is_empty());
@@ -863,7 +888,7 @@ mod delta_adjustment_tests {
             let adjustments = strategy.underlying_adjustments.borrow();
             assert_eq!(adjustments.len(), 1);
             assert_eq!(adjustments[0], (pos!(1.0), Side::Long));
-        }  // préstamo inmutable termina aquí
+        } // préstamo inmutable termina aquí
 
         // Test with short side
         strategy.adjust_underlying_position(pos!(2.0), Side::Short)?;

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -16,7 +16,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::{GreeksError, ProbabilityError};
 use crate::greeks::Greeks;
@@ -259,6 +259,97 @@ impl Positionable for IronButterfly {
             &self.long_call,
             &self.long_put,
         ])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_call])
+                }
+            (Side::Short, OptionStyle::Put, strike)
+            if *strike == self.short_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_put])
+                }
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_call])
+                }
+            (Side::Long, OptionStyle::Put, _)
+            if *strike == self.long_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_put])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+
+        if position.option.strike_price != self.long_call.option.strike_price
+            && position.option.strike_price != self.long_put.option.strike_price
+            && position.option.strike_price != self.short_call.option.strike_price
+            && position.option.strike_price != self.short_put.option.strike_price
+        {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Strike not found in positions".to_string(),
+            ));
+        }
+
+        match (&position.option.option_style, &position.option.side) {
+            (OptionStyle::Call, Side::Short) => {
+                self.short_call = position.clone();
+            }
+            (OptionStyle::Put, Side::Short) => {
+                self.short_put = position.clone();
+            }
+            (OptionStyle::Call, Side::Long) => {
+                self.long_call = position.clone();
+            }
+            (OptionStyle::Put, Side::Long) => {
+                self.long_put = position.clone();
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -1934,7 +2025,7 @@ mod tests_iron_butterfly_graph {
 }
 
 #[cfg(test)]
-mod tests_iron_condor_delta {
+mod tests_iron_butterfly_delta {
     use super::*;
     use crate::model::types::{ExpirationDate, OptionStyle};
     use crate::strategies::delta_neutral::DELTA_THRESHOLD;
@@ -2091,7 +2182,7 @@ mod tests_iron_condor_delta {
 }
 
 #[cfg(test)]
-mod tests_iron_condor_delta_size {
+mod tests_iron_butterfly_delta_size {
     use super::*;
     use crate::model::types::{ExpirationDate, OptionStyle};
     use crate::strategies::delta_neutral::DELTA_THRESHOLD;
@@ -2455,4 +2546,187 @@ mod tests_iron_butterfly_probability {
             assert!(prob <= pos!(1.0));
         }
     }
+}
+
+#[cfg(test)]
+mod tests_iron_butterfly_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_iron_butterfly() -> IronButterfly {
+        IronButterfly::new(
+            "GOLD".to_string(),
+            pos!(2646.9), // underlying_price
+            pos!(2725.0),     // short_call_strike
+            pos!(2800.0),     // long_call_strike
+            pos!(2500.0),     // long_put_strike
+            ExpirationDate::Days(pos!(30.0)),
+            pos!(0.1548),   // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(2.0),      // quantity
+            pos!(38.8),     // premium_short_call
+            pos!(30.4),     // premium_short_put
+            pos!(23.3),     // premium_long_call
+            pos!(16.8),     // premium_long_put
+            pos!(0.96),     // open_fee
+            pos!(0.96),     // close_fee
+        )
+    }
+
+    #[test]
+    fn test_short_iron_butterfly_get_position() {
+        let mut iron_butterfly = create_test_iron_butterfly();
+
+        // Test getting short call position
+        let call_position = iron_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(2725.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2725.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting short put position
+        let put_position = iron_butterfly.get_position(&OptionStyle::Put, &Side::Short, &pos!(2725.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2725.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            iron_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_long_iron_butterfly_get_position() {
+        let mut iron_butterfly = create_test_iron_butterfly();
+
+        // Test getting short call position
+        let call_position = iron_butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(2800.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2800.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = iron_butterfly.get_position(&OptionStyle::Put, &Side::Long, &pos!(2500.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2500.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting non-existent position
+        let invalid_position =
+            iron_butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_iron_butterfly_modify_position() {
+        let mut iron_butterfly = create_test_iron_butterfly();
+
+        // Modify short call position
+        let mut modified_call = iron_butterfly.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = iron_butterfly.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(iron_butterfly.short_call.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = iron_butterfly.short_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = iron_butterfly.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(iron_butterfly.short_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = iron_butterfly.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = iron_butterfly.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
+    #[test]
+    fn test_long_iron_butterfly_modify_position() {
+        let mut iron_butterfly = create_test_iron_butterfly();
+
+        // Modify long call position
+        let mut modified_call = iron_butterfly.long_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = iron_butterfly.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(iron_butterfly.long_call.option.quantity, pos!(2.0));
+
+        // Modify long put position
+        let mut modified_put = iron_butterfly.long_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = iron_butterfly.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(iron_butterfly.long_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = iron_butterfly.long_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = iron_butterfly.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
 }

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -279,25 +279,23 @@ impl Positionable for IronButterfly {
     ) -> Result<Vec<&mut Position>, PositionError> {
         match (side, option_style, strike) {
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call])
-                }
+                if *strike == self.short_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call])
+            }
             (Side::Short, OptionStyle::Put, strike)
-            if *strike == self.short_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_put])
-                }
+                if *strike == self.short_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_put])
+            }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call])
-                }
-            (Side::Long, OptionStyle::Put, _)
-            if *strike == self.long_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_put])
-                }
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
+            (Side::Long, OptionStyle::Put, _) if *strike == self.long_put.option.strike_price => {
+                Ok(vec![&mut self.long_put])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -321,7 +319,6 @@ impl Positionable for IronButterfly {
                 },
             ));
         }
-
 
         if position.option.strike_price != self.long_call.option.strike_price
             && position.option.strike_price != self.long_put.option.strike_price
@@ -2560,9 +2557,9 @@ mod tests_iron_butterfly_position_management {
         IronButterfly::new(
             "GOLD".to_string(),
             pos!(2646.9), // underlying_price
-            pos!(2725.0),     // short_call_strike
-            pos!(2800.0),     // long_call_strike
-            pos!(2500.0),     // long_put_strike
+            pos!(2725.0), // short_call_strike
+            pos!(2800.0), // long_call_strike
+            pos!(2500.0), // long_put_strike
             ExpirationDate::Days(pos!(30.0)),
             pos!(0.1548),   // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -2582,7 +2579,8 @@ mod tests_iron_butterfly_position_management {
         let mut iron_butterfly = create_test_iron_butterfly();
 
         // Test getting short call position
-        let call_position = iron_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(2725.0));
+        let call_position =
+            iron_butterfly.get_position(&OptionStyle::Call, &Side::Short, &pos!(2725.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2591,7 +2589,8 @@ mod tests_iron_butterfly_position_management {
         assert_eq!(positions[0].option.side, Side::Short);
 
         // Test getting short put position
-        let put_position = iron_butterfly.get_position(&OptionStyle::Put, &Side::Short, &pos!(2725.0));
+        let put_position =
+            iron_butterfly.get_position(&OptionStyle::Put, &Side::Short, &pos!(2725.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2605,11 +2604,11 @@ mod tests_iron_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -2624,7 +2623,8 @@ mod tests_iron_butterfly_position_management {
         let mut iron_butterfly = create_test_iron_butterfly();
 
         // Test getting short call position
-        let call_position = iron_butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(2800.0));
+        let call_position =
+            iron_butterfly.get_position(&OptionStyle::Call, &Side::Long, &pos!(2800.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2633,7 +2633,8 @@ mod tests_iron_butterfly_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting short put position
-        let put_position = iron_butterfly.get_position(&OptionStyle::Put, &Side::Long, &pos!(2500.0));
+        let put_position =
+            iron_butterfly.get_position(&OptionStyle::Put, &Side::Long, &pos!(2500.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2647,11 +2648,11 @@ mod tests_iron_butterfly_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -2686,7 +2687,10 @@ mod tests_iron_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -2720,7 +2724,10 @@ mod tests_iron_butterfly_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -2728,5 +2735,4 @@ mod tests_iron_butterfly_position_management {
             _ => panic!("Expected ValidationError"),
         }
     }
-
 }

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -14,7 +14,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::{GreeksError, ProbabilityError};
 use crate::greeks::Greeks;
@@ -258,6 +258,97 @@ impl Positionable for IronCondor {
             &self.long_call,
             &self.long_put,
         ])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_call])
+                }
+            (Side::Short, OptionStyle::Put, strike)
+            if *strike == self.short_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_put])
+                }
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_call])
+                }
+            (Side::Long, OptionStyle::Put, strike)
+            if *strike == self.long_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_put])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+        
+
+        if position.option.strike_price != self.long_call.option.strike_price
+            && position.option.strike_price != self.long_put.option.strike_price
+            && position.option.strike_price != self.short_call.option.strike_price
+            && position.option.strike_price != self.short_put.option.strike_price
+        {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Strike not found in positions".to_string(),
+            ));
+        }
+        
+        match (&position.option.option_style, &position.option.side) {
+            (OptionStyle::Call, Side::Short) => {
+                self.short_call = position.clone();
+            }
+            (OptionStyle::Put, Side::Short) => {
+                self.short_put = position.clone();
+            }
+            (OptionStyle::Call, Side::Long) => {
+                self.long_call = position.clone();
+            }
+            (OptionStyle::Put, Side::Long) => {
+                self.long_put = position.clone();
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -2717,4 +2808,188 @@ mod tests_iron_condor_probability {
         assert!(max_loss_prob >= Positive::ZERO);
         assert!(max_profit_prob + max_loss_prob <= pos!(1.0));
     }
+}
+
+#[cfg(test)]
+mod tests_iron_condor_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_iron_condor() -> IronCondor {
+        IronCondor::new(
+            "GOLD".to_string(),
+            pos!(2646.9), // underlying_price
+            pos!(2725.0),     // short_call_strike
+            pos!(2560.0),     // short_put_strike
+            pos!(2800.0),     // long_call_strike
+            pos!(2500.0),     // long_put_strike
+            ExpirationDate::Days(pos!(30.0)),
+            pos!(0.1548),   // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(1.0),      // quantity
+            pos!(38.8),     // premium_short_call
+            pos!(30.4),     // premium_short_put
+            pos!(23.3),     // premium_long_call
+            pos!(16.8),     // premium_long_put
+            pos!(0.96),     // open_fee
+            pos!(0.96),     // close_fee
+        )
+    }
+    
+    #[test]
+    fn test_short_iron_condor_get_position_short() {
+        let mut iron_condor = create_test_iron_condor();
+
+        // Test getting short call position
+        let call_position = iron_condor.get_position(&OptionStyle::Call, &Side::Short, &pos!(2725.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2725.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting short put position
+        let put_position = iron_condor.get_position(&OptionStyle::Put, &Side::Short, &pos!(2560.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2560.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            iron_condor.get_position(&OptionStyle::Call, &Side::Short, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_iron_condor_get_position_long() {
+        let mut iron_condor = create_test_iron_condor();
+
+        // Test getting short call position
+        let call_position = iron_condor.get_position(&OptionStyle::Call, &Side::Long, &pos!(2800.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2800.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = iron_condor.get_position(&OptionStyle::Put, &Side::Long, &pos!(2500.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2500.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting non-existent position
+        let invalid_position =
+            iron_condor.get_position(&OptionStyle::Call, &Side::Long, &pos!(2715.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_iron_condor_modify_position() {
+        let mut iron_condor = create_test_iron_condor();
+    
+        // Modify short call position
+        let mut modified_call = iron_condor.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = iron_condor.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(iron_condor.short_call.option.quantity, pos!(2.0));
+    
+        // Modify short put position
+        let mut modified_put = iron_condor.short_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = iron_condor.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(iron_condor.short_put.option.quantity, pos!(2.0));
+    
+        // Test modifying with invalid position
+        let mut invalid_position = iron_condor.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = iron_condor.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
+    #[test]
+    fn test_long_iron_condor_modify_position() {
+        let mut iron_condor = create_test_iron_condor();
+
+        // Modify long call position
+        let mut modified_call = iron_condor.long_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = iron_condor.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(iron_condor.long_call.option.quantity, pos!(2.0));
+
+        // Modify long put position
+        let mut modified_put = iron_condor.long_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = iron_condor.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(iron_condor.long_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = iron_condor.long_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = iron_condor.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+    
 }

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -278,25 +278,25 @@ impl Positionable for IronCondor {
     ) -> Result<Vec<&mut Position>, PositionError> {
         match (side, option_style, strike) {
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call])
-                }
+                if *strike == self.short_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call])
+            }
             (Side::Short, OptionStyle::Put, strike)
-            if *strike == self.short_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_put])
-                }
+                if *strike == self.short_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_put])
+            }
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call])
-                }
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
             (Side::Long, OptionStyle::Put, strike)
-            if *strike == self.long_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_put])
-                }
+                if *strike == self.long_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_put])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -320,7 +320,6 @@ impl Positionable for IronCondor {
                 },
             ));
         }
-        
 
         if position.option.strike_price != self.long_call.option.strike_price
             && position.option.strike_price != self.long_put.option.strike_price
@@ -332,7 +331,7 @@ impl Positionable for IronCondor {
                 "Strike not found in positions".to_string(),
             ));
         }
-        
+
         match (&position.option.option_style, &position.option.side) {
             (OptionStyle::Call, Side::Short) => {
                 self.short_call = position.clone();
@@ -2822,10 +2821,10 @@ mod tests_iron_condor_position_management {
         IronCondor::new(
             "GOLD".to_string(),
             pos!(2646.9), // underlying_price
-            pos!(2725.0),     // short_call_strike
-            pos!(2560.0),     // short_put_strike
-            pos!(2800.0),     // long_call_strike
-            pos!(2500.0),     // long_put_strike
+            pos!(2725.0), // short_call_strike
+            pos!(2560.0), // short_put_strike
+            pos!(2800.0), // long_call_strike
+            pos!(2500.0), // long_put_strike
             ExpirationDate::Days(pos!(30.0)),
             pos!(0.1548),   // implied_volatility
             dec!(0.05),     // risk_free_rate
@@ -2839,13 +2838,14 @@ mod tests_iron_condor_position_management {
             pos!(0.96),     // close_fee
         )
     }
-    
+
     #[test]
     fn test_short_iron_condor_get_position() {
         let mut iron_condor = create_test_iron_condor();
 
         // Test getting short call position
-        let call_position = iron_condor.get_position(&OptionStyle::Call, &Side::Short, &pos!(2725.0));
+        let call_position =
+            iron_condor.get_position(&OptionStyle::Call, &Side::Short, &pos!(2725.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2868,11 +2868,11 @@ mod tests_iron_condor_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -2887,7 +2887,8 @@ mod tests_iron_condor_position_management {
         let mut iron_condor = create_test_iron_condor();
 
         // Test getting short call position
-        let call_position = iron_condor.get_position(&OptionStyle::Call, &Side::Long, &pos!(2800.0));
+        let call_position =
+            iron_condor.get_position(&OptionStyle::Call, &Side::Long, &pos!(2800.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2910,11 +2911,11 @@ mod tests_iron_condor_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -2927,21 +2928,21 @@ mod tests_iron_condor_position_management {
     #[test]
     fn test_short_iron_condor_modify_position() {
         let mut iron_condor = create_test_iron_condor();
-    
+
         // Modify short call position
         let mut modified_call = iron_condor.short_call.clone();
         modified_call.option.quantity = pos!(2.0);
         let result = iron_condor.modify_position(&modified_call);
         assert!(result.is_ok());
         assert_eq!(iron_condor.short_call.option.quantity, pos!(2.0));
-    
+
         // Modify short put position
         let mut modified_put = iron_condor.short_put.clone();
         modified_put.option.quantity = pos!(2.0);
         let result = iron_condor.modify_position(&modified_put);
         assert!(result.is_ok());
         assert_eq!(iron_condor.short_put.option.quantity, pos!(2.0));
-    
+
         // Test modifying with invalid position
         let mut invalid_position = iron_condor.short_call.clone();
         invalid_position.option.strike_price = pos!(95.0);
@@ -2949,7 +2950,10 @@ mod tests_iron_condor_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -2983,7 +2987,10 @@ mod tests_iron_condor_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -2991,5 +2998,4 @@ mod tests_iron_condor_position_management {
             _ => panic!("Expected ValidationError"),
         }
     }
-    
 }

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -2841,7 +2841,7 @@ mod tests_iron_condor_position_management {
     }
     
     #[test]
-    fn test_short_iron_condor_get_position_short() {
+    fn test_short_iron_condor_get_position() {
         let mut iron_condor = create_test_iron_condor();
 
         // Test getting short call position
@@ -2883,7 +2883,7 @@ mod tests_iron_condor_position_management {
     }
 
     #[test]
-    fn test_short_iron_condor_get_position_long() {
+    fn test_long_iron_condor_get_position() {
         let mut iron_condor = create_test_iron_condor();
 
         // Test getting short call position

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -35,7 +35,7 @@ use super::base::{Optimizable, Positionable, Strategies, StrategyType, Validable
 use crate::chains::chain::{OptionChain, OptionData};
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN, ZERO};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::{GreeksError, ProbabilityError};
 use crate::greeks::Greeks;
@@ -196,6 +196,93 @@ impl Positionable for PoorMansCoveredCall {
 
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.short_call, &self.long_call])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (_, OptionStyle::Put, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Put is not valid for PoorMansCoveredCall".to_string(),
+            )),
+            (Side::Long, OptionStyle::Call, strike)
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
+            (Side::Short, OptionStyle::Call, strike)
+                if *strike == self.short_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call])
+            }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        match (
+            &position.option.side,
+            &position.option.option_style,
+            &position.option.strike_price,
+        ) {
+            (_, OptionStyle::Put, _) => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Put is not valid for PoorMansCoveredCall".to_string(),
+                ))
+            }
+            (Side::Long, OptionStyle::Call, strike)
+                if *strike == self.long_call.option.strike_price =>
+            {
+                self.long_call = position.clone();
+            }
+            (Side::Short, OptionStyle::Call, strike)
+                if *strike == self.short_call.option.strike_price =>
+            {
+                self.short_call = position.clone();
+            }
+            _ => {
+                return Err(PositionError::invalid_position_type(
+                    position.option.side.clone(),
+                    "Strike not found in positions".to_string(),
+                ))
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -1863,5 +1950,114 @@ mod tests_poor_mans_covered_call_probability {
         let pmcc = create_test_pmcc();
         // Short call strike should be higher than long call strike for a valid PMCC
         assert!(pmcc.short_call.option.strike_price > pmcc.long_call.option.strike_price);
+    }
+}
+
+#[cfg(test)]
+mod tests_strangle_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_short_strangle() -> PoorMansCoveredCall {
+        PoorMansCoveredCall::new(
+            "GOLD".to_string(),                // underlying_symbol
+            pos!(2703.3),                      // underlying_price
+            pos!(2600.0),                      // long_call_strike
+            pos!(2800.0),                      // short_call_strike OTM
+            ExpirationDate::Days(pos!(120.0)), // long_call_expiration
+            ExpirationDate::Days(pos!(30.0)), // short_call_expiration 30-45 days delta 0.30 or less
+            pos!(0.17),                       // implied_volatility
+            dec!(0.05),                       // risk_free_rate
+            Positive::ZERO,                   // dividend_yield
+            pos!(2.0),                        // quantity
+            pos!(154.7),                      // premium_short_call
+            pos!(30.8),                       // premium_short_put
+            pos!(1.74),                       // open_fee_short_call
+            pos!(1.74),                       // close_fee_short_call
+            pos!(0.85),                       // open_fee_short_put
+            pos!(0.85),                       // close_fee_short_put
+        )
+    }
+
+    #[test]
+    fn test_short_strangle_get_position() {
+        let mut strangle = create_test_short_strangle();
+
+        // Test getting short call position
+        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(2600.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2600.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting short put position
+        let put_position = strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(2800.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(2800.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(2801.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_strangle_modify_position() {
+        let mut strangle = create_test_short_strangle();
+
+        // Modify short call position
+        let mut modified_call = strangle.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(strangle.short_call.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = strangle.long_call.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(strangle.long_call.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = strangle.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = strangle.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
     }
 }

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -1987,7 +1987,8 @@ mod tests_poor_mans_covered_call_position_management {
         let mut poor_mans_covered_call = create_test_short_poor_mans_covered_call();
 
         // Test getting short call position
-        let call_position = poor_mans_covered_call.get_position(&OptionStyle::Call, &Side::Long, &pos!(2600.0));
+        let call_position =
+            poor_mans_covered_call.get_position(&OptionStyle::Call, &Side::Long, &pos!(2600.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -1996,7 +1997,8 @@ mod tests_poor_mans_covered_call_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting short put position
-        let put_position = poor_mans_covered_call.get_position(&OptionStyle::Call, &Side::Short, &pos!(2800.0));
+        let put_position =
+            poor_mans_covered_call.get_position(&OptionStyle::Call, &Side::Short, &pos!(2800.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -1954,14 +1954,14 @@ mod tests_poor_mans_covered_call_probability {
 }
 
 #[cfg(test)]
-mod tests_strangle_position_management {
+mod tests_poor_mans_covered_call_position_management {
     use super::*;
     use crate::error::position::PositionValidationErrorKind;
     use crate::model::types::{ExpirationDate, OptionStyle, Side};
     use crate::pos;
     use rust_decimal_macros::dec;
 
-    fn create_test_short_strangle() -> PoorMansCoveredCall {
+    fn create_test_short_poor_mans_covered_call() -> PoorMansCoveredCall {
         PoorMansCoveredCall::new(
             "GOLD".to_string(),                // underlying_symbol
             pos!(2703.3),                      // underlying_price
@@ -1983,11 +1983,11 @@ mod tests_strangle_position_management {
     }
 
     #[test]
-    fn test_short_strangle_get_position() {
-        let mut strangle = create_test_short_strangle();
+    fn test_short_poor_mans_covered_call_get_position() {
+        let mut poor_mans_covered_call = create_test_short_poor_mans_covered_call();
 
         // Test getting short call position
-        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(2600.0));
+        let call_position = poor_mans_covered_call.get_position(&OptionStyle::Call, &Side::Long, &pos!(2600.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -1996,7 +1996,7 @@ mod tests_strangle_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting short put position
-        let put_position = strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(2800.0));
+        let put_position = poor_mans_covered_call.get_position(&OptionStyle::Call, &Side::Short, &pos!(2800.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2006,7 +2006,7 @@ mod tests_strangle_position_management {
 
         // Test getting non-existent position
         let invalid_position =
-            strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(2801.0));
+            poor_mans_covered_call.get_position(&OptionStyle::Call, &Side::Short, &pos!(2801.0));
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
@@ -2025,27 +2025,27 @@ mod tests_strangle_position_management {
     }
 
     #[test]
-    fn test_short_strangle_modify_position() {
-        let mut strangle = create_test_short_strangle();
+    fn test_short_poor_mans_covered_call_modify_position() {
+        let mut poor_mans_covered_call = create_test_short_poor_mans_covered_call();
 
         // Modify short call position
-        let mut modified_call = strangle.short_call.clone();
+        let mut modified_call = poor_mans_covered_call.short_call.clone();
         modified_call.option.quantity = pos!(2.0);
-        let result = strangle.modify_position(&modified_call);
+        let result = poor_mans_covered_call.modify_position(&modified_call);
         assert!(result.is_ok());
-        assert_eq!(strangle.short_call.option.quantity, pos!(2.0));
+        assert_eq!(poor_mans_covered_call.short_call.option.quantity, pos!(2.0));
 
         // Modify short put position
-        let mut modified_put = strangle.long_call.clone();
+        let mut modified_put = poor_mans_covered_call.long_call.clone();
         modified_put.option.quantity = pos!(2.0);
-        let result = strangle.modify_position(&modified_put);
+        let result = poor_mans_covered_call.modify_position(&modified_put);
         assert!(result.is_ok());
-        assert_eq!(strangle.long_call.option.quantity, pos!(2.0));
+        assert_eq!(poor_mans_covered_call.long_call.option.quantity, pos!(2.0));
 
         // Test modifying with invalid position
-        let mut invalid_position = strangle.short_call.clone();
+        let mut invalid_position = poor_mans_covered_call.short_call.clone();
         invalid_position.option.strike_price = pos!(95.0);
-        let result = strangle.modify_position(&invalid_position);
+        let result = poor_mans_covered_call.modify_position(&invalid_position);
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {

--- a/src/strategies/straddle.rs
+++ b/src/strategies/straddle.rs
@@ -14,7 +14,7 @@ use crate::chains::chain::OptionChain;
 use crate::chains::utils::OptionDataGroup;
 use crate::chains::StrategyLegs;
 use crate::constants::{DARK_BLUE, DARK_GREEN, ZERO};
-use crate::error::position::PositionError;
+use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
 use crate::error::GreeksError;
@@ -183,6 +183,88 @@ impl Positionable for ShortStraddle {
 
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.short_call, &self.short_put])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (Side::Long, _, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Position side is Long, it is not valid for ShortStraddle".to_string(),
+            )),
+            (Side::Short, OptionStyle::Call, strike)
+            if *strike == self.short_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_call])
+                }
+            (Side::Short, OptionStyle::Put, strike)
+            if *strike == self.short_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.short_put])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        if position.option.side == Side::Long {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Position side is Long, it is not valid for ShortStraddle".to_string(),
+            ));
+        }
+
+        if position.option.strike_price != self.short_call.option.strike_price
+            && position.option.strike_price != self.short_put.option.strike_price
+        {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Strike not found in positions".to_string(),
+            ));
+        }
+
+        if position.option.option_style == OptionStyle::Call {
+            self.short_call = position.clone();
+        }
+
+        if position.option.option_style == OptionStyle::Put {
+            self.short_put = position.clone();
+        }
+
+        Ok(())
     }
 }
 
@@ -711,6 +793,88 @@ impl Positionable for LongStraddle {
 
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.long_call, &self.long_put])
+    }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (Side::Short, _, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Position side is Short, it is not valid for LongStraddle".to_string(),
+            )),
+            (Side::Long, OptionStyle::Call, strike)
+            if *strike == self.long_call.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_call])
+                }
+            (Side::Long, OptionStyle::Put, strike)
+            if *strike == self.long_put.option.strike_price =>
+                {
+                    Ok(vec![&mut self.long_put])
+                }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        if position.option.side == Side::Short {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Position side is Short, it is not valid for LongStraddle".to_string(),
+            ));
+        }
+
+        if position.option.strike_price != self.long_call.option.strike_price
+            && position.option.strike_price != self.long_put.option.strike_price
+        {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Strike not found in positions".to_string(),
+            ));
+        }
+
+        if position.option.option_style == OptionStyle::Call {
+            self.long_call = position.clone();
+        }
+
+        if position.option.option_style == OptionStyle::Put {
+            self.long_put = position.clone();
+        }
+
+        Ok(())
     }
 }
 
@@ -2748,5 +2912,203 @@ mod tests_long_straddle_delta_size {
         assert!(strategy.is_delta_neutral());
         let suggestion = strategy.suggest_delta_adjustments();
         assert_eq!(suggestion[0], DeltaAdjustment::NoAdjustmentNeeded);
+    }
+}
+
+#[cfg(test)]
+mod tests_straddle_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_short_strangle() -> ShortStraddle {
+        ShortStraddle::new(
+            "TEST".to_string(),
+            pos!(100.0), // underlying_price
+            pos!(110.0), // strike
+            ExpirationDate::Days(pos!(30.0)),
+            pos!(0.2),      // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(1.0),      // quantity
+            pos!(2.0),      // premium_short_call
+            pos!(2.0),      // premium_short_put
+            pos!(0.1),      // open_fee_short_call
+            pos!(0.1),      // close_fee_short_call
+            pos!(0.1),      // open_fee_short_put
+            pos!(0.1),      // close_fee_short_put
+        )
+    }
+
+    fn create_test_long_strangle() -> LongStraddle {
+        LongStraddle::new(
+            "TEST".to_string(),
+            pos!(100.0), // underlying_price
+            pos!(110.0), // strike
+            ExpirationDate::Days(pos!(30.0)),
+            pos!(0.2),      // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(1.0),      // quantity
+            pos!(2.0),      // premium_long_call
+            pos!(2.0),      // premium_long_put
+            pos!(0.1),      // open_fee_long_call
+            pos!(0.1),      // close_fee_long_call
+            pos!(0.1),      // open_fee_long_put
+            pos!(0.1),      // close_fee_long_put
+        )
+    }
+
+    #[test]
+    fn test_short_strangle_get_position() {
+        let mut strangle = create_test_short_strangle();
+
+        // Test getting short call position
+        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(110.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(110.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting short put position
+        let put_position = strangle.get_position(&OptionStyle::Put, &Side::Short, &pos!(110.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(110.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(100.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_strangle_modify_position() {
+        let mut strangle = create_test_short_strangle();
+
+        // Modify short call position
+        let mut modified_call = strangle.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(strangle.short_call.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = strangle.short_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(strangle.short_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = strangle.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = strangle.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
+    #[test]
+    fn test_long_strangle_get_position() {
+        let mut strangle = create_test_long_strangle();
+
+        // Test getting long call position
+        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(110.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(110.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting long put position
+        let put_position = strangle.get_position(&OptionStyle::Put, &Side::Long, &pos!(110.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(110.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting non-existent position
+        let invalid_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(100.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_long_strangle_modify_position() {
+        let mut strangle = create_test_long_strangle();
+
+        // Modify long call position
+        let mut modified_call = strangle.long_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(strangle.long_call.option.quantity, pos!(2.0));
+
+        // Modify long put position
+        let mut modified_put = strangle.long_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(strangle.long_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = strangle.long_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = strangle.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
     }
 }

--- a/src/strategies/straddle.rs
+++ b/src/strategies/straddle.rs
@@ -207,15 +207,15 @@ impl Positionable for ShortStraddle {
                 "Position side is Long, it is not valid for ShortStraddle".to_string(),
             )),
             (Side::Short, OptionStyle::Call, strike)
-            if *strike == self.short_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_call])
-                }
+                if *strike == self.short_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_call])
+            }
             (Side::Short, OptionStyle::Put, strike)
-            if *strike == self.short_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.short_put])
-                }
+                if *strike == self.short_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.short_put])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -817,15 +817,15 @@ impl Positionable for LongStraddle {
                 "Position side is Short, it is not valid for LongStraddle".to_string(),
             )),
             (Side::Long, OptionStyle::Call, strike)
-            if *strike == self.long_call.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_call])
-                }
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
             (Side::Long, OptionStyle::Put, strike)
-            if *strike == self.long_put.option.strike_price =>
-                {
-                    Ok(vec![&mut self.long_put])
-                }
+                if *strike == self.long_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_put])
+            }
             _ => Err(PositionError::invalid_position_type(
                 side.clone(),
                 "Strike not found in positions".to_string(),
@@ -2989,11 +2989,11 @@ mod tests_straddle_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -3028,7 +3028,10 @@ mod tests_straddle_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -3064,11 +3067,11 @@ mod tests_straddle_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -3103,7 +3106,10 @@ mod tests_straddle_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),

--- a/src/strategies/straddle.rs
+++ b/src/strategies/straddle.rs
@@ -2923,7 +2923,7 @@ mod tests_straddle_position_management {
     use crate::pos;
     use rust_decimal_macros::dec;
 
-    fn create_test_short_strangle() -> ShortStraddle {
+    fn create_test_short_straddle() -> ShortStraddle {
         ShortStraddle::new(
             "TEST".to_string(),
             pos!(100.0), // underlying_price
@@ -2942,7 +2942,7 @@ mod tests_straddle_position_management {
         )
     }
 
-    fn create_test_long_strangle() -> LongStraddle {
+    fn create_test_long_straddle() -> LongStraddle {
         LongStraddle::new(
             "TEST".to_string(),
             pos!(100.0), // underlying_price
@@ -2962,11 +2962,11 @@ mod tests_straddle_position_management {
     }
 
     #[test]
-    fn test_short_strangle_get_position() {
-        let mut strangle = create_test_short_strangle();
+    fn test_short_straddle_get_position() {
+        let mut straddle = create_test_short_straddle();
 
         // Test getting short call position
-        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(110.0));
+        let call_position = straddle.get_position(&OptionStyle::Call, &Side::Short, &pos!(110.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2975,7 +2975,7 @@ mod tests_straddle_position_management {
         assert_eq!(positions[0].option.side, Side::Short);
 
         // Test getting short put position
-        let put_position = strangle.get_position(&OptionStyle::Put, &Side::Short, &pos!(110.0));
+        let put_position = straddle.get_position(&OptionStyle::Put, &Side::Short, &pos!(110.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -2985,7 +2985,7 @@ mod tests_straddle_position_management {
 
         // Test getting non-existent position
         let invalid_position =
-            strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(100.0));
+            straddle.get_position(&OptionStyle::Call, &Side::Short, &pos!(100.0));
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
@@ -3004,27 +3004,27 @@ mod tests_straddle_position_management {
     }
 
     #[test]
-    fn test_short_strangle_modify_position() {
-        let mut strangle = create_test_short_strangle();
+    fn test_short_straddle_modify_position() {
+        let mut straddle = create_test_short_straddle();
 
         // Modify short call position
-        let mut modified_call = strangle.short_call.clone();
+        let mut modified_call = straddle.short_call.clone();
         modified_call.option.quantity = pos!(2.0);
-        let result = strangle.modify_position(&modified_call);
+        let result = straddle.modify_position(&modified_call);
         assert!(result.is_ok());
-        assert_eq!(strangle.short_call.option.quantity, pos!(2.0));
+        assert_eq!(straddle.short_call.option.quantity, pos!(2.0));
 
         // Modify short put position
-        let mut modified_put = strangle.short_put.clone();
+        let mut modified_put = straddle.short_put.clone();
         modified_put.option.quantity = pos!(2.0);
-        let result = strangle.modify_position(&modified_put);
+        let result = straddle.modify_position(&modified_put);
         assert!(result.is_ok());
-        assert_eq!(strangle.short_put.option.quantity, pos!(2.0));
+        assert_eq!(straddle.short_put.option.quantity, pos!(2.0));
 
         // Test modifying with invalid position
-        let mut invalid_position = strangle.short_call.clone();
+        let mut invalid_position = straddle.short_call.clone();
         invalid_position.option.strike_price = pos!(95.0);
-        let result = strangle.modify_position(&invalid_position);
+        let result = straddle.modify_position(&invalid_position);
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
@@ -3038,11 +3038,11 @@ mod tests_straddle_position_management {
     }
 
     #[test]
-    fn test_long_strangle_get_position() {
-        let mut strangle = create_test_long_strangle();
+    fn test_long_straddle_get_position() {
+        let mut straddle = create_test_long_straddle();
 
         // Test getting long call position
-        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(110.0));
+        let call_position = straddle.get_position(&OptionStyle::Call, &Side::Long, &pos!(110.0));
         assert!(call_position.is_ok());
         let positions = call_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -3051,7 +3051,7 @@ mod tests_straddle_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting long put position
-        let put_position = strangle.get_position(&OptionStyle::Put, &Side::Long, &pos!(110.0));
+        let put_position = straddle.get_position(&OptionStyle::Put, &Side::Long, &pos!(110.0));
         assert!(put_position.is_ok());
         let positions = put_position.unwrap();
         assert_eq!(positions.len(), 1);
@@ -3060,7 +3060,7 @@ mod tests_straddle_position_management {
         assert_eq!(positions[0].option.side, Side::Long);
 
         // Test getting non-existent position
-        let invalid_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(100.0));
+        let invalid_position = straddle.get_position(&OptionStyle::Call, &Side::Long, &pos!(100.0));
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
@@ -3079,27 +3079,27 @@ mod tests_straddle_position_management {
     }
 
     #[test]
-    fn test_long_strangle_modify_position() {
-        let mut strangle = create_test_long_strangle();
+    fn test_long_straddle_modify_position() {
+        let mut straddle = create_test_long_straddle();
 
         // Modify long call position
-        let mut modified_call = strangle.long_call.clone();
+        let mut modified_call = straddle.long_call.clone();
         modified_call.option.quantity = pos!(2.0);
-        let result = strangle.modify_position(&modified_call);
+        let result = straddle.modify_position(&modified_call);
         assert!(result.is_ok());
-        assert_eq!(strangle.long_call.option.quantity, pos!(2.0));
+        assert_eq!(straddle.long_call.option.quantity, pos!(2.0));
 
         // Modify long put position
-        let mut modified_put = strangle.long_put.clone();
+        let mut modified_put = straddle.long_put.clone();
         modified_put.option.quantity = pos!(2.0);
-        let result = strangle.modify_position(&modified_put);
+        let result = straddle.modify_position(&modified_put);
         assert!(result.is_ok());
-        assert_eq!(strangle.long_put.option.quantity, pos!(2.0));
+        assert_eq!(straddle.long_put.option.quantity, pos!(2.0));
 
         // Test modifying with invalid position
-        let mut invalid_position = strangle.long_call.clone();
+        let mut invalid_position = straddle.long_call.clone();
         invalid_position.option.strike_price = pos!(95.0);
-        let result = strangle.modify_position(&invalid_position);
+        let result = straddle.modify_position(&invalid_position);
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {

--- a/src/strategies/strangle.rs
+++ b/src/strategies/strangle.rs
@@ -860,6 +860,88 @@ impl Positionable for LongStrangle {
     fn get_positions(&self) -> Result<Vec<&Position>, PositionError> {
         Ok(vec![&self.long_call, &self.long_put])
     }
+
+    /// Gets mutable positions matching the specified criteria from the strategy.
+    ///
+    /// # Arguments
+    /// * `option_style` - The style of the option (Put/Call)
+    /// * `side` - The side of the position (Long/Short)
+    /// * `strike` - The strike price of the option
+    ///
+    /// # Returns
+    /// * `Ok(Vec<&mut Position>)` - A vector containing mutable references to matching positions
+    /// * `Err(PositionError)` - If there was an error retrieving positions
+    fn get_position(
+        &mut self,
+        option_style: &OptionStyle,
+        side: &Side,
+        strike: &Positive,
+    ) -> Result<Vec<&mut Position>, PositionError> {
+        match (side, option_style, strike) {
+            (Side::Short, _, _) => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Position side is Short, it is not valid for LongStrangle".to_string(),
+            )),
+            (Side::Long, OptionStyle::Call, strike)
+                if *strike == self.long_call.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_call])
+            }
+            (Side::Long, OptionStyle::Put, strike)
+                if *strike == self.long_put.option.strike_price =>
+            {
+                Ok(vec![&mut self.long_put])
+            }
+            _ => Err(PositionError::invalid_position_type(
+                side.clone(),
+                "Strike not found in positions".to_string(),
+            )),
+        }
+    }
+
+    /// Modifies an existing position in the strategy.
+    ///
+    /// # Arguments
+    /// * `position` - The new position data to update
+    ///
+    /// # Returns
+    /// * `Ok(())` if position was successfully modified
+    /// * `Err(PositionError)` if position was not found or validation failed
+    fn modify_position(&mut self, position: &Position) -> Result<(), PositionError> {
+        if !position.validate() {
+            return Err(PositionError::ValidationError(
+                PositionValidationErrorKind::InvalidPosition {
+                    reason: "Invalid position data".to_string(),
+                },
+            ));
+        }
+
+        if position.option.side == Side::Short {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Position side is Short, it is not valid for LongStrangle".to_string(),
+            ));
+        }
+
+        if position.option.strike_price != self.long_call.option.strike_price
+            && position.option.strike_price != self.long_put.option.strike_price
+        {
+            return Err(PositionError::invalid_position_type(
+                position.option.side.clone(),
+                "Strike not found in positions".to_string(),
+            ));
+        }
+
+        if position.option.option_style == OptionStyle::Call {
+            self.long_call = position.clone();
+        }
+
+        if position.option.option_style == OptionStyle::Put {
+            self.long_put = position.clone();
+        }
+
+        Ok(())
+    }
 }
 
 impl Strategies for LongStrangle {
@@ -2950,5 +3032,205 @@ mod tests_long_strangle_delta_size {
         assert!(strategy.is_delta_neutral());
         let suggestion = strategy.suggest_delta_adjustments();
         assert_eq!(suggestion[0], DeltaAdjustment::NoAdjustmentNeeded);
+    }
+}
+
+#[cfg(test)]
+mod tests_strangle_position_management {
+    use super::*;
+    use crate::error::position::PositionValidationErrorKind;
+    use crate::model::types::{ExpirationDate, OptionStyle, Side};
+    use crate::pos;
+    use rust_decimal_macros::dec;
+
+    fn create_test_short_strangle() -> ShortStrangle {
+        ShortStrangle::new(
+            "TEST".to_string(),
+            pos!(100.0), // underlying_price
+            pos!(110.0), // call_strike
+            pos!(90.0),  // put_strike
+            ExpirationDate::Days(pos!(30.0)),
+            pos!(0.2),      // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(1.0),      // quantity
+            pos!(2.0),      // premium_short_call
+            pos!(2.0),      // premium_short_put
+            pos!(0.1),      // open_fee_short_call
+            pos!(0.1),      // close_fee_short_call
+            pos!(0.1),      // open_fee_short_put
+            pos!(0.1),      // close_fee_short_put
+        )
+    }
+
+    fn create_test_long_strangle() -> LongStrangle {
+        LongStrangle::new(
+            "TEST".to_string(),
+            pos!(100.0), // underlying_price
+            pos!(110.0), // call_strike
+            pos!(90.0),  // put_strike
+            ExpirationDate::Days(pos!(30.0)),
+            pos!(0.2),      // implied_volatility
+            dec!(0.05),     // risk_free_rate
+            Positive::ZERO, // dividend_yield
+            pos!(1.0),      // quantity
+            pos!(2.0),      // premium_long_call
+            pos!(2.0),      // premium_long_put
+            pos!(0.1),      // open_fee_long_call
+            pos!(0.1),      // close_fee_long_call
+            pos!(0.1),      // open_fee_long_put
+            pos!(0.1),      // close_fee_long_put
+        )
+    }
+
+    #[test]
+    fn test_short_strangle_get_position() {
+        let mut strangle = create_test_short_strangle();
+
+        // Test getting short call position
+        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(110.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(110.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting short put position
+        let put_position = strangle.get_position(&OptionStyle::Put, &Side::Short, &pos!(90.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(90.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Short);
+
+        // Test getting non-existent position
+        let invalid_position =
+            strangle.get_position(&OptionStyle::Call, &Side::Short, &pos!(100.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_strangle_modify_position() {
+        let mut strangle = create_test_short_strangle();
+
+        // Modify short call position
+        let mut modified_call = strangle.short_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(strangle.short_call.option.quantity, pos!(2.0));
+
+        // Modify short put position
+        let mut modified_put = strangle.short_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(strangle.short_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = strangle.short_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = strangle.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
+    }
+
+    #[test]
+    fn test_long_strangle_get_position() {
+        let mut strangle = create_test_long_strangle();
+
+        // Test getting long call position
+        let call_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(110.0));
+        assert!(call_position.is_ok());
+        let positions = call_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(110.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Call);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting long put position
+        let put_position = strangle.get_position(&OptionStyle::Put, &Side::Long, &pos!(90.0));
+        assert!(put_position.is_ok());
+        let positions = put_position.unwrap();
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].option.strike_price, pos!(90.0));
+        assert_eq!(positions[0].option.option_style, OptionStyle::Put);
+        assert_eq!(positions[0].option.side, Side::Long);
+
+        // Test getting non-existent position
+        let invalid_position = strangle.get_position(&OptionStyle::Call, &Side::Long, &pos!(100.0));
+        assert!(invalid_position.is_err());
+        match invalid_position {
+            Err(PositionError::ValidationError(
+                    PositionValidationErrorKind::IncompatibleSide {
+                        position_side: _,
+                        reason,
+                    },
+                )) => {
+                assert_eq!(reason, "Strike not found in positions");
+            }
+            _ => {
+                println!("Unexpected error: {:?}", invalid_position);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    fn test_long_strangle_modify_position() {
+        let mut strangle = create_test_long_strangle();
+
+        // Modify long call position
+        let mut modified_call = strangle.long_call.clone();
+        modified_call.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_call);
+        assert!(result.is_ok());
+        assert_eq!(strangle.long_call.option.quantity, pos!(2.0));
+
+        // Modify long put position
+        let mut modified_put = strangle.long_put.clone();
+        modified_put.option.quantity = pos!(2.0);
+        let result = strangle.modify_position(&modified_put);
+        assert!(result.is_ok());
+        assert_eq!(strangle.long_put.option.quantity, pos!(2.0));
+
+        // Test modifying with invalid position
+        let mut invalid_position = strangle.long_call.clone();
+        invalid_position.option.strike_price = pos!(95.0);
+        let result = strangle.modify_position(&invalid_position);
+        assert!(result.is_err());
+        match result {
+            Err(PositionError::ValidationError(kind)) => match kind {
+                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                    assert_eq!(reason, "Strike not found in positions");
+                }
+                _ => panic!("Expected ValidationError::InvalidPosition"),
+            },
+            _ => panic!("Expected ValidationError"),
+        }
     }
 }

--- a/src/strategies/strangle.rs
+++ b/src/strategies/strangle.rs
@@ -3150,7 +3150,10 @@ mod tests_strangle_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),
@@ -3186,11 +3189,11 @@ mod tests_strangle_position_management {
         assert!(invalid_position.is_err());
         match invalid_position {
             Err(PositionError::ValidationError(
-                    PositionValidationErrorKind::IncompatibleSide {
-                        position_side: _,
-                        reason,
-                    },
-                )) => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                },
+            )) => {
                 assert_eq!(reason, "Strike not found in positions");
             }
             _ => {
@@ -3225,7 +3228,10 @@ mod tests_strangle_position_management {
         assert!(result.is_err());
         match result {
             Err(PositionError::ValidationError(kind)) => match kind {
-                PositionValidationErrorKind::IncompatibleSide { position_side:_,reason } => {
+                PositionValidationErrorKind::IncompatibleSide {
+                    position_side: _,
+                    reason,
+                } => {
                     assert_eq!(reason, "Strike not found in positions");
                 }
                 _ => panic!("Expected ValidationError::InvalidPosition"),


### PR DESCRIPTION
# Implement `get_position` and `modify_position` in the `Positionable` Trait for All Strategies

## Description
This pull request implements the `get_position` and `modify_position` methods in all strategies that implement the `Positionable` trait. The absence of these methods previously prevented proper position management within the system. This enhancement ensures that strategies can retrieve and modify positions while maintaining consistency with the existing architecture.

Each strategy now correctly implements:
- `fn get_position(&mut self, _option_style: &OptionStyle, _side: &Side, _strike: &Positive) -> Result<Vec<&mut Position>, PositionError>`
- `fn modify_position(&mut self, _position: &Position) -> Result<(), PositionError>`

Additionally, extensive unit tests have been added to verify the correctness of these implementations.

---

## Changes Made
- Implemented `get_position` and `modify_position` for the following strategies:
  - `BullCallSpread`
  - `BullPutSpread`
  - `BearPutSpread`
  - `BearCallSpread`
  - `PoorMansCoveredCall`
  - `CallButterfly`
  - `IronButterfly`
  - `IronCondor`
  - `ShortStraddle`
  - `LongStraddle`
  - `LongStrangle`
- Added comprehensive error handling to ensure proper validation of retrieved and modified positions.
- Introduced unit tests for both methods, covering standard and edge cases.
- Refactored position naming in `ButterflySpread` strategies for better clarity.
- Updated the documentation for `Positionable` to reflect the new functionality.

---

## Testing
- **Unit Tests:**
  - Verified that `get_position` returns the expected positions based on input parameters.
  - Ensured `modify_position` correctly updates existing positions while preventing invalid modifications.
- **Edge Case Testing:**
  - Attempting to retrieve a position that does not exist.
  - Trying to modify a non-existent position.
  - Ensuring modifications do not interfere with unrelated positions.
- **Manual Testing:**
  - Manually validated retrieval and modification in multiple scenarios.
  
---

## Additional Notes
- This implementation follows the system's existing architecture and data flow, ensuring consistency.
- Tests confirm that positions are correctly manipulated without unintended side effects.
- Future work may include optimizing position retrieval performance in large-scale scenarios.

---

## References
- Resolves #119.
- Related test refactors: commits `013dc0e`, `132e1cc`, `44ea1bd`.

---

## Checklist
- [x] Implemented `get_position` and `modify_position` in all relevant strategies.
- [x] Added unit tests for validation.
- [x] Refactored naming inconsistencies for clarity.
- [x] Updated documentation to reflect changes.
- [x] Ensured compatibility with existing system architecture.

