### PR TITLE
Refactor strategy types for greater specificity and consistency.

### DIFF
--- a/src/strategies/straddle.rs
+++ b/src/strategies/straddle.rs
@@ -97,7 +97,7 @@ impl ShortStraddle {
 
         let mut strategy = ShortStraddle {
             name: "Short Straddle".to_string(),
-            kind: StrategyType::Straddle,
+            kind: StrategyType::ShortStraddle,
             description: SHORT_STRADDLE_DESCRIPTION.to_string(),
             break_even_points: Vec::new(),
             short_call: Position::default(),
@@ -449,7 +449,7 @@ impl Profit for ShortStraddle {
 
 impl Graph for ShortStraddle {
     fn title(&self) -> String {
-        let strategy_title = format!("Short {:?} Strategy: ", self.kind);
+        let strategy_title = format!("{:?} Strategy: ", self.kind);
         let leg_titles: Vec<String> = [self.short_call.title(), self.short_put.title()]
             .iter()
             .map(|leg| leg.to_string())
@@ -729,7 +729,7 @@ impl LongStraddle {
 
         let mut strategy = LongStraddle {
             name: "Long Straddle".to_string(),
-            kind: StrategyType::Straddle,
+            kind: StrategyType::LongStraddle,
             description: LONG_STRADDLE_DESCRIPTION.to_string(),
             break_even_points: Vec::new(),
             long_call: Position::default(),
@@ -1059,7 +1059,7 @@ impl Profit for LongStraddle {
 
 impl Graph for LongStraddle {
     fn title(&self) -> String {
-        let strategy_title = format!("Long {:?} Strategy: ", self.kind);
+        let strategy_title = format!("{:?} Strategy: ", self.kind);
         let leg_titles: Vec<String> = [self.long_call.title(), self.long_put.title()]
             .iter()
             .map(|leg| leg.to_string())
@@ -1338,7 +1338,7 @@ mod tests_short_straddle {
     fn test_new() {
         let strategy = setup();
         assert_eq!(strategy.name, "Short Straddle");
-        assert_eq!(strategy.kind, StrategyType::Straddle);
+        assert_eq!(strategy.kind, StrategyType::ShortStraddle);
         assert_eq!(
             strategy.description,
             "Short Straddle strategy involves simultaneously selling a put and a call option with \
@@ -1494,7 +1494,7 @@ mod tests_short_straddle {
         }
 
         let title = strategy.title();
-        assert!(title.contains("Short Straddle Strategy"));
+        assert!(title.contains("ShortStraddle Strategy"));
         assert!(title.contains("Call"));
         assert!(title.contains("Put"));
     }
@@ -1712,7 +1712,7 @@ mod tests_long_straddle {
         );
 
         assert_eq!(strategy.name, "Long Straddle");
-        assert_eq!(strategy.kind, StrategyType::Straddle);
+        assert_eq!(strategy.kind, StrategyType::LongStraddle);
         assert_eq!(strategy.description, LONG_STRADDLE_DESCRIPTION);
 
         let break_even_points = vec![148.0, 172.0];
@@ -1761,7 +1761,7 @@ mod tests_long_straddle {
     fn test_new() {
         let strategy = setup_long_straddle();
         assert_eq!(strategy.name, "Long Straddle");
-        assert_eq!(strategy.kind, StrategyType::Straddle);
+        assert_eq!(strategy.kind, StrategyType::LongStraddle);
         assert_eq!(strategy.description, LONG_STRADDLE_DESCRIPTION);
     }
 
@@ -1871,7 +1871,7 @@ mod tests_long_straddle {
 
         // Test title
         let title = strategy.title();
-        assert!(title.contains("Long Straddle Strategy"));
+        assert!(title.contains("LongStraddle Strategy"));
         assert!(title.contains("Call"));
         assert!(title.contains("Put"));
     }

--- a/src/strategies/strangle.rs
+++ b/src/strategies/strangle.rs
@@ -83,7 +83,7 @@ impl ShortStrangle {
         }
         let mut strategy = ShortStrangle {
             name: "Short Strangle".to_string(),
-            kind: StrategyType::Strangle,
+            kind: StrategyType::ShortStrangle,
             description: SHORT_STRANGLE_DESCRIPTION.to_string(),
             break_even_points: Vec::new(),
             short_call: Position::default(),
@@ -465,7 +465,7 @@ impl Profit for ShortStrangle {
 
 impl Graph for ShortStrangle {
     fn title(&self) -> String {
-        let strategy_title = format!("Short {:?} Strategy: ", self.kind);
+        let strategy_title = format!("{:?} Strategy: ", self.kind);
         let leg_titles: Vec<String> = [self.short_call.title(), self.short_put.title()]
             .iter()
             .map(|leg| leg.to_string())
@@ -766,7 +766,7 @@ impl LongStrangle {
         }
         let mut strategy = LongStrangle {
             name: "Long Strangle".to_string(),
-            kind: StrategyType::Strangle,
+            kind: StrategyType::LongStrangle,
             description: LONG_STRANGLE_DESCRIPTION.to_string(),
             break_even_points: Vec::new(),
             long_call: Position::default(),
@@ -1132,7 +1132,7 @@ impl Profit for LongStrangle {
 
 impl Graph for LongStrangle {
     fn title(&self) -> String {
-        let strategy_title = format!("Long {:?} Strategy: ", self.kind);
+        let strategy_title = format!("{:?} Strategy: ", self.kind);
         let leg_titles: Vec<String> = [self.long_call.title(), self.long_put.title()]
             .iter()
             .map(|leg| leg.to_string())
@@ -1439,7 +1439,7 @@ mod tests_short_strangle {
     fn test_new() {
         let strategy = setup();
         assert_eq!(strategy.name, "Short Strangle");
-        assert_eq!(strategy.kind, StrategyType::Strangle);
+        assert_eq!(strategy.kind, StrategyType::ShortStrangle);
         assert_eq!(
             strategy.description,
             "A short strangle involves selling an out-of-the-money call and an \
@@ -1564,7 +1564,7 @@ is expected and the underlying asset's price is anticipated to remain stable."
         }
 
         let title = strategy.title();
-        assert!(title.contains("Short Strangle Strategy"));
+        assert!(title.contains("ShortStrangle Strategy"));
         assert!(title.contains("Call"));
         assert!(title.contains("Put"));
     }
@@ -1765,7 +1765,7 @@ mod tests_long_strangle {
         );
 
         assert_eq!(strategy.name, "Long Strangle");
-        assert_eq!(strategy.kind, StrategyType::Strangle);
+        assert_eq!(strategy.kind, StrategyType::LongStrangle);
         assert_eq!(strategy.description, LONG_STRANGLE_DESCRIPTION);
 
         let break_even_points = vec![128.0, 172.0];
@@ -1855,7 +1855,7 @@ mod tests_long_strangle {
     fn test_new() {
         let strategy = setup_long_strangle();
         assert_eq!(strategy.name, "Long Strangle");
-        assert_eq!(strategy.kind, StrategyType::Strangle);
+        assert_eq!(strategy.kind, StrategyType::LongStrangle);
         assert_eq!(strategy.description, LONG_STRANGLE_DESCRIPTION);
     }
 
@@ -1972,7 +1972,7 @@ mod tests_long_strangle {
 
         // Test title
         let title = strategy.title();
-        assert!(title.contains("Long Strangle Strategy"));
+        assert!(title.contains("LongStrangle Strategy"));
         assert!(title.contains("Call"));
         assert!(title.contains("Put"));
     }

--- a/tests/unit/strategies/simple/strategy_long_straddle.rs
+++ b/tests/unit/strategies/simple/strategy_long_straddle.rs
@@ -38,7 +38,7 @@ fn test_long_straddle_integration() -> Result<(), Box<dyn Error>> {
     );
 
     // Assertions to validate strategy properties and computations
-    assert_eq!(strategy.title(), "Long Straddle Strategy: \n\tUnderlying: CL @ $7140 Long Call European Option\n\tUnderlying: CL @ $7140 Long Put European Option");
+    assert_eq!(strategy.title(), "LongStraddle Strategy: \n\tUnderlying: CL @ $7140 Long Call European Option\n\tUnderlying: CL @ $7140 Long Put European Option");
     assert_eq!(strategy.get_break_even_points().unwrap().len(), 2);
     assert_relative_eq!(
         strategy.net_premium_received().unwrap().to_f64(),

--- a/tests/unit/strategies/simple/strategy_long_strangle.rs
+++ b/tests/unit/strategies/simple/strategy_long_strangle.rs
@@ -38,7 +38,7 @@ fn test_long_strangle_integration() -> Result<(), Box<dyn Error>> {
     );
 
     // Assertions to validate strategy properties and computations
-    assert_eq!(strategy.title(), "Long Strangle Strategy: \n\tUnderlying: CL @ $7450 Long Call European Option\n\tUnderlying: CL @ $7050 Long Put European Option");
+    assert_eq!(strategy.title(), "LongStrangle Strategy: \n\tUnderlying: CL @ $7450 Long Call European Option\n\tUnderlying: CL @ $7050 Long Put European Option");
     assert_eq!(strategy.get_break_even_points().unwrap().len(), 2);
     assert_relative_eq!(
         strategy.net_premium_received().unwrap().to_f64(),


### PR DESCRIPTION
Replaced generic "Straddle" and "Strangle" types with more specific variants: "LongStraddle," "ShortStraddle," "LongStrangle," and "ShortStrangle." Updated associated logic, tests, and titles to align with the new types. Added serialization, deserialization, and validation support for the StrategyType enum.