### PR TITLE
Add comprehensive tests for transaction getters, updaters, and PnL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ csv = { version = "1.3.1"}
 serde = { version = "1.0.219", features = ["derive"] }
 rayon = { version = "1.10.0" }
 itertools = "0.14.0"
-rust_decimal = { version = "1.37.0", features = ["maths", "serde"] }
-rust_decimal_macros = "1.37.0"
+rust_decimal = { version = "1.37.1", features = ["maths", "serde"] }
+rust_decimal_macros = "1.37.1"
 zip = "2.6.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This commit introduces detailed unit tests covering transaction getters, updaters, and profit-and-loss (PnL) calculations. It ensures proper validation for different transaction statuses and unsupported option types. Additionally, dependencies `rust_decimal` and `rust_decimal_macros` were updated to version `1.37.1`.