### PR TITLE
refactor: replace unwrap() with Result in build_chain and build_series

### DIFF
--- a/.windsurf/issue_198_base_asset_legs_implementation.md
+++ b/.windsurf/issue_198_base_asset_legs_implementation.md
@@ -1,0 +1,588 @@
+# Issue #198: Base Asset Legs Support Implementation Guide
+
+## Executive Summary
+
+This document outlines the implementation strategy for supporting base asset legs (spot positions) in custom strategies, enabling strategies like Covered Call, Protective Put, and Collar.
+
+---
+
+## Problem Statement
+
+Currently, `Position` only supports option contracts (Call/Put). Strategies requiring underlying asset positions cannot be implemented:
+
+- **Covered Call** = Long Stock + Short Call
+- **Protective Put** = Long Stock + Long Put  
+- **Collar** = Long Stock + Long Put + Short Call
+
+The `CustomStrategy.positions` field is `Vec<Position>`, and `Position.option` requires `OptionStyle::Call` or `OptionStyle::Put`.
+
+---
+
+## Recommended Solution: Separate Leg Types (Option B)
+
+### Why This Approach
+
+| Consideration | Option A (Extend Position) | Option B (Separate Leg Types) |
+|---------------|---------------------------|-------------------------------|
+| Breaking changes | High - modifies core struct | None - additive only |
+| Type safety | Mixed concerns in one struct | Each type has relevant fields |
+| Extensibility | Limited | Easy to add Futures, CFDs, etc. |
+| Existing code impact | All 22+ strategies affected | Zero impact on existing code |
+| Greeks handling | Complex conditional logic | Clean separation (Spot delta=±1) |
+
+### Core Principle
+
+Create a new `Leg` enum that can represent multiple instrument types, while keeping the existing `Position` struct unchanged for backward compatibility.
+
+---
+
+## Architecture Overview
+
+### New Module Structure
+
+```
+src/model/
+├── mod.rs                 # Add leg module export
+├── position.rs            # UNCHANGED
+├── leg/                   # NEW MODULE
+│   ├── mod.rs             # Module exports and re-exports
+│   ├── traits.rs          # Common leg traits (LegAble)
+│   ├── leg_enum.rs        # Leg enum definition
+│   ├── spot.rs            # SpotPosition struct
+│   ├── future.rs          # FuturePosition struct
+│   ├── perpetual.rs       # PerpetualPosition struct (crypto)
+│   ├── cfd.rs             # CfdPosition struct
+│   └── forward.rs         # ForwardPosition struct
+```
+
+### Type Hierarchy
+
+```
+Leg (enum)
+├── Option(Position)           # Existing option positions
+├── Spot(SpotPosition)         # NEW: Underlying asset positions
+├── Future(FuturePosition)     # Futures contracts (expiring)
+├── Perpetual(PerpetualPosition) # Crypto perpetual contracts
+├── Cfd(CfdPosition)           # Contracts for Difference
+└── Forward(ForwardPosition)   # OTC forward contracts
+```
+
+### Instrument Characteristics Comparison
+
+| Instrument | Expiration | Margin | Funding | Greeks | Primary Use |
+|------------|------------|--------|---------|--------|-------------|
+| **Spot** | No | No | No | Delta only | Stock, crypto spot |
+| **Option** | Yes | No* | No | Full | Hedging, speculation |
+| **Future** | Yes | Yes | No | Delta, Rho | Hedging, arbitrage |
+| **Perpetual** | No | Yes | Yes | Delta | Crypto leverage |
+| **CFD** | No | Yes | Overnight | Delta | Retail leverage |
+| **Forward** | Yes | Varies | No | Delta, Rho | OTC hedging |
+
+*Options may require margin for short positions
+
+---
+
+## Implementation Phases
+
+### Phase 1: SpotPosition Struct
+
+Create a new struct to represent spot/underlying asset positions.
+
+**Fields to include:**
+- `symbol` - Ticker symbol of the underlying asset
+- `quantity` - Number of shares/units held
+- `cost_basis` - Average cost per unit
+- `side` - Long or Short position
+- `date` - Position open date
+- `open_fee` - Transaction fee to open
+- `close_fee` - Transaction fee to close
+
+**Methods to implement:**
+- `new()` - Constructor
+- `total_cost()` - Calculate total position cost
+- `pnl_at_price()` - Calculate P&L at a given price
+- `fees()` - Total fees for the position
+
+**Traits to implement:**
+- `Profit` - For P&L calculations
+- `PnLCalculator` - For detailed P&L analysis
+- `Display` - For formatted output
+- `Serialize/Deserialize` - For JSON support
+
+### Phase 2: Leg Enum
+
+Create an enum that wraps different position types.
+
+**Variants:**
+- `Option(Position)` - Wraps existing option positions
+- `Spot(SpotPosition)` - Wraps new spot positions
+
+**Common interface methods:**
+- `symbol()` - Get the underlying symbol
+- `quantity()` - Get position quantity
+- `side()` - Get position side (Long/Short)
+- `total_cost()` - Calculate total cost
+- `pnl_at_price()` - Calculate P&L at price
+- `fees()` - Get total fees
+- `delta()` - Get position delta (Spot = ±1.0, Option = calculated)
+
+### Phase 3: LegAble Trait
+
+Define a common trait for leg operations that both `Position` and `SpotPosition` implement.
+
+**Trait methods:**
+- `get_symbol()` - Returns the symbol
+- `get_quantity()` - Returns the quantity
+- `get_side()` - Returns Long/Short
+- `calculate_pnl()` - Calculates profit/loss
+- `get_delta()` - Returns delta value
+
+This trait enables polymorphic handling of different leg types.
+
+### Phase 4: Covered Call Strategy
+
+Implement the first strategy using the new leg system.
+
+**Structure:**
+- `spot_leg: SpotPosition` - Long underlying position
+- `option_leg: Position` - Short call option
+- `break_even_points: Vec<Positive>`
+
+**Key calculations:**
+- Max profit = Strike - Cost Basis + Premium Received
+- Max loss = Cost Basis - Premium Received (if stock goes to zero)
+- Break-even = Cost Basis - Premium Received
+
+**Traits to implement:**
+- `Strategies`
+- `BasicAble`
+- `Positionable` (adapted for mixed legs)
+- `BreakEvenable`
+- `Profit`
+- `DeltaNeutrality`
+
+### Phase 5: Protective Put and Collar
+
+Apply the same pattern to implement remaining strategies.
+
+**Protective Put:**
+- `spot_leg: SpotPosition` - Long underlying
+- `option_leg: Position` - Long put option
+
+**Collar:**
+- `spot_leg: SpotPosition` - Long underlying
+- `put_leg: Position` - Long put (protection)
+- `call_leg: Position` - Short call (income)
+
+### Phase 6: CustomStrategy Extension (Optional)
+
+Extend `CustomStrategy` to optionally support mixed legs.
+
+**Two approaches:**
+
+1. **New field approach:**
+   - Add `legs: Vec<Leg>` field
+   - Keep `positions: Vec<Position>` for backward compatibility
+   - Use `legs` when present, fall back to `positions`
+
+2. **New strategy type approach:**
+   - Create `MixedStrategy` struct with `legs: Vec<Leg>`
+   - Keep `CustomStrategy` unchanged
+   - Users choose which to use based on needs
+
+---
+
+## Greeks Handling
+
+### Spot Position Greeks
+
+| Greek | Value | Rationale |
+|-------|-------|-----------|
+| Delta | ±1.0 per share | Long = +1, Short = -1 |
+| Gamma | 0 | No convexity |
+| Theta | 0 | No time decay |
+| Vega | 0 | No volatility sensitivity |
+| Rho | 0 | Simplified (could model dividend yield) |
+
+### Portfolio Greeks Aggregation
+
+When combining spot and option legs:
+- Delta = Σ(option deltas) + Σ(spot deltas)
+- Gamma = Σ(option gammas) only
+- Theta = Σ(option thetas) only
+- Vega = Σ(option vegas) only
+
+---
+
+## Integration Points
+
+### Existing Traits to Consider
+
+| Trait | SpotPosition Support | Notes |
+|-------|---------------------|-------|
+| `Profit` | Yes | Simple linear P&L |
+| `PnLCalculator` | Yes | Cost basis tracking |
+| `Greeks` | Partial | Only delta is meaningful |
+| `Validable` | Yes | Quantity > 0, valid symbol |
+| `Serialize/Deserialize` | Yes | JSON support |
+
+### Strategy Builder Integration
+
+The `StrategyRequest` in `src/strategies/build/model.rs` needs updates:
+- Add `CoveredCall`, `ProtectivePut`, `Collar` to the match statement
+- These strategies will use `Leg` instead of just `Position`
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **SpotPosition tests:**
+   - Construction and validation
+   - P&L calculations at various prices
+   - Fee calculations
+   - Serialization/deserialization
+
+2. **Leg enum tests:**
+   - Wrapping and unwrapping positions
+   - Common interface methods
+   - Delta calculations
+
+3. **CoveredCall tests:**
+   - Strategy construction
+   - Break-even calculation
+   - Max profit/loss
+   - P&L at various prices
+   - Greeks aggregation
+
+### Integration Tests
+
+1. Strategy validation with mixed legs
+2. Visualization/graphing support
+3. Delta neutrality calculations
+
+---
+
+## Migration Considerations
+
+### Backward Compatibility
+
+- All existing strategies continue to work unchanged
+- `Position` struct remains the same
+- Existing `CustomStrategy` usage is unaffected
+- New functionality is purely additive
+
+### API Stability
+
+- New types are added, none removed
+- Existing method signatures unchanged
+- New strategies follow established patterns
+
+---
+
+## Derivative Types Detailed Specification
+
+### SpotPosition
+
+Represents direct ownership of the underlying asset (stocks, crypto spot, forex spot).
+
+**Fields:**
+- `symbol` - Asset ticker/symbol
+- `quantity` - Number of units held
+- `cost_basis` - Average acquisition price per unit
+- `side` - Long or Short
+- `date` - Position open timestamp
+- `open_fee` / `close_fee` - Transaction fees
+
+**Characteristics:**
+- No expiration
+- No margin requirements (fully funded)
+- Delta = ±1.0 per unit
+- No funding costs
+
+---
+
+### FuturePosition
+
+Represents standardized exchange-traded futures contracts.
+
+**Fields:**
+- `symbol` - Contract symbol (e.g., "ES", "BTC-PERP")
+- `quantity` - Number of contracts
+- `entry_price` - Average entry price
+- `side` - Long or Short
+- `expiration_date` - Contract expiry
+- `contract_size` - Multiplier (e.g., 50 for ES, 1 for BTC)
+- `margin` - Initial margin requirement
+- `maintenance_margin` - Maintenance margin level
+- `date` - Position open timestamp
+- `fees` - Commission and exchange fees
+
+**Characteristics:**
+- Fixed expiration date
+- Margin-based (leveraged)
+- Mark-to-market daily settlement
+- Delta ≈ ±1.0 per contract (adjusted for contract size)
+- Rho sensitivity for interest rate changes
+
+**Use Cases:**
+- Hedging underlying exposure
+- Calendar spreads (long near / short far)
+- Basis trades (spot vs futures)
+- Index futures strategies
+
+---
+
+### PerpetualPosition (Crypto)
+
+Represents perpetual swap contracts common in cryptocurrency markets.
+
+**Fields:**
+- `symbol` - Trading pair (e.g., "BTC-USDT-PERP")
+- `quantity` - Position size in base currency
+- `entry_price` - Average entry price
+- `side` - Long or Short
+- `leverage` - Applied leverage (1x to 125x typical)
+- `margin` - Collateral posted
+- `margin_type` - Cross or Isolated margin mode
+- `liquidation_price` - Price at which position is liquidated
+- `funding_rate` - Current funding rate (updated periodically)
+- `next_funding_time` - Timestamp of next funding payment
+- `unrealized_pnl` - Current unrealized P&L
+- `date` - Position open timestamp
+- `fees` - Trading fees (maker/taker)
+
+**Characteristics:**
+- No expiration (perpetual)
+- High leverage available
+- Funding rate mechanism to anchor price to spot
+- Funding payments every 8 hours (typically)
+- Delta = ±leverage per unit of margin
+- Liquidation risk
+
+**Funding Rate Mechanics:**
+- Positive rate: Longs pay shorts
+- Negative rate: Shorts pay longs
+- Rate based on premium/discount to spot index
+
+**Use Cases:**
+- Leveraged directional trades
+- Delta-neutral funding rate arbitrage
+- Hedging spot crypto holdings
+- Basis trades (spot vs perp)
+
+---
+
+### CfdPosition
+
+Represents Contracts for Difference (common in forex and retail trading).
+
+**Fields:**
+- `symbol` - Instrument symbol
+- `quantity` - Position size (lots or units)
+- `entry_price` - Average entry price
+- `side` - Long or Short
+- `leverage` - Applied leverage
+- `margin` - Required margin
+- `overnight_rate` - Swap/rollover rate
+- `date` - Position open timestamp
+- `fees` - Spread cost and commissions
+
+**Characteristics:**
+- No expiration
+- Leveraged product
+- Overnight financing charges (swap rates)
+- No ownership of underlying
+- Delta = ±leverage per unit
+
+**Use Cases:**
+- Retail forex trading
+- Index CFD trading
+- Commodity exposure without physical delivery
+
+---
+
+### ForwardPosition
+
+Represents OTC forward contracts (customizable terms).
+
+**Fields:**
+- `symbol` - Underlying asset
+- `quantity` - Contract size
+- `forward_price` - Agreed forward price
+- `side` - Long or Short
+- `settlement_date` - Contract maturity
+- `settlement_type` - Physical or Cash settlement
+- `counterparty` - Optional counterparty identifier
+- `date` - Contract inception date
+- `fees` - Arrangement fees
+
+**Characteristics:**
+- Customizable expiration
+- OTC (counterparty risk)
+- No daily settlement (settled at maturity)
+- Delta ≈ ±1.0
+- Rho sensitivity
+
+**Use Cases:**
+- Corporate hedging (FX forwards)
+- Commodity price locking
+- Custom expiration requirements
+
+---
+
+## Greeks by Instrument Type
+
+| Greek | Spot | Option | Future | Perpetual | CFD | Forward |
+|-------|------|--------|--------|-----------|-----|---------|
+| **Delta** | ±1.0 | Calculated | ±1.0 × size | ±leverage | ±leverage | ±1.0 |
+| **Gamma** | 0 | Calculated | 0 | 0 | 0 | 0 |
+| **Theta** | 0 | Calculated | ~0* | Funding** | Overnight** | ~0* |
+| **Vega** | 0 | Calculated | 0 | 0 | 0 | 0 |
+| **Rho** | 0 | Calculated | Yes | 0 | 0 | Yes |
+
+*Futures have time value that decays as basis converges
+**Perpetuals have funding; CFDs have overnight financing
+
+---
+
+## Crypto-Specific Considerations
+
+### Exchange Integration
+
+Different exchanges have varying perpetual contract specifications:
+
+| Exchange | Funding Interval | Max Leverage | Margin Modes |
+|----------|-----------------|--------------|--------------|
+| Binance | 8h | 125x | Cross, Isolated |
+| Bybit | 8h | 100x | Cross, Isolated |
+| OKX | 8h | 125x | Cross, Isolated |
+| dYdX | 1h | 20x | Cross |
+| GMX | Continuous | 50x | Isolated |
+
+### Funding Rate Calculation
+
+The funding rate typically consists of:
+1. **Interest Rate Component** - Usually fixed (e.g., 0.01% per 8h)
+2. **Premium/Discount Component** - Based on mark price vs index price
+
+### Liquidation Mechanics
+
+For perpetuals, track:
+- **Maintenance Margin Ratio** - Minimum margin to avoid liquidation
+- **Liquidation Price** - Price at which position is force-closed
+- **Insurance Fund** - Exchange backstop for bankrupt positions
+
+### Position Sizing
+
+Perpetual position size can be expressed as:
+- **Notional Value** = Quantity × Mark Price
+- **Margin Used** = Notional Value / Leverage
+- **Available Margin** = Total Collateral - Margin Used
+
+---
+
+## Implementation Priority
+
+Given the crypto focus, recommended implementation order:
+
+| Priority | Instrument | Rationale |
+|----------|------------|-----------|
+| 1 | SpotPosition | Foundation for all strategies |
+| 2 | PerpetualPosition | High demand in crypto |
+| 3 | FuturePosition | Traditional markets + crypto quarterly |
+| 4 | CfdPosition | Retail trading support |
+| 5 | ForwardPosition | OTC/institutional use |
+
+---
+
+## Example Strategies Enabled
+
+### Traditional Markets
+
+| Strategy | Legs | Description |
+|----------|------|-------------|
+| Covered Call | Spot + Short Call | Income on holdings |
+| Protective Put | Spot + Long Put | Downside protection |
+| Collar | Spot + Long Put + Short Call | Range-bound protection |
+| Synthetic Long | Long Call + Short Put | Replicate stock |
+| Conversion | Spot + Long Put + Short Call | Arbitrage |
+
+### Crypto Markets
+
+| Strategy | Legs | Description |
+|----------|------|-------------|
+| Cash & Carry | Spot + Short Perp | Funding rate arbitrage |
+| Basis Trade | Spot + Short Future | Basis capture |
+| Delta Neutral Funding | Spot + Short Perp (equal size) | Pure funding income |
+| Hedged Perp | Perp + Options | Leveraged with protection |
+| Perp Spread | Long Perp (Exchange A) + Short Perp (Exchange B) | Cross-exchange arb |
+
+### Funding Rate Arbitrage Example
+
+A common crypto strategy:
+1. Buy 1 BTC spot at $50,000
+2. Short 1 BTC perpetual at $50,000
+3. Net delta = 0 (delta neutral)
+4. Collect funding rate (if positive) every 8 hours
+5. Expected APY = Funding Rate × 3 × 365 (annualized)
+
+---
+
+## Estimated Effort
+
+### Core Infrastructure
+
+| Phase | Complexity | Estimated Time |
+|-------|------------|----------------|
+| Phase 1: SpotPosition | Low | 2-3 hours |
+| Phase 2: Leg Enum | Low | 1-2 hours |
+| Phase 3: LegAble Trait | Medium | 2-3 hours |
+| Phase 4: CoveredCall | Medium | 3-4 hours |
+| Phase 5: ProtectivePut/Collar | Low | 2-3 hours |
+| Phase 6: CustomStrategy Extension | Medium | 3-4 hours |
+
+**Core subtotal: 13-19 hours**
+
+### Additional Derivatives
+
+| Derivative | Complexity | Estimated Time |
+|------------|------------|----------------|
+| PerpetualPosition | Medium-High | 4-6 hours |
+| FuturePosition | Medium | 3-4 hours |
+| CfdPosition | Low-Medium | 2-3 hours |
+| ForwardPosition | Low | 2-3 hours |
+
+**Derivatives subtotal: 11-16 hours**
+
+### Testing & Documentation
+
+| Task | Estimated Time |
+|------|----------------|
+| Unit tests per derivative | 1-2 hours each |
+| Integration tests | 2-3 hours |
+| Documentation | 2-3 hours |
+| Examples | 2-3 hours |
+
+**Testing subtotal: 10-15 hours**
+
+### Total Estimated Effort
+
+| Scope | Time Range |
+|-------|------------|
+| Core only (Spot + Options strategies) | 16-23 hours |
+| Core + Perpetuals | 22-32 hours |
+| Full implementation (all derivatives) | 34-50 hours |
+
+---
+
+## References
+
+- Issue #198: https://github.com/joaquinbejar/OptionStratLib/issues/198
+- Existing placeholder files:
+  - `src/strategies/covered_call.rs`
+  - `src/strategies/collar.rs`
+- Related implementation patterns:
+  - `src/model/position.rs`
+  - `src/strategies/custom.rs`

--- a/.windsurf/issues/README.md
+++ b/.windsurf/issues/README.md
@@ -1,0 +1,103 @@
+# OptionStratLib Refactoring Issues
+
+This directory contains individual issue files for the refactoring of OptionStratLib.
+Each file describes a self-contained issue that can be worked on independently.
+
+## Issue Index
+
+### Priority High (Critical Fixes)
+
+| Issue | Title | Effort | File |
+|-------|-------|--------|------|
+| #1 | Reduce unwrap() in chains/chain.rs | Medium | [issue_001](./issue_001_unwrap_chains_chain.md) |
+| #2 | Reduce unwrap() in greeks/equations.rs | Medium | [issue_002](./issue_002_unwrap_greeks_equations.md) |
+| #3 | Reduce unwrap() in model/option.rs | Medium | [issue_003](./issue_003_unwrap_model_option.md) |
+| #4 | Resolve TODOs in black_scholes_model.rs | High | [issue_004](./issue_004_todos_black_scholes.md) |
+| #16 | Improve Positive type safety and API | High | [issue_016](./issue_016_improve_positive_type.md) |
+| #17 | Reduce unwrap() in src/model (remaining files) | High | [issue_017](./issue_017_unwrap_model_remaining.md) |
+
+### Priority Medium (Code Quality)
+
+| Issue | Title | Effort | File |
+|-------|-------|--------|------|
+| #5 | Resolve TODOs in model/position.rs | Low | [issue_005](./issue_005_todos_position.md) |
+| #6 | Extract common strategy logic | High | [issue_006](./issue_006_extract_strategy_logic.md) |
+| #7 | Reduce unnecessary clone() calls | Medium | [issue_007](./issue_007_reduce_clone_calls.md) |
+| #8 | Implement Collar strategy | High | [issue_008](./issue_008_implement_collar.md) |
+| #9 | Implement Protective Put strategy | Medium | [issue_009](./issue_009_implement_protective_put.md) |
+| #15 | Reduce expect() usage | Medium | [issue_015](./issue_015_reduce_expect_usage.md) |
+
+### Priority Low (Polish)
+
+| Issue | Title | Effort | File |
+|-------|-------|--------|------|
+| #10 | Improve error context with anyhow | Low | [issue_010](./issue_010_error_context_anyhow.md) |
+| #11 | Add benchmarks for critical paths | Medium | [issue_011](./issue_011_add_benchmarks.md) |
+| #12 | Add property-based testing | Medium | [issue_012](./issue_012_property_based_testing.md) |
+| #13 | Add async feature flag | Medium | [issue_013](./issue_013_async_feature_flag.md) |
+| #14 | Improve metrics documentation | Low | [issue_014](./issue_014_improve_metrics_docs.md) |
+
+## Recommended Execution Order
+
+### Phase 1: Critical Fixes (3-4 weeks)
+1. Issue #16 - Improve Positive type safety and API
+2. Issue #4 - Resolve TODOs in black_scholes_model.rs
+3. Issue #1 - Reduce unwrap() in chains/chain.rs
+4. Issue #2 - Reduce unwrap() in greeks/equations.rs
+5. Issue #3 - Reduce unwrap() in model/option.rs
+6. Issue #17 - Reduce unwrap() in src/model (remaining files)
+
+### Phase 2: Code Quality (2 weeks)
+7. Issue #5 - Resolve TODOs in model/position.rs
+8. Issue #15 - Reduce expect() usage
+9. Issue #6 - Extract common strategy logic
+10. Issue #7 - Reduce unnecessary clone() calls
+
+### Phase 3: Feature Completion (1-2 weeks)
+11. Issue #8 - Implement Collar strategy
+12. Issue #9 - Implement Protective Put strategy
+
+### Phase 4: Polish (2 weeks)
+13. Issue #11 - Add benchmarks for critical paths
+14. Issue #12 - Add property-based testing
+15. Issue #10 - Improve error context with anyhow
+16. Issue #13 - Add async feature flag
+17. Issue #14 - Improve metrics documentation
+
+## Labels Reference
+
+| Label | Description |
+|-------|-------------|
+| `priority-high` | Critical issues that should be addressed first |
+| `priority-medium` | Important but not blocking |
+| `priority-low` | Nice-to-have improvements |
+| `refactor` | Code refactoring without changing behavior |
+| `bug` | Something isn't working correctly |
+| `enhancement` | New feature or request |
+| `error-handling` | Related to error handling improvements |
+| `performance` | Performance optimization |
+| `testing` | Testing improvements |
+| `documentation` | Documentation improvements |
+| `strategies` | Related to trading strategies |
+| `pricing` | Related to options pricing |
+| `model` | Related to core data models |
+
+## Effort Estimates
+
+| Effort | Hours |
+|--------|-------|
+| Low | 2-3 hours |
+| Medium | 4-6 hours |
+| High | 6-12 hours |
+
+## Total Estimated Effort
+
+- **Phase 1**: 35-51 hours (includes Issue #16: 8-12h, Issue #17: 10-14h)
+- **Phase 2**: 17-26 hours
+- **Phase 3**: 10-14 hours
+- **Phase 4**: 12-19 hours
+- **Total**: 74-110 hours
+
+---
+
+*Updated on: 2024-12-25*

--- a/.windsurf/issues/issue_001_unwrap_chains_chain.md
+++ b/.windsurf/issues/issue_001_unwrap_chains_chain.md
@@ -1,0 +1,81 @@
+# Issue #1: Reduce `.unwrap()` usage in `chains/chain.rs`
+
+## Title
+`refactor: Replace unwrap() calls with proper error handling in chains/chain.rs`
+
+## Labels
+- `refactor`
+- `error-handling`
+- `priority-high`
+
+## Description
+
+The file `src/chains/chain.rs` contains **257 occurrences** of `.unwrap()` which can cause panics in production. This issue focuses on replacing these with proper error handling.
+
+### Current State
+- 257 `.unwrap()` calls in production code
+- Potential for runtime panics when invalid data is encountered
+- Poor error messages for debugging
+
+### Target State
+- Zero `.unwrap()` calls in production code (only in tests)
+- Proper `Result` types with meaningful error messages
+- Graceful error handling for edge cases
+
+## Tasks
+
+- [ ] Audit all `.unwrap()` calls in `chains/chain.rs`
+- [ ] Categorize calls by:
+  - Can be replaced with `?` operator
+  - Can use `unwrap_or_default()`
+  - Can use `unwrap_or_else()`
+  - Requires new error variant in `ChainError`
+- [ ] Add new error variants to `error/chains.rs` if needed
+- [ ] Replace `.unwrap()` calls systematically
+- [ ] Update function signatures to return `Result` where needed
+- [ ] Update tests to verify error handling behavior
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] No `.unwrap()` calls remain in production code (only in tests)
+- [ ] All existing tests pass
+- [ ] New error cases are properly documented
+- [ ] Error messages are clear and actionable
+- [ ] No performance regression
+
+## Technical Notes
+
+### Common Patterns to Apply
+
+```rust
+// Before
+let value = some_option.unwrap();
+
+// After - Option 1: Propagate error
+let value = some_option.ok_or(ChainError::MissingValue)?;
+
+// After - Option 2: Default value
+let value = some_option.unwrap_or_default();
+
+// After - Option 3: Computed default
+let value = some_option.unwrap_or_else(|| compute_default());
+```
+
+### Files to Update
+- `src/chains/chain.rs` (primary)
+- `src/error/chains.rs` (add error variants)
+- Related test files
+
+## Estimated Effort
+
+**Medium (4-6 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #2: Reduce unwrap() in greeks/equations.rs
+- Issue #3: Reduce unwrap() in model/option.rs

--- a/.windsurf/issues/issue_002_unwrap_greeks_equations.md
+++ b/.windsurf/issues/issue_002_unwrap_greeks_equations.md
@@ -1,0 +1,92 @@
+# Issue #2: Reduce `.unwrap()` usage in `greeks/equations.rs`
+
+## Title
+`refactor: Replace unwrap() calls with proper error handling in greeks/equations.rs`
+
+## Labels
+- `refactor`
+- `error-handling`
+- `priority-high`
+
+## Description
+
+The file `src/greeks/equations.rs` contains **156 occurrences** of `.unwrap()`. Greeks calculations are critical for options pricing and should never panic.
+
+### Current State
+- 156 `.unwrap()` calls in production code
+- Greeks calculations can panic on edge cases
+- Mathematical errors are not properly propagated
+
+### Target State
+- Zero `.unwrap()` calls in production code
+- All mathematical edge cases handled gracefully
+- Proper `GreeksError` types for domain-specific errors
+
+## Tasks
+
+- [ ] Audit all `.unwrap()` calls in `greeks/equations.rs`
+- [ ] Identify mathematical edge cases:
+  - Division by zero
+  - Negative values under square root
+  - Overflow/underflow conditions
+- [ ] Replace with `?` operator where the function returns `Result`
+- [ ] Use `GreeksError` for domain-specific errors
+- [ ] Add `#[must_use]` annotations where appropriate
+- [ ] Update tests to verify error handling behavior
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] No `.unwrap()` calls remain in production code
+- [ ] All existing tests pass
+- [ ] Error messages are clear and actionable
+- [ ] Mathematical edge cases are documented
+- [ ] Greeks calculations remain accurate
+
+## Technical Notes
+
+### Common Mathematical Edge Cases
+
+```rust
+// Division by zero
+let d1 = (ln(S/K) + (r + sigma^2/2) * T) / (sigma * sqrt(T));
+// When T = 0 or sigma = 0, this fails
+
+// Square root of negative
+let sqrt_t = T.sqrt(); // Fails if T < 0
+
+// Logarithm of non-positive
+let ln_ratio = (S / K).ln(); // Fails if S <= 0 or K <= 0
+```
+
+### Error Handling Pattern
+
+```rust
+// Before
+let d1 = calculate_d1(s, k, r, sigma, t).unwrap();
+
+// After
+let d1 = calculate_d1(s, k, r, sigma, t)
+    .map_err(|e| GreeksError::CalculationFailed {
+        greek: "d1",
+        reason: e.to_string(),
+    })?;
+```
+
+### Files to Update
+- `src/greeks/equations.rs` (primary)
+- `src/error/greeks.rs` (add error variants)
+- Related test files
+
+## Estimated Effort
+
+**Medium (3-5 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #1: Reduce unwrap() in chains/chain.rs
+- Issue #3: Reduce unwrap() in model/option.rs

--- a/.windsurf/issues/issue_003_unwrap_model_option.md
+++ b/.windsurf/issues/issue_003_unwrap_model_option.md
@@ -1,0 +1,98 @@
+# Issue #3: Reduce `.unwrap()` usage in `model/option.rs`
+
+## Title
+`refactor: Replace unwrap() calls with proper error handling in model/option.rs`
+
+## Labels
+- `refactor`
+- `error-handling`
+- `priority-high`
+
+## Description
+
+The file `src/model/option.rs` contains **134 occurrences** of `.unwrap()`. The `Options` struct is fundamental to the library and should handle errors gracefully.
+
+### Current State
+- 134 `.unwrap()` calls in production code
+- Core option operations can panic
+- Invalid option parameters cause crashes instead of errors
+
+### Target State
+- Zero `.unwrap()` calls in production code
+- All public methods return `Result` where failure is possible
+- Clear error messages for invalid parameters
+
+## Tasks
+
+- [ ] Audit all `.unwrap()` calls in `model/option.rs`
+- [ ] Replace with proper error handling using `OptionsError`
+- [ ] Ensure all public methods return `Result` where failure is possible
+- [ ] Add validation for option parameters:
+  - Strike price > 0
+  - Underlying price > 0
+  - Volatility > 0
+  - Time to expiration >= 0
+- [ ] Update documentation with error conditions
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] No `.unwrap()` calls remain in production code
+- [ ] All existing tests pass
+- [ ] API documentation includes error conditions
+- [ ] Invalid parameters produce clear error messages
+- [ ] Option creation validates all inputs
+
+## Technical Notes
+
+### Validation Pattern
+
+```rust
+impl Options {
+    pub fn new(
+        strike: Positive,
+        underlying: Positive,
+        volatility: Positive,
+        // ...
+    ) -> Result<Self, OptionsError> {
+        // Validation is handled by Positive type
+        // Additional business logic validation here
+        
+        Ok(Self {
+            strike,
+            underlying,
+            volatility,
+            // ...
+        })
+    }
+}
+```
+
+### Error Handling Pattern
+
+```rust
+// Before
+let price = self.calculate_price().unwrap();
+
+// After
+let price = self.calculate_price()
+    .map_err(|e| OptionsError::PricingFailed(e.to_string()))?;
+```
+
+### Files to Update
+- `src/model/option.rs` (primary)
+- `src/error/options.rs` (add error variants)
+- Related test files
+
+## Estimated Effort
+
+**Medium (4-6 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #1: Reduce unwrap() in chains/chain.rs
+- Issue #2: Reduce unwrap() in greeks/equations.rs

--- a/.windsurf/issues/issue_004_todos_black_scholes.md
+++ b/.windsurf/issues/issue_004_todos_black_scholes.md
@@ -1,0 +1,77 @@
+# Issue #4: Resolve TODOs in `pricing/black_scholes_model.rs`
+
+## Title
+`fix: Resolve 14 TODO/FIXME items in black_scholes_model.rs`
+
+## Labels
+- `bug`
+- `pricing`
+- `priority-high`
+
+## Description
+
+The file `src/pricing/black_scholes_model.rs` contains **14 TODO/FIXME** comments that need to be addressed. These are critical for correct options pricing.
+
+### Current State
+- 14 unresolved TODO/FIXME comments
+- Potential incomplete functionality in pricing calculations
+- Edge cases may not be handled correctly
+
+### Target State
+- All TODO/FIXME comments resolved
+- Complete and accurate Black-Scholes implementation
+- All edge cases properly handled
+
+## Tasks
+
+- [ ] Review each TODO/FIXME comment in the file
+- [ ] Document what each TODO requires
+- [ ] Implement missing functionality for each item
+- [ ] Add tests for edge cases mentioned in TODOs
+- [ ] Verify pricing accuracy against known values
+- [ ] Remove TODO comments once resolved
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] All TODO/FIXME comments are resolved or converted to tracked issues
+- [ ] Pricing accuracy is maintained or improved
+- [ ] New tests cover the resolved items
+- [ ] No regression in existing functionality
+- [ ] Documentation updated for any API changes
+
+## Technical Notes
+
+### Black-Scholes Formula Reference
+
+```
+C = S * N(d1) - K * e^(-rT) * N(d2)
+P = K * e^(-rT) * N(-d2) - S * N(-d1)
+
+where:
+d1 = (ln(S/K) + (r + σ²/2) * T) / (σ * √T)
+d2 = d1 - σ * √T
+```
+
+### Common Edge Cases to Handle
+- T = 0 (at expiration)
+- σ = 0 (zero volatility)
+- Deep ITM/OTM options
+- Very short/long time to expiration
+- Extreme volatility values
+
+### Files to Update
+- `src/pricing/black_scholes_model.rs` (primary)
+- Related test files
+
+## Estimated Effort
+
+**High (6-8 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #5: Resolve TODOs in model/position.rs

--- a/.windsurf/issues/issue_005_todos_position.md
+++ b/.windsurf/issues/issue_005_todos_position.md
@@ -1,0 +1,58 @@
+# Issue #5: Resolve TODOs in `model/position.rs`
+
+## Title
+`fix: Resolve 4 TODO/FIXME items in model/position.rs`
+
+## Labels
+- `bug`
+- `model`
+- `priority-medium`
+
+## Description
+
+The file `src/model/position.rs` contains **4 TODO/FIXME** comments that need to be addressed.
+
+### Current State
+- 4 unresolved TODO/FIXME comments
+- Position management may have incomplete functionality
+- Edge cases may not be handled correctly
+
+### Target State
+- All TODO/FIXME comments resolved
+- Complete position management functionality
+- All edge cases properly handled
+
+## Tasks
+
+- [ ] Review each TODO/FIXME comment in the file
+- [ ] Document what each TODO requires
+- [ ] Implement missing functionality for each item
+- [ ] Add tests for resolved items
+- [ ] Remove TODO comments once resolved
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] All TODO/FIXME comments are resolved
+- [ ] Position management works correctly
+- [ ] Tests verify the resolved functionality
+- [ ] No regression in existing functionality
+
+## Technical Notes
+
+### Files to Update
+- `src/model/position.rs` (primary)
+- `src/error/position.rs` (if new errors needed)
+- Related test files
+
+## Estimated Effort
+
+**Low (2-3 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #4: Resolve TODOs in black_scholes_model.rs

--- a/.windsurf/issues/issue_006_extract_strategy_logic.md
+++ b/.windsurf/issues/issue_006_extract_strategy_logic.md
@@ -1,0 +1,148 @@
+# Issue #6: Extract common logic from strategy files
+
+## Title
+`refactor: Extract common strategy logic to reduce file sizes`
+
+## Labels
+- `refactor`
+- `strategies`
+- `priority-medium`
+
+## Description
+
+Several strategy files are excessively large due to duplicated logic:
+
+| File | Size |
+|------|------|
+| `short_strangle.rs` | 129KB |
+| `iron_condor.rs` | 126KB |
+| `iron_butterfly.rs` | 113KB |
+| `long_butterfly_spread.rs` | 112KB |
+| `bear_call_spread.rs` | 101KB |
+| `bear_put_spread.rs` | 100KB |
+
+### Current State
+- Large files that are difficult to maintain
+- Significant code duplication across strategies
+- Similar patterns repeated in each strategy
+
+### Target State
+- Each strategy file under 50KB
+- Common logic extracted to shared modules
+- Clear separation between strategy-specific and shared code
+
+## Tasks
+
+- [ ] Identify common patterns across strategy implementations:
+  - Break-even calculations
+  - Profit/loss calculations
+  - Greeks aggregation
+  - Validation logic
+  - Optimization routines
+- [ ] Create shared traits for strategy categories:
+  - `SpreadStrategy` for vertical spreads
+  - `ButterflyStrategy` for butterfly patterns
+  - `CondorStrategy` for condor patterns
+  - `StraddleStrategy` for straddle/strangle patterns
+- [ ] Extract common calculation methods to `strategies/utils.rs`
+- [ ] Create helper macros in `strategies/macros.rs` for repetitive code
+- [ ] Refactor strategies to use shared traits and utilities
+- [ ] Ensure all tests pass after refactoring
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Each strategy file is under 50KB
+- [ ] No functionality is lost
+- [ ] Code duplication is significantly reduced
+- [ ] All tests pass
+- [ ] New shared code is well documented
+
+## Technical Notes
+
+### Proposed Trait Hierarchy
+
+```rust
+/// Base trait for all spread strategies
+pub trait SpreadStrategy: Strategable {
+    /// Returns the lower strike price
+    fn lower_strike(&self) -> Positive;
+    
+    /// Returns the upper strike price
+    fn upper_strike(&self) -> Positive;
+    
+    /// Returns the spread width
+    fn spread_width(&self) -> Positive {
+        self.upper_strike() - self.lower_strike()
+    }
+}
+
+/// Trait for butterfly-type strategies
+pub trait ButterflyStrategy: Strategable {
+    /// Returns the wing strikes (lower, upper)
+    fn wing_strikes(&self) -> (Positive, Positive);
+    
+    /// Returns the body (middle) strike
+    fn body_strike(&self) -> Positive;
+    
+    /// Returns the wing width
+    fn wing_width(&self) -> Positive {
+        let (lower, upper) = self.wing_strikes();
+        (upper - lower) / dec!(2)
+    }
+}
+
+/// Trait for condor-type strategies
+pub trait CondorStrategy: Strategable {
+    /// Returns all four strikes (lowest to highest)
+    fn strikes(&self) -> (Positive, Positive, Positive);
+    
+    /// Returns the inner spread width
+    fn inner_width(&self) -> Positive;
+    
+    /// Returns the outer spread width
+    fn outer_width(&self) -> Positive;
+}
+```
+
+### Common Utility Functions to Extract
+
+```rust
+// strategies/utils.rs
+
+/// Calculate break-even for a two-leg spread
+pub fn spread_break_even(
+    lower_strike: Positive,
+    upper_strike: Positive,
+    net_premium: Decimal,
+    is_credit: bool,
+) -> Vec<Positive>;
+
+/// Aggregate Greeks from multiple positions
+pub fn aggregate_greeks(positions: &[Position]) -> Result<Greeks, GreeksError>;
+
+/// Calculate max profit/loss for bounded strategies
+pub fn calculate_bounded_pnl(
+    positions: &[Position],
+    lower_bound: Positive,
+    upper_bound: Positive,
+) -> (Option<Decimal>, Option<Decimal>);
+```
+
+### Files to Update
+- `src/strategies/utils.rs` (add shared utilities)
+- `src/strategies/macros.rs` (add helper macros)
+- All strategy files (refactor to use shared code)
+- `src/strategies/mod.rs` (export new traits)
+
+## Estimated Effort
+
+**High (8-12 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #7: Reduce unnecessary clone() calls

--- a/.windsurf/issues/issue_007_reduce_clone_calls.md
+++ b/.windsurf/issues/issue_007_reduce_clone_calls.md
@@ -1,0 +1,119 @@
+# Issue #7: Reduce unnecessary `.clone()` calls
+
+## Title
+`perf: Reduce unnecessary clone() calls across the codebase`
+
+## Labels
+- `performance`
+- `refactor`
+- `priority-medium`
+
+## Description
+
+The codebase contains **795 occurrences** of `.clone()`. Many of these could be avoided with better use of references, `Cow<T>`, or `Arc<T>`.
+
+### Current State
+- 795 `.clone()` calls across the codebase
+- Unnecessary memory allocations
+- Potential performance impact in hot paths
+
+### Target State
+- Clone count reduced by at least 50%
+- No unnecessary memory allocations
+- Improved performance in critical paths
+
+### Top Files by Clone Count
+
+| File | Count |
+|------|-------|
+| `chains/chain.rs` | 55 |
+| `strategies/short_strangle.rs` | 49 |
+| `strategies/iron_condor.rs` | 46 |
+| `strategies/call_butterfly.rs` | 39 |
+| `strategies/iron_butterfly.rs` | 38 |
+
+## Tasks
+
+- [ ] Audit `.clone()` calls in high-frequency code paths
+- [ ] Categorize clones by necessity:
+  - Required for ownership transfer
+  - Can be replaced with reference
+  - Can use `Cow<'_, T>`
+  - Can use `Arc<T>` for shared data
+- [ ] Replace unnecessary clones with references
+- [ ] Use `Cow<'_, T>` for data that is rarely modified
+- [ ] Use `Arc<T>` for shared data in multi-threaded contexts
+- [ ] Benchmark critical paths before and after
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Clone count reduced by at least 50%
+- [ ] No performance regression (verified by benchmarks)
+- [ ] All tests pass
+- [ ] Code remains readable and maintainable
+
+## Technical Notes
+
+### Common Patterns to Apply
+
+```rust
+// Before: Unnecessary clone
+fn process(data: &MyStruct) {
+    let owned = data.clone();
+    do_something(&owned);
+}
+
+// After: Use reference directly
+fn process(data: &MyStruct) {
+    do_something(data);
+}
+```
+
+```rust
+// Before: Clone for potential modification
+fn maybe_modify(data: String) -> String {
+    if should_modify() {
+        data.to_uppercase()
+    } else {
+        data
+    }
+}
+
+// After: Use Cow for lazy cloning
+fn maybe_modify(data: &str) -> Cow<'_, str> {
+    if should_modify() {
+        Cow::Owned(data.to_uppercase())
+    } else {
+        Cow::Borrowed(data)
+    }
+}
+```
+
+```rust
+// Before: Clone for sharing
+let config = config.clone();
+thread::spawn(move || use_config(&config));
+
+// After: Use Arc for sharing
+let config = Arc::new(config);
+let config_clone = Arc::clone(&config);
+thread::spawn(move || use_config(&config_clone));
+```
+
+### Files to Update
+- `src/chains/chain.rs`
+- `src/strategies/*.rs`
+- Other files with high clone counts
+
+## Estimated Effort
+
+**Medium (4-6 hours)**
+
+## Dependencies
+
+- Issue #6 (may reduce clones as side effect)
+
+## Related Issues
+
+- Issue #6: Extract common strategy logic

--- a/.windsurf/issues/issue_008_implement_collar.md
+++ b/.windsurf/issues/issue_008_implement_collar.md
@@ -1,0 +1,133 @@
+# Issue #8: Implement Collar strategy
+
+## Title
+`feat: Complete implementation of Collar strategy`
+
+## Labels
+- `enhancement`
+- `strategies`
+- `priority-medium`
+
+## Description
+
+The file `src/strategies/collar.rs` is almost empty (**388 bytes**). The Collar strategy is an important protective strategy that should be fully implemented.
+
+### What is a Collar?
+
+A Collar is a protective options strategy that involves:
+1. **Long stock position** (or equivalent)
+2. **Long put** (protective put) at a lower strike
+3. **Short call** (covered call) at a higher strike
+
+The strategy limits both upside and downside, creating a "collar" around the current price.
+
+### Current State
+- File exists but is essentially empty
+- Strategy is not functional
+- Missing from available strategies
+
+### Target State
+- Fully functional Collar strategy
+- All required traits implemented
+- Comprehensive tests and documentation
+
+## Tasks
+
+- [ ] Implement `Collar` struct with all required fields:
+  - Underlying position (stock/spot)
+  - Long put position
+  - Short call position
+  - Break-even points
+- [ ] Implement `Strategable` trait
+- [ ] Implement `StrategyConstructor` trait
+- [ ] Implement `Profit` calculations
+- [ ] Implement `Greeks` calculations
+- [ ] Implement `DeltaNeutrality` trait
+- [ ] Implement `Graph` trait for visualization
+- [ ] Implement `ProbabilityAnalysis` trait
+- [ ] Add comprehensive tests
+- [ ] Add documentation with examples
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Collar strategy is fully functional
+- [ ] All trait implementations are complete
+- [ ] Tests cover edge cases
+- [ ] Documentation includes usage examples
+- [ ] Strategy appears in prelude exports
+
+## Technical Notes
+
+### Collar Structure
+
+```rust
+pub struct Collar {
+    /// Name/identifier for the strategy
+    pub name: String,
+    /// Underlying asset symbol
+    pub symbol: String,
+    /// Current underlying price
+    pub underlying_price: Positive,
+    /// Long put strike (lower)
+    pub put_strike: Positive,
+    /// Short call strike (upper)
+    pub call_strike: Positive,
+    /// Expiration date
+    pub expiration: ExpirationDate,
+    /// Implied volatility
+    pub implied_volatility: Positive,
+    /// Quantity of underlying shares
+    pub quantity: Positive,
+    /// Long put position
+    pub long_put: Position,
+    /// Short call position
+    pub short_call: Position,
+    /// Underlying position (spot leg)
+    pub underlying: Position,
+    /// Break-even points
+    pub break_even_points: Vec<Positive>,
+}
+```
+
+### Profit/Loss Profile
+
+```
+Profit
+  ^
+  |     ___________  <- Max profit (capped by short call)
+  |    /
+  |   /
+  |--/-------------> Underlying Price
+  | /
+  |/______________ <- Max loss (limited by long put)
+  |
+```
+
+### Key Formulas
+
+```
+Max Profit = Call Strike - Entry Price + Net Premium
+Max Loss = Entry Price - Put Strike - Net Premium
+Break-even = Entry Price - Net Premium (if credit)
+           = Entry Price + Net Premium (if debit)
+```
+
+### Files to Create/Update
+- `src/strategies/collar.rs` (implement)
+- `src/strategies/mod.rs` (export)
+- `src/prelude.rs` (add to prelude)
+- `tests/unit/strategies/collar_test.rs` (tests)
+
+## Estimated Effort
+
+**High (6-8 hours)**
+
+## Dependencies
+
+- Requires spot/underlying leg support (Issue #198)
+
+## Related Issues
+
+- Issue #9: Implement Protective Put strategy
+- Issue #198: Base asset legs implementation

--- a/.windsurf/issues/issue_009_implement_protective_put.md
+++ b/.windsurf/issues/issue_009_implement_protective_put.md
@@ -1,0 +1,126 @@
+# Issue #9: Implement Protective Put strategy
+
+## Title
+`feat: Complete implementation of Protective Put strategy`
+
+## Labels
+- `enhancement`
+- `strategies`
+- `priority-medium`
+
+## Description
+
+The file `src/strategies/protective_put.rs` is almost empty (**358 bytes**). The Protective Put is a fundamental hedging strategy that should be fully implemented.
+
+### What is a Protective Put?
+
+A Protective Put (also known as a "married put") is a hedging strategy that involves:
+1. **Long stock position** (or equivalent)
+2. **Long put** at or below the current price
+
+The strategy provides downside protection while maintaining unlimited upside potential.
+
+### Current State
+- File exists but is essentially empty
+- Strategy is not functional
+- Missing from available strategies
+
+### Target State
+- Fully functional Protective Put strategy
+- All required traits implemented
+- Comprehensive tests and documentation
+
+## Tasks
+
+- [ ] Implement `ProtectivePut` struct with all required fields:
+  - Underlying position (stock/spot)
+  - Long put position
+  - Break-even points
+- [ ] Implement `Strategable` trait
+- [ ] Implement `StrategyConstructor` trait
+- [ ] Implement `Profit` calculations
+- [ ] Implement `Greeks` calculations
+- [ ] Implement `DeltaNeutrality` trait
+- [ ] Implement `Graph` trait for visualization
+- [ ] Implement `ProbabilityAnalysis` trait
+- [ ] Add comprehensive tests
+- [ ] Add documentation with examples
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Protective Put strategy is fully functional
+- [ ] All trait implementations are complete
+- [ ] Tests cover edge cases
+- [ ] Documentation includes usage examples
+- [ ] Strategy appears in prelude exports
+
+## Technical Notes
+
+### Protective Put Structure
+
+```rust
+pub struct ProtectivePut {
+    /// Name/identifier for the strategy
+    pub name: String,
+    /// Underlying asset symbol
+    pub symbol: String,
+    /// Current underlying price
+    pub underlying_price: Positive,
+    /// Put strike price
+    pub put_strike: Positive,
+    /// Expiration date
+    pub expiration: ExpirationDate,
+    /// Implied volatility
+    pub implied_volatility: Positive,
+    /// Quantity of underlying shares
+    pub quantity: Positive,
+    /// Long put position
+    pub long_put: Position,
+    /// Underlying position (spot leg)
+    pub underlying: Position,
+    /// Break-even point
+    pub break_even_points: Vec<Positive>,
+}
+```
+
+### Profit/Loss Profile
+
+```
+Profit
+  ^
+  |                    /
+  |                   /
+  |                  /  <- Unlimited upside
+  |                 /
+  |-----------------/---> Underlying Price
+  |________________/
+  |                 <- Max loss = Entry - Strike + Premium
+```
+
+### Key Formulas
+
+```
+Max Profit = Unlimited
+Max Loss = (Entry Price - Put Strike) + Put Premium
+Break-even = Entry Price + Put Premium
+```
+
+### Files to Create/Update
+- `src/strategies/protective_put.rs` (implement)
+- `src/strategies/mod.rs` (export)
+- `src/prelude.rs` (add to prelude)
+- `tests/unit/strategies/protective_put_test.rs` (tests)
+
+## Estimated Effort
+
+**Medium (4-6 hours)**
+
+## Dependencies
+
+- Requires spot/underlying leg support (Issue #198)
+
+## Related Issues
+
+- Issue #8: Implement Collar strategy
+- Issue #198: Base asset legs implementation

--- a/.windsurf/issues/issue_010_error_context_anyhow.md
+++ b/.windsurf/issues/issue_010_error_context_anyhow.md
@@ -1,0 +1,85 @@
+# Issue #10: Improve error context with anyhow
+
+## Title
+`refactor: Add error context using anyhow at API boundaries`
+
+## Labels
+- `refactor`
+- `error-handling`
+- `priority-low`
+
+## Description
+
+While the project uses `thiserror` for typed errors, adding `anyhow::Context` at API boundaries would improve error messages for users.
+
+### Current State
+- Errors use `thiserror` for type safety
+- Error messages may lack context about what operation failed
+- Users may struggle to debug issues
+
+### Target State
+- Error messages include context about what operation failed
+- Existing error types are preserved
+- Better debugging experience for library users
+
+## Tasks
+
+- [ ] Add `anyhow` as a dependency in `Cargo.toml`
+- [ ] Identify public API boundaries where context would help
+- [ ] Add `.context()` calls to provide meaningful error messages
+- [ ] Update error documentation
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Error messages include context about what operation failed
+- [ ] Existing error types are preserved
+- [ ] No breaking changes to public API
+- [ ] Documentation updated with error handling examples
+
+## Technical Notes
+
+### Adding Context Pattern
+
+```rust
+use anyhow::{Context, Result};
+
+// Before
+pub fn load_chain(path: &str) -> Result<OptionChain, ChainError> {
+    let data = std::fs::read_to_string(path)?;
+    serde_json::from_str(&data)?
+}
+
+// After
+pub fn load_chain(path: &str) -> Result<OptionChain, anyhow::Error> {
+    let data = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read option chain from '{}'", path))?;
+    
+    serde_json::from_str(&data)
+        .with_context(|| format!("Failed to parse option chain JSON from '{}'", path))
+}
+```
+
+### Where to Add Context
+- File I/O operations
+- Network requests (if any)
+- Complex calculations that can fail
+- Strategy construction
+- Chain loading/parsing
+
+### Files to Update
+- `Cargo.toml` (add dependency)
+- Public API functions across modules
+- Error documentation
+
+## Estimated Effort
+
+**Low (2-3 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #1-#3: Error handling improvements

--- a/.windsurf/issues/issue_011_add_benchmarks.md
+++ b/.windsurf/issues/issue_011_add_benchmarks.md
@@ -1,0 +1,114 @@
+# Issue #11: Add benchmarks for critical paths
+
+## Title
+`test: Add comprehensive benchmarks for critical code paths`
+
+## Labels
+- `testing`
+- `performance`
+- `priority-low`
+
+## Description
+
+Currently there is only one benchmark file. Adding more benchmarks will help identify performance regressions and guide optimization efforts.
+
+### Current State
+- Limited benchmark coverage
+- No baseline performance metrics documented
+- Difficult to detect performance regressions
+
+### Target State
+- Comprehensive benchmarks for all critical paths
+- Baseline metrics documented
+- CI can detect performance regressions
+
+## Tasks
+
+- [ ] Add benchmarks for Greeks calculations:
+  - Delta, Gamma, Theta, Vega, Rho
+  - Individual and batch calculations
+- [ ] Add benchmarks for Black-Scholes pricing:
+  - Call and put pricing
+  - With and without Greeks
+- [ ] Add benchmarks for option chain construction:
+  - Chain building from parameters
+  - Chain loading from JSON/CSV
+- [ ] Add benchmarks for strategy profit calculations:
+  - Single point P&L
+  - P&L curve generation
+- [ ] Add benchmarks for optimization routines:
+  - Strategy optimization
+  - Delta neutrality adjustments
+- [ ] Document baseline performance metrics
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Benchmarks cover all critical code paths
+- [ ] Baseline metrics are documented in README or docs
+- [ ] Benchmarks run in CI (optional but recommended)
+- [ ] No significant performance regressions detected
+
+## Technical Notes
+
+### Benchmark Structure
+
+```rust
+// benches/greeks_bench.rs
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use optionstratlib::prelude::*;
+
+fn delta_benchmark(c: &mut Criterion) {
+    let option = create_test_option();
+    
+    c.bench_function("delta_calculation", |b| {
+        b.iter(|| {
+            black_box(option.delta())
+        })
+    });
+}
+
+fn greeks_batch_benchmark(c: &mut Criterion) {
+    let options: Vec<Options> = create_test_options(1000);
+    
+    c.bench_function("greeks_batch_1000", |b| {
+        b.iter(|| {
+            for opt in &options {
+                black_box(opt.greeks());
+            }
+        })
+    });
+}
+
+criterion_group!(benches, delta_benchmark, greeks_batch_benchmark);
+criterion_main!(benches);
+```
+
+### Benchmark Categories
+
+| Category | Benchmarks |
+|----------|------------|
+| Greeks | delta, gamma, theta, vega, rho, all_greeks |
+| Pricing | bs_call, bs_put, binomial, monte_carlo |
+| Chains | build_chain, load_json, filter_chain |
+| Strategies | profit_at_price, profit_curve, break_even |
+| Optimization | find_optimal, delta_adjust |
+
+### Files to Create
+- `benches/greeks_bench.rs`
+- `benches/pricing_bench.rs`
+- `benches/chain_bench.rs`
+- `benches/strategy_bench.rs`
+- `benches/mod.rs` (update)
+
+## Estimated Effort
+
+**Medium (4-6 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #7: Reduce unnecessary clone() calls (benchmarks will help verify)

--- a/.windsurf/issues/issue_012_property_based_testing.md
+++ b/.windsurf/issues/issue_012_property_based_testing.md
@@ -1,0 +1,134 @@
+# Issue #12: Add property-based testing
+
+## Title
+`test: Add property-based testing for mathematical invariants`
+
+## Labels
+- `testing`
+- `quality`
+- `priority-low`
+
+## Description
+
+Add property-based testing using `proptest` to validate mathematical invariants like Put-Call Parity and Greeks bounds.
+
+### Current State
+- Tests use specific example values
+- Mathematical invariants not systematically tested
+- Edge cases may be missed
+
+### Target State
+- Property-based tests cover key mathematical invariants
+- Tests run as part of the test suite
+- Higher confidence in mathematical correctness
+
+## Tasks
+
+- [ ] Add `proptest` as a dev dependency
+- [ ] Add property tests for Put-Call Parity:
+  - `C - P = S - K * e^(-rT)`
+- [ ] Add property tests for Greeks bounds:
+  - `0 ≤ delta ≤ 1` for calls
+  - `-1 ≤ delta ≤ 0` for puts
+  - `gamma ≥ 0` for all options
+- [ ] Add property tests for arbitrage-free pricing:
+  - `C ≥ max(0, S - K * e^(-rT))`
+  - `P ≥ max(0, K * e^(-rT) - S)`
+- [ ] Add property tests for Positive type invariants:
+  - Value is always > 0
+  - Operations preserve positivity where expected
+- [ ] Add property tests for strategy invariants:
+  - Break-even points are within valid range
+  - Max profit/loss are consistent
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Property tests cover key mathematical invariants
+- [ ] Tests run as part of the test suite
+- [ ] No false positives in normal operation
+- [ ] Edge cases are properly handled
+
+## Technical Notes
+
+### Put-Call Parity Test
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_put_call_parity(
+        s in 10.0f64..1000.0,
+        k in 10.0f64..1000.0,
+        r in 0.0f64..0.2,
+        sigma in 0.05f64..1.0,
+        t in 0.01f64..2.0,
+    ) {
+        let s = pos!(s);
+        let k = pos!(k);
+        let sigma = pos!(sigma);
+        let t = pos!(t);
+        
+        let call = black_scholes_call(s, k, r, sigma, t);
+        let put = black_scholes_put(s, k, r, sigma, t);
+        
+        let parity_lhs = call - put;
+        let parity_rhs = s.to_dec() - k.to_dec() * (-r * t.to_dec()).exp();
+        
+        prop_assert!((parity_lhs - parity_rhs).abs() < dec!(0.0001));
+    }
+}
+```
+
+### Greeks Bounds Test
+
+```rust
+proptest! {
+    #[test]
+    fn test_call_delta_bounds(
+        s in 10.0f64..1000.0,
+        k in 10.0f64..1000.0,
+        sigma in 0.05f64..1.0,
+        t in 0.01f64..2.0,
+    ) {
+        let option = create_call_option(s, k, sigma, t);
+        let delta = option.delta().unwrap();
+        
+        prop_assert!(delta >= dec!(0.0));
+        prop_assert!(delta <= dec!(1.0));
+    }
+    
+    #[test]
+    fn test_gamma_non_negative(
+        s in 10.0f64..1000.0,
+        k in 10.0f64..1000.0,
+        sigma in 0.05f64..1.0,
+        t in 0.01f64..2.0,
+    ) {
+        let option = create_call_option(s, k, sigma, t);
+        let gamma = option.gamma().unwrap();
+        
+        prop_assert!(gamma >= dec!(0.0));
+    }
+}
+```
+
+### Files to Create/Update
+- `Cargo.toml` (add proptest dependency)
+- `tests/property/mod.rs`
+- `tests/property/put_call_parity_test.rs`
+- `tests/property/greeks_bounds_test.rs`
+- `tests/property/positive_invariants_test.rs`
+
+## Estimated Effort
+
+**Medium (4-6 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #11: Add benchmarks for critical paths

--- a/.windsurf/issues/issue_013_async_feature_flag.md
+++ b/.windsurf/issues/issue_013_async_feature_flag.md
@@ -1,0 +1,110 @@
+# Issue #13: Add async feature flag for I/O operations
+
+## Title
+`feat: Add async feature flag for asynchronous I/O operations`
+
+## Labels
+- `enhancement`
+- `feature`
+- `priority-low`
+
+## Description
+
+Add an optional `async` feature flag that enables asynchronous I/O operations for loading option chains and market data.
+
+### Current State
+- All I/O operations are synchronous
+- May block the main thread during data loading
+- Not suitable for async applications
+
+### Target State
+- Async feature is optional and doesn't affect sync users
+- Async API mirrors sync API
+- Better integration with async runtimes
+
+## Tasks
+
+- [ ] Add `tokio` as an optional dependency in `Cargo.toml`
+- [ ] Create `async` feature flag in `Cargo.toml`
+- [ ] Add async versions of file loading functions:
+  - `load_chain_async`
+  - `read_ohlcv_async`
+- [ ] Add async versions of data fetching functions (if applicable)
+- [ ] Ensure feature doesn't affect sync users
+- [ ] Add documentation for async usage
+- [ ] Add async examples
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] Async feature is optional and doesn't affect sync users
+- [ ] Async API mirrors sync API
+- [ ] Documentation explains when to use async
+- [ ] Examples demonstrate async usage
+- [ ] No performance regression for sync users
+
+## Technical Notes
+
+### Cargo.toml Changes
+
+```toml
+[features]
+default = []
+plotly = ["dep:plotly"]
+async = ["tokio"]
+
+[dependencies]
+tokio = { version = "1", features = ["fs", "io-util"], optional = true }
+```
+
+### Async API Pattern
+
+```rust
+// src/chains/chain.rs
+
+impl OptionChain {
+    /// Loads an option chain from a JSON file (sync version)
+    pub fn load_from_json(path: &str) -> Result<Self, ChainError> {
+        let data = std::fs::read_to_string(path)?;
+        serde_json::from_str(&data).map_err(ChainError::from)
+    }
+    
+    /// Loads an option chain from a JSON file (async version)
+    #[cfg(feature = "async")]
+    pub async fn load_from_json_async(path: &str) -> Result<Self, ChainError> {
+        let data = tokio::fs::read_to_string(path).await?;
+        serde_json::from_str(&data).map_err(ChainError::from)
+    }
+}
+```
+
+### Example Usage
+
+```rust
+// examples/async_chain_loading.rs
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let chain = OptionChain::load_from_json_async("data/options.json").await?;
+    println!("Loaded {} options", chain.options.len());
+    Ok(())
+}
+```
+
+### Files to Update
+- `Cargo.toml` (add feature and dependency)
+- `src/chains/chain.rs` (add async methods)
+- `src/utils/csv.rs` (add async methods)
+- `examples/` (add async examples)
+
+## Estimated Effort
+
+**Medium (4-6 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+None

--- a/.windsurf/issues/issue_014_improve_metrics_docs.md
+++ b/.windsurf/issues/issue_014_improve_metrics_docs.md
@@ -1,0 +1,117 @@
+# Issue #14: Improve documentation for metrics modules
+
+## Title
+`docs: Add comprehensive documentation for metrics modules`
+
+## Labels
+- `documentation`
+- `priority-low`
+
+## Description
+
+The new metrics modules (`composite/`, `liquidity/`, `stress/`, `temporal/`) need more comprehensive documentation with examples.
+
+### Current State
+- Basic documentation exists
+- Limited examples
+- Mathematical background could be expanded
+
+### Target State
+- All public items have documentation
+- Examples are runnable
+- Mathematical formulas are explained
+
+## Tasks
+
+- [ ] Add module-level documentation with overview for:
+  - `src/metrics/composite/` (Vanna-Volga, Delta-Gamma, Smile Dynamics)
+  - `src/metrics/liquidity/` (Bid-Ask Spread, Volume Profile, Open Interest)
+  - `src/metrics/stress/` (Volatility Sensitivity, Time Decay, Price Shock)
+  - `src/metrics/temporal/` (Theta, Charm, Color)
+- [ ] Add examples for each trait implementation
+- [ ] Add mathematical background where appropriate
+- [ ] Add usage examples in doc comments
+- [ ] Verify examples compile with `cargo test --doc`
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] All public items have documentation
+- [ ] Examples are runnable (`cargo test --doc` passes)
+- [ ] Mathematical formulas are explained
+- [ ] Documentation follows library style
+
+## Technical Notes
+
+### Documentation Template
+
+```rust
+/// # Vanna-Volga Hedge Surface
+///
+/// Computes the Vanna-Volga hedge cost surface across price and volatility.
+///
+/// ## Mathematical Background
+///
+/// The Vanna-Volga method adjusts Black-Scholes prices to account for
+/// the volatility smile using three benchmark options:
+///
+/// ```text
+/// Price_VV = Price_BS + Vanna × (σ_market - σ_ATM) × S × √T
+///          + 0.5 × Volga × (σ_market - σ_ATM)²
+/// ```
+///
+/// ## Example
+///
+/// ```rust
+/// use optionstratlib::prelude::*;
+/// use optionstratlib::metrics::VannaVolgaSurface;
+///
+/// let chain = OptionChain::new("SPY", pos!(450.0), "2024-12-31".to_string(), None, None);
+/// let price_range = (pos!(400.0), pos!(500.0));
+/// let vol_range = (pos!(0.10), pos!(0.40));
+///
+/// let surface = chain.vanna_volga_surface(price_range, vol_range, 20, 20)?;
+/// println!("Surface has {} points", surface.points.len());
+/// # Ok::<(), optionstratlib::error::SurfaceError>(())
+/// ```
+///
+/// ## Returns
+///
+/// A `Surface` where:
+/// - **X-axis**: Underlying price in currency units
+/// - **Y-axis**: Implied volatility as a decimal
+/// - **Z-axis**: Vanna-Volga hedge cost/adjustment
+pub trait VannaVolgaSurface {
+    // ...
+}
+```
+
+### Files to Update
+- `src/metrics/composite/mod.rs`
+- `src/metrics/composite/vanna_volga.rs`
+- `src/metrics/composite/delta_gamma_profile.rs`
+- `src/metrics/composite/smile_dynamics.rs`
+- `src/metrics/liquidity/mod.rs`
+- `src/metrics/liquidity/bid_ask_spread.rs`
+- `src/metrics/liquidity/volume_profile.rs`
+- `src/metrics/liquidity/open_interest.rs`
+- `src/metrics/stress/mod.rs`
+- `src/metrics/stress/volatility_sensitivity.rs`
+- `src/metrics/stress/time_decay.rs`
+- `src/metrics/stress/price_shock.rs`
+- `src/metrics/temporal/mod.rs`
+- `src/metrics/temporal/theta.rs`
+- `src/metrics/temporal/charm.rs`
+- `src/metrics/temporal/color.rs`
+
+## Estimated Effort
+
+**Low (2-4 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+None

--- a/.windsurf/issues/issue_015_reduce_expect_usage.md
+++ b/.windsurf/issues/issue_015_reduce_expect_usage.md
@@ -1,0 +1,118 @@
+# Issue #15: Reduce `.expect()` usage in production code
+
+## Title
+`refactor: Replace expect() calls with proper error handling`
+
+## Labels
+- `refactor`
+- `error-handling`
+- `priority-medium`
+
+## Description
+
+The codebase contains **163 occurrences** of `.expect()`. While better than `.unwrap()`, these should still be replaced with proper error handling in production code.
+
+### Current State
+- 163 `.expect()` calls across the codebase
+- Better than `.unwrap()` but still can panic
+- Error messages are static strings
+
+### Target State
+- `.expect()` only used in tests and initialization code
+- Production code uses proper error handling
+- Error messages are preserved or improved
+
+### Top Files by Expect Count
+
+| File | Count |
+|------|-------|
+| `pnl/metrics.rs` | 37 |
+| `model/format.rs` | 14 |
+| `strategies/iron_butterfly.rs` | 8 |
+| `strategies/iron_condor.rs` | 8 |
+| `curves/visualization/plotters.rs` | 7 |
+
+## Tasks
+
+- [ ] Audit `.expect()` calls in production code
+- [ ] Focus on high-impact files first:
+  - `pnl/metrics.rs` (37 occurrences)
+  - `model/format.rs` (14 occurrences)
+- [ ] Categorize by:
+  - Can be replaced with `?` operator
+  - Can use `unwrap_or_else()` with logging
+  - Is truly unreachable (document with `unreachable!()`)
+- [ ] Replace with `?` operator or proper error handling
+- [ ] Keep `.expect()` only in tests and initialization code
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] `.expect()` only used in tests and initialization
+- [ ] All existing tests pass
+- [ ] Error messages are preserved or improved
+- [ ] No panics in production code paths
+
+## Technical Notes
+
+### Replacement Patterns
+
+```rust
+// Before: expect in production code
+let value = some_result.expect("Failed to get value");
+
+// After Option 1: Propagate error
+let value = some_result.map_err(|e| MyError::from(e))?;
+
+// After Option 2: Log and use default
+let value = some_result.unwrap_or_else(|e| {
+    tracing::warn!("Failed to get value: {}", e);
+    default_value()
+});
+
+// After Option 3: Document unreachable
+let value = some_result.unwrap_or_else(|_| {
+    unreachable!("This case is impossible because...")
+});
+```
+
+### When `.expect()` is Acceptable
+
+1. **Tests**: Panicking on failure is expected behavior
+2. **Initialization**: One-time setup that must succeed
+3. **Truly unreachable**: When logic guarantees success (document why)
+
+```rust
+// Acceptable in tests
+#[test]
+fn test_something() {
+    let result = do_thing().expect("should succeed in test");
+    assert_eq!(result, expected);
+}
+
+// Acceptable in initialization
+lazy_static! {
+    static ref REGEX: Regex = Regex::new(r"^\d+$").expect("valid regex");
+}
+```
+
+### Files to Update
+- `src/pnl/metrics.rs`
+- `src/model/format.rs`
+- `src/strategies/iron_butterfly.rs`
+- `src/strategies/iron_condor.rs`
+- Other files with `.expect()` calls
+
+## Estimated Effort
+
+**Medium (3-5 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #1: Reduce unwrap() in chains/chain.rs
+- Issue #2: Reduce unwrap() in greeks/equations.rs
+- Issue #3: Reduce unwrap() in model/option.rs

--- a/.windsurf/issues/issue_016_improve_positive_type.md
+++ b/.windsurf/issues/issue_016_improve_positive_type.md
@@ -1,0 +1,259 @@
+# Issue #16: Improve `Positive` type safety and API
+
+## Title
+`refactor: Improve Positive type to eliminate panics and enhance type safety`
+
+## Labels
+- `refactor`
+- `type-safety`
+- `error-handling`
+- `priority-high`
+
+## Description
+
+The `Positive` type in `src/model/positive.rs` is a wrapper around `Decimal` that guarantees non-negative values. However, the current implementation has several issues that can lead to runtime panics and violate the positivity invariant.
+
+### Current State
+- **50+ `.unwrap()` calls** in conversion methods that can panic
+- **Arithmetic operations that panic** when results would be negative
+- **`to_dec_ref_mut()` method** that allows breaking the invariant
+- **`From` implementations that panic** instead of using `TryFrom`
+- **`is_multiple()` uses `f64::EPSILON`** instead of `Decimal` precision
+
+### Target State
+- Zero panics in production code paths
+- Safe arithmetic operations with `checked_*` and `saturating_*` variants
+- Invariant cannot be violated through public API
+- `TryFrom` for fallible conversions
+- Proper `Decimal`-based precision for comparisons
+
+## Tasks
+
+### Phase 1: Add Safe Conversion Methods
+- [ ] Add `to_f64_checked(&self) -> Option<f64>`
+- [ ] Add `to_f64_lossy(&self) -> f64` (returns 0.0 on failure)
+- [ ] Add `to_i64_checked(&self) -> Option<i64>`
+- [ ] Add `to_u64_checked(&self) -> Option<u64>`
+- [ ] Add `to_usize_checked(&self) -> Option<usize>`
+- [ ] Add `#[must_use]` to all methods that return values
+- [ ] Deprecate panicking versions with `#[deprecated]`
+
+### Phase 2: Add Safe Arithmetic Operations
+- [ ] Create `CheckedOps` trait with:
+  - `checked_sub(&self, rhs: &Self) -> Result<Self, DecimalError>`
+  - `checked_div(&self, rhs: &Self) -> Result<Self, DecimalError>`
+- [ ] Create `SaturatingOps` trait with:
+  - `saturating_sub(&self, rhs: &Self) -> Self` (returns ZERO if negative)
+- [ ] Add `sqrt_checked(&self) -> Result<Positive, DecimalError>`
+- [ ] Add `ln_checked(&self) -> Result<Decimal, DecimalError>` (ln can be negative)
+
+### Phase 3: Fix Invariant Violations
+- [ ] Remove or make `to_dec_ref_mut()` private (`pub(crate)`)
+- [ ] Review all `impl From<T> for Positive` and convert to `TryFrom`
+- [ ] Add `const unsafe fn new_unchecked(value: Decimal) -> Self` for performance-critical code
+- [ ] Document safety requirements for `new_unchecked`
+
+### Phase 4: Improve Precision
+- [ ] Change `is_multiple(&self, other: f64)` to `is_multiple(&self, other: Positive)`
+- [ ] Use `EPSILON` constant from `constants.rs` instead of `f64::EPSILON`
+
+### Phase 5: Add NonZeroPositive Type (Optional)
+- [ ] Create `NonZeroPositive` struct for values > 0 (not >= 0)
+- [ ] Implement conversions between `Positive` and `NonZeroPositive`
+- [ ] Use for division denominators and other cases requiring > 0
+
+### Phase 6: Update Tests and Documentation
+- [ ] Add tests for all new `_checked` methods
+- [ ] Add tests for `saturating_*` operations
+- [ ] Update documentation with panic conditions
+- [ ] Add examples showing safe vs unsafe usage patterns
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+## Acceptance Criteria
+
+- [ ] No `.unwrap()` in non-test code paths (except where mathematically impossible to fail)
+- [ ] All arithmetic operations have safe alternatives
+- [ ] `to_dec_ref_mut()` is not publicly accessible
+- [ ] All `From` implementations that can fail are converted to `TryFrom`
+- [ ] All methods that return values have `#[must_use]`
+- [ ] All existing tests pass
+- [ ] New tests cover edge cases
+
+## Technical Notes
+
+### Safe Conversion Pattern
+
+```rust
+impl Positive {
+    /// Converts to f64, returning None if conversion fails.
+    #[must_use]
+    pub fn to_f64_checked(&self) -> Option<f64> {
+        self.0.to_f64()
+    }
+
+    /// Converts to f64 with lossy conversion (returns 0.0 on failure).
+    #[must_use]
+    pub fn to_f64_lossy(&self) -> f64 {
+        self.0.to_f64().unwrap_or(0.0)
+    }
+
+    /// Converts to f64.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the value cannot be represented as f64.
+    /// Consider using `to_f64_checked()` or `to_f64_lossy()` instead.
+    #[deprecated(since = "0.15.0", note = "Use to_f64_checked() or to_f64_lossy() instead")]
+    pub fn to_f64(&self) -> f64 {
+        self.0.to_f64().unwrap()
+    }
+}
+```
+
+### Checked Arithmetic Pattern
+
+```rust
+/// Trait for checked arithmetic operations on Positive values.
+pub trait CheckedOps {
+    type Error;
+    
+    /// Checked subtraction that returns Result instead of panicking.
+    fn checked_sub(&self, rhs: &Self) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+impl CheckedOps for Positive {
+    type Error = DecimalError;
+    
+    fn checked_sub(&self, rhs: &Self) -> Result<Self, DecimalError> {
+        let result = self.0 - rhs.0;
+        Positive::new_decimal(result)
+    }
+}
+
+/// Trait for saturating arithmetic operations on Positive values.
+pub trait SaturatingOps {
+    /// Saturating subtraction that returns ZERO instead of negative.
+    fn saturating_sub(&self, rhs: &Self) -> Self
+    where
+        Self: Sized;
+}
+
+impl SaturatingOps for Positive {
+    fn saturating_sub(&self, rhs: &Self) -> Self {
+        if self.0 > rhs.0 {
+            Positive(self.0 - rhs.0)
+        } else {
+            Positive::ZERO
+        }
+    }
+}
+```
+
+### TryFrom Pattern
+
+```rust
+// Replace this:
+impl From<f64> for Positive {
+    fn from(value: f64) -> Self {
+        Positive::new(value).expect("Value must be positive")
+    }
+}
+
+// With this:
+impl TryFrom<f64> for Positive {
+    type Error = DecimalError;
+    
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Positive::new(value)
+    }
+}
+```
+
+### NonZeroPositive Type (Optional)
+
+```rust
+/// A wrapper type that represents a strictly positive decimal value (> 0).
+/// 
+/// Unlike `Positive` which allows zero, `NonZeroPositive` guarantees
+/// the value is always greater than zero. This is useful for:
+/// - Division denominators
+/// - Volatility values
+/// - Time to expiration
+#[derive(PartialEq, Clone, Copy, Hash, ToSchema)]
+pub struct NonZeroPositive(Decimal);
+
+impl NonZeroPositive {
+    pub fn new(value: f64) -> Result<Self, DecimalError> {
+        let dec = Decimal::from_f64(value);
+        match dec {
+            Some(value) if value > Decimal::ZERO => Ok(NonZeroPositive(value)),
+            Some(_) => Err(DecimalError::OutOfBounds {
+                value,
+                min: f64::MIN_POSITIVE,
+                max: f64::MAX,
+            }),
+            None => Err(DecimalError::ConversionError { ... }),
+        }
+    }
+    
+    /// Converts to Positive (always succeeds).
+    #[must_use]
+    pub fn to_positive(self) -> Positive {
+        Positive(self.0)
+    }
+}
+
+impl From<NonZeroPositive> for Positive {
+    fn from(value: NonZeroPositive) -> Self {
+        Positive(value.0)
+    }
+}
+```
+
+## Files to Update
+
+- `src/model/positive.rs` (primary)
+- `src/error/decimal.rs` (add new error variants if needed)
+- `src/constants.rs` (verify EPSILON usage)
+- `src/prelude.rs` (export new traits)
+- Tests throughout the codebase that use `Positive`
+
+## Estimated Effort
+
+**High (8-12 hours)**
+
+## Dependencies
+
+None
+
+## Related Issues
+
+- Issue #1: Reduce unwrap() in chains/chain.rs
+- Issue #2: Reduce unwrap() in greeks/equations.rs
+- Issue #3: Reduce unwrap() in model/option.rs
+
+## Breaking Changes
+
+This issue introduces breaking changes:
+
+1. **`From<f64>` → `TryFrom<f64>`**: Code using `.into()` will need to use `try_into()` or `Positive::new()`
+2. **`to_dec_ref_mut()` removal**: Code modifying the inner value will need refactoring
+3. **Deprecation warnings**: Existing code using `to_f64()`, `to_i64()`, etc. will show warnings
+
+### Migration Guide
+
+```rust
+// Before
+let p: Positive = 5.0.into();
+let f = p.to_f64();
+
+// After
+let p = Positive::new(5.0)?;  // or use pos! macro
+let f = p.to_f64_lossy();     // or to_f64_checked().unwrap_or(0.0)
+```
+
+---
+
+*Generated on: 2024-12-25*

--- a/.windsurf/issues/issue_017_unwrap_model_remaining.md
+++ b/.windsurf/issues/issue_017_unwrap_model_remaining.md
@@ -1,0 +1,222 @@
+# Issue #17: Reduce `.unwrap()` usage in remaining `src/model` files
+
+## Title
+`refactor: Replace unwrap() calls with proper error handling in src/model (excluding option.rs and positive.rs)`
+
+## Labels
+- `refactor`
+- `error-handling`
+- `priority-high`
+
+## Description
+
+The `src/model` directory contains **440 occurrences** of `.unwrap()` across 18 files. This issue focuses on the files **not already covered** by other issues:
+
+- **Issue #3** covers `model/option.rs` (134 occurrences)
+- **Issue #16** covers `model/positive.rs` (50 occurrences)
+
+This issue covers the remaining **256 occurrences** across **16 files**.
+
+### Current State
+
+| File | `.unwrap()` Count |
+|------|-------------------|
+| `position.rs` | 116 |
+| `expiration.rs` | 72 |
+| `trade.rs` | 14 |
+| `decimal.rs` | 12 |
+| `profit_range.rs` | 9 |
+| `utils.rs` | 7 |
+| `leg/leg_enum.rs` | 5 |
+| `leg/spot.rs` | 5 |
+| `axis.rs` | 4 |
+| `format.rs` | 2 |
+| `leg/future.rs` | 2 |
+| `leg/mod.rs` | 2 |
+| `leg/perpetual.rs` | 2 |
+| `leg/traits.rs` | 2 |
+| `balance.rs` | 1 |
+| `types.rs` | 1 |
+| **Total** | **256** |
+
+### Target State
+- Zero `.unwrap()` calls in production code (only in tests)
+- Proper `Result` types with meaningful error messages
+- Graceful error handling for edge cases
+
+## Tasks
+
+### Phase 1: High-Impact Files (116 + 72 = 188 occurrences)
+
+#### `position.rs` (116 occurrences)
+- [ ] Audit all `.unwrap()` calls in `position.rs`
+- [ ] Replace with `?` operator where function returns `Result`
+- [ ] Use `unwrap_or_default()` or `unwrap_or_else()` where appropriate
+- [ ] Add new error variants to `PositionError` if needed
+
+#### `expiration.rs` (72 occurrences)
+- [ ] Audit all `.unwrap()` calls in `expiration.rs`
+- [ ] Handle date/time parsing errors gracefully
+- [ ] Add proper error types for expiration date operations
+
+### Phase 2: Medium-Impact Files (14 + 12 + 9 + 7 = 42 occurrences)
+
+#### `trade.rs` (14 occurrences)
+- [ ] Audit all `.unwrap()` calls in `trade.rs`
+- [ ] Replace with proper error handling
+
+#### `decimal.rs` (12 occurrences)
+- [ ] Audit all `.unwrap()` calls in `decimal.rs`
+- [ ] Handle decimal conversion errors
+
+#### `profit_range.rs` (9 occurrences)
+- [ ] Audit all `.unwrap()` calls in `profit_range.rs`
+- [ ] Replace with proper error handling
+
+#### `utils.rs` (7 occurrences)
+- [ ] Audit all `.unwrap()` calls in `utils.rs`
+- [ ] Replace with proper error handling
+
+### Phase 3: Low-Impact Files (26 occurrences)
+
+#### `leg/` submodule (18 occurrences total)
+- [ ] `leg/leg_enum.rs` (5 occurrences)
+- [ ] `leg/spot.rs` (5 occurrences)
+- [ ] `leg/future.rs` (2 occurrences)
+- [ ] `leg/mod.rs` (2 occurrences)
+- [ ] `leg/perpetual.rs` (2 occurrences)
+- [ ] `leg/traits.rs` (2 occurrences)
+
+#### Other files (8 occurrences total)
+- [ ] `axis.rs` (4 occurrences)
+- [ ] `format.rs` (2 occurrences)
+- [ ] `balance.rs` (1 occurrence)
+- [ ] `types.rs` (1 occurrence)
+
+### Phase 4: Verification
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+- [ ] Ensure all existing tests pass
+- [ ] Add tests for new error handling paths
+
+## Acceptance Criteria
+
+- [ ] No `.unwrap()` calls remain in production code (only in tests)
+- [ ] All existing tests pass
+- [ ] New error cases are properly documented
+- [ ] Error messages are clear and actionable
+- [ ] No performance regression
+
+## Technical Notes
+
+### Common Patterns to Apply
+
+```rust
+// Before
+let value = some_option.unwrap();
+
+// After - Option 1: Propagate error
+let value = some_option.ok_or(ModelError::MissingValue)?;
+
+// After - Option 2: Default value
+let value = some_option.unwrap_or_default();
+
+// After - Option 3: Computed default
+let value = some_option.unwrap_or_else(|| compute_default());
+
+// After - Option 4: Log and default
+let value = some_option.unwrap_or_else(|| {
+    tracing::warn!("Value missing, using default");
+    default_value()
+});
+```
+
+### Date/Time Handling in `expiration.rs`
+
+```rust
+// Before
+let date = NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap();
+
+// After
+let date = NaiveDate::parse_from_str(s, "%Y-%m-%d")
+    .map_err(|e| ExpirationError::ParseError {
+        input: s.to_string(),
+        reason: e.to_string(),
+    })?;
+```
+
+### Position Calculations
+
+```rust
+// Before
+let delta = position.option.delta().unwrap();
+
+// After
+let delta = position.option.delta()
+    .map_err(|e| PositionError::GreeksCalculationFailed(e))?;
+```
+
+## Files to Update
+
+### Primary Files
+- `src/model/position.rs`
+- `src/model/expiration.rs`
+- `src/model/trade.rs`
+- `src/model/decimal.rs`
+- `src/model/profit_range.rs`
+- `src/model/utils.rs`
+
+### Leg Submodule
+- `src/model/leg/leg_enum.rs`
+- `src/model/leg/spot.rs`
+- `src/model/leg/future.rs`
+- `src/model/leg/mod.rs`
+- `src/model/leg/perpetual.rs`
+- `src/model/leg/traits.rs`
+
+### Other Files
+- `src/model/axis.rs`
+- `src/model/format.rs`
+- `src/model/balance.rs`
+- `src/model/types.rs`
+
+### Error Files (may need updates)
+- `src/error/position.rs`
+- `src/error/decimal.rs`
+
+## Estimated Effort
+
+**High (10-14 hours)**
+
+- Phase 1 (position.rs + expiration.rs): 6-8 hours
+- Phase 2 (trade, decimal, profit_range, utils): 2-3 hours
+- Phase 3 (leg submodule + others): 1-2 hours
+- Phase 4 (verification): 1 hour
+
+## Dependencies
+
+- Issue #3: Reduce unwrap() in model/option.rs (should be done first or in parallel)
+- Issue #16: Improve Positive type safety (should be done first)
+
+## Related Issues
+
+- Issue #1: Reduce unwrap() in chains/chain.rs
+- Issue #2: Reduce unwrap() in greeks/equations.rs
+- Issue #3: Reduce unwrap() in model/option.rs
+- Issue #15: Reduce expect() usage
+- Issue #16: Improve Positive type safety and API
+
+## Notes
+
+This issue is part of a broader effort to eliminate panics from the codebase. The `src/model` directory is critical because it contains the core data structures used throughout the library.
+
+### Priority Order Within This Issue
+
+1. **`position.rs`** - Most critical, used everywhere
+2. **`expiration.rs`** - Date handling is error-prone
+3. **`trade.rs`** - Trading operations should never panic
+4. **`decimal.rs`** - Numeric conversions need safety
+5. **Remaining files** - Lower impact but still important
+
+---
+
+*Generated on: 2024-12-25*

--- a/.windsurf/optionstratlib_implementation_study_v2.md
+++ b/.windsurf/optionstratlib_implementation_study_v2.md
@@ -1,0 +1,1702 @@
+# OptionStratLib Implementation Study v2
+
+## Executive Summary
+
+After reviewing the actual codebase structure, the implementation strategy changes significantly. The library already has robust infrastructure for curves, surfaces, and interpolation that we should leverage rather than recreate.
+
+---
+
+## Existing Infrastructure Analysis
+
+### What Already Exists
+
+```
+src/curves/          → Curve types, traits, and visualization (plotters)
+src/surfaces/        → Surface types, traits, and visualization
+src/geometrics/
+  └── interpolation/ → bilinear, cubic, linear, spline implementations
+src/metrics/
+  └── price/         → volatility_skew.rs (starting point)
+src/strategies/
+  └── delta_neutral/ → model.rs (base for Issue #187)
+src/greeks/          → equations.rs, utils.rs
+```
+
+### Key Insight
+
+The architecture follows a clear pattern:
+- **Domain types** live in dedicated modules (`curves/`, `surfaces/`)
+- **Metrics** is already structured to hold analytical functions by category (`metrics/price/`)
+- **Strategies** have their own submodules for complex features (`delta_neutral/`)
+
+---
+
+## Revised Architecture Proposal
+
+### Extend `src/metrics/` Module
+
+```
+src/metrics/
+├── mod.rs                      # Re-export all metric categories
+├── traits.rs                   # NEW: Common metric traits
+│
+├── price/                      # EXISTING
+│   ├── mod.rs
+│   └── volatility_skew.rs
+│
+├── temporal/                   # NEW: Issue #137
+│   ├── mod.rs
+│   ├── theta.rs                # Theta curves/surfaces
+│   ├── charm.rs                # Charm (delta decay)
+│   └── color.rs                # Color (gamma decay)
+│
+├── risk/                       # NEW: Issue #139
+│   ├── mod.rs
+│   ├── implied_volatility.rs   # IV surface generation
+│   ├── risk_reversal.rs        # Risk reversal curve
+│   └── dollar_gamma.rs         # Dollar gamma curve
+│
+├── composite/                  # NEW: Issue #140
+│   ├── mod.rs
+│   ├── vanna_volga.rs          # Vanna-Volga hedge surface
+│   ├── delta_gamma_profile.rs  # Combined exposure analysis
+│   └── smile_dynamics.rs       # Smile evolution over time
+│
+├── liquidity/                  # NEW: Issue #141
+│   ├── mod.rs
+│   ├── spread.rs               # Bid-ask spread curve
+│   ├── volume.rs               # Volume profile curve/surface
+│   └── open_interest.rs        # OI distribution curve
+│
+└── stress/                     # NEW: Issue #142
+    ├── mod.rs
+    ├── vol_sensitivity.rs      # Vega exposure analysis
+    ├── time_decay.rs           # Theta profile surface
+    └── price_shock.rs          # Scenario matrix generation
+```
+
+### Extend `src/strategies/delta_neutral/` for Issue #187
+
+```
+src/strategies/delta_neutral/
+├── mod.rs                      # EXISTING: add new exports
+├── model.rs                    # EXISTING: DeltaAdjustment enum
+├── adjustment.rs               # NEW: Extended adjustment actions
+├── portfolio.rs                # NEW: Portfolio-level Greeks aggregation
+└── optimizer.rs                # NEW: Multi-leg adjustment optimization
+```
+
+### Add Error Types to `src/error/`
+
+```
+src/error/
+├── metrics.rs                  # EXISTING: extend with new error variants
+└── adjustment.rs               # NEW: adjustment-specific errors
+```
+
+---
+
+## Integration with Existing Types
+
+### Using Existing Curve Infrastructure
+
+```rust
+// src/curves/curve.rs already provides the foundation
+// We extend it by implementing traits for our metrics
+
+use crate::curves::{Curve, CurvePoint};
+use crate::curves::traits::CurveOperations;
+
+// Example: ThetaCurve generates a standard Curve
+pub struct ThetaCurveGenerator {
+    // configuration
+}
+
+impl ThetaCurveGenerator {
+    pub fn generate(&self, chain: &OptionChain) -> Result<Curve, CurveError> {
+        let points: Vec<CurvePoint> = chain
+            .options_iter()
+            .filter_map(|opt| {
+                opt.theta().ok().map(|theta| {
+                    CurvePoint::new(opt.strike_price, theta)
+                })
+            })
+            .collect();
+        
+        Curve::from_points(points)
+    }
+}
+```
+
+### Using Existing Surface Infrastructure
+
+```rust
+// src/surfaces/surface.rs provides Surface type
+use crate::surfaces::{Surface, SurfacePoint};
+use crate::surfaces::traits::SurfaceOperations;
+
+pub struct IVSurfaceGenerator {
+    // configuration
+}
+
+impl IVSurfaceGenerator {
+    pub fn generate(&self, chain: &OptionChain) -> Result<Surface, SurfaceError> {
+        // Group by expiration, create surface points
+        let points: Vec<SurfacePoint> = chain
+            .options_iter()
+            .map(|opt| {
+                SurfacePoint::new(
+                    opt.strike_price,                    // x
+                    opt.expiration_date.get_years(),     // y  
+                    opt.implied_volatility,              // z
+                )
+            })
+            .collect();
+        
+        Surface::from_points(points)
+    }
+}
+```
+
+### Using Existing Interpolation
+
+```rust
+// src/geometrics/interpolation/ already has what we need
+use crate::geometrics::interpolation::{
+    CubicSplineInterpolator,
+    BilinearInterpolator,
+    InterpolationMethod,
+};
+
+impl Surface {
+    pub fn interpolate_at(&self, x: Positive, y: Positive) -> Result<Decimal, InterpolationError> {
+        let interpolator = BilinearInterpolator::new(&self.points)?;
+        interpolator.interpolate(x, y)
+    }
+}
+```
+
+---
+
+## Detailed Implementation by Issue
+
+### Issue #137: Temporal Metrics
+
+**Files to create:**
+- `src/metrics/temporal/mod.rs`
+- `src/metrics/temporal/theta.rs`
+- `src/metrics/temporal/charm.rs`
+- `src/metrics/temporal/color.rs`
+
+**Files to modify:**
+- `src/metrics/mod.rs` - add `pub mod temporal;`
+- `src/model/option.rs` - add helper methods if needed
+
+```rust
+// src/metrics/temporal/mod.rs
+mod theta;
+mod charm;
+mod color;
+
+pub use theta::{ThetaCurveGenerator, ThetaSurfaceGenerator};
+pub use charm::{CharmCalculator, CharmCurveGenerator};
+pub use color::{ColorCalculator, ColorCurveGenerator};
+
+// src/metrics/temporal/theta.rs
+use crate::chains::OptionChain;
+use crate::curves::Curve;
+use crate::surfaces::Surface;
+use crate::error::MetricError;
+use crate::greeks::Greeks;
+
+/// Generates theta curve across strikes at fixed expiration
+pub struct ThetaCurveGenerator {
+    option_style: Option<OptionStyle>,  // Filter calls/puts
+}
+
+impl ThetaCurveGenerator {
+    pub fn new() -> Self {
+        Self { option_style: None }
+    }
+    
+    pub fn with_style(mut self, style: OptionStyle) -> Self {
+        self.option_style = Some(style);
+        self
+    }
+    
+    pub fn generate(&self, chain: &OptionChain) -> Result<Curve, MetricError> {
+        let mut points = Vec::new();
+        
+        for option_data in chain.options_iter() {
+            // Apply filter if set
+            if let Some(style) = &self.option_style {
+                if option_data.option_style != *style {
+                    continue;
+                }
+            }
+            
+            // Build Options struct to calculate theta
+            let option = option_data.to_option(chain.underlying_price)?;
+            let theta = option.theta()?;
+            
+            points.push((option_data.strike_price, theta));
+        }
+        
+        // Sort by strike
+        points.sort_by(|a, b| a.0.cmp(&b.0));
+        
+        Ok(Curve::from_xy_pairs(points)?)
+    }
+}
+
+/// Generates theta surface: strike × time → theta
+pub struct ThetaSurfaceGenerator {
+    time_steps: Vec<Positive>,  // Days to expiration values
+}
+
+impl ThetaSurfaceGenerator {
+    pub fn new(time_steps: Vec<Positive>) -> Self {
+        Self { time_steps }
+    }
+    
+    pub fn with_range(start_days: Positive, end_days: Positive, step: Positive) -> Self {
+        let mut time_steps = Vec::new();
+        let mut current = start_days;
+        while current <= end_days {
+            time_steps.push(current);
+            current = current + step;
+        }
+        Self { time_steps }
+    }
+    
+    pub fn generate(&self, chain: &OptionChain) -> Result<Surface, MetricError> {
+        let mut surface_points = Vec::new();
+        
+        for &days in &self.time_steps {
+            for option_data in chain.options_iter() {
+                // Create option with modified expiration
+                let option = option_data
+                    .to_option(chain.underlying_price)?
+                    .with_expiration(ExpirationDate::Days(days));
+                
+                let theta = option.theta()?;
+                
+                surface_points.push((
+                    option_data.strike_price,  // x: strike
+                    days,                       // y: time
+                    theta,                      // z: theta value
+                ));
+            }
+        }
+        
+        Ok(Surface::from_xyz_points(surface_points)?)
+    }
+}
+
+// src/metrics/temporal/charm.rs
+use crate::model::Options;
+use crate::error::MetricError;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+/// Charm = ∂Δ/∂t (rate of change of delta with time)
+pub struct CharmCalculator;
+
+impl CharmCalculator {
+    /// Calculate charm using finite difference approximation
+    /// 
+    /// # Arguments
+    /// * `option` - The option to analyze
+    /// * `dt` - Time step in years (default: 1/365 for 1 day)
+    pub fn calculate(option: &Options, dt: Option<Decimal>) -> Result<Decimal, MetricError> {
+        let dt = dt.unwrap_or(dec!(0.00274));  // ~1 day in years
+        
+        let delta_now = option.delta()?;
+        
+        // Shift time forward (less time to expiry)
+        let option_later = option.with_time_shift(-dt)?;
+        let delta_later = option_later.delta()?;
+        
+        // Charm = (delta_later - delta_now) / dt
+        Ok((delta_later - delta_now) / dt)
+    }
+    
+    /// Calculate charm for an option (using 1-day default)
+    pub fn charm(option: &Options) -> Result<Decimal, MetricError> {
+        Self::calculate(option, None)
+    }
+}
+
+/// Generates charm curve across strikes
+pub struct CharmCurveGenerator {
+    dt: Decimal,
+}
+
+impl CharmCurveGenerator {
+    pub fn new() -> Self {
+        Self { dt: dec!(0.00274) }
+    }
+    
+    pub fn with_time_step(mut self, dt: Decimal) -> Self {
+        self.dt = dt;
+        self
+    }
+    
+    pub fn generate(&self, chain: &OptionChain) -> Result<Curve, MetricError> {
+        let mut points = Vec::new();
+        
+        for option_data in chain.options_iter() {
+            let option = option_data.to_option(chain.underlying_price)?;
+            let charm = CharmCalculator::calculate(&option, Some(self.dt))?;
+            points.push((option_data.strike_price, charm));
+        }
+        
+        points.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(Curve::from_xy_pairs(points)?)
+    }
+}
+
+// src/metrics/temporal/color.rs
+/// Color = ∂Γ/∂t (rate of change of gamma with time)
+pub struct ColorCalculator;
+
+impl ColorCalculator {
+    pub fn calculate(option: &Options, dt: Option<Decimal>) -> Result<Decimal, MetricError> {
+        let dt = dt.unwrap_or(dec!(0.00274));
+        
+        let gamma_now = option.gamma()?;
+        let option_later = option.with_time_shift(-dt)?;
+        let gamma_later = option_later.gamma()?;
+        
+        Ok((gamma_later - gamma_now) / dt)
+    }
+    
+    pub fn color(option: &Options) -> Result<Decimal, MetricError> {
+        Self::calculate(option, None)
+    }
+}
+```
+
+---
+
+### Issue #139: Risk Metrics
+
+**Files to create:**
+- `src/metrics/risk/mod.rs`
+- `src/metrics/risk/implied_volatility.rs`
+- `src/metrics/risk/risk_reversal.rs`
+- `src/metrics/risk/dollar_gamma.rs`
+
+```rust
+// src/metrics/risk/implied_volatility.rs
+use crate::chains::OptionChain;
+use crate::surfaces::Surface;
+use crate::error::MetricError;
+
+/// Generates implied volatility surface from option chain
+pub struct IVSurfaceGenerator {
+    moneyness_centered: bool,  // Use moneyness instead of absolute strike
+}
+
+impl IVSurfaceGenerator {
+    pub fn new() -> Self {
+        Self { moneyness_centered: false }
+    }
+    
+    /// Use log-moneyness (ln(K/S)) instead of absolute strike
+    pub fn with_moneyness(mut self) -> Self {
+        self.moneyness_centered = true;
+        self
+    }
+    
+    pub fn generate(&self, chain: &OptionChain) -> Result<Surface, MetricError> {
+        let spot = chain.underlying_price;
+        let mut points = Vec::new();
+        
+        // Group options by expiration to build surface
+        let by_expiry = chain.group_by_expiration();
+        
+        for (expiry, options) in by_expiry {
+            let time_to_expiry = expiry.get_years();
+            
+            for opt in options {
+                let x = if self.moneyness_centered {
+                    // Log-moneyness: ln(K/S)
+                    (opt.strike_price / spot).ln()
+                } else {
+                    opt.strike_price
+                };
+                
+                points.push((
+                    x,
+                    Positive::from(time_to_expiry * 365.0),  // days
+                    opt.implied_volatility,
+                ));
+            }
+        }
+        
+        Surface::from_xyz_points(points)
+    }
+}
+
+// src/metrics/risk/risk_reversal.rs
+use crate::chains::OptionChain;
+use crate::curves::Curve;
+use crate::error::MetricError;
+use crate::model::OptionStyle;
+
+/// Risk Reversal = IV(OTM Call at Δ) - IV(OTM Put at same Δ)
+/// Measures market skew/sentiment
+pub struct RiskReversal;
+
+impl RiskReversal {
+    /// Calculate risk reversal at a specific delta level
+    pub fn at_delta(chain: &OptionChain, target_delta: Positive) -> Result<Decimal, MetricError> {
+        let call = chain.find_option_at_delta(target_delta, OptionStyle::Call)?;
+        let put = chain.find_option_at_delta(target_delta, OptionStyle::Put)?;
+        
+        Ok(call.implied_volatility.to_decimal() - put.implied_volatility.to_decimal())
+    }
+    
+    /// Generate risk reversal curve across standard deltas
+    pub fn curve(chain: &OptionChain) -> Result<Curve, MetricError> {
+        let deltas = [
+            pos!(0.10), pos!(0.15), pos!(0.20), pos!(0.25),
+            pos!(0.30), pos!(0.35), pos!(0.40), pos!(0.45),
+        ];
+        
+        let mut points = Vec::new();
+        
+        for delta in deltas {
+            match Self::at_delta(chain, delta) {
+                Ok(rr) => points.push((delta, rr)),
+                Err(_) => continue,  // Skip if can't find options at this delta
+            }
+        }
+        
+        if points.is_empty() {
+            return Err(MetricError::InsufficientData("No valid delta points found".into()));
+        }
+        
+        Curve::from_xy_pairs(points)
+    }
+}
+
+// src/metrics/risk/dollar_gamma.rs
+use crate::model::{Options, Positive};
+use crate::chains::OptionChain;
+use crate::curves::Curve;
+use crate::error::MetricError;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+/// Dollar Gamma = Γ × S² / 100
+/// Represents P&L for a 1% move in underlying
+pub struct DollarGamma;
+
+impl DollarGamma {
+    /// Calculate dollar gamma for a single option
+    pub fn calculate(option: &Options) -> Result<Decimal, MetricError> {
+        let gamma = option.gamma()?;
+        let spot = option.underlying_price.to_decimal();
+        
+        // Dollar gamma formula
+        Ok(gamma * spot * spot / dec!(100))
+    }
+    
+    /// Generate dollar gamma curve across strikes
+    pub fn curve(chain: &OptionChain) -> Result<Curve, MetricError> {
+        let mut points = Vec::new();
+        
+        for option_data in chain.options_iter() {
+            let option = option_data.to_option(chain.underlying_price)?;
+            let dg = Self::calculate(&option)?;
+            points.push((option_data.strike_price, dg));
+        }
+        
+        points.sort_by(|a, b| a.0.cmp(&b.0));
+        Curve::from_xy_pairs(points)
+    }
+    
+    /// Calculate total dollar gamma for a portfolio
+    pub fn portfolio_total(positions: &[Position]) -> Result<Decimal, MetricError> {
+        let mut total = Decimal::ZERO;
+        
+        for pos in positions {
+            let dg = Self::calculate(&pos.option)?;
+            let sign = if pos.option.is_long() { dec!(1) } else { dec!(-1) };
+            total += dg * pos.option.quantity.to_decimal() * sign;
+        }
+        
+        Ok(total)
+    }
+}
+```
+
+---
+
+### Issue #140: Composite Metrics
+
+```rust
+// src/metrics/composite/delta_gamma_profile.rs
+use crate::model::Position;
+use crate::curves::Curve;
+use crate::surfaces::Surface;
+use crate::error::MetricError;
+
+/// Combined delta-gamma exposure analysis
+#[derive(Debug, Clone)]
+pub struct DeltaGammaPoint {
+    pub price: Positive,
+    pub delta_exposure: Decimal,
+    pub gamma_exposure: Decimal,
+    pub dollar_delta: Decimal,
+    pub dollar_gamma: Decimal,
+}
+
+pub struct DeltaGammaProfile;
+
+impl DeltaGammaProfile {
+    /// Calculate profile at a specific underlying price
+    pub fn at_price(
+        positions: &[Position],
+        underlying_price: Positive,
+    ) -> Result<DeltaGammaPoint, MetricError> {
+        let mut delta_exp = Decimal::ZERO;
+        let mut gamma_exp = Decimal::ZERO;
+        
+        for pos in positions {
+            // Recalculate with new underlying price
+            let option = pos.option.with_underlying_price(underlying_price);
+            let qty = pos.option.quantity.to_decimal();
+            let sign = if pos.option.is_long() { dec!(1) } else { dec!(-1) };
+            
+            delta_exp += option.delta()? * qty * sign;
+            gamma_exp += option.gamma()? * qty * sign;
+        }
+        
+        let spot = underlying_price.to_decimal();
+        
+        Ok(DeltaGammaPoint {
+            price: underlying_price,
+            delta_exposure: delta_exp,
+            gamma_exposure: gamma_exp,
+            dollar_delta: delta_exp * spot,
+            dollar_gamma: gamma_exp * spot * spot / dec!(100),
+        })
+    }
+    
+    /// Generate exposure curve across price range
+    pub fn curve(
+        positions: &[Position],
+        price_range: (Positive, Positive),
+        steps: usize,
+    ) -> Result<Curve, MetricError> {
+        let (min_price, max_price) = price_range;
+        let step_size = (max_price - min_price) / Positive::from(steps as f64);
+        
+        let mut points = Vec::new();
+        let mut price = min_price;
+        
+        for _ in 0..=steps {
+            let profile = Self::at_price(positions, price)?;
+            points.push((price, profile.delta_exposure));
+            price = price + step_size;
+        }
+        
+        Curve::from_xy_pairs(points)
+    }
+    
+    /// Generate surface: price × time → delta exposure
+    pub fn surface(
+        positions: &[Position],
+        price_range: (Positive, Positive),
+        time_range: (Positive, Positive),  // days
+        price_steps: usize,
+        time_steps: usize,
+    ) -> Result<Surface, MetricError> {
+        let mut points = Vec::new();
+        
+        let price_step = (price_range.1 - price_range.0) / Positive::from(price_steps as f64);
+        let time_step = (time_range.1 - time_range.0) / Positive::from(time_steps as f64);
+        
+        for t in 0..=time_steps {
+            let days = time_range.0 + time_step * Positive::from(t as f64);
+            
+            // Shift all positions to this time
+            let shifted_positions: Vec<Position> = positions
+                .iter()
+                .filter_map(|p| p.with_days_to_expiry(days).ok())
+                .collect();
+            
+            for p in 0..=price_steps {
+                let price = price_range.0 + price_step * Positive::from(p as f64);
+                let profile = Self::at_price(&shifted_positions, price)?;
+                
+                points.push((price, days, profile.delta_exposure));
+            }
+        }
+        
+        Surface::from_xyz_points(points)
+    }
+}
+
+// src/metrics/composite/smile_dynamics.rs
+use crate::chains::OptionChain;
+use crate::curves::Curve;
+use crate::surfaces::Surface;
+use crate::error::MetricError;
+
+/// Tracks how the volatility smile evolves over time
+#[derive(Debug, Clone)]
+pub struct SmileShift {
+    pub parallel_shift: Decimal,    // ATM vol change
+    pub slope_change: Decimal,      // Skew change  
+    pub curvature_change: Decimal,  // Smile curvature change
+}
+
+pub struct SmileDynamics;
+
+impl SmileDynamics {
+    /// Extract smile parameters from a chain at single expiry
+    fn extract_smile_params(chain: &OptionChain) -> Result<SmileParams, MetricError> {
+        let atm_vol = chain.atm_implied_volatility()?;
+        
+        // Use 25-delta to measure skew
+        let call_25d = chain.find_option_at_delta(pos!(0.25), OptionStyle::Call)?;
+        let put_25d = chain.find_option_at_delta(pos!(0.25), OptionStyle::Put)?;
+        
+        let skew = call_25d.implied_volatility.to_decimal() 
+                 - put_25d.implied_volatility.to_decimal();
+        
+        // Butterfly for curvature
+        let butterfly = (call_25d.implied_volatility.to_decimal() 
+                       + put_25d.implied_volatility.to_decimal()) / dec!(2)
+                       - atm_vol.to_decimal();
+        
+        Ok(SmileParams {
+            atm_vol,
+            skew,
+            curvature: butterfly,
+        })
+    }
+    
+    /// Compare two snapshots of the smile
+    pub fn calculate_shift(
+        chain_before: &OptionChain,
+        chain_after: &OptionChain,
+    ) -> Result<SmileShift, MetricError> {
+        let params_before = Self::extract_smile_params(chain_before)?;
+        let params_after = Self::extract_smile_params(chain_after)?;
+        
+        Ok(SmileShift {
+            parallel_shift: params_after.atm_vol.to_decimal() - params_before.atm_vol.to_decimal(),
+            slope_change: params_after.skew - params_before.skew,
+            curvature_change: params_after.curvature - params_before.curvature,
+        })
+    }
+    
+    /// Generate smile curve at specific expiry
+    pub fn smile_curve(chain: &OptionChain) -> Result<Curve, MetricError> {
+        let spot = chain.underlying_price;
+        let mut points = Vec::new();
+        
+        for opt in chain.options_iter() {
+            // Use log-moneyness for x-axis
+            let moneyness = (opt.strike_price / spot).ln();
+            points.push((moneyness, opt.implied_volatility));
+        }
+        
+        points.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        Curve::from_xy_pairs(points)
+    }
+    
+    /// Generate surface: moneyness × expiry → IV
+    pub fn surface(chains_by_expiry: &[(ExpirationDate, OptionChain)]) -> Result<Surface, MetricError> {
+        let mut points = Vec::new();
+        
+        for (expiry, chain) in chains_by_expiry {
+            let time = expiry.get_years() * dec!(365);
+            let spot = chain.underlying_price;
+            
+            for opt in chain.options_iter() {
+                let moneyness = (opt.strike_price / spot).ln();
+                points.push((moneyness, time, opt.implied_volatility));
+            }
+        }
+        
+        Surface::from_xyz_points(points)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SmileParams {
+    atm_vol: Positive,
+    skew: Decimal,
+    curvature: Decimal,
+}
+```
+
+---
+
+### Issue #141: Liquidity Metrics
+
+```rust
+// src/metrics/liquidity/mod.rs
+
+/// Trait for market data providers (bid/ask, volume, OI)
+pub trait MarketDataSource {
+    fn bid(&self, option: &OptionData) -> Option<Positive>;
+    fn ask(&self, option: &OptionData) -> Option<Positive>;
+    fn volume(&self, option: &OptionData) -> Option<u64>;
+    fn open_interest(&self, option: &OptionData) -> Option<u64>;
+}
+
+// src/metrics/liquidity/spread.rs
+use crate::chains::OptionChain;
+use crate::curves::Curve;
+use crate::error::MetricError;
+
+pub struct BidAskSpread<D: MarketDataSource> {
+    data_source: D,
+}
+
+impl<D: MarketDataSource> BidAskSpread<D> {
+    pub fn new(data_source: D) -> Self {
+        Self { data_source }
+    }
+    
+    /// Absolute spread in price terms
+    pub fn absolute(&self, option: &OptionData) -> Option<Positive> {
+        let bid = self.data_source.bid(option)?;
+        let ask = self.data_source.ask(option)?;
+        Some(ask - bid)
+    }
+    
+    /// Relative spread as percentage of mid price
+    pub fn relative(&self, option: &OptionData) -> Option<Positive> {
+        let bid = self.data_source.bid(option)?;
+        let ask = self.data_source.ask(option)?;
+        let mid = (bid + ask) / pos!(2.0);
+        
+        if mid > Positive::ZERO {
+            Some((ask - bid) / mid)
+        } else {
+            None
+        }
+    }
+    
+    /// Generate spread curve by strike
+    pub fn curve(&self, chain: &OptionChain) -> Result<Curve, MetricError> {
+        let mut points = Vec::new();
+        
+        for opt in chain.options_iter() {
+            if let Some(spread) = self.relative(opt) {
+                points.push((opt.strike_price, spread));
+            }
+        }
+        
+        if points.is_empty() {
+            return Err(MetricError::InsufficientData("No spread data available".into()));
+        }
+        
+        points.sort_by(|a, b| a.0.cmp(&b.0));
+        Curve::from_xy_pairs(points)
+    }
+}
+
+// src/metrics/liquidity/open_interest.rs
+pub struct OpenInterestDistribution<D: MarketDataSource> {
+    data_source: D,
+}
+
+impl<D: MarketDataSource> OpenInterestDistribution<D> {
+    pub fn new(data_source: D) -> Self {
+        Self { data_source }
+    }
+    
+    /// Generate OI curve by strike
+    pub fn curve(&self, chain: &OptionChain) -> Result<Curve, MetricError> {
+        let mut points = Vec::new();
+        
+        for opt in chain.options_iter() {
+            if let Some(oi) = self.data_source.open_interest(opt) {
+                points.push((opt.strike_price, Decimal::from(oi)));
+            }
+        }
+        
+        points.sort_by(|a, b| a.0.cmp(&b.0));
+        Curve::from_xy_pairs(points)
+    }
+    
+    /// Find strike with maximum open interest (potential support/resistance)
+    pub fn max_pain_strike(&self, chain: &OptionChain) -> Result<Positive, MetricError> {
+        let curve = self.curve(chain)?;
+        curve.max_point().map(|(strike, _)| strike)
+    }
+    
+    /// Put/Call OI ratio by strike
+    pub fn put_call_ratio(&self, chain: &OptionChain) -> Result<Curve, MetricError> {
+        let mut ratios = Vec::new();
+        
+        let by_strike = chain.group_by_strike();
+        
+        for (strike, options) in by_strike {
+            let call_oi: u64 = options.iter()
+                .filter(|o| o.option_style == OptionStyle::Call)
+                .filter_map(|o| self.data_source.open_interest(o))
+                .sum();
+                
+            let put_oi: u64 = options.iter()
+                .filter(|o| o.option_style == OptionStyle::Put)
+                .filter_map(|o| self.data_source.open_interest(o))
+                .sum();
+            
+            if call_oi > 0 {
+                let ratio = Decimal::from(put_oi) / Decimal::from(call_oi);
+                ratios.push((strike, ratio));
+            }
+        }
+        
+        Curve::from_xy_pairs(ratios)
+    }
+}
+```
+
+---
+
+### Issue #142: Stress Metrics
+
+```rust
+// src/metrics/stress/vol_sensitivity.rs
+use crate::model::Position;
+use crate::curves::Curve;
+use crate::surfaces::Surface;
+use crate::error::MetricError;
+
+/// Analyzes portfolio sensitivity to volatility changes
+pub struct VolatilitySensitivity;
+
+impl VolatilitySensitivity {
+    /// Calculate P&L for a given volatility shock
+    pub fn pnl_for_shock(positions: &[Position], vol_shock: Decimal) -> Result<Decimal, MetricError> {
+        let mut total_pnl = Decimal::ZERO;
+        
+        for pos in positions {
+            let vega = pos.option.vega()?;
+            let vomma = pos.option.vomma()?;
+            let qty = pos.option.quantity.to_decimal();
+            let sign = if pos.option.is_long() { dec!(1) } else { dec!(-1) };
+            
+            // Taylor expansion: Vega * Δσ + 0.5 * Vomma * Δσ²
+            let pnl = (vega * vol_shock + dec!(0.5) * vomma * vol_shock * vol_shock) * qty * sign;
+            total_pnl += pnl;
+        }
+        
+        Ok(total_pnl)
+    }
+    
+    /// Generate sensitivity curve across vol shocks
+    pub fn curve(
+        positions: &[Position],
+        shock_range: (Decimal, Decimal),
+        steps: usize,
+    ) -> Result<Curve, MetricError> {
+        let (min_shock, max_shock) = shock_range;
+        let step_size = (max_shock - min_shock) / Decimal::from(steps);
+        
+        let mut points = Vec::new();
+        
+        for i in 0..=steps {
+            let shock = min_shock + step_size * Decimal::from(i);
+            let pnl = Self::pnl_for_shock(positions, shock)?;
+            points.push((shock, pnl));
+        }
+        
+        Curve::from_xy_pairs(points)
+    }
+}
+
+// src/metrics/stress/price_shock.rs
+use crate::model::Position;
+use crate::error::MetricError;
+
+/// Scenario matrix for combined price and volatility shocks
+#[derive(Debug, Clone)]
+pub struct ScenarioMatrix {
+    pub price_shocks: Vec<Decimal>,   // e.g., [-20%, -10%, 0%, +10%, +20%]
+    pub vol_shocks: Vec<Decimal>,     // e.g., [-25%, 0%, +25%, +50%]
+    pub pnl_matrix: Vec<Vec<Decimal>>, // price_shock × vol_shock → P&L
+}
+
+impl ScenarioMatrix {
+    /// Pretty print the matrix
+    pub fn display(&self) -> String {
+        let mut output = String::new();
+        
+        // Header row
+        output.push_str("Price\\Vol\t");
+        for vs in &self.vol_shocks {
+            output.push_str(&format!("{:.0}%\t", vs * dec!(100)));
+        }
+        output.push('\n');
+        
+        // Data rows
+        for (i, ps) in self.price_shocks.iter().enumerate() {
+            output.push_str(&format!("{:.0}%\t", ps * dec!(100)));
+            for pnl in &self.pnl_matrix[i] {
+                output.push_str(&format!("{:.2}\t", pnl));
+            }
+            output.push('\n');
+        }
+        
+        output
+    }
+}
+
+pub struct PriceShockAnalysis;
+
+impl PriceShockAnalysis {
+    /// Generate scenario matrix
+    pub fn scenario_matrix(
+        positions: &[Position],
+        price_shocks: &[Decimal],
+        vol_shocks: &[Decimal],
+    ) -> Result<ScenarioMatrix, MetricError> {
+        let mut matrix = Vec::new();
+        
+        for &price_shock in price_shocks {
+            let mut row = Vec::new();
+            
+            for &vol_shock in vol_shocks {
+                let pnl = Self::combined_shock_pnl(positions, price_shock, vol_shock)?;
+                row.push(pnl);
+            }
+            
+            matrix.push(row);
+        }
+        
+        Ok(ScenarioMatrix {
+            price_shocks: price_shocks.to_vec(),
+            vol_shocks: vol_shocks.to_vec(),
+            pnl_matrix: matrix,
+        })
+    }
+    
+    /// Calculate P&L for combined shocks using Taylor expansion
+    fn combined_shock_pnl(
+        positions: &[Position],
+        price_shock: Decimal,
+        vol_shock: Decimal,
+    ) -> Result<Decimal, MetricError> {
+        let mut total_pnl = Decimal::ZERO;
+        
+        for pos in positions {
+            let spot = pos.option.underlying_price.to_decimal();
+            let price_move = spot * price_shock;
+            
+            let delta = pos.option.delta()?;
+            let gamma = pos.option.gamma()?;
+            let vega = pos.option.vega()?;
+            let vanna = pos.option.vanna()?;
+            
+            let qty = pos.option.quantity.to_decimal();
+            let sign = if pos.option.is_long() { dec!(1) } else { dec!(-1) };
+            
+            // Full Taylor expansion with cross-term
+            let pnl = (
+                delta * price_move
+                + dec!(0.5) * gamma * price_move * price_move
+                + vega * vol_shock
+                + vanna * price_move * vol_shock
+            ) * qty * sign;
+            
+            total_pnl += pnl;
+        }
+        
+        Ok(total_pnl)
+    }
+    
+    /// Standard shock matrix with common values
+    pub fn standard_matrix(positions: &[Position]) -> Result<ScenarioMatrix, MetricError> {
+        let price_shocks = vec![
+            dec!(-0.20), dec!(-0.10), dec!(-0.05), 
+            dec!(0.0), 
+            dec!(0.05), dec!(0.10), dec!(0.20)
+        ];
+        let vol_shocks = vec![
+            dec!(-0.25), dec!(0.0), dec!(0.25), dec!(0.50), dec!(1.0)
+        ];
+        
+        Self::scenario_matrix(positions, &price_shocks, &vol_shocks)
+    }
+}
+```
+
+---
+
+### Issue #187: Extended Delta Adjustment
+
+**Files to create/modify:**
+- `src/strategies/delta_neutral/adjustment.rs` (NEW)
+- `src/strategies/delta_neutral/portfolio.rs` (NEW)
+- `src/strategies/delta_neutral/optimizer.rs` (NEW)
+- `src/strategies/delta_neutral/mod.rs` (MODIFY)
+- `src/strategies/delta_neutral/model.rs` (MODIFY)
+
+```rust
+// src/strategies/delta_neutral/adjustment.rs
+
+/// Extended adjustment actions beyond quantity modification
+#[derive(Debug, Clone)]
+pub enum AdjustmentAction {
+    /// Modify quantity of existing leg (current behavior)
+    ModifyQuantity {
+        leg_index: usize,
+        new_quantity: Positive,
+    },
+    
+    /// Add a new option leg to the position
+    AddLeg {
+        option: Options,
+        side: Side,
+        quantity: Positive,
+    },
+    
+    /// Close/remove an existing leg
+    CloseLeg {
+        leg_index: usize,
+    },
+    
+    /// Roll to different strike (close old, open new)
+    RollStrike {
+        leg_index: usize,
+        new_strike: Positive,
+        quantity: Positive,
+    },
+    
+    /// Roll to different expiration
+    RollExpiration {
+        leg_index: usize,
+        new_expiration: ExpirationDate,
+        quantity: Positive,
+    },
+    
+    /// Add underlying position for delta hedge
+    AddUnderlying {
+        quantity: Decimal,  // Negative for short
+    },
+}
+
+/// Configuration for adjustment behavior
+#[derive(Debug, Clone)]
+pub struct AdjustmentConfig {
+    /// Allow adding new legs
+    pub allow_new_legs: bool,
+    
+    /// Allow using underlying for hedging
+    pub allow_underlying: bool,
+    
+    /// Maximum number of new legs to add
+    pub max_new_legs: Option<usize>,
+    
+    /// Allowed option styles for new legs
+    pub allowed_styles: Vec<OptionStyle>,
+    
+    /// Strike range for new legs (relative to ATM)
+    pub strike_range: Option<(Positive, Positive)>,
+    
+    /// Maximum cost for adjustments
+    pub max_cost: Option<Positive>,
+    
+    /// Minimum option liquidity (open interest)
+    pub min_liquidity: Option<u64>,
+}
+
+impl Default for AdjustmentConfig {
+    fn default() -> Self {
+        Self {
+            allow_new_legs: true,
+            allow_underlying: false,
+            max_new_legs: Some(2),
+            allowed_styles: vec![OptionStyle::Call, OptionStyle::Put],
+            strike_range: None,
+            max_cost: None,
+            min_liquidity: None,
+        }
+    }
+}
+
+/// Result of adjustment calculation
+#[derive(Debug, Clone)]
+pub struct AdjustmentPlan {
+    /// Actions to execute
+    pub actions: Vec<AdjustmentAction>,
+    
+    /// Estimated cost of adjustments
+    pub estimated_cost: Decimal,
+    
+    /// Greeks after adjustment
+    pub resulting_greeks: PortfolioGreeks,
+    
+    /// Residual delta after adjustment
+    pub residual_delta: Decimal,
+    
+    /// Quality score (lower is better)
+    pub quality_score: Decimal,
+}
+
+// src/strategies/delta_neutral/portfolio.rs
+
+/// Aggregated Greeks at portfolio level
+#[derive(Debug, Clone, Default)]
+pub struct PortfolioGreeks {
+    pub delta: Decimal,
+    pub gamma: Decimal,
+    pub theta: Decimal,
+    pub vega: Decimal,
+    pub vanna: Decimal,
+    pub vomma: Decimal,
+    pub rho: Decimal,
+}
+
+impl PortfolioGreeks {
+    /// Calculate from a set of positions
+    pub fn from_positions(positions: &[Position]) -> Result<Self, GreekError> {
+        let mut greeks = Self::default();
+        
+        for pos in positions {
+            let qty = pos.option.quantity.to_decimal();
+            let sign = if pos.option.is_long() { dec!(1) } else { dec!(-1) };
+            let mult = qty * sign;
+            
+            greeks.delta += pos.option.delta()? * mult;
+            greeks.gamma += pos.option.gamma()? * mult;
+            greeks.theta += pos.option.theta()? * mult;
+            greeks.vega += pos.option.vega()? * mult;
+            greeks.vanna += pos.option.vanna()? * mult;
+            greeks.vomma += pos.option.vomma()? * mult;
+            greeks.rho += pos.option.rho()? * mult;
+        }
+        
+        Ok(greeks)
+    }
+    
+    /// Check if approximately delta neutral
+    pub fn is_delta_neutral(&self, tolerance: Decimal) -> bool {
+        self.delta.abs() <= tolerance
+    }
+    
+    /// Check if approximately gamma neutral
+    pub fn is_gamma_neutral(&self, tolerance: Decimal) -> bool {
+        self.gamma.abs() <= tolerance
+    }
+}
+
+/// Target Greeks for adjustment
+#[derive(Debug, Clone, Default)]
+pub struct AdjustmentTarget {
+    pub delta: Option<Decimal>,
+    pub gamma: Option<Decimal>,
+    pub vega: Option<Decimal>,
+    pub theta: Option<Decimal>,
+}
+
+impl AdjustmentTarget {
+    pub fn delta_neutral() -> Self {
+        Self {
+            delta: Some(Decimal::ZERO),
+            ..Default::default()
+        }
+    }
+    
+    pub fn delta_gamma_neutral() -> Self {
+        Self {
+            delta: Some(Decimal::ZERO),
+            gamma: Some(Decimal::ZERO),
+            ..Default::default()
+        }
+    }
+}
+
+// src/strategies/delta_neutral/optimizer.rs
+
+use crate::chains::OptionChain;
+
+/// Portfolio-level adjustment optimizer
+pub struct AdjustmentOptimizer<'a> {
+    positions: &'a [Position],
+    chain: &'a OptionChain,
+    config: AdjustmentConfig,
+    target: AdjustmentTarget,
+}
+
+impl<'a> AdjustmentOptimizer<'a> {
+    pub fn new(
+        positions: &'a [Position],
+        chain: &'a OptionChain,
+        config: AdjustmentConfig,
+        target: AdjustmentTarget,
+    ) -> Self {
+        Self { positions, chain, config, target }
+    }
+    
+    /// Calculate optimal adjustment plan
+    pub fn optimize(&self) -> Result<AdjustmentPlan, AdjustmentError> {
+        let current_greeks = PortfolioGreeks::from_positions(self.positions)?;
+        
+        // Calculate gaps to target
+        let delta_gap = self.target.delta
+            .map(|t| t - current_greeks.delta)
+            .unwrap_or(Decimal::ZERO);
+        
+        let gamma_gap = self.target.gamma
+            .map(|t| t - current_greeks.gamma);
+        
+        // Try different adjustment strategies
+        let mut best_plan: Option<AdjustmentPlan> = None;
+        
+        // Strategy 1: Adjust existing legs only
+        if let Ok(plan) = self.optimize_existing_legs(delta_gap, gamma_gap) {
+            best_plan = Some(plan);
+        }
+        
+        // Strategy 2: Add new legs
+        if self.config.allow_new_legs {
+            if let Ok(plan) = self.optimize_with_new_legs(delta_gap, gamma_gap) {
+                if best_plan.is_none() || plan.quality_score < best_plan.as_ref().unwrap().quality_score {
+                    best_plan = Some(plan);
+                }
+            }
+        }
+        
+        // Strategy 3: Use underlying
+        if self.config.allow_underlying && gamma_gap.is_none() {
+            if let Ok(plan) = self.optimize_with_underlying(delta_gap) {
+                if best_plan.is_none() || plan.quality_score < best_plan.as_ref().unwrap().quality_score {
+                    best_plan = Some(plan);
+                }
+            }
+        }
+        
+        best_plan.ok_or(AdjustmentError::NoViablePlan)
+    }
+    
+    /// Optimize by adjusting existing leg quantities
+    fn optimize_existing_legs(
+        &self,
+        delta_gap: Decimal,
+        gamma_gap: Option<Decimal>,
+    ) -> Result<AdjustmentPlan, AdjustmentError> {
+        let mut actions = Vec::new();
+        let mut remaining_delta = delta_gap;
+        
+        // Sort legs by delta contribution
+        let mut legs_with_delta: Vec<(usize, Decimal)> = self.positions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| {
+                p.option.delta().ok().map(|d| {
+                    let sign = if p.option.is_long() { dec!(1) } else { dec!(-1) };
+                    (i, d * sign)
+                })
+            })
+            .collect();
+        
+        legs_with_delta.sort_by(|a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap());
+        
+        // Greedily adjust quantities
+        for (idx, leg_delta) in legs_with_delta {
+            if remaining_delta.abs() < dec!(0.01) {
+                break;
+            }
+            
+            if leg_delta.abs() < dec!(0.001) {
+                continue;
+            }
+            
+            let current_qty = self.positions[idx].option.quantity.to_decimal();
+            let adjustment_qty = remaining_delta / leg_delta;
+            
+            // Can't adjust more than current quantity for shorts
+            let new_qty = current_qty + adjustment_qty;
+            if new_qty > Decimal::ZERO {
+                actions.push(AdjustmentAction::ModifyQuantity {
+                    leg_index: idx,
+                    new_quantity: Positive::try_from(new_qty)?,
+                });
+                remaining_delta -= adjustment_qty * leg_delta;
+            }
+        }
+        
+        self.build_plan(actions, remaining_delta)
+    }
+    
+    /// Optimize by adding new option legs
+    fn optimize_with_new_legs(
+        &self,
+        delta_gap: Decimal,
+        gamma_gap: Option<Decimal>,
+    ) -> Result<AdjustmentPlan, AdjustmentError> {
+        let mut actions = Vec::new();
+        let atm_strike = self.positions
+            .first()
+            .map(|p| p.option.underlying_price)
+            .ok_or(AdjustmentError::NoPositions)?;
+        
+        // Find best option to add based on delta gap
+        let candidates = self.find_candidate_options(delta_gap)?;
+        
+        if let Some((option, quantity)) = candidates.first() {
+            let side = if delta_gap > Decimal::ZERO { Side::Long } else { Side::Short };
+            
+            actions.push(AdjustmentAction::AddLeg {
+                option: option.clone(),
+                side,
+                quantity: *quantity,
+            });
+        }
+        
+        let residual = self.calculate_residual(&actions, delta_gap)?;
+        self.build_plan(actions, residual)
+    }
+    
+    /// Optimize using underlying shares
+    fn optimize_with_underlying(&self, delta_gap: Decimal) -> Result<AdjustmentPlan, AdjustmentError> {
+        // Each share has delta = 1
+        let shares_needed = delta_gap;
+        
+        let actions = vec![AdjustmentAction::AddUnderlying {
+            quantity: shares_needed,
+        }];
+        
+        self.build_plan(actions, Decimal::ZERO)
+    }
+    
+    /// Find candidate options for delta adjustment
+    fn find_candidate_options(&self, delta_gap: Decimal) -> Result<Vec<(Options, Positive)>, AdjustmentError> {
+        let mut candidates = Vec::new();
+        let target_delta_sign = delta_gap.signum();
+        
+        for opt_data in self.chain.options_iter() {
+            // Filter by style
+            if !self.config.allowed_styles.contains(&opt_data.option_style) {
+                continue;
+            }
+            
+            // Filter by liquidity
+            if let Some(min_oi) = self.config.min_liquidity {
+                if opt_data.open_interest.unwrap_or(0) < min_oi {
+                    continue;
+                }
+            }
+            
+            let option = opt_data.to_option(self.chain.underlying_price)?;
+            let option_delta = option.delta()?;
+            
+            // Check if this option helps reduce the gap
+            if option_delta.signum() == target_delta_sign {
+                let quantity = (delta_gap.abs() / option_delta.abs()).min(dec!(100));
+                if let Ok(qty) = Positive::try_from(quantity) {
+                    candidates.push((option, qty));
+                }
+            }
+        }
+        
+        // Sort by efficiency (delta per dollar cost)
+        candidates.sort_by(|a, b| {
+            let eff_a = a.0.delta().unwrap_or(Decimal::ZERO) / a.0.calculate_price_black_scholes().unwrap_or(dec!(1));
+            let eff_b = b.0.delta().unwrap_or(Decimal::ZERO) / b.0.calculate_price_black_scholes().unwrap_or(dec!(1));
+            eff_b.abs().partial_cmp(&eff_a.abs()).unwrap()
+        });
+        
+        Ok(candidates)
+    }
+    
+    fn calculate_residual(&self, actions: &[AdjustmentAction], original_gap: Decimal) -> Result<Decimal, AdjustmentError> {
+        let mut delta_change = Decimal::ZERO;
+        
+        for action in actions {
+            match action {
+                AdjustmentAction::AddLeg { option, side, quantity } => {
+                    let d = option.delta()?;
+                    let sign = if *side == Side::Long { dec!(1) } else { dec!(-1) };
+                    delta_change += d * quantity.to_decimal() * sign;
+                }
+                AdjustmentAction::AddUnderlying { quantity } => {
+                    delta_change += *quantity;
+                }
+                AdjustmentAction::ModifyQuantity { leg_index, new_quantity } => {
+                    let old_qty = self.positions[*leg_index].option.quantity.to_decimal();
+                    let d = self.positions[*leg_index].option.delta()?;
+                    let sign = if self.positions[*leg_index].option.is_long() { dec!(1) } else { dec!(-1) };
+                    delta_change += d * (new_quantity.to_decimal() - old_qty) * sign;
+                }
+                _ => {}
+            }
+        }
+        
+        Ok(original_gap - delta_change)
+    }
+    
+    fn build_plan(&self, actions: Vec<AdjustmentAction>, residual_delta: Decimal) -> Result<AdjustmentPlan, AdjustmentError> {
+        let cost = self.estimate_cost(&actions)?;
+        
+        // Validate cost constraint
+        if let Some(max_cost) = &self.config.max_cost {
+            if cost > max_cost.to_decimal() {
+                return Err(AdjustmentError::CostExceeded);
+            }
+        }
+        
+        // Apply actions to get resulting Greeks
+        let new_positions = self.apply_actions_preview(&actions)?;
+        let resulting_greeks = PortfolioGreeks::from_positions(&new_positions)?;
+        
+        // Quality score: lower is better
+        let quality = residual_delta.abs() + cost * dec!(0.01);
+        
+        Ok(AdjustmentPlan {
+            actions,
+            estimated_cost: cost,
+            resulting_greeks,
+            residual_delta,
+            quality_score: quality,
+        })
+    }
+    
+    fn estimate_cost(&self, actions: &[AdjustmentAction]) -> Result<Decimal, AdjustmentError> {
+        let mut cost = Decimal::ZERO;
+        
+        for action in actions {
+            match action {
+                AdjustmentAction::AddLeg { option, quantity, .. } => {
+                    let price = option.calculate_price_black_scholes()?;
+                    cost += price * quantity.to_decimal();
+                }
+                AdjustmentAction::AddUnderlying { quantity } => {
+                    let spot = self.positions.first()
+                        .map(|p| p.option.underlying_price.to_decimal())
+                        .unwrap_or(Decimal::ZERO);
+                    cost += (spot * quantity).abs();
+                }
+                _ => {}
+            }
+        }
+        
+        Ok(cost)
+    }
+    
+    fn apply_actions_preview(&self, actions: &[AdjustmentAction]) -> Result<Vec<Position>, AdjustmentError> {
+        let mut positions = self.positions.to_vec();
+        
+        for action in actions {
+            match action {
+                AdjustmentAction::ModifyQuantity { leg_index, new_quantity } => {
+                    if let Some(pos) = positions.get_mut(*leg_index) {
+                        pos.option.quantity = *new_quantity;
+                    }
+                }
+                AdjustmentAction::AddLeg { option, quantity, .. } => {
+                    let mut new_option = option.clone();
+                    new_option.quantity = *quantity;
+                    positions.push(Position::new(
+                        new_option,
+                        Positive::ZERO,  // Will be filled at execution
+                        Utc::now(),
+                        Positive::ZERO,
+                        Positive::ZERO,
+                        None,
+                        None,
+                    ));
+                }
+                AdjustmentAction::CloseLeg { leg_index } => {
+                    if *leg_index < positions.len() {
+                        positions.remove(*leg_index);
+                    }
+                }
+                _ => {}
+            }
+        }
+        
+        Ok(positions)
+    }
+}
+```
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Foundation (1 week)
+1. Create `src/metrics/traits.rs` with common interfaces
+2. Update `src/metrics/mod.rs` to organize submodules
+3. Add helper methods to `Options` and `OptionChain` if needed
+4. Add new error variants to `src/error/metrics.rs`
+
+### Phase 2: Temporal Metrics - #137 (1 week)
+1. Implement `ThetaCurveGenerator` and `ThetaSurfaceGenerator`
+2. Implement `CharmCalculator` with curve generation
+3. Implement `ColorCalculator` with curve generation
+4. Add tests and examples
+
+### Phase 3: Risk Metrics - #139 (1 week)
+1. Implement `IVSurfaceGenerator`
+2. Implement `RiskReversal` with curve
+3. Implement `DollarGamma` with curve
+4. Add chain helper for delta-based lookups
+
+### Phase 4: Composite Metrics - #140 (1.5 weeks)
+1. Implement `DeltaGammaProfile`
+2. Implement `SmileDynamics`
+3. Implement `VannaVolgaHedge` (more complex)
+
+### Phase 5: Liquidity Metrics - #141 (1 week)
+1. Define `MarketDataSource` trait
+2. Implement `BidAskSpread`
+3. Implement `OpenInterestDistribution`
+4. Implement `VolumeProfile`
+
+### Phase 6: Stress Metrics - #142 (1 week)
+1. Implement `VolatilitySensitivity`
+2. Implement `PriceShockAnalysis` with scenario matrix
+3. Implement `TimeDecayProfile`
+
+### Phase 7: Delta Adjustment - #187 (1.5 weeks)
+1. Create new adjustment types
+2. Implement `PortfolioGreeks`
+3. Implement `AdjustmentOptimizer`
+4. Integrate with existing `delta_neutral` module
+5. Add comprehensive tests
+
+---
+
+## Dependencies Between Issues
+
+```
+                    ┌─────────────────┐
+                    │  #137 Temporal  │
+                    └────────┬────────┘
+                             │
+         ┌───────────────────┼───────────────────┐
+         │                   │                   │
+         ▼                   ▼                   ▼
+┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐
+│   #139 Risk     │ │ #142 Stress    │ │   #141 Liquidity│
+└────────┬────────┘ └────────┬────────┘ └─────────────────┘
+         │                   │
+         └─────────┬─────────┘
+                   │
+                   ▼
+         ┌─────────────────┐
+         │ #140 Composite  │
+         └─────────────────┘
+
+         ┌─────────────────┐
+         │ #187 Adjustment │  (Independent track)
+         └─────────────────┘
+```
+
+Issue #187 can be developed in parallel since it extends `delta_neutral/` rather than the metrics system.
+
+---
+
+## Testing Strategy
+
+### Unit Tests Per Module
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::tests::create_test_chain;
+    
+    #[test]
+    fn test_theta_curve_generation() {
+        let chain = create_test_chain();
+        let generator = ThetaCurveGenerator::new();
+        
+        let curve = generator.generate(&chain).unwrap();
+        
+        assert!(!curve.points.is_empty());
+        // Theta should be negative for long options
+        assert!(curve.points.iter().all(|(_, theta)| *theta < Decimal::ZERO));
+    }
+    
+    #[test]
+    fn test_charm_approximation_accuracy() {
+        let option = create_test_option();
+        let charm = CharmCalculator::charm(&option).unwrap();
+        
+        // Numerical verification
+        let dt = dec!(0.00274);
+        let delta_t0 = option.delta().unwrap();
+        let delta_t1 = option.with_time_shift(-dt).unwrap().delta().unwrap();
+        let expected = (delta_t1 - delta_t0) / dt;
+        
+        assert!((charm - expected).abs() < dec!(0.0001));
+    }
+}
+```
+
+### Integration Tests
+
+```rust
+// tests/integration/metrics_integration.rs
+
+#[test]
+fn test_full_metrics_pipeline() {
+    let chain = load_test_chain("SPY_2024_01.json");
+    
+    // Generate all temporal curves
+    let theta = ThetaCurveGenerator::new().generate(&chain).unwrap();
+    let charm = CharmCurveGenerator::new().generate(&chain).unwrap();
+    
+    // Generate IV surface
+    let iv_surface = IVSurfaceGenerator::new().generate(&chain).unwrap();
+    
+    // Verify consistency
+    assert_eq!(theta.points.len(), charm.points.len());
+}
+```
+
+---
+
+## Visualization Integration
+
+The existing `visualization/` module with plotly support can be extended:
+
+```rust
+// Example: Add to visualization/utils.rs or create visualization/metrics.rs
+
+impl Curve {
+    #[cfg(feature = "plotly")]
+    pub fn to_plotly_trace(&self, name: &str) -> Box<Scatter<f64, f64>> {
+        let x: Vec<f64> = self.points.iter().map(|(x, _)| x.to_f64()).collect();
+        let y: Vec<f64> = self.points.iter().map(|(_, y)| y.to_f64()).collect();
+        
+        Scatter::new(x, y).name(name)
+    }
+}
+
+impl Surface {
+    #[cfg(feature = "plotly")]
+    pub fn to_plotly_surface(&self, name: &str) -> Box<Surface3D<f64, f64, f64>> {
+        // Transform points to plotly format
+        // ...
+    }
+}
+```
+
+---
+
+## Summary
+
+This revised implementation plan integrates with your existing architecture:
+
+1. **Metrics go in `src/metrics/`** - expanding the existing structure
+2. **Reuse `Curve` and `Surface`** types from existing modules
+3. **Reuse interpolation** from `src/geometrics/interpolation/`
+4. **Delta adjustment extends** `src/strategies/delta_neutral/`
+
+Estimated total: **8-10 weeks** for one developer, with #187 parallelizable with the metrics track.

--- a/.windsurf/refactoring_issues.md
+++ b/.windsurf/refactoring_issues.md
@@ -1,0 +1,502 @@
+# OptionStratLib Refactoring Issues
+
+This document describes the GitHub issues to be created for the refactoring of OptionStratLib.
+Each issue is designed to be self-contained and can be worked on independently.
+
+---
+
+## Issue #1: Reduce `.unwrap()` usage in `chains/chain.rs`
+
+### Title
+`refactor: Replace unwrap() calls with proper error handling in chains/chain.rs`
+
+### Labels
+`refactor`, `error-handling`, `priority-high`
+
+### Description
+The file `src/chains/chain.rs` contains 257 occurrences of `.unwrap()` which can cause panics in production. This issue focuses on replacing these with proper error handling.
+
+### Tasks
+- [ ] Audit all `.unwrap()` calls in `chains/chain.rs`
+- [ ] Replace with `?` operator where the function returns `Result`
+- [ ] Replace with `unwrap_or_default()` or `unwrap_or_else()` where appropriate
+- [ ] Add proper error types to `error/chains.rs` if needed
+- [ ] Update tests to verify error handling behavior
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- No `.unwrap()` calls remain in production code (only in tests)
+- All existing tests pass
+- New error cases are properly documented
+
+### Estimated Effort
+Medium (4-6 hours)
+
+---
+
+## Issue #2: Reduce `.unwrap()` usage in `greeks/equations.rs`
+
+### Title
+`refactor: Replace unwrap() calls with proper error handling in greeks/equations.rs`
+
+### Labels
+`refactor`, `error-handling`, `priority-high`
+
+### Description
+The file `src/greeks/equations.rs` contains 156 occurrences of `.unwrap()`. Greeks calculations are critical for options pricing and should never panic.
+
+### Tasks
+- [ ] Audit all `.unwrap()` calls in `greeks/equations.rs`
+- [ ] Replace with `?` operator where the function returns `Result`
+- [ ] Use `GreeksError` for domain-specific errors
+- [ ] Add `#[must_use]` annotations where appropriate
+- [ ] Update tests to verify error handling behavior
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- No `.unwrap()` calls remain in production code
+- All existing tests pass
+- Error messages are clear and actionable
+
+### Estimated Effort
+Medium (3-5 hours)
+
+---
+
+## Issue #3: Reduce `.unwrap()` usage in `model/option.rs`
+
+### Title
+`refactor: Replace unwrap() calls with proper error handling in model/option.rs`
+
+### Labels
+`refactor`, `error-handling`, `priority-high`
+
+### Description
+The file `src/model/option.rs` contains 134 occurrences of `.unwrap()`. The Options struct is fundamental to the library and should handle errors gracefully.
+
+### Tasks
+- [ ] Audit all `.unwrap()` calls in `model/option.rs`
+- [ ] Replace with proper error handling using `OptionsError`
+- [ ] Ensure all public methods return `Result` where failure is possible
+- [ ] Update documentation with error conditions
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- No `.unwrap()` calls remain in production code
+- All existing tests pass
+- API documentation includes error conditions
+
+### Estimated Effort
+Medium (4-6 hours)
+
+---
+
+## Issue #4: Resolve TODOs in `pricing/black_scholes_model.rs`
+
+### Title
+`fix: Resolve 14 TODO/FIXME items in black_scholes_model.rs`
+
+### Labels
+`bug`, `pricing`, `priority-high`
+
+### Description
+The file `src/pricing/black_scholes_model.rs` contains 14 TODO/FIXME comments that need to be addressed. These are critical for correct options pricing.
+
+### Tasks
+- [ ] Review each TODO/FIXME comment
+- [ ] Implement missing functionality
+- [ ] Add tests for edge cases mentioned in TODOs
+- [ ] Remove TODO comments once resolved
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- All TODO/FIXME comments are resolved or converted to tracked issues
+- Pricing accuracy is maintained or improved
+- New tests cover the resolved items
+
+### Estimated Effort
+High (6-8 hours)
+
+---
+
+## Issue #5: Resolve TODOs in `model/position.rs`
+
+### Title
+`fix: Resolve 4 TODO/FIXME items in model/position.rs`
+
+### Labels
+`bug`, `model`, `priority-medium`
+
+### Description
+The file `src/model/position.rs` contains 4 TODO/FIXME comments that need to be addressed.
+
+### Tasks
+- [ ] Review each TODO/FIXME comment
+- [ ] Implement missing functionality
+- [ ] Add tests for resolved items
+- [ ] Remove TODO comments once resolved
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- All TODO/FIXME comments are resolved
+- Position management works correctly
+- Tests verify the resolved functionality
+
+### Estimated Effort
+Low (2-3 hours)
+
+---
+
+## Issue #6: Extract common logic from strategy files
+
+### Title
+`refactor: Extract common strategy logic to reduce file sizes`
+
+### Labels
+`refactor`, `strategies`, `priority-medium`
+
+### Description
+Several strategy files are excessively large due to duplicated logic:
+- `short_strangle.rs` (129KB)
+- `iron_condor.rs` (126KB)
+- `iron_butterfly.rs` (113KB)
+- `long_butterfly_spread.rs` (112KB)
+
+### Tasks
+- [ ] Identify common patterns across strategy implementations
+- [ ] Create shared traits for strategy categories:
+  - `SpreadStrategy` for vertical spreads
+  - `ButterflyStrategy` for butterfly patterns
+  - `CondorStrategy` for condor patterns
+- [ ] Extract common calculation methods to `strategies/utils.rs`
+- [ ] Refactor strategies to use shared traits and utilities
+- [ ] Ensure all tests pass after refactoring
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Each strategy file is under 50KB
+- No functionality is lost
+- Code duplication is significantly reduced
+- All tests pass
+
+### Estimated Effort
+High (8-12 hours)
+
+---
+
+## Issue #7: Reduce unnecessary `.clone()` calls
+
+### Title
+`perf: Reduce unnecessary clone() calls across the codebase`
+
+### Labels
+`performance`, `refactor`, `priority-medium`
+
+### Description
+The codebase contains 795 occurrences of `.clone()`. Many of these could be avoided with better use of references, `Cow<T>`, or `Arc<T>`.
+
+### Tasks
+- [ ] Audit `.clone()` calls in high-frequency code paths:
+  - `chains/chain.rs` (55 occurrences)
+  - `strategies/short_strangle.rs` (49 occurrences)
+  - `strategies/iron_condor.rs` (46 occurrences)
+- [ ] Replace with references where possible
+- [ ] Use `Cow<'_, T>` for data that is rarely modified
+- [ ] Use `Arc<T>` for shared data in multi-threaded contexts
+- [ ] Benchmark critical paths before and after
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Clone count reduced by at least 50%
+- No performance regression (verified by benchmarks)
+- All tests pass
+
+### Estimated Effort
+Medium (4-6 hours)
+
+---
+
+## Issue #8: Implement Collar strategy
+
+### Title
+`feat: Complete implementation of Collar strategy`
+
+### Labels
+`enhancement`, `strategies`, `priority-medium`
+
+### Description
+The file `src/strategies/collar.rs` is almost empty (388 bytes). The Collar strategy is an important protective strategy that should be fully implemented.
+
+### Tasks
+- [ ] Implement `Collar` struct with all required fields
+- [ ] Implement `Strategable` trait
+- [ ] Implement `StrategyConstructor` trait
+- [ ] Implement `Profit` calculations
+- [ ] Implement `Greeks` calculations
+- [ ] Implement `DeltaNeutrality` trait
+- [ ] Add comprehensive tests
+- [ ] Add documentation with examples
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Collar strategy is fully functional
+- All trait implementations are complete
+- Tests cover edge cases
+- Documentation includes usage examples
+
+### Estimated Effort
+High (6-8 hours)
+
+---
+
+## Issue #9: Implement Protective Put strategy
+
+### Title
+`feat: Complete implementation of Protective Put strategy`
+
+### Labels
+`enhancement`, `strategies`, `priority-medium`
+
+### Description
+The file `src/strategies/protective_put.rs` is almost empty (358 bytes). The Protective Put is a fundamental hedging strategy that should be fully implemented.
+
+### Tasks
+- [ ] Implement `ProtectivePut` struct with all required fields
+- [ ] Implement `Strategable` trait
+- [ ] Implement `StrategyConstructor` trait
+- [ ] Implement `Profit` calculations
+- [ ] Implement `Greeks` calculations
+- [ ] Implement `DeltaNeutrality` trait
+- [ ] Add comprehensive tests
+- [ ] Add documentation with examples
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Protective Put strategy is fully functional
+- All trait implementations are complete
+- Tests cover edge cases
+- Documentation includes usage examples
+
+### Estimated Effort
+Medium (4-6 hours)
+
+---
+
+## Issue #10: Improve error context with anyhow
+
+### Title
+`refactor: Add error context using anyhow at API boundaries`
+
+### Labels
+`refactor`, `error-handling`, `priority-low`
+
+### Description
+While the project uses `thiserror` for typed errors, adding `anyhow::Context` at API boundaries would improve error messages for users.
+
+### Tasks
+- [ ] Add `anyhow` as a dependency
+- [ ] Identify public API boundaries
+- [ ] Add `.context()` calls to provide meaningful error messages
+- [ ] Update error documentation
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Error messages include context about what operation failed
+- Existing error types are preserved
+- No breaking changes to public API
+
+### Estimated Effort
+Low (2-3 hours)
+
+---
+
+## Issue #11: Add benchmarks for critical paths
+
+### Title
+`test: Add comprehensive benchmarks for critical code paths`
+
+### Labels
+`testing`, `performance`, `priority-low`
+
+### Description
+Currently there is only one benchmark file. Adding more benchmarks will help identify performance regressions.
+
+### Tasks
+- [ ] Add benchmarks for Greeks calculations
+- [ ] Add benchmarks for Black-Scholes pricing
+- [ ] Add benchmarks for option chain construction
+- [ ] Add benchmarks for strategy profit calculations
+- [ ] Document baseline performance metrics
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Benchmarks cover all critical code paths
+- Baseline metrics are documented
+- CI can detect performance regressions
+
+### Estimated Effort
+Medium (4-6 hours)
+
+---
+
+## Issue #12: Add property-based testing
+
+### Title
+`test: Add property-based testing for mathematical invariants`
+
+### Labels
+`testing`, `quality`, `priority-low`
+
+### Description
+Add property-based testing using `proptest` to validate mathematical invariants like Put-Call Parity and Greeks bounds.
+
+### Tasks
+- [ ] Add `proptest` as a dev dependency
+- [ ] Add property tests for Put-Call Parity
+- [ ] Add property tests for Greeks bounds (0 ≤ delta ≤ 1 for calls)
+- [ ] Add property tests for arbitrage-free pricing
+- [ ] Add property tests for Positive type invariants
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Property tests cover key mathematical invariants
+- Tests run as part of the test suite
+- No false positives in normal operation
+
+### Estimated Effort
+Medium (4-6 hours)
+
+---
+
+## Issue #13: Add async feature flag for I/O operations
+
+### Title
+`feat: Add async feature flag for asynchronous I/O operations`
+
+### Labels
+`enhancement`, `feature`, `priority-low`
+
+### Description
+Add an optional `async` feature flag that enables asynchronous I/O operations for loading option chains and market data.
+
+### Tasks
+- [ ] Add `tokio` as an optional dependency
+- [ ] Create `async` feature flag in `Cargo.toml`
+- [ ] Add async versions of file loading functions
+- [ ] Add async versions of data fetching functions
+- [ ] Add documentation for async usage
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- Async feature is optional and doesn't affect sync users
+- Async API mirrors sync API
+- Documentation explains when to use async
+
+### Estimated Effort
+Medium (4-6 hours)
+
+---
+
+## Issue #14: Improve documentation for new metrics modules
+
+### Title
+`docs: Add comprehensive documentation for metrics modules`
+
+### Labels
+`documentation`, `priority-low`
+
+### Description
+The new metrics modules (`composite/`, `liquidity/`, `stress/`, `temporal/`) need more comprehensive documentation with examples.
+
+### Tasks
+- [ ] Add module-level documentation with overview
+- [ ] Add examples for each trait implementation
+- [ ] Add mathematical background where appropriate
+- [ ] Add usage examples in doc comments
+- [ ] Verify examples compile with `cargo test --doc`
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- All public items have documentation
+- Examples are runnable
+- Mathematical formulas are explained
+
+### Estimated Effort
+Low (2-4 hours)
+
+---
+
+## Issue #15: Reduce `.expect()` usage in production code
+
+### Title
+`refactor: Replace expect() calls with proper error handling`
+
+### Labels
+`refactor`, `error-handling`, `priority-medium`
+
+### Description
+The codebase contains 163 occurrences of `.expect()`. While better than `.unwrap()`, these should still be replaced with proper error handling in production code.
+
+### Tasks
+- [ ] Audit `.expect()` calls in production code
+- [ ] Focus on high-impact files:
+  - `pnl/metrics.rs` (37 occurrences)
+  - `model/format.rs` (14 occurrences)
+- [ ] Replace with `?` operator or proper error handling
+- [ ] Keep `.expect()` only in tests and initialization code
+- [ ] Run `make lint-fix` and `make pre-push` to verify
+
+### Acceptance Criteria
+- `.expect()` only used in tests and initialization
+- All existing tests pass
+- Error messages are preserved or improved
+
+### Estimated Effort
+Medium (3-5 hours)
+
+---
+
+## Summary Table
+
+| Issue | Title | Priority | Effort | Labels |
+|-------|-------|----------|--------|--------|
+| #1 | Reduce unwrap() in chains/chain.rs | High | Medium | refactor, error-handling |
+| #2 | Reduce unwrap() in greeks/equations.rs | High | Medium | refactor, error-handling |
+| #3 | Reduce unwrap() in model/option.rs | High | Medium | refactor, error-handling |
+| #4 | Resolve TODOs in black_scholes_model.rs | High | High | bug, pricing |
+| #5 | Resolve TODOs in model/position.rs | Medium | Low | bug, model |
+| #6 | Extract common strategy logic | Medium | High | refactor, strategies |
+| #7 | Reduce unnecessary clone() calls | Medium | Medium | performance, refactor |
+| #8 | Implement Collar strategy | Medium | High | enhancement, strategies |
+| #9 | Implement Protective Put strategy | Medium | Medium | enhancement, strategies |
+| #10 | Improve error context with anyhow | Low | Low | refactor, error-handling |
+| #11 | Add benchmarks for critical paths | Low | Medium | testing, performance |
+| #12 | Add property-based testing | Low | Medium | testing, quality |
+| #13 | Add async feature flag | Low | Medium | enhancement, feature |
+| #14 | Improve metrics documentation | Low | Low | documentation |
+| #15 | Reduce expect() usage | Medium | Medium | refactor, error-handling |
+
+---
+
+## Recommended Order of Execution
+
+1. **Phase 1 - Critical Fixes** (Issues #1-#4)
+   - Focus on error handling and pricing correctness
+   - Estimated: 2-3 weeks
+
+2. **Phase 2 - Code Quality** (Issues #5-#7, #15)
+   - Reduce technical debt and improve performance
+   - Estimated: 2 weeks
+
+3. **Phase 3 - Feature Completion** (Issues #8-#9)
+   - Complete missing strategies
+   - Estimated: 1-2 weeks
+
+4. **Phase 4 - Polish** (Issues #10-#14)
+   - Improve testing, documentation, and developer experience
+   - Estimated: 2 weeks
+
+---
+
+*Generated on: 2024-12-24*
+*Total Estimated Effort: 60-90 hours*

--- a/examples/examples_chain/src/bin/option_chain_build_synthetic.rs
+++ b/examples/examples_chain/src/bin/option_chain_build_synthetic.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     option_chain_base.update_expiration_date(get_x_days_formatted(2));
     let chain_params = option_chain_base.to_build_params()?;
     info!("Chain params: {}", chain_params);
-    let mut option_chain = OptionChain::build_chain(&chain_params);
+    let mut option_chain = OptionChain::build_chain(&chain_params)?;
     option_chain.update_greeks();
     info!("{}", option_chain);
     option_chain.show();

--- a/examples/examples_chain/src/bin/test_yellow_highlight.rs
+++ b/examples/examples_chain/src/bin/test_yellow_highlight.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
         Positive::new(0.20)?,        // implied_volatility
     );
 
-    let mut chain = OptionChain::build_chain(&params);
+    let mut chain = OptionChain::build_chain(&params).unwrap();
     chain.update_greeks();
 
     tracing::info!("=== Testing Yellow Highlighting for Strike Prices Multiple of 25 ===");

--- a/examples/examples_metrics/src/bin/all_composite_metrics.rs
+++ b/examples/examples_metrics/src/bin/all_composite_metrics.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!("Option Chain Information:");
     tracing::info!("  Symbol: {}", option_chain.symbol);

--- a/examples/examples_metrics/src/bin/all_risk_metrics.rs
+++ b/examples/examples_metrics/src/bin/all_risk_metrics.rs
@@ -188,7 +188,8 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20), // 20% base IV
     );
 
-    let dg_chain = OptionChain::build_chain(&dg_params);
+    let dg_chain = OptionChain::build_chain(&dg_params)
+        .map_err(|e| CurveError::ConstructionError(e.to_string()))?;
 
     let dg_curve_call = dg_chain.dollar_gamma_curve(&OptionStyle::Call)?;
     let dg_curve_put = dg_chain.dollar_gamma_curve(&OptionStyle::Put)?;

--- a/examples/examples_metrics/src/bin/all_stress_metrics.rs
+++ b/examples/examples_metrics/src/bin/all_stress_metrics.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!("Option Chain Information:");
     tracing::info!("  Symbol: {}", option_chain.symbol);

--- a/examples/examples_metrics/src/bin/all_temporal_metrics.rs
+++ b/examples/examples_metrics/src/bin/all_temporal_metrics.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!("Option Chain Information:");
     tracing::info!("  Symbol: {}", option_chain.symbol);

--- a/examples/examples_metrics/src/bin/charm_metrics.rs
+++ b/examples/examples_metrics/src/bin/charm_metrics.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/color_metrics.rs
+++ b/examples/examples_metrics/src/bin/color_metrics.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/delta_gamma_profile.rs
+++ b/examples/examples_metrics/src/bin/delta_gamma_profile.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/dollar_gamma_curve.rs
+++ b/examples/examples_metrics/src/bin/dollar_gamma_curve.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20), // Base IV of 20%
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/price_shock_impact.rs
+++ b/examples/examples_metrics/src/bin/price_shock_impact.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/smile_dynamics.rs
+++ b/examples/examples_metrics/src/bin/smile_dynamics.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.18), // 18% base IV
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/theta_metrics.rs
+++ b/examples/examples_metrics/src/bin/theta_metrics.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/time_decay_profile.rs
+++ b/examples/examples_metrics/src/bin/time_decay_profile.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/vanna_volga_surface.rs
+++ b/examples/examples_metrics/src/bin/vanna_volga_surface.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), SurfaceError> {
         pos_or_panic!(0.20), // 20% base IV
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_metrics/src/bin/volatility_sensitivity.rs
+++ b/examples/examples_metrics/src/bin/volatility_sensitivity.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), CurveError> {
         pos_or_panic!(0.20),
     );
 
-    let option_chain = OptionChain::build_chain(&params);
+    let option_chain = OptionChain::build_chain(&params).unwrap();
 
     tracing::info!(
         "Built option chain for {} with {} options",

--- a/examples/examples_simulation/src/bin/historical_build_chain.rs
+++ b/examples/examples_simulation/src/bin/historical_build_chain.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Error> {
         price_params,
         implied_volatility,
     );
-    let mut initial_chain = OptionChain::build_chain(&build_params);
+    let mut initial_chain = OptionChain::build_chain(&build_params)?;
     initial_chain.update_expiration_date(get_x_days_formatted(2));
     let walker = Box::new(Walker::new());
 

--- a/examples/examples_simulation/src/bin/random_walk_build_chain.rs
+++ b/examples/examples_simulation/src/bin/random_walk_build_chain.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Error> {
         price_params,
         implied_volatility,
     );
-    let mut initial_chain = OptionChain::build_chain(&build_params);
+    let mut initial_chain = OptionChain::build_chain(&build_params)?;
     initial_chain.update_expiration_date(get_x_days_formatted(2));
     let walker = Box::new(Walker::new());
 

--- a/examples/examples_simulation/src/bin/random_walk_build_series.rs
+++ b/examples/examples_simulation/src/bin/random_walk_build_series.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Error> {
             pos_or_panic!(120.0),
         ],
     );
-    let initial_series = OptionSeries::build_series(&series_params);
+    let initial_series = OptionSeries::build_series(&series_params)?;
     let walker = Box::new(Walker::new());
 
     let walk_params = WalkParams {

--- a/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_area.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Error> {
     option_chain.update_expiration_date(get_x_days_formatted(30));
     let chain_params = option_chain.to_build_params()?;
     info!("Chain params: {:#?}", chain_params);
-    let mut option_chain = OptionChain::build_chain(&chain_params);
+    let mut option_chain = OptionChain::build_chain(&chain_params)?;
     option_chain.update_greeks();
 
     debug!("Option Chain:  {}", option_chain);

--- a/src/chains/generators.rs
+++ b/src/chains/generators.rs
@@ -49,7 +49,7 @@ fn create_chain_from_step(
         chain_params.price_params.expiration_date = Some(exp_date);
     }
 
-    let mut new_chain = OptionChain::build_chain(&chain_params);
+    let mut new_chain = OptionChain::build_chain(&chain_params)?;
     new_chain.update_greeks();
     Ok(new_chain)
 }

--- a/src/chains/mod.rs
+++ b/src/chains/mod.rs
@@ -47,7 +47,7 @@
 //!             pos_or_panic!(0.2),
 //!         );
 //!
-//! let built_chain = OptionChain::build_chain(&option_chain_params);
+//! let built_chain = OptionChain::build_chain(&option_chain_params).unwrap();
 //! assert_eq!(built_chain.symbol, "SP500");
 //! assert_eq!(built_chain.underlying_price, Positive::new(100.0).unwrap());
 //! ```
@@ -148,7 +148,7 @@
 //!     pos_or_panic!(0.2),
 //! );
 //!
-//! let option_chain = OptionChain::build_chain(&option_chain_params);
+//! let option_chain = OptionChain::build_chain(&option_chain_params).unwrap();
 //! // Calculate RND from option chain
 //! let rnd_result = option_chain.calculate_rnd(&params).unwrap();
 //!

--- a/src/chains/rnd.rs
+++ b/src/chains/rnd.rs
@@ -66,7 +66,7 @@
 //!             pos_or_panic!(0.1),
 //!         );
 //!
-//! let option_chain = OptionChain::build_chain(&option_chain_params);
+//! let option_chain = OptionChain::build_chain(&option_chain_params).unwrap();
 //! // Calculate RND from option chain
 //! let rnd_result = option_chain.calculate_rnd(&params).unwrap();
 //!
@@ -1530,7 +1530,7 @@ mod chain_test {
             pos_or_panic!(0.2),
         );
 
-        OptionChain::build_chain(&option_chain_params)
+        OptionChain::build_chain(&option_chain_params).unwrap()
     }
     #[test]
     fn test_chain_creation() {
@@ -1553,7 +1553,7 @@ mod chain_test {
             pos_or_panic!(0.2),
         );
 
-        let chain = OptionChain::build_chain(&option_chain_params);
+        let chain = OptionChain::build_chain(&option_chain_params).unwrap();
 
         let params = RNDParameters {
             risk_free_rate: dec!(0.05),
@@ -1597,7 +1597,7 @@ mod chain_test {
             pos_or_panic!(0.2),
         );
 
-        let chain = OptionChain::build_chain(&option_chain_params);
+        let chain = OptionChain::build_chain(&option_chain_params).unwrap();
         let params = RNDParameters {
             risk_free_rate: dec!(0.05),
             interpolation_points: 100,

--- a/src/chains/utils.rs
+++ b/src/chains/utils.rs
@@ -802,7 +802,7 @@ mod tests_strike_step {
             price_params,
             implied_volatility,
         );
-        let initial_chain = OptionChain::build_chain(&build_params);
+        let initial_chain = OptionChain::build_chain(&build_params).unwrap();
         assert_eq!(initial_chain.len() - 1, chain_size);
     }
 }
@@ -1519,7 +1519,7 @@ mod tests_sample {
             pos_or_panic!(0.25),
         );
 
-        let built_chain = OptionChain::build_chain(&params);
+        let built_chain = OptionChain::build_chain(&params).unwrap();
 
         assert_eq!(built_chain.symbol, "AAPL");
         assert_eq!(built_chain.underlying_price, Positive::new(100.0).unwrap());

--- a/src/series/generators.rs
+++ b/src/series/generators.rs
@@ -42,7 +42,7 @@ fn create_series_from_step(
     if let Some(volatility) = volatility {
         series_params.set_implied_volatility(volatility);
     }
-    let new_chain = OptionSeries::build_series(&series_params);
+    let new_chain = OptionSeries::build_series(&series_params)?;
     Ok(new_chain)
 }
 
@@ -252,7 +252,7 @@ mod tests_generator_optionseries {
         let series_params = OptionSeriesBuildParams::new(chain_params, series);
 
         // Build the option series
-        OptionSeries::build_series(&series_params)
+        OptionSeries::build_series(&series_params).unwrap()
     }
 
     #[test]

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -1212,7 +1212,7 @@ mod tests_short_straddle {
             option_data_price_params,
             pos_or_panic!(0.2),
         );
-        OptionChain::build_chain(&option_chain_build_params)
+        OptionChain::build_chain(&option_chain_build_params).unwrap()
     }
 }
 

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -1499,7 +1499,7 @@ is expected and the underlying asset's price is anticipated to remain stable."
             option_data_price_params,
             pos_or_panic!(0.2),
         );
-        OptionChain::build_chain(&option_chain_build_params)
+        OptionChain::build_chain(&option_chain_build_params).unwrap()
     }
 }
 

--- a/tests/unit/chain/composite_metrics_test.rs
+++ b/tests/unit/chain/composite_metrics_test.rs
@@ -43,7 +43,7 @@ fn create_test_chain() -> OptionChain {
         pos_or_panic!(0.20), // Base IV of 20%
     );
 
-    OptionChain::build_chain(&params)
+    OptionChain::build_chain(&params).unwrap()
 }
 
 /// Creates an empty option chain for edge case testing

--- a/tests/unit/chain/random_walk_chain.rs
+++ b/tests/unit/chain/random_walk_chain.rs
@@ -36,7 +36,7 @@ fn create_chain_from_step(
         chain_params.set_implied_volatility(volatility);
     }
 
-    let new_chain = OptionChain::build_chain(&chain_params);
+    let new_chain = OptionChain::build_chain(&chain_params)?;
     assert!(new_chain.len() > 0,);
     Ok(new_chain)
 }

--- a/tests/unit/chain/risk_metrics_test.rs
+++ b/tests/unit/chain/risk_metrics_test.rs
@@ -43,7 +43,7 @@ fn create_test_chain() -> OptionChain {
         pos_or_panic!(0.20),
     );
 
-    OptionChain::build_chain(&params)
+    OptionChain::build_chain(&params).unwrap()
 }
 
 /// Creates an empty option chain for edge case testing.
@@ -411,7 +411,7 @@ mod tests_edge_cases {
             pos_or_panic!(0.80), // High base volatility
         );
 
-        let chain = OptionChain::build_chain(&params);
+        let chain = OptionChain::build_chain(&params).unwrap();
 
         // All metrics should still work
         assert!(chain.iv_curve().is_ok());
@@ -440,7 +440,7 @@ mod tests_edge_cases {
             pos_or_panic!(0.05), // Low base volatility
         );
 
-        let chain = OptionChain::build_chain(&params);
+        let chain = OptionChain::build_chain(&params).unwrap();
 
         // All metrics should still work
         assert!(chain.iv_curve().is_ok());
@@ -469,7 +469,7 @@ mod tests_edge_cases {
             pos_or_panic!(0.25),
         );
 
-        let chain = OptionChain::build_chain(&params);
+        let chain = OptionChain::build_chain(&params).unwrap();
 
         // Risk reversal should show the skew
         let rr_curve = chain.risk_reversal_curve().unwrap();

--- a/tests/unit/chain/stress_metrics_test.rs
+++ b/tests/unit/chain/stress_metrics_test.rs
@@ -42,7 +42,7 @@ fn create_test_chain() -> OptionChain {
         pos_or_panic!(0.20),
     );
 
-    OptionChain::build_chain(&params)
+    OptionChain::build_chain(&params).unwrap()
 }
 
 /// Creates an empty option chain for edge case testing

--- a/tests/unit/chain/temporal_metrics_test.rs
+++ b/tests/unit/chain/temporal_metrics_test.rs
@@ -39,7 +39,7 @@ fn create_test_chain() -> OptionChain {
         pos_or_panic!(0.20),
     );
 
-    OptionChain::build_chain(&params)
+    OptionChain::build_chain(&params).unwrap()
 }
 
 /// Creates an empty option chain for edge case testing


### PR DESCRIPTION
## Summary

This PR improves error handling in the option chain building process by replacing `unwrap()` calls with proper `Result` returns.

## Changes

### Core Changes
- **`OptionChain::build_chain`**: Now returns `Result<Self, ChainError>` instead of `Self`
- **`OptionSeries::build_series`**: Now returns `Result<Self, ChainError>` instead of `Self`
- **`set_from_title`**: Replaced `unwrap()` and `panic!()` with proper error handling

### Error Handling Improvements
- Replaced `unwrap()` with `?` operator for error propagation
- Replaced `is_some() && unwrap()` pattern with `map_or()` for delta filtering
- Added proper error messages using `ChainError::invalid_parameters`

### Updated Files
- `src/chains/chain.rs`: Core changes to `build_chain` and related methods
- `src/chains/generators.rs`: Updated to propagate errors
- `src/series/model.rs`: Updated `build_series` to return `Result`
- `src/series/generators.rs`: Updated to propagate errors
- All tests and examples updated to handle the new `Result` return type

## Benefits
- More robust API that doesn't panic on invalid input
- Better error messages for debugging
- Follows Rust best practices for error handling
- Allows callers to decide how to handle errors

## Testing
- All library tests pass (`cargo test --lib`)
- All integration tests pass (`cargo test --test tests`)
- `make lint-fix` passes
- `make pre-push` passes

## Breaking Changes
This is a breaking change for any code that calls:
- `OptionChain::build_chain()`
- `OptionSeries::build_series()`

Callers need to add `.unwrap()` or `?` to handle the `Result`.