### PR TITLE
test(option,position,expiration): replace unwrap() with expect() for descriptive error messages - Phase 4 of #227

### DIFF
--- a/src/model/expiration.rs
+++ b/src/model/expiration.rs
@@ -664,13 +664,28 @@ mod tests_expiration_date {
     #[test]
     fn test_expiration_date_days() {
         let expiration = ExpirationDate::Days(DAYS_IN_A_YEAR);
-        assert_eq!(expiration.get_years().unwrap(), 1.0);
+        assert_eq!(
+            expiration
+                .get_years()
+                .expect("get_years should succeed for 365 days"),
+            1.0
+        );
 
         let expiration = ExpirationDate::Days(pos_or_panic!(182.5));
-        assert_eq!(expiration.get_years().unwrap(), 0.5);
+        assert_eq!(
+            expiration
+                .get_years()
+                .expect("get_years should succeed for 182.5 days"),
+            0.5
+        );
 
         let expiration = ExpirationDate::Days(Positive::ZERO);
-        assert_eq!(expiration.get_years().unwrap(), ZERO);
+        assert_eq!(
+            expiration
+                .get_years()
+                .expect("get_years should succeed for zero days"),
+            ZERO
+        );
     }
 
     #[test]
@@ -678,12 +693,28 @@ mod tests_expiration_date {
         // Test for a date exactly one year in the future
         let one_year_future = Utc::now() + Duration::days(365);
         let expiration = ExpirationDate::DateTime(one_year_future);
-        assert!((expiration.get_years().unwrap().to_f64() - 1.0).abs() < 0.01); // Allow small deviation due to leap years
+        assert!(
+            (expiration
+                .get_years()
+                .expect("get_years should succeed for datetime one year future")
+                .to_f64()
+                - 1.0)
+                .abs()
+                < 0.01
+        ); // Allow small deviation due to leap years
 
         // Test for a date 6 months in the future
         let six_months_future = Utc::now() + Duration::days(182);
         let expiration = ExpirationDate::DateTime(six_months_future);
-        assert!((expiration.get_years().unwrap().to_f64() - 0.5).abs() < 0.01);
+        assert!(
+            (expiration
+                .get_years()
+                .expect("get_years should succeed for datetime six months future")
+                .to_f64()
+                - 0.5)
+                .abs()
+                < 0.01
+        );
     }
 
     #[test]
@@ -692,14 +723,21 @@ mod tests_expiration_date {
         // let specific_date = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
         let specific_date = Utc::now() + Duration::days(1);
         let expiration = ExpirationDate::DateTime(specific_date);
-        assert!(expiration.get_years().unwrap() > Positive::ZERO);
+        assert!(
+            expiration
+                .get_years()
+                .expect("get_years should succeed for specific datetime")
+                > Positive::ZERO
+        );
     }
 
     #[test]
     fn test_get_date_from_datetime() {
         let future_date = Utc::now() + Duration::days(60);
         let expiration = ExpirationDate::DateTime(future_date);
-        let result = expiration.get_date().unwrap();
+        let result = expiration
+            .get_date()
+            .expect("get_date should succeed for future datetime");
 
         assert_eq!(result, future_date);
     }
@@ -708,14 +746,18 @@ mod tests_expiration_date {
     fn test_get_date_from_past_datetime() {
         let past_date = Utc::now() - Duration::days(30);
         let expiration = ExpirationDate::DateTime(past_date);
-        let result = expiration.get_date().unwrap();
+        let result = expiration
+            .get_date()
+            .expect("get_date should succeed for past datetime");
         assert_eq!(result, past_date);
     }
 
     #[test]
     fn test_positive_days() {
         let expiration = ExpirationDate::Days(DAYS_IN_A_YEAR);
-        let years = expiration.get_years().unwrap();
+        let years = expiration
+            .get_years()
+            .expect("get_years should succeed for positive days");
         assert_eq!(years, 1.0);
     }
 

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -1018,7 +1018,10 @@ mod tests_options {
     fn test_time_to_expiration() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         assert_relative_eq!(
-            option.time_to_expiration().unwrap().to_f64(),
+            option
+                .time_to_expiration()
+                .expect("time_to_expiration should succeed for valid option")
+                .to_f64(),
             30.0 / 365.0,
             epsilon = 0.0001
         );
@@ -1038,8 +1041,18 @@ mod tests_options {
             pos_or_panic!(0.01),
             None,
         );
-        assert!(option_with_datetime.time_to_expiration().unwrap() >= 59.0 / 365.0);
-        assert!(option_with_datetime.time_to_expiration().unwrap() < 61.0 / 365.0);
+        assert!(
+            option_with_datetime
+                .time_to_expiration()
+                .expect("time_to_expiration should succeed for datetime option")
+                >= 59.0 / 365.0
+        );
+        assert!(
+            option_with_datetime
+                .time_to_expiration()
+                .expect("time_to_expiration should succeed for datetime option")
+                < 61.0 / 365.0
+        );
     }
 
     #[test]
@@ -1069,14 +1082,18 @@ mod tests_options {
     #[test]
     fn test_calculate_price_binomial() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        let price = option.calculate_price_binomial(100).unwrap();
+        let price = option
+            .calculate_price_binomial(100)
+            .expect("binomial pricing should succeed for valid option");
         assert!(price > Decimal::ZERO);
     }
 
     #[test]
     fn test_calculate_price_binomial_tree() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        let (price, asset_tree, option_tree) = option.calculate_price_binomial_tree(5).unwrap();
+        let (price, asset_tree, option_tree) = option
+            .calculate_price_binomial_tree(5)
+            .expect("binomial tree pricing should succeed");
         assert!(price > Decimal::ZERO);
         assert_eq!(asset_tree.len(), 6);
         assert_eq!(option_tree.len(), 6);
@@ -1085,7 +1102,9 @@ mod tests_options {
     #[test]
     fn test_calculate_price_binomial_tree_short() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Short);
-        let (price, asset_tree, option_tree) = option.calculate_price_binomial_tree(5).unwrap();
+        let (price, asset_tree, option_tree) = option
+            .calculate_price_binomial_tree(5)
+            .expect("binomial tree pricing should succeed for short option");
         assert!(price > Decimal::ZERO);
         assert_eq!(asset_tree.len(), 6);
         assert_eq!(option_tree.len(), 6);
@@ -1094,14 +1113,18 @@ mod tests_options {
     #[test]
     fn test_calculate_price_black_scholes() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        let price = option.calculate_price_black_scholes().unwrap();
+        let price = option
+            .calculate_price_black_scholes()
+            .expect("Black-Scholes pricing should succeed for valid option");
         assert!(price > Decimal::ZERO);
     }
 
     #[test]
     fn test_payoff_european_call_long() {
         let call_option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        let call_payoff = call_option.payoff().unwrap();
+        let call_payoff = call_option
+            .payoff()
+            .expect("payoff calculation should succeed for call option");
         assert_eq!(call_payoff, Decimal::ZERO); // max(100 - 100, 0) = 0
 
         let put_option = Options::new(
@@ -1118,8 +1141,13 @@ mod tests_options {
             pos_or_panic!(0.01),
             None,
         );
-        let put_payoff = put_option.payoff().unwrap();
-        assert_eq!(put_payoff.to_f64().unwrap(), 5.0); // max(100 - 95, 0) = 5
+        let put_payoff = put_option
+            .payoff()
+            .expect("payoff calculation should succeed for put option");
+        assert_eq!(
+            put_payoff.to_f64().expect("payoff should convert to f64"),
+            5.0
+        ); // max(100 - 95, 0) = 5
     }
 
     #[test]
@@ -1139,9 +1167,16 @@ mod tests_options {
             None,
         );
 
-        let time_value = option.time_value().unwrap();
+        let time_value = option
+            .time_value()
+            .expect("time_value calculation should succeed");
         assert!(time_value > Decimal::ZERO);
-        assert!(time_value < option.calculate_price_black_scholes().unwrap());
+        assert!(
+            time_value
+                < option
+                    .calculate_price_black_scholes()
+                    .expect("Black-Scholes pricing should succeed")
+        );
     }
 }
 

--- a/src/model/position.rs
+++ b/src/model/position.rs
@@ -1217,7 +1217,9 @@ mod tests_position {
             None,
         );
         assert_eq!(
-            position.total_cost().unwrap(),
+            position
+                .total_cost()
+                .expect("total_cost should succeed for valid position"),
             7.0,
             "Total cost calculation is incorrect."
         );
@@ -1243,7 +1245,9 @@ mod tests_position {
             None,
         );
         assert_eq!(
-            position.total_cost().unwrap(),
+            position
+                .total_cost()
+                .expect("total_cost should succeed for position with quantity"),
             70.0,
             "Total cost calculation is incorrect."
         );
@@ -1269,7 +1273,9 @@ mod tests_position {
             None,
         );
         assert_eq!(
-            position.total_cost().unwrap(),
+            position
+                .total_cost()
+                .expect("total_cost should succeed for short position"),
             2.0,
             "Total cost calculation is incorrect."
         );
@@ -1295,7 +1301,9 @@ mod tests_position {
             None,
         );
         assert_eq!(
-            position.total_cost().unwrap(),
+            position
+                .total_cost()
+                .expect("total_cost should succeed for short position with quantity"),
             20.0,
             "Total cost calculation is incorrect."
         );
@@ -1321,7 +1329,9 @@ mod tests_position {
             None,
         );
         assert_eq!(
-            position.pnl_at_expiration(&None).unwrap(),
+            position
+                .pnl_at_expiration(&None)
+                .expect("pnl_at_expiration should succeed"),
             dec!(3.0),
             "PNL at expiration for long call ITM is incorrect."
         );
@@ -1347,7 +1357,9 @@ mod tests_position {
             None,
         );
         assert_eq!(
-            position.pnl_at_expiration(&None).unwrap(),
+            position
+                .pnl_at_expiration(&None)
+                .expect("pnl_at_expiration should succeed for long call ITM"),
             dec!(3.0),
             "PNL at expiration for long call ITM is incorrect."
         );


### PR DESCRIPTION
## Summary

This PR implements Phase 4 of issue #227, improving test code by replacing unwrap() with expect() to provide descriptive error messages when tests fail.

## Changes

### src/model/option.rs
- **tests_options module**: Replace unwrap() with expect() in:
  - time_to_expiration tests
  - calculate_price_binomial tests
  - calculate_price_binomial_tree tests
  - calculate_price_black_scholes tests
  - payoff tests
  - time_value tests

### src/model/position.rs
- **tests_position module**: Replace unwrap() with expect() in:
  - total_cost tests (4 tests)
  - pnl_at_expiration tests (2 tests)

### src/model/expiration.rs
- **tests_expiration_date module**: Replace unwrap() with expect() in:
  - get_years tests (3 tests)
  - get_date tests (2 tests)

## Benefits

- More descriptive error messages when tests fail
- Easier debugging of test failures
- Better documentation of expected behavior in tests

## Testing

- cargo build - Compiles successfully
- cargo test --lib - All 3631 tests pass
- cargo clippy -- -D warnings - No warnings
- cargo fmt --check - Properly formatted
- cargo test --doc - All 193 doctests pass

## Related Issue

Close #227 (Phase 4: Test code improvements)
Depends on PR #255 (Phase 3)

## Note

This phase covers selective improvements to the most critical tests. There are still ~350 unwrap() calls in test code that could be improved in future iterations if needed.