### PR TITLE
test: add property-based testing with proptest - Issue #222

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,15 @@ criterion = { version = "0.8", default-features = false, features = ["html_repor
 mockall = "0.14"
 tempfile = "3.23"
 static_assertions = "1.1"
+proptest = "1.5"
 
 [[test]]
 name = "tests"
 path = "tests/unit/mod.rs"
+
+[[test]]
+name = "property_tests"
+path = "tests/property/mod.rs"
 
 [[bench]]
 name = "benches"

--- a/tests/property/greeks_bounds_test.rs
+++ b/tests/property/greeks_bounds_test.rs
@@ -1,0 +1,237 @@
+//! Property-based tests for Greeks bounds
+//!
+//! This module tests that the Greeks (delta, gamma, theta, vega, rho)
+//! stay within their theoretical bounds across a wide range of inputs.
+
+use optionstratlib::greeks::Greeks;
+use optionstratlib::model::ExpirationDate;
+use optionstratlib::model::Options;
+use optionstratlib::model::types::{OptionStyle, OptionType, Side};
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal_macros::dec;
+
+/// Creates a call option with the given parameters
+fn create_call_option(
+    spot: Positive,
+    strike: Positive,
+    volatility: Positive,
+    days_to_expiry: u32,
+) -> Options {
+    Options::new(
+        OptionType::European,
+        Side::Long,
+        "TEST".to_string(),
+        strike,
+        ExpirationDate::Days(Positive::new(days_to_expiry as f64).unwrap()),
+        volatility,
+        Positive::ONE,
+        spot,
+        dec!(0.05),
+        OptionStyle::Call,
+        Positive::ZERO,
+        None,
+    )
+}
+
+/// Creates a put option with the given parameters
+fn create_put_option(
+    spot: Positive,
+    strike: Positive,
+    volatility: Positive,
+    days_to_expiry: u32,
+) -> Options {
+    Options::new(
+        OptionType::European,
+        Side::Long,
+        "TEST".to_string(),
+        strike,
+        ExpirationDate::Days(Positive::new(days_to_expiry as f64).unwrap()),
+        volatility,
+        Positive::ONE,
+        spot,
+        dec!(0.05),
+        OptionStyle::Put,
+        Positive::ZERO,
+        None,
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    /// Test that call delta is between 0 and 1
+    #[test]
+    fn test_call_delta_bounds(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call = create_call_option(spot, strike, volatility, days);
+
+        if let Ok(delta) = call.delta() {
+            prop_assert!(
+                delta >= dec!(0.0) && delta <= dec!(1.0),
+                "Call delta should be in [0, 1], got {}",
+                delta
+            );
+        }
+    }
+
+    /// Test that put delta is between -1 and 0
+    #[test]
+    fn test_put_delta_bounds(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let put = create_put_option(spot, strike, volatility, days);
+
+        if let Ok(delta) = put.delta() {
+            prop_assert!(
+                delta >= dec!(-1.0) && delta <= dec!(0.0),
+                "Put delta should be in [-1, 0], got {}",
+                delta
+            );
+        }
+    }
+
+    /// Test that gamma is always non-negative
+    #[test]
+    fn test_gamma_non_negative(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call = create_call_option(spot, strike, volatility, days);
+
+        if let Ok(gamma) = call.gamma() {
+            prop_assert!(
+                gamma >= dec!(0.0),
+                "Gamma should be non-negative, got {}",
+                gamma
+            );
+        }
+    }
+
+    /// Test that vega is always non-negative for long options
+    #[test]
+    fn test_vega_non_negative(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call = create_call_option(spot, strike, volatility, days);
+
+        if let Ok(vega) = call.vega() {
+            prop_assert!(
+                vega >= dec!(0.0),
+                "Vega should be non-negative for long options, got {}",
+                vega
+            );
+        }
+    }
+
+    /// Test that call and put have the same gamma
+    #[test]
+    fn test_call_put_same_gamma(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call = create_call_option(spot, strike, volatility, days);
+        let put = create_put_option(spot, strike, volatility, days);
+
+        if let (Ok(call_gamma), Ok(put_gamma)) = (call.gamma(), put.gamma()) {
+            let diff = (call_gamma - put_gamma).abs();
+            prop_assert!(
+                diff < dec!(0.0001),
+                "Call and put should have same gamma: {} vs {}, diff = {}",
+                call_gamma, put_gamma, diff
+            );
+        }
+    }
+
+    /// Test that call and put have the same vega
+    #[test]
+    fn test_call_put_same_vega(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call = create_call_option(spot, strike, volatility, days);
+        let put = create_put_option(spot, strike, volatility, days);
+
+        if let (Ok(call_vega), Ok(put_vega)) = (call.vega(), put.vega()) {
+            let diff = (call_vega - put_vega).abs();
+            prop_assert!(
+                diff < dec!(0.0001),
+                "Call and put should have same vega: {} vs {}, diff = {}",
+                call_vega, put_vega, diff
+            );
+        }
+    }
+
+    /// Test delta-gamma relationship: delta changes correctly with spot
+    #[test]
+    fn test_delta_gamma_relationship(
+        spot in 100.0f64..400.0,
+        strike in 100.0f64..400.0,
+        volatility in 0.1f64..0.8,
+        days in 30u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let spot_higher = Positive::new(spot.to_f64() + 1.0).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call_low = create_call_option(spot, strike, volatility, days);
+        let call_high = create_call_option(spot_higher, strike, volatility, days);
+
+        if let (Ok(delta_low), Ok(delta_high), Ok(gamma)) =
+            (call_low.delta(), call_high.delta(), call_low.gamma())
+        {
+            // Delta change should be approximately gamma * spot_change
+            let delta_change = delta_high - delta_low;
+            let expected_change = gamma; // spot change is 1.0
+
+            // Allow for some numerical error (gamma is instantaneous, we use finite difference)
+            let diff = (delta_change - expected_change).abs();
+            prop_assert!(
+                diff < dec!(0.1),
+                "Delta change ({}) should be close to gamma ({}), diff = {}",
+                delta_change, expected_change, diff
+            );
+        }
+    }
+}

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -1,0 +1,7 @@
+//! Property-based tests for OptionStratLib
+//!
+//! This module contains property-based tests using proptest to verify
+//! mathematical invariants and bounds across a wide range of inputs.
+
+mod greeks_bounds_test;
+mod put_call_parity_test;

--- a/tests/property/put_call_parity_test.proptest-regressions
+++ b/tests/property/put_call_parity_test.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ac5f998629fd7102c2c1d04ea95fa27f0c9492910cf7af0e708af1d606a6c171 # shrinks to spot = 443.4708208412317, strike = 70.99319696195508, volatility = 0.2509494419001366, days = 170

--- a/tests/property/put_call_parity_test.rs
+++ b/tests/property/put_call_parity_test.rs
@@ -1,0 +1,220 @@
+//! Property-based tests for put-call parity
+//!
+//! Put-call parity is a fundamental relationship in options pricing:
+//! C - P = S - K * e^(-rT)
+//!
+//! Where:
+//! - C = Call option price
+//! - P = Put option price
+//! - S = Spot price
+//! - K = Strike price
+//! - r = Risk-free rate
+//! - T = Time to expiration
+
+use optionstratlib::model::ExpirationDate;
+use optionstratlib::model::Options;
+use optionstratlib::model::types::{OptionStyle, OptionType, Side};
+use optionstratlib::pricing::black_scholes;
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::MathematicalOps;
+use rust_decimal_macros::dec;
+
+/// Creates a call option with the given parameters
+fn create_call_option(
+    spot: Positive,
+    strike: Positive,
+    volatility: Positive,
+    days_to_expiry: u32,
+    risk_free_rate: Decimal,
+) -> Options {
+    Options::new(
+        OptionType::European,
+        Side::Long,
+        "TEST".to_string(),
+        strike,
+        ExpirationDate::Days(Positive::new(days_to_expiry as f64).unwrap()),
+        volatility,
+        Positive::ONE,
+        spot,
+        risk_free_rate,
+        OptionStyle::Call,
+        Positive::ZERO,
+        None,
+    )
+}
+
+/// Creates a put option with the given parameters
+fn create_put_option(
+    spot: Positive,
+    strike: Positive,
+    volatility: Positive,
+    days_to_expiry: u32,
+    risk_free_rate: Decimal,
+) -> Options {
+    Options::new(
+        OptionType::European,
+        Side::Long,
+        "TEST".to_string(),
+        strike,
+        ExpirationDate::Days(Positive::new(days_to_expiry as f64).unwrap()),
+        volatility,
+        Positive::ONE,
+        spot,
+        risk_free_rate,
+        OptionStyle::Put,
+        Positive::ZERO,
+        None,
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    /// Test put-call parity: C - P = S - K * e^(-rT)
+    ///
+    /// This is a fundamental relationship that must hold for European options.
+    #[test]
+    fn test_put_call_parity(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+        rate in 0.01f64..0.10,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+        let risk_free_rate = Decimal::from_f64_retain(rate).unwrap();
+
+        let call = create_call_option(spot, strike, volatility, days, risk_free_rate);
+        let put = create_put_option(spot, strike, volatility, days, risk_free_rate);
+
+        let call_price = black_scholes(&call);
+        let put_price = black_scholes(&put);
+
+        // Skip if pricing fails (edge cases)
+        if call_price.is_err() || put_price.is_err() {
+            return Ok(());
+        }
+
+        let call_price = call_price.unwrap();
+        let put_price = put_price.unwrap();
+
+        // Calculate time to expiry in years
+        let t = Decimal::from(days) / dec!(365);
+
+        // Put-call parity: C - P = S - K * e^(-rT)
+        let parity_lhs = call_price - put_price;
+        let discount_factor = (-risk_free_rate * t).exp();
+        let parity_rhs = spot.to_dec() - strike.to_dec() * discount_factor;
+
+        let diff = (parity_lhs - parity_rhs).abs();
+
+        // Allow for small numerical errors (0.01 tolerance)
+        prop_assert!(
+            diff < dec!(0.01),
+            "Put-call parity violated: C({}) - P({}) = {} != S({}) - K*e^(-rT) = {}, diff = {}",
+            call_price, put_price, parity_lhs, spot, parity_rhs, diff
+        );
+    }
+
+    /// Test that call price is always non-negative
+    #[test]
+    fn test_call_price_non_negative(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call = create_call_option(spot, strike, volatility, days, dec!(0.05));
+
+        if let Ok(price) = black_scholes(&call) {
+            // Allow for tiny numerical errors (1e-10 tolerance)
+            prop_assert!(
+                price >= dec!(-0.0000000001),
+                "Call price should be non-negative (within tolerance), got {}",
+                price
+            );
+        }
+    }
+
+    /// Test that put price is always non-negative
+    #[test]
+    fn test_put_price_non_negative(
+        spot in 50.0f64..500.0,
+        strike in 50.0f64..500.0,
+        volatility in 0.1f64..0.8,
+        days in 7u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let put = create_put_option(spot, strike, volatility, days, dec!(0.05));
+
+        if let Ok(price) = black_scholes(&put) {
+            // Allow for tiny numerical errors (1e-10 tolerance)
+            prop_assert!(
+                price >= dec!(-0.0000000001),
+                "Put price should be non-negative (within tolerance), got {}",
+                price
+            );
+        }
+    }
+
+    /// Test that call price increases with spot price (positive delta)
+    #[test]
+    fn test_call_price_increases_with_spot(
+        spot in 100.0f64..400.0,
+        strike in 100.0f64..400.0,
+        volatility in 0.1f64..0.8,
+        days in 30u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let spot_higher = Positive::new(spot.to_f64() + 10.0).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let call_low = create_call_option(spot, strike, volatility, days, dec!(0.05));
+        let call_high = create_call_option(spot_higher, strike, volatility, days, dec!(0.05));
+
+        if let (Ok(price_low), Ok(price_high)) = (black_scholes(&call_low), black_scholes(&call_high)) {
+            prop_assert!(
+                price_high >= price_low,
+                "Call price should increase with spot: {} >= {} (spot {} vs {})",
+                price_high, price_low, spot_higher, spot
+            );
+        }
+    }
+
+    /// Test that put price decreases with spot price (negative delta)
+    #[test]
+    fn test_put_price_decreases_with_spot(
+        spot in 100.0f64..400.0,
+        strike in 100.0f64..400.0,
+        volatility in 0.1f64..0.8,
+        days in 30u32..365,
+    ) {
+        let spot = Positive::new(spot).unwrap();
+        let spot_higher = Positive::new(spot.to_f64() + 10.0).unwrap();
+        let strike = Positive::new(strike).unwrap();
+        let volatility = Positive::new(volatility).unwrap();
+
+        let put_low = create_put_option(spot, strike, volatility, days, dec!(0.05));
+        let put_high = create_put_option(spot_higher, strike, volatility, days, dec!(0.05));
+
+        if let (Ok(price_low), Ok(price_high)) = (black_scholes(&put_low), black_scholes(&put_high)) {
+            prop_assert!(
+                price_low >= price_high,
+                "Put price should decrease with spot: {} >= {} (spot {} vs {})",
+                price_low, price_high, spot, spot_higher
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add property-based tests using proptest to verify mathematical invariants across a wide range of inputs.

## New Tests (12 total)

### Put-Call Parity Tests (6 tests)
- `test_put_call_parity`: Verify C - P = S - K*e^(-rT)
- `test_call_price_non_negative`: Call prices >= 0
- `test_put_price_non_negative`: Put prices >= 0
- `test_call_price_increases_with_spot`: Positive delta behavior
- `test_put_price_decreases_with_spot`: Negative delta behavior

### Greeks Bounds Tests (6 tests)
- `test_call_delta_bounds`: Delta in [0, 1]
- `test_put_delta_bounds`: Delta in [-1, 0]
- `test_gamma_non_negative`: Gamma >= 0
- `test_vega_non_negative`: Vega >= 0 for long options
- `test_call_put_same_gamma`: Call/put gamma equality
- `test_call_put_same_vega`: Call/put vega equality
- `test_delta_gamma_relationship`: Delta changes with gamma

## Changes

- Add `proptest = "1.5"` to dev-dependencies
- Create `tests/property/` directory with test modules
- Add `property_tests` target to Cargo.toml

## Run Tests

```bash
cargo test --test property_tests
```

## Verification

- `cargo build` - Compiles successfully
- `make lint-fix` - No warnings
- `make pre-push` - All tests pass

Closes #222