### PR TITLE
Refactor get_strategy signatures to use slices instead of Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ include = [
 ]
 
 [dependencies]
-chrono = { version = ">=0.4.39", features = ["wasmbind"] }
+chrono = { version = ">=0.4.39", features = ["wasmbind","serde"] }
 approx = "0.5.1"
 plotters = { version = "0.3.7" }
 plotters-canvas = "0.3.0"

--- a/src/chains/options.rs
+++ b/src/chains/options.rs
@@ -62,14 +62,14 @@ mod tests_options_in_strike {
             OptionType::European,
             side,
             "TEST".to_string(),
-            pos!(100.0),        // strike_price
+            pos!(100.0), // strike_price
             ExpirationDate::Days(pos!(30.0)),
-            pos!(0.2),         // implied_volatility
-            pos!(1.0),         // quantity
-            pos!(100.0),       // underlying_price
-            dec!(0.05),        // risk_free_rate
+            pos!(0.2),   // implied_volatility
+            pos!(1.0),   // quantity
+            pos!(100.0), // underlying_price
+            dec!(0.05),  // risk_free_rate
             style,
-            pos!(0.01),        // dividend_yield
+            pos!(0.01), // dividend_yield
             None,
         )
     }
@@ -105,12 +105,7 @@ mod tests_options_in_strike {
         let long_put = create_test_option(Side::Long, OptionStyle::Put);
         let short_put = create_test_option(Side::Short, OptionStyle::Put);
 
-        let options_in_strike = OptionsInStrike::new(
-            long_call,
-            short_call,
-            long_put,
-            short_put,
-        );
+        let options_in_strike = OptionsInStrike::new(long_call, short_call, long_put, short_put);
 
         let deltas = options_in_strike.deltas().unwrap();
 
@@ -131,19 +126,26 @@ mod tests_options_in_strike {
         let long_put = create_test_option(Side::Long, OptionStyle::Put);
         let short_put = create_test_option(Side::Short, OptionStyle::Put);
 
-        let options_in_strike = OptionsInStrike::new(
-            long_call,
-            short_call,
-            long_put,
-            short_put,
-        );
+        let options_in_strike = OptionsInStrike::new(long_call, short_call, long_put, short_put);
 
         let cloned = options_in_strike.clone();
 
-        assert_eq!(cloned.long_call.strike_price, options_in_strike.long_call.strike_price);
-        assert_eq!(cloned.short_call.strike_price, options_in_strike.short_call.strike_price);
-        assert_eq!(cloned.long_put.strike_price, options_in_strike.long_put.strike_price);
-        assert_eq!(cloned.short_put.strike_price, options_in_strike.short_put.strike_price);
+        assert_eq!(
+            cloned.long_call.strike_price,
+            options_in_strike.long_call.strike_price
+        );
+        assert_eq!(
+            cloned.short_call.strike_price,
+            options_in_strike.short_call.strike_price
+        );
+        assert_eq!(
+            cloned.long_put.strike_price,
+            options_in_strike.long_put.strike_price
+        );
+        assert_eq!(
+            cloned.short_put.strike_price,
+            options_in_strike.short_put.strike_price
+        );
     }
 }
 

--- a/src/chains/utils.rs
+++ b/src/chains/utils.rs
@@ -798,7 +798,7 @@ mod tests_option_data_price_params {
         let params = OptionDataPriceParams::new(
             pos!(100.0),
             ExpirationDate::Days(pos!(30.0)),
-            None,  // No implied volatility
+            None, // No implied volatility
             dec!(0.05),
             pos!(0.02),
             None,
@@ -810,7 +810,7 @@ mod tests_option_data_price_params {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn test_option_data_price_params_getters_with_datetime_expiration() {
-        use chrono::{Utc, Duration};
+        use chrono::{Duration, Utc};
 
         let future_date = Utc::now() + Duration::days(30);
         let expiration_date = ExpirationDate::DateTime(future_date);
@@ -840,7 +840,10 @@ mod tests_option_data_price_params {
         );
 
         assert_eq!(params.get_underlying_price(), Positive::ZERO);
-        assert_eq!(params.get_expiration_date(), ExpirationDate::Days(Positive::ZERO));
+        assert_eq!(
+            params.get_expiration_date(),
+            ExpirationDate::Days(Positive::ZERO)
+        );
         assert_eq!(params.get_implied_volatility(), Some(Positive::ZERO));
         assert_eq!(params.get_risk_free_rate(), Decimal::ZERO);
         assert_eq!(params.get_dividend_yield(), Positive::ZERO);
@@ -1018,6 +1021,3 @@ mod tests_sample {
         assert_eq!(built_chain.underlying_price, Positive::new(2000.0).unwrap());
     }
 }
-
-
-

--- a/src/curves/basic.rs
+++ b/src/curves/basic.rs
@@ -202,9 +202,9 @@ mod tests_basic_curves_trait {
 
         assert_eq!(strike, option.strike_price.to_dec());
 
-        assert!(price > Decimal::ZERO); 
+        assert!(price > Decimal::ZERO);
         let direct_bs_price = option.calculate_price_black_scholes().unwrap();
-        assert_eq!(price, direct_bs_price); 
+        assert_eq!(price, direct_bs_price);
     }
 
     #[test]
@@ -215,10 +215,9 @@ mod tests_basic_curves_trait {
 
         assert!(result.is_err());
         match result {
-            Err(CurveError::OperationError(crate::error::OperationErrorKind::InvalidParameters {
-                                               operation,
-                                               reason,
-                                           })) => {
+            Err(CurveError::OperationError(
+                crate::error::OperationErrorKind::InvalidParameters { operation, reason },
+            )) => {
                 assert_eq!(operation, "get_axis_value");
                 assert!(reason.contains("not supported"));
                 assert!(reason.contains("Expiration"));

--- a/src/error/strategies.rs
+++ b/src/error/strategies.rs
@@ -91,7 +91,7 @@ pub enum StrategyError {
     StdError {
         reason: String,
     },
-    
+
     NotImplemented,
 }
 

--- a/src/geometrics/analysis/traits.rs
+++ b/src/geometrics/analysis/traits.rs
@@ -389,7 +389,10 @@ mod tests {
             assert_eq!(surface_metrics.shape.skewness, curve_metrics.shape.skewness);
             assert_eq!(surface_metrics.range.range, curve_metrics.range.range);
             assert_eq!(surface_metrics.trend.slope, curve_metrics.trend.slope);
-            assert_eq!(surface_metrics.risk.volatility, curve_metrics.risk.volatility);
+            assert_eq!(
+                surface_metrics.risk.volatility,
+                curve_metrics.risk.volatility
+            );
         }
     }
 }

--- a/src/geometrics/utils.rs
+++ b/src/geometrics/utils.rs
@@ -86,7 +86,10 @@ mod tests_geometric_object {
 
     impl From<(Decimal, Decimal)> for TestPoint {
         fn from(tuple: (Decimal, Decimal)) -> Self {
-            TestPoint { x: tuple.0, y: tuple.1 }
+            TestPoint {
+                x: tuple.0,
+                y: tuple.1,
+            }
         }
     }
 
@@ -139,11 +142,19 @@ mod tests_geometric_object {
     #[test]
     fn test_get_points() {
         let points = BTreeSet::from([
-            TestPoint { x: dec!(1.0), y: dec!(2.0) },
-            TestPoint { x: dec!(3.0), y: dec!(4.0) },
+            TestPoint {
+                x: dec!(1.0),
+                y: dec!(2.0),
+            },
+            TestPoint {
+                x: dec!(3.0),
+                y: dec!(4.0),
+            },
         ]);
 
-        let obj = TestGeometricObject { points: points.clone() };
+        let obj = TestGeometricObject {
+            points: points.clone(),
+        };
         let retrieved_points = obj.get_points();
 
         assert_eq!(retrieved_points.len(), points.len());
@@ -158,18 +169,32 @@ mod tests_geometric_object {
         let obj = TestGeometricObject::from_vector(points);
 
         assert_eq!(obj.points.len(), 2);
-        assert!(obj.points.contains(&TestPoint { x: dec!(1.0), y: dec!(2.0) }));
-        assert!(obj.points.contains(&TestPoint { x: dec!(3.0), y: dec!(4.0) }));
+        assert!(obj.points.contains(&TestPoint {
+            x: dec!(1.0),
+            y: dec!(2.0)
+        }));
+        assert!(obj.points.contains(&TestPoint {
+            x: dec!(3.0),
+            y: dec!(4.0)
+        }));
     }
 
     #[test]
     fn test_construct_from_data() {
         let points = BTreeSet::from([
-            TestPoint { x: dec!(1.0), y: dec!(2.0) },
-            TestPoint { x: dec!(3.0), y: dec!(4.0) },
+            TestPoint {
+                x: dec!(1.0),
+                y: dec!(2.0),
+            },
+            TestPoint {
+                x: dec!(3.0),
+                y: dec!(4.0),
+            },
         ]);
 
-        let result = TestGeometricObject::construct(ConstructionMethod::FromData { points: points.clone() });
+        let result = TestGeometricObject::construct(ConstructionMethod::FromData {
+            points: points.clone(),
+        });
 
         assert!(result.is_ok());
         let obj = result.unwrap();
@@ -187,11 +212,19 @@ mod tests_geometric_object {
     #[test]
     fn test_to_vector() {
         let points = BTreeSet::from([
-            TestPoint { x: dec!(1.0), y: dec!(2.0) },
-            TestPoint { x: dec!(3.0), y: dec!(4.0) },
+            TestPoint {
+                x: dec!(1.0),
+                y: dec!(2.0),
+            },
+            TestPoint {
+                x: dec!(3.0),
+                y: dec!(4.0),
+            },
         ]);
 
-        let obj = TestGeometricObject { points: points.clone() };
+        let obj = TestGeometricObject {
+            points: points.clone(),
+        };
         let vector = obj.to_vector();
 
         assert_eq!(vector.len(), points.len());
@@ -213,8 +246,14 @@ mod tests_geometric_object {
     #[test]
     fn test_len_trait() {
         let points = BTreeSet::from([
-            TestPoint { x: dec!(1.0), y: dec!(2.0) },
-            TestPoint { x: dec!(3.0), y: dec!(4.0) },
+            TestPoint {
+                x: dec!(1.0),
+                y: dec!(2.0),
+            },
+            TestPoint {
+                x: dec!(3.0),
+                y: dec!(4.0),
+            },
         ]);
 
         let obj = TestGeometricObject { points };

--- a/src/geometrics/visualization/plotters.rs
+++ b/src/geometrics/visualization/plotters.rs
@@ -159,7 +159,6 @@ pub trait PlotBuilderExt<T: Plottable> {
     fn save(self, path: impl AsRef<Path>) -> Result<(), T::Error>;
 }
 
-
 #[cfg(test)]
 mod tests_plot_builder {
     use super::*;
@@ -212,9 +211,7 @@ mod tests_plot_builder {
     #[test]
     fn test_point_size_method_multiple_calls() {
         // Test that multiple calls override the previous value
-        let builder = create_test_builder()
-            .point_size(5)
-            .point_size(15);
+        let builder = create_test_builder().point_size(5).point_size(15);
 
         assert_eq!(builder.options.point_size, Some(15));
     }
@@ -230,9 +227,7 @@ mod tests_plot_builder {
     #[test]
     fn test_label_size_method_multiple_calls() {
         // Test that multiple calls override the previous value
-        let builder = create_test_builder()
-            .label_size(10.0)
-            .label_size(20.5);
+        let builder = create_test_builder().label_size(10.0).label_size(20.5);
 
         assert_eq!(builder.options.labels_size, Some(20.5));
     }

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -15,8 +15,8 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use plotters::prelude::{ShapeStyle, BLACK};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use std::error::Error;
 use serde::{Deserialize, Serialize};
+use std::error::Error;
 use tracing::{error, trace};
 
 type PriceBinomialTree = OptionsResult<(Decimal, Vec<Vec<Decimal>>, Vec<Vec<Decimal>>)>;
@@ -1920,11 +1920,11 @@ mod tests_serialize_deserialize {
 
     #[test]
     fn test_serialize_deserialize_options() {
-        let options = create_sample_option_simplest_strike(Side::Long, OptionStyle::Call, pos!(95.0));
+        let options =
+            create_sample_option_simplest_strike(Side::Long, OptionStyle::Call, pos!(95.0));
         let serialized = serde_json::to_string(&options).expect("Failed to serialize");
-        let deserialized: Options = serde_json::from_str(&serialized).expect("Failed to deserialize");
+        let deserialized: Options =
+            serde_json::from_str(&serialized).expect("Failed to deserialize");
         assert_eq!(options, deserialized);
     }
 }
-
-

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -369,13 +369,11 @@ impl<'de> Deserialize<'de> for ExpirationDate {
     }
 }
 
-
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Side {
     Long,
     Short,
 }
-
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum OptionStyle {

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -4,6 +4,7 @@
    Date: 21/8/24
 ******************************************************************************/
 use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
+use crate::model::Position;
 use crate::{pos, Options, Positive};
 use chrono::{NaiveDateTime, TimeZone, Utc};
 use rust_decimal_macros::dec;
@@ -35,6 +36,37 @@ pub(crate) fn create_sample_option(
         pos!(0.01),
         None,
     )
+}
+
+#[allow(dead_code)]
+pub(crate) fn create_sample_position(
+    option_style: OptionStyle,
+    side: Side,
+    underlying_price: Positive,
+    quantity: Positive,
+    strike_price: Positive,
+    implied_volatility: Positive,
+) -> Position {
+    Position {
+        option: Options {
+            option_type: OptionType::European,
+            side,
+            underlying_symbol: "AAPL".to_string(),
+            strike_price,
+            expiration_date: ExpirationDate::Days(pos!(30.0)),
+            implied_volatility,
+            quantity,
+            underlying_price,
+            risk_free_rate: dec!(0.05),
+            option_style,
+            dividend_yield: pos!(0.01),
+            exotic_params: None,
+        },
+        premium: pos!(5.0),
+        date: Utc::now(),
+        open_fee: pos!(0.5),
+        close_fee: pos!(0.5),
+    }
 }
 
 #[allow(dead_code)]

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -15,9 +15,9 @@ use crate::strategies::utils::{calculate_price_range, FindOptimalSide, Optimizat
 use crate::{OptionStyle, Positive, Side};
 use itertools::Itertools;
 use rust_decimal::Decimal;
-use std::{f64, fmt};
-use std::str::FromStr;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use std::{f64, fmt};
 use tracing::error;
 
 /// This enum represents different types of trading strategies.
@@ -852,12 +852,21 @@ mod tests_strategy_type {
             }
         }
     }
-    
+
     #[test]
     fn test_strategy_type_from_str() {
-        assert_eq!(StrategyType::from_str("ShortStrangle"), Ok(StrategyType::ShortStrangle));
-        assert_eq!(StrategyType::from_str("LongCall"), Ok(StrategyType::LongCall));
-        assert_eq!(StrategyType::from_str("BullCallSpread"), Ok(StrategyType::BullCallSpread));
+        assert_eq!(
+            StrategyType::from_str("ShortStrangle"),
+            Ok(StrategyType::ShortStrangle)
+        );
+        assert_eq!(
+            StrategyType::from_str("LongCall"),
+            Ok(StrategyType::LongCall)
+        );
+        assert_eq!(
+            StrategyType::from_str("BullCallSpread"),
+            Ok(StrategyType::BullCallSpread)
+        );
         assert_eq!(StrategyType::from_str("InvalidStrategy"), Err(()));
     }
 
@@ -1686,5 +1695,3 @@ mod tests_strategy_net_operations {
         assert!(result > Positive::ZERO);
     }
 }
-
-

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -172,7 +172,7 @@ impl BearCallSpread {
 }
 
 impl StrategyConstructor for BearCallSpread {
-    fn get_strategy(vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         // Need exactly 2 options for a bear call spread
         if vec_options.len() != 2 {
             return Err(StrategyError::OperationError(OperationErrorKind::InvalidParameters {
@@ -182,7 +182,7 @@ impl StrategyConstructor for BearCallSpread {
         }
 
         // Sort options by strike price to identify short and long positions
-        let mut sorted_options = vec_options.clone();
+        let mut sorted_options = vec_options.to_vec();
         sorted_options.sort_by(|a, b| a.option.strike_price.partial_cmp(&b.option.strike_price).unwrap());
 
         let lower_strike_option = &sorted_options[0];

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -48,6 +48,7 @@ use crate::strategies::delta_neutral::{
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::Options;
@@ -58,7 +59,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::debug;
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const BEAR_CALL_SPREAD_DESCRIPTION: &str =
     "A bear call spread is created by selling a call option with a lower strike price \
@@ -172,34 +172,45 @@ impl BearCallSpread {
 }
 
 impl StrategyConstructor for BearCallSpread {
-    fn get_strategy(vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(vec_options: &[Position]) -> Result<Self, StrategyError> {
         // Need exactly 2 options for a bear call spread
         if vec_options.len() != 2 {
-            return Err(StrategyError::OperationError(OperationErrorKind::InvalidParameters {
-                operation: "Bear Call Spread get_strategy".to_string(),
-                reason: "Must have exactly 2 options".to_string(),
-            }));
+            return Err(StrategyError::OperationError(
+                OperationErrorKind::InvalidParameters {
+                    operation: "Bear Call Spread get_strategy".to_string(),
+                    reason: "Must have exactly 2 options".to_string(),
+                },
+            ));
         }
 
         // Sort options by strike price to identify short and long positions
         let mut sorted_options = vec_options.to_vec();
-        sorted_options.sort_by(|a, b| a.option.strike_price.partial_cmp(&b.option.strike_price).unwrap());
+        sorted_options.sort_by(|a, b| {
+            a.option
+                .strike_price
+                .partial_cmp(&b.option.strike_price)
+                .unwrap()
+        });
 
         let lower_strike_option = &sorted_options[0];
         let higher_strike_option = &sorted_options[1];
 
         // Validate options are calls
         if lower_strike_option.option.option_style != OptionStyle::Call
-            || higher_strike_option.option.option_style != OptionStyle::Call {
-            return Err(StrategyError::OperationError(OperationErrorKind::InvalidParameters {
-                operation: "Bear Call Spread get_strategy".to_string(),
-                reason: "Options must be calls".to_string(),
-            }));
+            || higher_strike_option.option.option_style != OptionStyle::Call
+        {
+            return Err(StrategyError::OperationError(
+                OperationErrorKind::InvalidParameters {
+                    operation: "Bear Call Spread get_strategy".to_string(),
+                    reason: "Options must be calls".to_string(),
+                },
+            ));
         }
 
         // Validate option sides
         if lower_strike_option.option.side != Side::Short
-            || higher_strike_option.option.side != Side::Long {
+            || higher_strike_option.option.side != Side::Long
+        {
             return Err(StrategyError::OperationError(OperationErrorKind::InvalidParameters {
                 operation: "Bear Call Spread get_strategy".to_string(),
                 reason: "Bear Call Spread requires a short lower strike call and a long higher strike call".to_string(),
@@ -207,11 +218,14 @@ impl StrategyConstructor for BearCallSpread {
         }
 
         // Validate expiration dates match
-        if lower_strike_option.option.expiration_date != higher_strike_option.option.expiration_date {
-            return Err(StrategyError::OperationError(OperationErrorKind::InvalidParameters {
-                operation: "Bear Call Spread get_strategy".to_string(),
-                reason: "Options must have the same expiration date".to_string(),
-            }));
+        if lower_strike_option.option.expiration_date != higher_strike_option.option.expiration_date
+        {
+            return Err(StrategyError::OperationError(
+                OperationErrorKind::InvalidParameters {
+                    operation: "Bear Call Spread get_strategy".to_string(),
+                    reason: "Options must have the same expiration date".to_string(),
+                },
+            ));
         }
 
         // Create positions
@@ -2646,36 +2660,28 @@ mod tests_adjust_option_position_short {
 #[cfg(test)]
 mod tests_strategy_constructor {
     use super::*;
-    use rust_decimal_macros::dec;
+    use crate::model::utils::create_sample_position;
     use crate::pos;
-
-    fn create_test_option(strike: Positive, side: Side) -> OptionWithCosts {
-        OptionWithCosts {
-            open_fee: Positive::ONE,
-            close_fee: Positive::ONE,
-            premium: pos!(5.0),
-            option: Options::new(
-                OptionType::European,
-                side,
-                "TEST".to_string(),
-                strike,
-                ExpirationDate::Days(pos!(30.0)),
-                pos!(0.2),
-                Positive::ONE,
-                pos!(100.0),
-                dec!(0.05),
-                OptionStyle::Call,
-                pos!(0.01),
-                None,
-            ),
-        }
-    }
 
     #[test]
     fn test_get_strategy_valid() {
         let options = vec![
-            create_test_option(pos!(95.0), Side::Short),
-            create_test_option(pos!(105.0), Side::Long),
+            create_sample_position(
+                OptionStyle::Call,
+                Side::Short,
+                pos!(90.0),
+                pos!(1.0),
+                pos!(95.0),
+                pos!(0.2),
+            ),
+            create_sample_position(
+                OptionStyle::Call,
+                Side::Long,
+                pos!(90.0),
+                pos!(1.0),
+                pos!(105.0),
+                pos!(0.2),
+            ),
         ];
 
         let result = BearCallSpread::get_strategy(&options);
@@ -2688,7 +2694,14 @@ mod tests_strategy_constructor {
 
     #[test]
     fn test_get_strategy_wrong_number_of_options() {
-        let options = vec![create_test_option(pos!(95.0), Side::Short)];
+        let options = vec![create_sample_position(
+            OptionStyle::Call,
+            Side::Short,
+            pos!(90.0),
+            pos!(1.0),
+            pos!(95.0),
+            pos!(0.2),
+        )];
 
         let result = BearCallSpread::get_strategy(&options);
         assert!(matches!(
@@ -2700,9 +2713,23 @@ mod tests_strategy_constructor {
 
     #[test]
     fn test_get_strategy_wrong_option_style() {
-        let mut option1 = create_test_option(pos!(95.0), Side::Short);
+        let mut option1 = create_sample_position(
+            OptionStyle::Call,
+            Side::Short,
+            pos!(90.0),
+            pos!(1.0),
+            pos!(95.0),
+            pos!(0.2),
+        );
         option1.option.option_style = OptionStyle::Put;
-        let option2 = create_test_option(pos!(105.0), Side::Long);
+        let option2 = create_sample_position(
+            OptionStyle::Call,
+            Side::Long,
+            pos!(90.0),
+            pos!(1.0),
+            pos!(105.0),
+            pos!(0.2),
+        );
 
         let options = vec![option1, option2];
         let result = BearCallSpread::get_strategy(&options);
@@ -2716,23 +2743,50 @@ mod tests_strategy_constructor {
     #[test]
     fn test_get_strategy_wrong_sides() {
         let options = vec![
-            create_test_option(pos!(95.0), Side::Long),
-            create_test_option(pos!(105.0), Side::Short),
+            create_sample_position(
+                OptionStyle::Call,
+                Side::Short,
+                pos!(90.0),
+                pos!(1.0),
+                pos!(115.0),
+                pos!(0.2),
+            ),
+            create_sample_position(
+                OptionStyle::Call,
+                Side::Long,
+                pos!(90.0),
+                pos!(1.0),
+                pos!(105.0),
+                pos!(0.2),
+            ),
         ];
-
         let result = BearCallSpread::get_strategy(&options);
         assert!(matches!(
             result,
             Err(StrategyError::OperationError(OperationErrorKind::InvalidParameters { operation, reason }))
-            if operation == "Bear Call Spread get_strategy" 
+            if operation == "Bear Call Spread get_strategy"
                 && reason == "Bear Call Spread requires a short lower strike call and a long higher strike call"
         ));
     }
 
     #[test]
     fn test_get_strategy_different_expiration_dates() {
-        let mut option1 = create_test_option(pos!(95.0), Side::Short);
-        let mut option2 = create_test_option(pos!(105.0), Side::Long);
+        let mut option1 = create_sample_position(
+            OptionStyle::Call,
+            Side::Short,
+            pos!(90.0),
+            pos!(1.0),
+            pos!(95.0),
+            pos!(0.2),
+        );
+        let mut option2 = create_sample_position(
+            OptionStyle::Call,
+            Side::Long,
+            pos!(90.0),
+            pos!(1.0),
+            pos!(105.0),
+            pos!(0.2),
+        );
 
         option1.option.expiration_date = ExpirationDate::Days(pos!(30.0));
         option2.option.expiration_date = ExpirationDate::Days(pos!(60.0));

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -28,7 +28,10 @@ use crate::pricing::Profit;
 use crate::strategies::base::{BreakEvenable, Optimizable, Positionable, StrategyType, Validable};
 use crate::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
 use crate::strategies::utils::OptimizationCriteria;
-use crate::strategies::{ DeltaAdjustment, DeltaInfo, DeltaNeutrality, FindOptimalSide, Strategies, DELTA_THRESHOLD};
+use crate::strategies::StrategyConstructor;
+use crate::strategies::{
+    DeltaAdjustment, DeltaInfo, DeltaNeutrality, FindOptimalSide, Strategies, DELTA_THRESHOLD,
+};
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::{pos, ExpirationDate, OptionStyle, OptionType, Options, Positive, Side};
@@ -38,7 +41,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{debug, info};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const BEAR_PUT_SPREAD_DESCRIPTION: &str =
     "A bear put spread is created by buying a put option with a higher strike price \
@@ -152,7 +154,7 @@ impl BearPutSpread {
 }
 
 impl StrategyConstructor for BearPutSpread {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -152,7 +152,7 @@ impl BearPutSpread {
 }
 
 impl StrategyConstructor for BearPutSpread {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/build/mod.rs
+++ b/src/strategies/build/mod.rs
@@ -1,9 +1,8 @@
 /******************************************************************************
-    Author: Joaquín Béjar García
-    Email: jb@taunais.com 
-    Date: 16/2/25
- ******************************************************************************/
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 16/2/25
+******************************************************************************/
 
-
-pub(crate) mod traits;
 pub(crate) mod model;
+pub(crate) mod traits;

--- a/src/strategies/build/model.rs
+++ b/src/strategies/build/model.rs
@@ -1,32 +1,28 @@
 /******************************************************************************
-    Author: Joaquín Béjar García
-    Email: jb@taunais.com 
-    Date: 16/2/25
- ******************************************************************************/
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 16/2/25
+******************************************************************************/
 
-use serde::{Deserialize, Serialize};
-use crate::{Options, Positive};
 use crate::error::StrategyError;
+use crate::model::Position;
 use crate::strategies::base::StrategyType;
-use crate::strategies::{BearCallSpread, BearPutSpread, BullCallSpread, BullPutSpread, CallButterfly, CustomStrategy, IronButterfly, IronCondor, LongButterflySpread, LongStraddle, LongStrangle, PoorMansCoveredCall, ShortButterflySpread, ShortStraddle, ShortStrangle, Strategies, StrategyConstructor};
-
-
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-pub struct OptionWithCosts {
-    pub open_fee: Positive,
-    pub close_fee: Positive,
-    pub premium: Positive,
-    pub option: Options,
-}
+use crate::strategies::{
+    BearCallSpread, BearPutSpread, BullCallSpread, BullPutSpread, CallButterfly, CustomStrategy,
+    IronButterfly, IronCondor, LongButterflySpread, LongStraddle, LongStrangle,
+    PoorMansCoveredCall, ShortButterflySpread, ShortStraddle, ShortStrangle, Strategies,
+    StrategyConstructor,
+};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct StrategyRequest {
     pub strategy_type: StrategyType,
-    pub options: Vec<OptionWithCosts>,
+    pub options: Vec<Position>,
 }
 
 impl StrategyRequest {
-    pub fn new(strategy_type: StrategyType, options: Vec<OptionWithCosts>) -> Self {
+    pub fn new(strategy_type: StrategyType, options: Vec<Position>) -> Self {
         Self {
             strategy_type,
             options,
@@ -35,27 +31,49 @@ impl StrategyRequest {
 
     pub fn get_strategy(&self) -> Result<Box<dyn Strategies>, StrategyError> {
         match self.strategy_type {
-            StrategyType::BullCallSpread => Ok(Box::new(BullCallSpread::get_strategy(&self.options)?)),
-            StrategyType::BearCallSpread => Ok(Box::new(BearCallSpread::get_strategy(&self.options)?)),
-            StrategyType::BullPutSpread => Ok(Box::new(BullPutSpread::get_strategy(&self.options)?)),
-            StrategyType::BearPutSpread => Ok(Box::new(BearPutSpread::get_strategy(&self.options)?)),
-            StrategyType::LongButterflySpread => Ok(Box::new(LongButterflySpread::get_strategy(&self.options)?)),
-            StrategyType::ShortButterflySpread => Ok(Box::new(ShortButterflySpread::get_strategy(&self.options)?)),
+            StrategyType::BullCallSpread => {
+                Ok(Box::new(BullCallSpread::get_strategy(&self.options)?))
+            }
+            StrategyType::BearCallSpread => {
+                Ok(Box::new(BearCallSpread::get_strategy(&self.options)?))
+            }
+            StrategyType::BullPutSpread => {
+                Ok(Box::new(BullPutSpread::get_strategy(&self.options)?))
+            }
+            StrategyType::BearPutSpread => {
+                Ok(Box::new(BearPutSpread::get_strategy(&self.options)?))
+            }
+            StrategyType::LongButterflySpread => {
+                Ok(Box::new(LongButterflySpread::get_strategy(&self.options)?))
+            }
+            StrategyType::ShortButterflySpread => {
+                Ok(Box::new(ShortButterflySpread::get_strategy(&self.options)?))
+            }
             StrategyType::IronCondor => Ok(Box::new(IronCondor::get_strategy(&self.options)?)),
-            StrategyType::IronButterfly => Ok(Box::new(IronButterfly::get_strategy(&self.options)?)),
+            StrategyType::IronButterfly => {
+                Ok(Box::new(IronButterfly::get_strategy(&self.options)?))
+            }
             StrategyType::LongStraddle => Ok(Box::new(LongStraddle::get_strategy(&self.options)?)),
-            StrategyType::ShortStraddle => Ok(Box::new(ShortStraddle::get_strategy(&self.options)?)),
+            StrategyType::ShortStraddle => {
+                Ok(Box::new(ShortStraddle::get_strategy(&self.options)?))
+            }
             StrategyType::LongStrangle => Ok(Box::new(LongStrangle::get_strategy(&self.options)?)),
-            StrategyType::ShortStrangle => Ok(Box::new(ShortStrangle::get_strategy(&self.options)?)),
+            StrategyType::ShortStrangle => {
+                Ok(Box::new(ShortStrangle::get_strategy(&self.options)?))
+            }
             StrategyType::CoveredCall => Err(StrategyError::NotImplemented),
             StrategyType::ProtectivePut => Err(StrategyError::NotImplemented),
             StrategyType::Collar => Err(StrategyError::NotImplemented),
             StrategyType::LongCall => Err(StrategyError::NotImplemented),
             StrategyType::LongPut => Err(StrategyError::NotImplemented),
-            StrategyType::ShortCall =>Err(StrategyError::NotImplemented),
+            StrategyType::ShortCall => Err(StrategyError::NotImplemented),
             StrategyType::ShortPut => Err(StrategyError::NotImplemented),
-            StrategyType::PoorMansCoveredCall => Ok(Box::new(PoorMansCoveredCall::get_strategy(&self.options)?)),
-            StrategyType::CallButterfly => Ok(Box::new(CallButterfly::get_strategy(&self.options)?)),
+            StrategyType::PoorMansCoveredCall => {
+                Ok(Box::new(PoorMansCoveredCall::get_strategy(&self.options)?))
+            }
+            StrategyType::CallButterfly => {
+                Ok(Box::new(CallButterfly::get_strategy(&self.options)?))
+            }
             StrategyType::Custom => Ok(Box::new(CustomStrategy::get_strategy(&self.options)?)),
         }
     }
@@ -64,86 +82,22 @@ impl StrategyRequest {
 #[cfg(test)]
 mod tests_serialization {
     use super::*;
-    use chrono::{TimeZone, Utc, DateTime, NaiveDateTime};
-    use rust_decimal_macros::dec;
-    use serde_json;
     use crate::model::utils::create_sample_option_with_date;
-    use crate::{pos, ExpirationDate, OptionStyle, OptionType, Side};
-
+    use crate::{pos, OptionStyle, Side};
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use serde_json;
 
     fn sample_date() -> NaiveDateTime {
         DateTime::from_timestamp(1672531200, 0).unwrap().naive_utc()
     }
 
     #[test]
-    fn test_options_serialization() {
-        let option = create_sample_option_with_date(
-            OptionStyle::Call,
-            Side::Long,
-            pos!(4600.0),
-            pos!(1.0),
-            pos!(4500.0),
-            pos!(0.25),
-            sample_date(),
-        );
-
-        let serialized = serde_json::to_string(&option).unwrap();
-        assert!(serialized.contains("\"underlying_symbol\":\"AAPL\""));
-        assert!(serialized.contains("\"option_style\":\"Call\""));
-        assert!(serialized.contains("\"side\":\"Long\""));
-    }
-
-    #[test]
-    fn test_options_deserialization() {
-        let json_data = r#"{"option_type":"European","side":"Short","underlying_symbol":"AAPL","strike_price":150.0,"expiration_date":{"datetime":"2023-01-01T00:00:00Z"},"implied_volatility":0.2,"quantity":2.0,"underlying_price":155.0,"risk_free_rate":0.01,"option_style":"Put","dividend_yield":0.01,"exotic_params":null}"#;
-        let deserialized: Options = serde_json::from_str(json_data).unwrap();
-
-        assert_eq!(deserialized.option_type, OptionType::European);
-        assert_eq!(deserialized.side, Side::Short);
-        assert_eq!(deserialized.underlying_symbol, "AAPL");
-        assert_eq!(deserialized.strike_price, pos!(150.0));
-        assert_eq!(deserialized.expiration_date, ExpirationDate::DateTime(Utc.from_utc_datetime(&sample_date())));
-        assert_eq!(deserialized.implied_volatility, pos!(0.2));
-        assert_eq!(deserialized.quantity, pos!(2.0));
-        assert_eq!(deserialized.underlying_price, pos!(155.0));
-        assert_eq!(deserialized.risk_free_rate, dec!(0.01));
-        assert_eq!(deserialized.option_style, OptionStyle::Put);
-    }
-
-    #[test]
-    fn test_option_with_costs_serialization() {
-        let option_with_costs = OptionWithCosts {
-            open_fee: pos!(1.5),
-            close_fee: pos!(2.0),
-            premium: pos!(5.0),
-            option: create_sample_option_with_date(
-                OptionStyle::Call,
-                Side::Long,
-                pos!(2850.0),
-                pos!(1.0),
-                pos!(2800.0),
-                pos!(0.3),
-                sample_date(),
-            ),
-        };
-
-        let serialized = serde_json::to_string(&option_with_costs).unwrap();
-        assert!(serialized.contains("\"open_fee\":1.5"));
-        assert!(serialized.contains("\"close_fee\":2"));
-        assert!(serialized.contains("\"premium\":5"));
-        assert!(serialized.contains("\"underlying_symbol\":\"AAPL\""));
-    }
-
-    #[test]
     fn test_strategy_request_serialization() {
         let strategy_request = StrategyRequest {
-            strategy_type: StrategyType::ShortStrangle,
+            strategy_type: StrategyType::BearCallSpread,
             options: vec![
-                OptionWithCosts {
-                    open_fee: pos!(1.0),
-                    close_fee: pos!(1.2),
-                    premium: pos!(4.5),
-                    option: create_sample_option_with_date(
+                Position::new(
+                    create_sample_option_with_date(
                         OptionStyle::Call,
                         Side::Short,
                         pos!(920.0),
@@ -152,45 +106,131 @@ mod tests_serialization {
                         pos!(0.35),
                         sample_date(),
                     ),
-                }
+                    pos!(4.5),
+                    Utc::now(),
+                    pos!(1.0),
+                    pos!(1.2),
+                ),
+                Position::new(
+                    create_sample_option_with_date(
+                        OptionStyle::Call,
+                        Side::Long,
+                        pos!(920.0),
+                        pos!(1.0),
+                        pos!(910.0),
+                        pos!(0.35),
+                        sample_date(),
+                    ),
+                    pos!(3.5),
+                    Utc::now(),
+                    pos!(1.0),
+                    pos!(1.2),
+                ),
             ],
         };
 
         let serialized = serde_json::to_string(&strategy_request).unwrap();
-        assert!(serialized.contains("\"strategy_type\":\"ShortStrangle\""));
+
+        // Verify structure
+        assert!(serialized.contains("\"strategy_type\":\"BearCallSpread\""));
+        assert!(serialized.contains("\"options\":["));
         assert!(serialized.contains("\"underlying_symbol\":\"AAPL\""));
+        assert!(serialized.contains("\"premium\":4.5"));
+        assert!(serialized.contains("\"open_fee\":1"));
+        assert!(serialized.contains("\"close_fee\":1.2"));
     }
 
     #[test]
     fn test_strategy_request_deserialization() {
-        let json_data = r#"{"strategy_type":"ShortStrangle","options":[{"open_fee":1.0,"close_fee":1.2,"premium":4.5,"option":{"option_type":"European","side":"Short","underlying_symbol":"AAPL","strike_price":900.0,"expiration_date":{"days":3},"implied_volatility":0.35,"quantity":1.0,"underlying_price":920.0,"risk_free_rate":0.02,"option_style":"Call","dividend_yield":0.01,"exotic_params":null}}]}"#;
+        let json_data = r#"{
+            "strategy_type": "BearCallSpread",
+            "options": [
+                {
+                    "option": {
+                        "option_type": "European",
+                        "side": "Short",
+                        "underlying_symbol": "AAPL",
+                        "strike_price": 900.0,
+                        "expiration_date": {"days": 30},
+                        "implied_volatility": 0.35,
+                        "quantity": 1.0,
+                        "underlying_price": 920.0,
+                        "risk_free_rate": 0.02,
+                        "option_style": "Call",
+                        "dividend_yield": 0.01,
+                        "exotic_params": null
+                    },
+                    "premium": 4.5,
+                    "date": "2024-01-01T00:00:00Z",
+                    "open_fee": 1.0,
+                    "close_fee": 1.2
+                },
+                {
+                    "option": {
+                        "option_type": "European",
+                        "side": "Long",
+                        "underlying_symbol": "AAPL",
+                        "strike_price": 910.0,
+                        "expiration_date": {"days": 30},
+                        "implied_volatility": 0.35,
+                        "quantity": 1.0,
+                        "underlying_price": 920.0,
+                        "risk_free_rate": 0.02,
+                        "option_style": "Call",
+                        "dividend_yield": 0.01,
+                        "exotic_params": null
+                    },
+                    "premium": 3.5,
+                    "date": "2024-01-01T00:00:00Z",
+                    "open_fee": 1.0,
+                    "close_fee": 1.2
+                }
+            ]
+        }"#;
 
         let deserialized: StrategyRequest = serde_json::from_str(json_data).unwrap();
-        assert_eq!(deserialized.strategy_type, StrategyType::ShortStrangle);
-        assert_eq!(deserialized.options.len(), 1);
-        assert_eq!(deserialized.options[0].open_fee, pos!(1.0));
-        assert_eq!(deserialized.options[0].option.underlying_symbol, "AAPL");
+
+        // Verify deserialized data
+        assert_eq!(deserialized.strategy_type, StrategyType::BearCallSpread);
+        assert_eq!(deserialized.options.len(), 2);
+
+        // Verify first option (Short Call)
+        let short_call = &deserialized.options[0];
+        assert_eq!(short_call.option.side, Side::Short);
+        assert_eq!(short_call.option.strike_price, pos!(900.0));
+        assert_eq!(short_call.premium, pos!(4.5));
+        assert_eq!(short_call.open_fee, pos!(1.0));
+        assert_eq!(short_call.close_fee, pos!(1.2));
+
+        // Verify second option (Long Call)
+        let long_call = &deserialized.options[1];
+        assert_eq!(long_call.option.side, Side::Long);
+        assert_eq!(long_call.option.strike_price, pos!(910.0));
+        assert_eq!(long_call.premium, pos!(3.5));
+        assert_eq!(long_call.open_fee, pos!(1.0));
+        assert_eq!(long_call.close_fee, pos!(1.2));
     }
 
     #[test]
-    fn test_options_methods() {
-        let option = create_sample_option_with_date(
-            OptionStyle::Call,
-            Side::Long,
-            pos!(155.0),
-            pos!(1.0),
-            pos!(150.0),
-            pos!(0.2),
-            sample_date(),
-        );
+    fn test_strategy_request_invalid_json() {
+        let invalid_json = r#"{
+            "strategy_type": "InvalidStrategy",
+            "options": []
+        }"#;
 
-        assert!(option.is_long());
-        assert!(!option.is_short());
+        let result = serde_json::from_str::<StrategyRequest>(invalid_json);
+        assert!(result.is_err());
+    }
 
-        let intrinsic_value = option.intrinsic_value(pos!(155.0)).unwrap();
-        assert_eq!(intrinsic_value, dec!(5.0));
+    #[test]
+    fn test_strategy_request_empty_options() {
+        let json_data = r#"{
+            "strategy_type": "BearCallSpread",
+            "options": []
+        }"#;
 
-        let payoff = option.payoff().unwrap();
-        assert!(payoff > dec!(0.0));
+        let deserialized: StrategyRequest = serde_json::from_str(json_data).unwrap();
+        assert_eq!(deserialized.strategy_type, StrategyType::BearCallSpread);
+        assert!(deserialized.options.is_empty());
     }
 }

--- a/src/strategies/build/traits.rs
+++ b/src/strategies/build/traits.rs
@@ -8,9 +8,8 @@ use crate::strategies::build::model::OptionWithCosts;
 use crate::strategies::Strategies;
 
 pub trait StrategyConstructor: Strategies {
-
-    #[allow(clippy::ptr_arg)]
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError>
+    
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError>
     where
         Self: Sized,
     {
@@ -61,7 +60,7 @@ mod tests {
     impl Strategies for ValidStrategy {}
 
     impl StrategyConstructor for ValidStrategy {
-        fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError>
+        fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError>
         where
             Self: Sized,
         {

--- a/src/strategies/build/traits.rs
+++ b/src/strategies/build/traits.rs
@@ -4,12 +4,11 @@
    Date: 16/2/25
 ******************************************************************************/
 use crate::error::StrategyError;
-use crate::strategies::build::model::OptionWithCosts;
+use crate::model::Position;
 use crate::strategies::Strategies;
 
 pub trait StrategyConstructor: Strategies {
-    
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError>
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError>
     where
         Self: Sized,
     {
@@ -22,7 +21,6 @@ mod tests {
     use super::*;
     use crate::error::StrategyError;
     use crate::strategies::base::{BreakEvenable, Positionable, Validable};
-    use crate::strategies::build::model::OptionWithCosts;
     use crate::strategies::Strategies;
 
     /// Mock para una estrategia específica
@@ -42,7 +40,7 @@ mod tests {
 
     #[test]
     fn test_get_strategy_not_implemented() {
-        let options = vec![]; // Vec vacío de `OptionWithCosts`
+        let options = vec![];
         let result = TestStrategy::get_strategy(&options);
 
         assert!(matches!(result, Err(StrategyError::NotImplemented)));
@@ -60,7 +58,7 @@ mod tests {
     impl Strategies for ValidStrategy {}
 
     impl StrategyConstructor for ValidStrategy {
-        fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError>
+        fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError>
         where
             Self: Sized,
         {
@@ -70,7 +68,7 @@ mod tests {
 
     #[test]
     fn test_get_strategy_success() {
-        let options = vec![]; // Vec vacío de `OptionWithCosts`
+        let options = vec![];
         let result = ValidStrategy::get_strategy(&options);
 
         assert!(result.is_ok());

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -35,6 +35,7 @@ use crate::strategies::delta_neutral::{
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::{pos, Options, Positive};
@@ -44,7 +45,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{debug, error, info};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const BULL_CALL_SPREAD_DESCRIPTION: &str =
     "A bull call spread is created by buying a call option with a lower strike price \
@@ -158,7 +158,7 @@ impl BullCallSpread {
 }
 
 impl StrategyConstructor for BullCallSpread {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -158,7 +158,7 @@ impl BullCallSpread {
 }
 
 impl StrategyConstructor for BullCallSpread {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -22,6 +22,7 @@ use crate::constants::{DARK_BLUE, DARK_GREEN, ZERO};
 use crate::error::position::{PositionError, PositionValidationErrorKind};
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::{ProfitLossErrorKind, StrategyError};
+use crate::error::GreeksError;
 use crate::greeks::Greeks;
 use crate::model::position::Position;
 use crate::model::types::{ExpirationDate, OptionStyle, OptionType, Side};
@@ -34,6 +35,7 @@ use crate::strategies::delta_neutral::{
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::Options;
@@ -43,9 +45,7 @@ use plotters::prelude::full_palette::ORANGE;
 use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
-use crate::error::GreeksError;
 use tracing::debug;
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const BULL_PUT_SPREAD_DESCRIPTION: &str =
     "A bull put spread is created by buying a put option with a lower strike price \
@@ -160,7 +160,7 @@ impl BullPutSpread {
 }
 
 impl StrategyConstructor for BullPutSpread {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -160,7 +160,7 @@ impl BullPutSpread {
 }
 
 impl StrategyConstructor for BullPutSpread {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/butterfly_spread.rs
+++ b/src/strategies/butterfly_spread.rs
@@ -178,7 +178,7 @@ impl LongButterflySpread {
 }
 
 impl StrategyConstructor for LongButterflySpread {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }
@@ -1015,7 +1015,7 @@ impl ShortButterflySpread {
 }
 
 impl StrategyConstructor for ShortButterflySpread {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/butterfly_spread.rs
+++ b/src/strategies/butterfly_spread.rs
@@ -35,6 +35,7 @@ use crate::strategies::delta_neutral::{
 };
 use crate::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::Options;
@@ -46,7 +47,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{debug, info};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const LONG_BUTTERFLY_DESCRIPTION: &str =
     "A long butterfly spread is created by buying one call at a lower strike price, \
@@ -178,7 +178,7 @@ impl LongButterflySpread {
 }
 
 impl StrategyConstructor for LongButterflySpread {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }
@@ -1015,7 +1015,7 @@ impl ShortButterflySpread {
 }
 
 impl StrategyConstructor for ShortButterflySpread {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -170,7 +170,7 @@ impl CallButterfly {
 }
 
 impl StrategyConstructor for CallButterfly {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -21,6 +21,7 @@ use crate::strategies::delta_neutral::{
 };
 use crate::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::Options;
@@ -32,7 +33,6 @@ use plotters::style::full_palette::ORANGE;
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{error, info};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const RATIO_CALL_SPREAD_DESCRIPTION: &str =
     "A Ratio Call Spread involves buying one call option and selling multiple call options \
@@ -170,7 +170,7 @@ impl CallButterfly {
 }
 
 impl StrategyConstructor for CallButterfly {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -17,6 +17,7 @@ use crate::strategies::base::{
 };
 use crate::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::utils::others::process_n_times_iter;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
@@ -27,7 +28,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{debug, error};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 #[derive(Clone, Debug)]
 pub struct CustomStrategy {
@@ -273,7 +273,7 @@ impl CustomStrategy {
 }
 
 impl StrategyConstructor for CustomStrategy {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -273,7 +273,7 @@ impl CustomStrategy {
 }
 
 impl StrategyConstructor for CustomStrategy {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -203,7 +203,7 @@ impl IronButterfly {
 }
 
 impl StrategyConstructor for IronButterfly {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -30,6 +30,7 @@ use crate::strategies::delta_neutral::{
 };
 use crate::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::{Options, Positive};
@@ -40,7 +41,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{error, info};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const IRON_BUTTERFLY_DESCRIPTION: &str =
     "An Iron Butterfly is a neutral options strategy combining selling an at-the-money put and call \
@@ -203,7 +203,7 @@ impl IronButterfly {
 }
 
 impl StrategyConstructor for IronButterfly {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -202,7 +202,7 @@ impl IronCondor {
 }
 
 impl StrategyConstructor for IronCondor {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -28,6 +28,7 @@ use crate::strategies::delta_neutral::{
 };
 use crate::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::{Options, Positive};
@@ -38,7 +39,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{error, info};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const IRON_CONDOR_DESCRIPTION: &str =
     "An Iron Condor is a neutral options strategy combining a bull put spread with a bear call spread. \
@@ -202,7 +202,7 @@ impl IronCondor {
 }
 
 impl StrategyConstructor for IronCondor {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -189,6 +189,7 @@
 pub mod base;
 pub mod bear_call_spread;
 pub mod bear_put_spread;
+mod build;
 pub mod bull_call_spread;
 pub mod bull_put_spread;
 pub mod butterfly_spread;
@@ -205,7 +206,6 @@ pub mod protective_put;
 pub mod straddle;
 pub mod strangle;
 pub mod utils;
-mod build;
 
 pub use base::Strategies;
 pub use bear_call_spread::BearCallSpread;
@@ -216,6 +216,8 @@ pub use butterfly_spread::{LongButterflySpread, ShortButterflySpread};
 pub use call_butterfly::CallButterfly;
 // pub use collar::Collar;
 // pub use covered_call::CoveredCall;
+pub use build::model::StrategyRequest;
+pub use build::traits::StrategyConstructor;
 pub use custom::CustomStrategy;
 pub use delta_neutral::{DeltaAdjustment, DeltaInfo, DeltaNeutrality, DELTA_THRESHOLD};
 pub use iron_butterfly::IronButterfly;
@@ -224,6 +226,3 @@ pub use poor_mans_covered_call::PoorMansCoveredCall;
 pub use straddle::{LongStraddle, ShortStraddle};
 pub use strangle::{LongStrangle, ShortStrangle};
 pub use utils::FindOptimalSide;
-pub use build::traits::StrategyConstructor;
-pub use build::model::{OptionWithCosts, StrategyRequest};
-

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -167,7 +167,7 @@ impl PoorMansCoveredCall {
 }
 
 impl StrategyConstructor for PoorMansCoveredCall {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -49,6 +49,7 @@ use crate::strategies::delta_neutral::{
 };
 use crate::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::Options;
@@ -60,7 +61,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{debug, error};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const PMCC_DESCRIPTION: &str =
     "A Poor Man's Covered Call (PMCC) is an options strategy that simulates a covered call \
@@ -167,7 +167,7 @@ impl PoorMansCoveredCall {
 }
 
 impl StrategyConstructor for PoorMansCoveredCall {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/straddle.rs
+++ b/src/strategies/straddle.rs
@@ -30,6 +30,7 @@ use crate::strategies::delta_neutral::{
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::utils::{FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::{Options, Positive};
@@ -40,7 +41,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{info, trace};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 /// A Short Straddle is an options trading strategy that involves simultaneously selling
 /// a put and a call option with the same strike price and expiration date. This neutral
@@ -163,11 +163,10 @@ impl ShortStraddle {
 }
 
 impl StrategyConstructor for ShortStraddle {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }
-
 
 impl BreakEvenable for ShortStraddle {
     fn get_break_even_points(&self) -> Result<&Vec<Positive>, StrategyError> {
@@ -802,7 +801,7 @@ impl LongStraddle {
 }
 
 impl StrategyConstructor for LongStraddle {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/straddle.rs
+++ b/src/strategies/straddle.rs
@@ -163,7 +163,7 @@ impl ShortStraddle {
 }
 
 impl StrategyConstructor for ShortStraddle {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }
@@ -802,7 +802,7 @@ impl LongStraddle {
 }
 
 impl StrategyConstructor for LongStraddle {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/strangle.rs
+++ b/src/strategies/strangle.rs
@@ -30,6 +30,7 @@ use crate::strategies::delta_neutral::{
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::utils::{calculate_price_range, FindOptimalSide, OptimizationCriteria};
+use crate::strategies::StrategyConstructor;
 use crate::visualization::model::{ChartPoint, ChartVerticalLine, LabelOffsetType};
 use crate::visualization::utils::Graph;
 use crate::{Options, Positive};
@@ -40,7 +41,6 @@ use plotters::prelude::{ShapeStyle, RED};
 use rust_decimal::Decimal;
 use std::error::Error;
 use tracing::{debug, error, info, trace};
-use crate::strategies::{OptionWithCosts, StrategyConstructor};
 
 const SHORT_STRANGLE_DESCRIPTION: &str =
     "A short strangle involves selling an out-of-the-money call and an \
@@ -149,7 +149,7 @@ impl ShortStrangle {
 }
 
 impl StrategyConstructor for ShortStrangle {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }
@@ -839,7 +839,7 @@ impl LongStrangle {
 }
 
 impl StrategyConstructor for LongStrangle {
-    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[Position]) -> Result<Self, StrategyError> {
         todo!()
     }
 }

--- a/src/strategies/strangle.rs
+++ b/src/strategies/strangle.rs
@@ -149,7 +149,7 @@ impl ShortStrangle {
 }
 
 impl StrategyConstructor for ShortStrangle {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }
@@ -839,7 +839,7 @@ impl LongStrangle {
 }
 
 impl StrategyConstructor for LongStrangle {
-    fn get_strategy(_vec_options: &Vec<OptionWithCosts>) -> Result<Self, StrategyError> {
+    fn get_strategy(_vec_options: &[OptionWithCosts]) -> Result<Self, StrategyError> {
         todo!()
     }
 }


### PR DESCRIPTION
Replaced `&Vec<OptionWithCosts>` with `&[OptionWithCosts]` across all strategy implementations. This improves API flexibility by allowing input types that can be converted to slices without requiring cloning. Adjusted related logic accordingly where necessary.