### PR TITLE
M1: Eliminate .unwrap()/.expect() from src/strategies/ (#316)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.15.3"
+version = "0.16.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Wiki](https://img.shields.io/badge/wiki-latest-blue.svg)](https://deepwiki.com/joaquinbejar/OptionStratLib)
 
 
-## OptionStratLib v0.15.3: Financial Options Library
+## OptionStratLib v0.16.0: Financial Options Library
 
 ### Table of Contents
 1. [Introduction](#introduction)
@@ -677,7 +677,7 @@ Add OptionStratLib to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-optionstratlib = "0.15.3"
+optionstratlib = "0.16.0"
 ```
 
 Or use cargo to add it to your project:
@@ -692,7 +692,7 @@ The library includes optional features for enhanced functionality:
 
 ```toml
 [dependencies]
-optionstratlib = { version = "0.15.3", features = ["plotly"] }
+optionstratlib = { version = "0.16.0", features = ["plotly"] }
 ```
 
 - `plotly`: Enables interactive visualization using plotly.rs
@@ -1042,7 +1042,7 @@ cargo test --all-features
 
 ---
 
-**OptionStratLib v0.15.3** - Built with ❤️ in Rust for the financial community
+**OptionStratLib v0.16.0** - Built with ❤️ in Rust for the financial community
 
 
 

--- a/benches/model/strategy.rs
+++ b/benches/model/strategy.rs
@@ -71,6 +71,7 @@ fn create_iron_condor() -> IronCondor {
         pos_or_panic!(0.5),                        // open_fee
         pos_or_panic!(0.5),                        // close_fee
     )
+    .unwrap()
 }
 
 fn create_iron_butterfly() -> IronButterfly {
@@ -92,6 +93,7 @@ fn create_iron_butterfly() -> IronButterfly {
         pos_or_panic!(0.5),                        // open_fee
         pos_or_panic!(0.5),                        // close_fee
     )
+    .unwrap()
 }
 
 pub(crate) fn benchmark_strategies(c: &mut Criterion) {

--- a/benches/model/strategy.rs
+++ b/benches/model/strategy.rs
@@ -29,6 +29,7 @@ fn create_long_call() -> LongCall {
         pos_or_panic!(0.5),                        // open_fee_long_call
         pos_or_panic!(0.5),                        // close_fee_long_call
     )
+    .unwrap()
 }
 
 fn create_bull_call_spread() -> BullCallSpread {

--- a/benches/model/strategy.rs
+++ b/benches/model/strategy.rs
@@ -49,6 +49,7 @@ fn create_bull_call_spread() -> BullCallSpread {
         pos_or_panic!(0.5),                        // open_fee_short_call
         pos_or_panic!(0.5),                        // close_fee_short_call
     )
+    .unwrap()
 }
 
 fn create_iron_condor() -> IronCondor {

--- a/examples/examples_chain/src/bin/creator.rs
+++ b/examples/examples_chain/src/bin/creator.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
         pos_or_panic!(0.1), // close_fee_short_call
         pos_or_panic!(0.1), // open_fee_short_put
         pos_or_panic!(0.1), // close_fee_short_put
-    );
+    )?;
     let max_delta = dec!(0.3);
     let min_delta = dec!(0.15);
     strategy.get_best_area(

--- a/examples/examples_chain/src/bin/option_chain_ger40.rs
+++ b/examples/examples_chain/src/bin/option_chain_ger40.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
         pos_or_panic!(0.10), // close_fee_short_call
         pos_or_panic!(0.10), // open_fee_short_put
         pos_or_panic!(0.10), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(
         &option_chain,
         FindOptimalSide::DeltaRange(dec!(-0.3), dec!(0.3)),

--- a/examples/examples_chain/src/bin/option_chain_raw.rs
+++ b/examples/examples_chain/src/bin/option_chain_raw.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
         pos_or_panic!(2.2), // close_fee_short_call
         pos_or_panic!(1.7), // open_fee_short_put
         pos_or_panic!(1.7), // close_fee_short_put
-    );
+    )?;
 
     // strategy.best_area(&option_chain, FindOptimalSide::Range(pos_or_panic!(21600.0), pos_or_panic!(21700.0) ));
     strategy.get_best_area(&option_chain, FindOptimalSide::Upper);

--- a/examples/examples_chain/src/bin/option_chain_raw_delta.rs
+++ b/examples/examples_chain/src/bin/option_chain_raw_delta.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
         pos_or_panic!(2.2), // close_fee_short_call
         pos_or_panic!(1.7), // open_fee_short_put
         pos_or_panic!(1.7), // close_fee_short_put
-    );
+    )?;
 
     strategy.get_best_area(
         &option_chain,

--- a/examples/examples_simulation/src/bin/long_call_strategy_simulation.rs
+++ b/examples/examples_simulation/src/bin/long_call_strategy_simulation.rs
@@ -105,7 +105,7 @@ fn main() -> Result<(), Error> {
         premium_positive, // premium paid
         Positive::ZERO,   // open_fee
         Positive::ZERO,   // close_fee
-    );
+    )?;
 
     // Define exit policy: 100% profit OR expiration
     let exit_policy = ExitPolicy::Or(vec![

--- a/examples/examples_simulation/src/bin/short_put_strategy_simulation.rs
+++ b/examples/examples_simulation/src/bin/short_put_strategy_simulation.rs
@@ -102,7 +102,7 @@ fn main() -> Result<(), Error> {
         premium_positive,   // premium received
         pos_or_panic!(1.5), // open_fee
         pos_or_panic!(1.5), // close_fee
-    );
+    )?;
 
     // Define exit policy: 50% profit OR 100% loss
     let exit_policy = ExitPolicy::profit_or_loss(dec!(0.7), dec!(0.6));

--- a/examples/examples_simulation/src/bin/strategy_simulator.rs
+++ b/examples/examples_simulation/src/bin/strategy_simulator.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Error> {
         open_premium,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     let walk_params = WalkParams {
         size: n_steps,

--- a/examples/examples_strategies/src/bin/strategy_bear_call_spread.rs
+++ b/examples/examples_strategies/src/bin/strategy_bear_call_spread.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);
     info!(

--- a/examples/examples_strategies/src/bin/strategy_bear_put_spread.rs
+++ b/examples/examples_strategies/src/bin/strategy_bear_put_spread.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);
     info!(

--- a/examples/examples_strategies/src/bin/strategy_bull_call_spread.rs
+++ b/examples/examples_strategies/src/bin/strategy_bull_call_spread.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);
     info!(

--- a/examples/examples_strategies/src/bin/strategy_bull_put_spread.rs
+++ b/examples/examples_strategies/src/bin/strategy_bull_put_spread.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies/src/bin/strategy_call_butterfly.rs
+++ b/examples/examples_strategies/src/bin/strategy_call_butterfly.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.72),  // open_fee_short
-    );
+    )?;
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);
 
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies/src/bin/strategy_custom_complex.rs
+++ b/examples/examples_strategies/src/bin/strategy_custom_complex.rs
@@ -124,7 +124,7 @@ fn main() -> Result<(), Error> {
         Default::default(),
         100,
         Default::default(),
-    );
+    )?;
 
     // Display strategy information
     info!("=== CUSTOM COMPLEX STRATEGY ===");

--- a/examples/examples_strategies/src/bin/strategy_custom_dax.rs
+++ b/examples/examples_strategies/src/bin/strategy_custom_dax.rs
@@ -103,7 +103,8 @@ fn main() {
         Positive::ONE, // Default quantity
         1,             // days to expiration
         implied_volatility,
-    );
+    )
+    .unwrap();
 
     // Fees are already set in Position::new() above
 

--- a/examples/examples_strategies/src/bin/strategy_custom_short_strangle.rs
+++ b/examples/examples_strategies/src/bin/strategy_custom_short_strangle.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), Error> {
         Default::default(),
         100,
         Default::default(),
-    );
+    )?;
 
     // Calculate range between break-even points (if we have at least 2)
     let range = if strategy.break_even_points.len() >= 2 {

--- a/examples/examples_strategies/src/bin/strategy_custom_simple.rs
+++ b/examples/examples_strategies/src/bin/strategy_custom_simple.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Error> {
         Default::default(),
         50, // Fewer calculation points for simplicity
         Default::default(),
-    );
+    )?;
 
     // Display strategy information
     info!("=== CUSTOM COVERED CALL STRATEGY ===");

--- a/examples/examples_strategies/src/bin/strategy_graph.rs
+++ b/examples/examples_strategies/src/bin/strategy_graph.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.58),
         pos_or_panic!(0.55),
         pos_or_panic!(0.54),
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even {:?}", strategy.get_break_even_points());

--- a/examples/examples_strategies/src/bin/strategy_iron_butterfly.rs
+++ b/examples/examples_strategies/src/bin/strategy_iron_butterfly.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
     if !strategy.validate() {
         return Err("Invalid strategy".into());
     }

--- a/examples/examples_strategies/src/bin/strategy_iron_condor.rs
+++ b/examples/examples_strategies/src/bin/strategy_iron_condor.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(30.7), // premium_long_put
         pos_or_panic!(0.1),  // open_fee
         pos_or_panic!(0.1),  // close_fee
-    );
+    )?;
     if !strategy.validate() {
         return Err("Invalid strategy".into());
     }

--- a/examples/examples_strategies/src/bin/strategy_long_butterfly_spread.rs
+++ b/examples/examples_strategies/src/bin/strategy_long_butterfly_spread.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.05),  // close_fee_long_call_low
         pos_or_panic!(0.05),  // open_fee_long_call_high
         pos_or_panic!(0.05),  // close_fee_long_call_high
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies/src/bin/strategy_long_straddle.rs
+++ b/examples/examples_strategies/src/bin/strategy_long_straddle.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies/src/bin/strategy_long_strangle.rs
+++ b/examples/examples_strategies/src/bin/strategy_long_strangle.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies/src/bin/strategy_poor_mans_covered_call.rs
+++ b/examples/examples_strategies/src/bin/strategy_poor_mans_covered_call.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(1.74),                       // close_fee_short_call
         pos_or_panic!(0.85),                       // open_fee_short_put
         pos_or_panic!(0.85),                       // close_fee_short_put
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies/src/bin/strategy_short_butterfly_spread.rs
+++ b/examples/examples_strategies/src/bin/strategy_short_butterfly_spread.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.05),
         pos_or_panic!(0.05),
         pos_or_panic!(0.05),
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies/src/bin/strategy_short_straddle.rs
+++ b/examples/examples_strategies/src/bin/strategy_short_straddle.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies/src/bin/strategy_short_strangle.rs
+++ b/examples/examples_strategies/src/bin/strategy_short_strangle.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies/src/bin/strategy_short_strangle_delta_simple.rs
+++ b/examples/examples_strategies/src/bin/strategy_short_strangle_delta_simple.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_area.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Center);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_ratio.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::Upper);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_area.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Center);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_ratio.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::Upper);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_area.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Center);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_ratio.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_area.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.81), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Center);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_ratio.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Lower);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_call_butterfly_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_call_butterfly_best_area.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.95), //    close_fee_short_low
         pos_or_panic!(0.95), //    open_fee_short_high
         pos_or_panic!(0.95), //    close_fee_short_high
-    );
+    )?;
 
     strategy.get_best_area(&option_chain, FindOptimalSide::Center);
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);

--- a/examples/examples_strategies_best/src/bin/strategy_call_butterfly_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_call_butterfly_best_ratio.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.73), // close_fee_short
         pos_or_panic!(0.73), // close_fee_short
         pos_or_panic!(0.73),
-    );
+    )?;
 
     strategy.get_best_ratio(
         &option_chain,

--- a/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_area.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO, // premium_long_put
         Positive::ONE,  // open_fee
         Positive::ONE,  // close_fee
-    );
+    )?;
 
     strategy.get_best_area(&option_chain, FindOptimalSide::Lower);
     debug!("Option Chain: {}", option_chain);

--- a/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_ratio.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO, // premium_long_put
         Positive::ONE,  // open_fee
         Positive::ONE,  // close_fee
-    );
+    )?;
 
     strategy.get_best_ratio(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);

--- a/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_area.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO, // premium_long_put
         Positive::ONE,  // open_fee
         Positive::ONE,  // close_fee
-    );
+    )?;
 
     strategy.get_best_area(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);

--- a/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_ratio.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO, // premium_long_put
         Positive::ONE,  // open_fee
         Positive::ONE,  // close_fee
-    );
+    )?;
 
     strategy.get_best_ratio(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);

--- a/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_area.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_ratio.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_area.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::All);
     debug!("Strategy:  {:#?}", strategy);
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);

--- a/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_ratio.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::All);
     debug!("Strategy:  {:#?}", strategy);
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);

--- a/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_area.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Center);
     debug!("Strategy:  {:#?}", strategy);
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);

--- a/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_ratio.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::All);
     debug!("Strategy:  {:#?}", strategy);
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);

--- a/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_area.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(1.74),                       // close_fee_short_call
         pos_or_panic!(0.85),                       // open_fee_short_put
         pos_or_panic!(0.85),                       // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Center);
     debug!("Strategy:  {:#?}", strategy);
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);

--- a/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_ratio.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(1.74),                       // close_fee_short_call
         pos_or_panic!(0.85),                       // open_fee_short_put
         pos_or_panic!(0.85),                       // close_fee_short_put
-    );
+    )?;
 
     strategy.get_best_ratio(&option_chain, FindOptimalSide::Upper);
     debug!("Option Chain: {}", option_chain);

--- a/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_area.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_ratio.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::All);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_area.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     // strategy.best_area(&option_chain, FindOptimalSide::Range(pos_or_panic!(5700.0), pos_or_panic!(6100.0)));
     strategy.get_best_area(&option_chain, FindOptimalSide::Upper);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_ratio.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::Upper);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_area.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.12), // close_fee_short_call
         pos_or_panic!(0.12), // open_fee_short_put
         pos_or_panic!(0.12), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_area(&option_chain, FindOptimalSide::Deltable(pos_or_panic!(0.3)));
     info!("Strategy:  {:#?}", strategy);
     let range = strategy.get_range_of_profit().unwrap_or(Positive::ZERO);

--- a/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_ratio.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.82), // close_fee_short_call
         pos_or_panic!(0.82), // open_fee_short_put
         pos_or_panic!(0.82), // close_fee_short_put
-    );
+    )?;
     strategy.get_best_ratio(&option_chain, FindOptimalSide::Upper);
     debug!("Option Chain: {}", option_chain);
     debug!("Strategy:  {:#?}", strategy);

--- a/examples/examples_strategies_delta/src/bin/strategy_bear_call_spread_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bear_call_spread_delta.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_bear_call_spread_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bear_call_spread_extended_delta.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== BearCallSpread Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_bear_put_spread_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bear_put_spread_delta.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_bear_put_spread_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bear_put_spread_extended_delta.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== BearPutSpread Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_bull_call_spread_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bull_call_spread_delta.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_bull_call_spread_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bull_call_spread_extended_delta.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== BullCallSpread Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_bull_put_spread_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bull_put_spread_delta.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_bull_put_spread_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bull_put_spread_extended_delta.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== BullPutSpread Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_call_butterfly_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_call_butterfly_delta.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_call_butterfly_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_call_butterfly_extended_delta.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.73),
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== CallButterfly Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_iron_butterfly_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_iron_butterfly_delta.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_iron_butterfly_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_iron_butterfly_extended_delta.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(16.0),
         pos_or_panic!(0.96),
         pos_or_panic!(0.96),
-    );
+    )?;
 
     info!("=== IronButterfly Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_iron_condor_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_iron_condor_delta.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_iron_condor_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_iron_condor_extended_delta.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(16.8),
         pos_or_panic!(0.96),
         pos_or_panic!(0.96),
-    );
+    )?;
 
     info!("=== IronCondor Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_long_butterfly_spread_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_long_butterfly_spread_delta.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_long_butterfly_spread_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_long_butterfly_spread_extended_delta.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.73),
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== LongButterflySpread Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_long_straddle_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_long_straddle_delta.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_long_straddle_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_long_straddle_extended_delta.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== LongStraddle Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_long_strangle_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_long_strangle_delta.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
     // let price_range = strategy.best_range_to_show(Positive::ONE).unwrap();
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 

--- a/examples/examples_strategies_delta/src/bin/strategy_long_strangle_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_long_strangle_extended_delta.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== LongStrangle Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_pmcc_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_pmcc_delta.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_pmcc_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_pmcc_extended_delta.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== PoorMansCoveredCall Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_short_butterfly_spread_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_short_butterfly_spread_delta.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Error> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     info!("Title: {}", strategy.get_title());
     info!("Break Even Points: {:?}", strategy.break_even_points);

--- a/examples/examples_strategies_delta/src/bin/strategy_short_butterfly_spread_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_short_butterfly_spread_extended_delta.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.73),
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== ShortButterflySpread Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_short_straddle_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_short_straddle_delta.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_short_straddle_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_short_straddle_extended_delta.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.78),
         pos_or_panic!(0.73),
         pos_or_panic!(0.73),
-    );
+    )?;
 
     info!("=== ShortStraddle Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/examples/examples_strategies_delta/src/bin/strategy_short_strangle_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_short_strangle_delta.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
     // let price_range = strategy.best_range_to_show(Positive::ONE).unwrap();
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 

--- a/examples/examples_strategies_delta/src/bin/strategy_short_strangle_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_short_strangle_extended_delta.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(7.01),
         pos_or_panic!(7.01),
         pos_or_panic!(7.01),
-    );
+    )?;
 
     info!("=== ShortStrangle Extended Delta Analysis ===");
     info!("Title: {}", strategy.get_title());

--- a/src/error/probability.rs
+++ b/src/error/probability.rs
@@ -462,6 +462,15 @@ impl From<StrategyError> for ProbabilityError {
             }
             StrategyError::GreeksError(err) => ProbabilityError::StdError(err.to_string()),
             StrategyError::PositiveError(err) => ProbabilityError::StdError(err.to_string()),
+            StrategyError::NumericConversion { value } => ProbabilityError::StdError(format!(
+                "numeric conversion failed: {value} is not a finite Decimal"
+            )),
+            StrategyError::MissingGreek { name } => {
+                ProbabilityError::StdError(format!("missing greek `{name}`"))
+            }
+            StrategyError::EmptyCollection { context } => {
+                ProbabilityError::StdError(format!("empty collection: {context}"))
+            }
         }
     }
 }

--- a/src/error/strategies.rs
+++ b/src/error/strategies.rs
@@ -512,6 +512,60 @@ mod tests {
 }
 
 #[cfg(test)]
+mod tests_panic_free_variants {
+    use super::*;
+
+    #[test]
+    fn test_numeric_conversion_constructor_and_display() {
+        let err = StrategyError::numeric_conversion(f64::NAN);
+        assert!(matches!(err, StrategyError::NumericConversion { .. }));
+        assert!(err.to_string().contains("NaN"));
+    }
+
+    #[test]
+    fn test_numeric_conversion_inf_message_includes_value() {
+        let err = StrategyError::numeric_conversion(f64::INFINITY);
+        assert!(err.to_string().contains("inf"));
+    }
+
+    #[test]
+    fn test_missing_greek_constructor() {
+        let err = StrategyError::missing_greek("delta");
+        match err {
+            StrategyError::MissingGreek { name } => assert_eq!(name, "delta"),
+            other => panic!("expected MissingGreek, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_missing_greek_display() {
+        let err = StrategyError::missing_greek("vega");
+        assert!(err.to_string().contains("missing greek `vega`"));
+    }
+
+    #[test]
+    fn test_empty_collection_constructor_accepts_str_and_string() {
+        let from_str = StrategyError::empty_collection("option chain");
+        let from_string = StrategyError::empty_collection(String::from("break-even points"));
+        assert!(matches!(from_str, StrategyError::EmptyCollection { .. }));
+        assert!(matches!(from_string, StrategyError::EmptyCollection { .. }));
+        assert!(from_str.to_string().contains("option chain"));
+        assert!(from_string.to_string().contains("break-even points"));
+    }
+
+    #[test]
+    fn test_panic_free_variants_route_through_probability_error() {
+        use crate::error::ProbabilityError;
+        let nc = ProbabilityError::from(StrategyError::numeric_conversion(f64::NAN));
+        let mg = ProbabilityError::from(StrategyError::missing_greek("delta"));
+        let ec = ProbabilityError::from(StrategyError::empty_collection("chain"));
+        assert!(nc.to_string().contains("numeric conversion"));
+        assert!(mg.to_string().contains("missing greek"));
+        assert!(ec.to_string().contains("empty collection"));
+    }
+}
+
+#[cfg(test)]
 mod tests_display {
     use super::*;
 

--- a/src/error/strategies.rs
+++ b/src/error/strategies.rs
@@ -128,6 +128,38 @@ pub enum StrategyError {
     /// Positive value errors
     #[error(transparent)]
     PositiveError(#[from] positive::PositiveError),
+
+    /// Numeric conversion failed at the `f64` ↔ `Decimal` boundary.
+    ///
+    /// Raised when a non-finite (`NaN` / `±Inf`) `f64` cannot be represented
+    /// as a `Decimal`, or when a representation overflow occurs.
+    #[error("numeric conversion failed: {value} is not a finite Decimal")]
+    NumericConversion {
+        /// The offending `f64` value that could not be converted.
+        value: f64,
+    },
+
+    /// A required greek value was missing from an option.
+    ///
+    /// Raised when a strategy expects a greek (delta, gamma, vega, theta,
+    /// rho) to be present on an option (e.g., for delta-neutral validation)
+    /// but the option's greek calculation returned `None`.
+    #[error("missing greek `{name}`: option not initialized for greek calculation")]
+    MissingGreek {
+        /// Name of the greek (`"delta"`, `"gamma"`, `"vega"`, `"theta"`, `"rho"`).
+        name: &'static str,
+    },
+
+    /// A required collection was empty when at least one element was expected.
+    ///
+    /// Raised when a strategy operation needs to pick an element out of a
+    /// collection (option chain, break-even points, profit ranges) and the
+    /// collection turned out to be empty.
+    #[error("empty collection in strategy operation: {context}")]
+    EmptyCollection {
+        /// Description of where the empty collection was encountered.
+        context: String,
+    },
 }
 
 /// Represents different types of errors that can occur during price-related operations.
@@ -337,6 +369,45 @@ impl StrategyError {
             operation: operation.to_string(),
             reason: reason.to_string(),
         })
+    }
+
+    /// Builds a `NumericConversion` error for an `f64` that could not be
+    /// converted to a `Decimal` (typically `NaN` / `Inf` or overflow).
+    ///
+    /// # Errors
+    ///
+    /// This is an error constructor — it always returns the variant.
+    #[cold]
+    #[inline(never)]
+    #[must_use]
+    pub fn numeric_conversion(value: f64) -> Self {
+        StrategyError::NumericConversion { value }
+    }
+
+    /// Builds a `MissingGreek` error for an option missing a required greek.
+    ///
+    /// # Errors
+    ///
+    /// This is an error constructor — it always returns the variant.
+    #[cold]
+    #[inline(never)]
+    #[must_use]
+    pub fn missing_greek(name: &'static str) -> Self {
+        StrategyError::MissingGreek { name }
+    }
+
+    /// Builds an `EmptyCollection` error for an unexpectedly empty collection.
+    ///
+    /// # Errors
+    ///
+    /// This is an error constructor — it always returns the variant.
+    #[cold]
+    #[inline(never)]
+    #[must_use]
+    pub fn empty_collection(context: impl Into<String>) -> Self {
+        StrategyError::EmptyCollection {
+            context: context.into(),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unknown_lints)]
 #![allow(clippy::literal_string_with_formatting_args)]
 
-//! # OptionStratLib v0.15.3: Financial Options Library
+//! # OptionStratLib v0.16.0: Financial Options Library
 //!
 //! ## Table of Contents
 //! 1. [Introduction](#introduction)
@@ -663,7 +663,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = "0.15.3"
+//! optionstratlib = "0.16.0"
 //! ```
 //!
 //! Or use cargo to add it to your project:
@@ -678,7 +678,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = { version = "0.15.3", features = ["plotly"] }
+//! optionstratlib = { version = "0.16.0", features = ["plotly"] }
 //! ```
 //!
 //! - `plotly`: Enables interactive visualization using plotly.rs
@@ -1028,7 +1028,7 @@
 //!
 //! ---
 //!
-//! **OptionStratLib v0.15.3** - Built with ❤️ in Rust for the financial community
+//! **OptionStratLib v0.16.0** - Built with ❤️ in Rust for the financial community
 //!
 
 /// # OptionsStratLib: Financial Options Trading Library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,7 +789,7 @@
 //!         pos_or_panic!(1.20),   // short_call_close_fee
 //!         Default::default(), Default::default(),
 //!         Default::default(), Default::default()
-//!     );
+//!     )?;
 //!
 //!     // Analyze the strategy
 //!     tracing::info!("Strategy: {}", strategy.get_title());
@@ -920,7 +920,7 @@
 //!     Positive::ONE,
 //!     30,
 //!     implied_volatility,
-//! );
+//! ).expect("valid custom strategy");
 //!
 //! tracing::info!("Strategy created: {}", strategy.get_title());
 //! ```

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -1275,13 +1275,28 @@ pub trait Optimizable: Validable + Strategies {
     }
 
     /// Creates a new strategy from the given `OptionChain` and `StrategyLegs`.
-    /// The default implementation panics. Specific strategies must override this.
+    ///
+    /// Specific strategies must override this method. The default implementation
+    /// returns `StrategyError::OperationError(NotSupported { .. })`.
     ///
     /// # Arguments
     /// * `_chain` - A reference to the `OptionChain` providing option data.
     /// * `_legs` - A reference to the `StrategyLegs` defining the strategy's components.
-    fn create_strategy(&self, _chain: &OptionChain, _legs: &StrategyLegs) -> Self::Strategy {
-        unimplemented!("Create strategy is not applicable for this strategy");
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` if the strategy cannot be built
+    /// from the supplied legs (e.g., missing bid/ask quotes, invalid leg
+    /// combination, or operation not supported by the concrete strategy).
+    fn create_strategy(
+        &self,
+        _chain: &OptionChain,
+        _legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
+        Err(StrategyError::operation_not_supported(
+            "create_strategy",
+            std::any::type_name::<Self>(),
+        ))
     }
 }
 

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -838,11 +838,11 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
     /// * `Err(PositionError)` - If there is an error retrieving the positions.
     fn get_total_cost(&self) -> Result<Positive, PositionError> {
         let positions = self.get_positions()?;
-        let costs = positions
-            .iter()
-            .map(|p| p.total_cost().unwrap())
-            .sum::<Positive>();
-        Ok(costs)
+        let mut total = Positive::ZERO;
+        for p in positions {
+            total += p.total_cost()?;
+        }
+        Ok(total)
     }
 
     /// Calculates the net cost of the strategy, which is the sum of the costs of all positions,
@@ -853,11 +853,11 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
     /// * `Err(PositionError)` - If there is an error retrieving the positions.
     fn get_net_cost(&self) -> Result<Decimal, PositionError> {
         let positions = self.get_positions()?;
-        let costs = positions
-            .iter()
-            .map(|p| p.net_cost().unwrap())
-            .sum::<Decimal>();
-        Ok(costs)
+        let mut total = Decimal::ZERO;
+        for p in positions {
+            total += p.net_cost()?;
+        }
+        Ok(total)
     }
 
     /// Calculates the net premium received for the strategy. This is the total premium received from short positions
@@ -868,16 +868,15 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
     /// * `Err(StrategyError)` - If there is an error retrieving the positions.
     fn get_net_premium_received(&self) -> Result<Positive, StrategyError> {
         let positions = self.get_positions()?;
-        let costs = positions
-            .iter()
-            .filter(|p| p.option.side == Side::Long)
-            .map(|p| p.net_cost().unwrap())
-            .sum::<Decimal>();
-        let premiums = positions
-            .iter()
-            .filter(|p| p.option.side == Side::Short)
-            .map(|p| p.net_premium_received().unwrap())
-            .sum::<Positive>();
+        let mut costs = Decimal::ZERO;
+        let mut premiums = Positive::ZERO;
+        for p in positions {
+            if p.option.side == Side::Long {
+                costs += p.net_cost()?;
+            } else if p.option.side == Side::Short {
+                premiums += p.net_premium_received()?;
+            }
+        }
         match premiums > costs {
             true => Ok(premiums - costs),
             false => Ok(Positive::ZERO),
@@ -961,10 +960,17 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
         all_points.push((*underlying_price + max_diff).max(last_strike));
 
         // Sort to find min and max
-        all_points.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
+        all_points.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-        let start_price = *all_points.first().unwrap() * STRIKE_PRICE_LOWER_BOUND_MULTIPLIER;
-        let end_price = *all_points.last().unwrap() * STRIKE_PRICE_UPPER_BOUND_MULTIPLIER;
+        let first = all_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("get_range_to_show: all_points is empty")
+        })?;
+        let last = all_points.last().ok_or_else(|| {
+            StrategyError::empty_collection("get_range_to_show: all_points is empty")
+        })?;
+        let start_price = *first * STRIKE_PRICE_LOWER_BOUND_MULTIPLIER;
+        let end_price = *last * STRIKE_PRICE_UPPER_BOUND_MULTIPLIER;
         Ok((start_price, end_price))
     }
 
@@ -1034,8 +1040,20 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
             2 => Ok(break_even_points[1] - break_even_points[0]),
             _ => {
                 // sort break even points and then get last minus first
-                break_even_points.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                Ok(*break_even_points.last().unwrap() - *break_even_points.first().unwrap())
+                // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
+                break_even_points
+                    .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let last = break_even_points.last().ok_or_else(|| {
+                    StrategyError::empty_collection(
+                        "get_range_of_profit: break_even_points is empty",
+                    )
+                })?;
+                let first = break_even_points.first().ok_or_else(|| {
+                    StrategyError::empty_collection(
+                        "get_range_of_profit: break_even_points is empty",
+                    )
+                })?;
+                Ok(*last - *first)
             }
         }
     }
@@ -1251,10 +1269,9 @@ pub trait Optimizable: Validable + Strategies {
             }
             FindOptimalSide::DeltaRange(min, max) => {
                 let (delta_call, delta_put) = option.current_deltas();
-                (delta_put.is_some() && delta_put.unwrap() >= *min && delta_put.unwrap() <= *max)
-                    || (delta_call.is_some()
-                        && delta_call.unwrap() >= *min
-                        && delta_call.unwrap() <= *max)
+                let put_in = delta_put.is_some_and(|d| d >= *min && d <= *max);
+                let call_in = delta_call.is_some_and(|d| d >= *min && d <= *max);
+                put_in || call_in
             }
         }
     }

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -679,11 +679,7 @@ impl Optimizable for BearCallSpread {
                     second: long_option,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -939,7 +935,8 @@ mod tests_bear_call_spread_strategies {
             pos_or_panic!(0.5),                        // close_fee_short_call
             pos_or_panic!(0.5),                        // open_fee_long_call
             pos_or_panic!(0.5),                        // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1110,7 +1107,8 @@ mod tests_bear_call_spread_strategies {
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         // Check that all calculations scale properly with quantity
         assert_relative_eq!(
@@ -1143,7 +1141,8 @@ mod tests_bear_call_spread_strategies {
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         // Check that strike width affects max loss calculation
         let base_spread = create_test_spread();
@@ -1211,7 +1210,8 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let short_position = create_test_position(Side::Short);
         let result = spread.add_position(&short_position);
@@ -1238,7 +1238,8 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let long_position = create_test_position(Side::Long);
         let result = spread.add_position(&long_position);
@@ -1265,7 +1266,8 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let result = spread.get_positions();
         assert!(result.is_ok());
@@ -1294,7 +1296,8 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let short_position = create_test_position(Side::Short);
         let long_position = create_test_position(Side::Long);
@@ -1324,7 +1327,8 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         // Create new positions
         let new_short = create_test_position(Side::Short);
@@ -1353,7 +1357,8 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let short_position = create_test_position(Side::Short);
         let long_position = create_test_position(Side::Long);
@@ -1399,7 +1404,8 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1426,7 +1432,8 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!spread.validate());
     }
 
@@ -1448,7 +1455,8 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!spread.validate());
     }
 
@@ -1487,7 +1495,8 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!spread.validate());
     }
 
@@ -1509,7 +1518,8 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!spread.validate());
     }
 
@@ -1531,7 +1541,8 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
         // Should still be valid as long as strikes are different
         assert!(spread.validate());
     }
@@ -1554,7 +1565,8 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
         // Should be valid as quantity > 0
         assert!(spread.validate());
     }
@@ -1589,7 +1601,8 @@ mod tests_bear_call_spread_profit {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_long_call
             Positive::ZERO,                            // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1696,7 +1709,8 @@ mod tests_bear_call_spread_profit {
             Positive::ZERO, // close_fee_short_call
             Positive::ZERO, // open_fee_long_call
             Positive::ZERO, // close_fee_long_call
-        ).unwrap();
+        )
+        .unwrap();
 
         let profit = spread
             .calculate_profit_at(&pos_or_panic!(90.0))
@@ -1735,7 +1749,8 @@ mod tests_bear_call_spread_profit {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap();
+        )
+        .unwrap();
 
         let profit = spread
             .calculate_profit_at(&pos_or_panic!(90.0))
@@ -1837,7 +1852,8 @@ mod tests_bear_call_spread_optimizable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2067,7 +2083,8 @@ mod tests_bear_call_spread_graph {
             Positive::ZERO, // close_fee_short_call
             Positive::ZERO, // open_fee_long_call
             Positive::ZERO, // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2105,7 +2122,8 @@ mod tests_bear_call_spread_probability {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2255,7 +2273,8 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2401,7 +2420,8 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2545,7 +2565,8 @@ mod tests_bear_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2657,7 +2678,8 @@ mod tests_adjust_option_position_short {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -127,10 +127,13 @@ impl BearCallSpread {
     ///
     /// # Panics
     ///
-    /// This function will panic if:
-    /// - Adding the short or long call positions fails
-    /// - Validating the strategy fails (e.g., if short strike price is >= long strike price)
-    /// - Calculating break-even points fails
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built bear
+    /// call spread and are surfaced only to keep the constructor
+    /// panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -148,7 +151,7 @@ impl BearCallSpread {
         close_fee_short_call: Positive,
         open_fee_long_call: Positive,
         close_fee_long_call: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if short_strike == Positive::ZERO {
             short_strike = underlying_price;
         }
@@ -188,9 +191,7 @@ impl BearCallSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Error adding short call");
+        strategy.add_position(&short_call)?;
 
         let long_call_option = Options::new(
             OptionType::European,
@@ -215,16 +216,12 @@ impl BearCallSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Error adding long call");
+        strategy.add_position(&long_call)?;
 
         strategy.validate();
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -242,11 +239,12 @@ impl StrategyConstructor for BearCallSpread {
 
         // Sort options by strike price to identify short and long positions
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lower_strike_position = &sorted_positions[0];
@@ -722,9 +720,16 @@ impl Optimizable for BearCallSpread {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -766,7 +771,7 @@ impl Optimizable for BearCallSpread {
                 "missing call_ask for long leg",
             )
         })?;
-        Ok(BearCallSpread::new(
+        BearCallSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             short.strike_price,
@@ -782,7 +787,7 @@ impl Optimizable for BearCallSpread {
             self.short_call.close_fee,
             self.long_call.open_fee,
             self.long_call.close_fee,
-        ))
+        )
     }
 }
 
@@ -934,7 +939,7 @@ mod tests_bear_call_spread_strategies {
             pos_or_panic!(0.5),                        // close_fee_short_call
             pos_or_panic!(0.5),                        // open_fee_long_call
             pos_or_panic!(0.5),                        // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1105,7 +1110,7 @@ mod tests_bear_call_spread_strategies {
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         // Check that all calculations scale properly with quantity
         assert_relative_eq!(
@@ -1138,7 +1143,7 @@ mod tests_bear_call_spread_strategies {
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         // Check that strike width affects max loss calculation
         let base_spread = create_test_spread();
@@ -1206,7 +1211,7 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let short_position = create_test_position(Side::Short);
         let result = spread.add_position(&short_position);
@@ -1233,7 +1238,7 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let long_position = create_test_position(Side::Long);
         let result = spread.add_position(&long_position);
@@ -1260,7 +1265,7 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let result = spread.get_positions();
         assert!(result.is_ok());
@@ -1289,7 +1294,7 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let short_position = create_test_position(Side::Short);
         let long_position = create_test_position(Side::Long);
@@ -1319,7 +1324,7 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         // Create new positions
         let new_short = create_test_position(Side::Short);
@@ -1348,7 +1353,7 @@ mod tests_bear_call_spread_positionable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let short_position = create_test_position(Side::Short);
         let long_position = create_test_position(Side::Long);
@@ -1394,7 +1399,7 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1421,7 +1426,7 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
         assert!(!spread.validate());
     }
 
@@ -1443,7 +1448,7 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
         assert!(!spread.validate());
     }
 
@@ -1482,7 +1487,7 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
         assert!(!spread.validate());
     }
 
@@ -1504,7 +1509,7 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
         assert!(!spread.validate());
     }
 
@@ -1526,7 +1531,7 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
         // Should still be valid as long as strikes are different
         assert!(spread.validate());
     }
@@ -1549,7 +1554,7 @@ mod tests_bear_call_spread_validable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
         // Should be valid as quantity > 0
         assert!(spread.validate());
     }
@@ -1584,7 +1589,7 @@ mod tests_bear_call_spread_profit {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_long_call
             Positive::ZERO,                            // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1691,7 +1696,7 @@ mod tests_bear_call_spread_profit {
             Positive::ZERO, // close_fee_short_call
             Positive::ZERO, // open_fee_long_call
             Positive::ZERO, // close_fee_long_call
-        );
+        ).unwrap();
 
         let profit = spread
             .calculate_profit_at(&pos_or_panic!(90.0))
@@ -1730,7 +1735,7 @@ mod tests_bear_call_spread_profit {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        );
+        ).unwrap();
 
         let profit = spread
             .calculate_profit_at(&pos_or_panic!(90.0))
@@ -1832,7 +1837,7 @@ mod tests_bear_call_spread_optimizable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2062,7 +2067,7 @@ mod tests_bear_call_spread_graph {
             Positive::ZERO, // close_fee_short_call
             Positive::ZERO, // open_fee_long_call
             Positive::ZERO, // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2100,7 +2105,7 @@ mod tests_bear_call_spread_probability {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2250,7 +2255,7 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2396,7 +2401,7 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2540,7 +2545,7 @@ mod tests_bear_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2652,7 +2657,7 @@ mod tests_adjust_option_position_short {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -680,10 +680,14 @@ impl Optimizable for BearCallSpread {
                     first: short_option,
                     second: long_option,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(short, long)| OptionDataGroup::Two(short, long))
@@ -710,7 +714,13 @@ impl Optimizable for BearCallSpread {
                 first: short_option,
                 second: long_option,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -726,14 +736,37 @@ impl Optimizable for BearCallSpread {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `BearCallSpread` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`short.call_bid`, `long.call_ask`) needed to
+    /// price the spread.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (short, long) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
         };
         let implied_volatility = short.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        BearCallSpread::new(
+        let short_call_bid = short.call_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_bid for short leg",
+            )
+        })?;
+        let long_call_ask = long.call_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_ask for long leg",
+            )
+        })?;
+        Ok(BearCallSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             short.strike_price,
@@ -743,13 +776,13 @@ impl Optimizable for BearCallSpread {
             self.short_call.option.risk_free_rate,
             self.short_call.option.dividend_yield,
             self.short_call.option.quantity,
-            short.call_bid.unwrap(),
-            long.call_ask.unwrap(),
+            short_call_bid,
+            long_call_ask,
             self.short_call.open_fee,
             self.short_call.close_fee,
             self.long_call.open_fee,
             self.long_call.close_fee,
-        )
+        ))
     }
 }
 
@@ -1874,7 +1907,7 @@ mod tests_bear_call_spread_optimizable {
             second: long_option,
         };
 
-        let new_strategy = strategy.create_strategy(&chain, &legs);
+        let new_strategy = strategy.create_strategy(&chain, &legs).unwrap();
 
         // Verify the new strategy
         assert!(new_strategy.validate());
@@ -1981,12 +2014,12 @@ mod tests_bear_call_spread_optimizable {
     }
 
     #[test]
-    #[should_panic]
     fn test_create_strategy_invalid_legs() {
         let strategy = create_test_strategy();
         let chain = create_mock_option_chain();
 
-        // Test with invalid leg configuration
+        // Test with invalid leg configuration: same option twice should
+        // either fail to construct or fail validation.
         let result = std::panic::catch_unwind(|| {
             strategy.create_strategy(
                 &chain,
@@ -1994,10 +2027,14 @@ mod tests_bear_call_spread_optimizable {
                     first: chain.options.iter().next().unwrap(),
                     second: chain.options.iter().next().unwrap(),
                 },
-            );
+            )
         });
 
-        assert!(result.is_err());
+        match result {
+            Err(_) => {}
+            Ok(Err(_)) => {}
+            Ok(Ok(s)) => assert!(!s.validate(), "duplicate legs should not validate"),
+        }
     }
 }
 

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -677,11 +677,7 @@ impl Optimizable for BearPutSpread {
                     second: long,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -941,7 +937,8 @@ mod tests_bear_put_spread_strategy {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1046,7 +1043,8 @@ mod tests_bear_put_spread_strategy {
             pos_or_panic!(0.5), // close_fee_long_put
             pos_or_panic!(0.5), // open_fee_short_put
             pos_or_panic!(0.5), // close_fee_short_put
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(spread.get_fees().unwrap().to_f64(), 2.0); // Total fees = 0.5 * 4
     }
@@ -1095,7 +1093,8 @@ mod tests_bear_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(spread.long_put.option.strike_price, Positive::HUNDRED);
         assert_eq!(spread.short_put.option.strike_price, Positive::HUNDRED);
@@ -1119,7 +1118,8 @@ mod tests_bear_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let max_profit = spread.get_max_profit().unwrap();
         let max_loss = spread.get_max_loss().unwrap();
@@ -1453,7 +1453,8 @@ mod tests_bear_put_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1601,7 +1602,8 @@ mod tests_bear_put_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let chain = create_test_chain();
 
@@ -1699,7 +1701,8 @@ mod tests_bear_put_spread_optimizable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1900,7 +1903,8 @@ mod tests_bear_put_spread_profit {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2016,7 +2020,8 @@ mod tests_bear_put_spread_profit {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let max_profit_price = pos_or_panic!(90.0);
         let max_loss_price = pos_or_panic!(110.0);
@@ -2053,7 +2058,8 @@ mod tests_bear_put_spread_profit {
             pos_or_panic!(0.5), // close_fee_long_put
             pos_or_panic!(0.5), // open_fee_short_put
             pos_or_panic!(0.5), // close_fee_short_put
-        ).unwrap();
+        )
+        .unwrap();
 
         let max_profit_price = pos_or_panic!(90.0);
 
@@ -2107,7 +2113,8 @@ mod tests_bear_put_spread_probability {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2253,7 +2260,8 @@ mod tests_bear_put_spread_graph {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2296,7 +2304,8 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2441,7 +2450,8 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2586,7 +2596,8 @@ mod tests_bear_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2697,7 +2708,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -673,10 +673,14 @@ impl Optimizable for BearPutSpread {
                     first: short,
                     second: long,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(short, long)| OptionDataGroup::Two(short, long))
@@ -703,7 +707,13 @@ impl Optimizable for BearPutSpread {
                 first: short,
                 second: long,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -719,14 +729,37 @@ impl Optimizable for BearPutSpread {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `BearPutSpread` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`long.put_ask`, `short.put_bid`) needed to
+    /// price the spread.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (short, long) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
         };
         let implied_volatility = long.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        BearPutSpread::new(
+        let long_put_ask = long.put_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_ask for long leg",
+            )
+        })?;
+        let short_put_bid = short.put_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_bid for short leg",
+            )
+        })?;
+        Ok(BearPutSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -736,13 +769,13 @@ impl Optimizable for BearPutSpread {
             self.long_put.option.risk_free_rate,
             self.long_put.option.dividend_yield,
             self.long_put.option.quantity,
-            long.put_ask.unwrap(),
-            short.put_bid.unwrap(),
+            long_put_ask,
+            short_put_bid,
             self.long_put.open_fee,
             self.long_put.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        )
+        ))
     }
 }
 
@@ -1494,7 +1527,7 @@ mod tests_bear_put_spread_optimization {
             first: long_option,
             second: short_option,
         };
-        let new_strategy = spread.create_strategy(&chain, &legs);
+        let new_strategy = spread.create_strategy(&chain, &legs).unwrap();
 
         assert!(new_strategy.validate());
         assert_eq!(

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -128,6 +128,14 @@ impl BearPutSpread {
     ///
     /// The maximum profit is limited to the difference between strike prices minus
     /// the net premium paid, while the maximum loss is limited to the net premium paid.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built bear
+    /// put spread and are surfaced only to keep the constructor
+    /// panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -145,7 +153,7 @@ impl BearPutSpread {
         close_fee_long_put: Positive,
         open_fee_short_put: Positive,
         close_fee_short_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if long_strike == Positive::ZERO {
             long_strike = underlying_price;
         }
@@ -185,9 +193,7 @@ impl BearPutSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&long_put)
-            .expect("Error adding long put");
+        strategy.add_position(&long_put)?;
 
         let short_put_option = Options::new(
             OptionType::European,
@@ -212,16 +218,12 @@ impl BearPutSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&short_put)
-            .expect("Error adding short put");
+        strategy.add_position(&short_put)?;
 
         strategy.validate();
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -239,11 +241,12 @@ impl StrategyConstructor for BearPutSpread {
 
         // Sort options by strike price to identify short and long positions
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lower_strike_position = &sorted_positions[0];
@@ -715,9 +718,16 @@ impl Optimizable for BearPutSpread {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -759,7 +769,7 @@ impl Optimizable for BearPutSpread {
                 "missing put_bid for short leg",
             )
         })?;
-        Ok(BearPutSpread::new(
+        BearPutSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -775,7 +785,7 @@ impl Optimizable for BearPutSpread {
             self.long_put.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        ))
+        )
     }
 }
 
@@ -931,7 +941,7 @@ mod tests_bear_put_spread_strategy {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1036,7 +1046,7 @@ mod tests_bear_put_spread_strategy {
             pos_or_panic!(0.5), // close_fee_long_put
             pos_or_panic!(0.5), // open_fee_short_put
             pos_or_panic!(0.5), // close_fee_short_put
-        );
+        ).unwrap();
 
         assert_eq!(spread.get_fees().unwrap().to_f64(), 2.0); // Total fees = 0.5 * 4
     }
@@ -1085,7 +1095,7 @@ mod tests_bear_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         assert_eq!(spread.long_put.option.strike_price, Positive::HUNDRED);
         assert_eq!(spread.short_put.option.strike_price, Positive::HUNDRED);
@@ -1109,7 +1119,7 @@ mod tests_bear_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let max_profit = spread.get_max_profit().unwrap();
         let max_loss = spread.get_max_loss().unwrap();
@@ -1443,7 +1453,7 @@ mod tests_bear_put_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1591,7 +1601,7 @@ mod tests_bear_put_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let chain = create_test_chain();
 
@@ -1689,7 +1699,7 @@ mod tests_bear_put_spread_optimizable {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1890,7 +1900,7 @@ mod tests_bear_put_spread_profit {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2006,7 +2016,7 @@ mod tests_bear_put_spread_profit {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let max_profit_price = pos_or_panic!(90.0);
         let max_loss_price = pos_or_panic!(110.0);
@@ -2043,7 +2053,7 @@ mod tests_bear_put_spread_profit {
             pos_or_panic!(0.5), // close_fee_long_put
             pos_or_panic!(0.5), // open_fee_short_put
             pos_or_panic!(0.5), // close_fee_short_put
-        );
+        ).unwrap();
 
         let max_profit_price = pos_or_panic!(90.0);
 
@@ -2097,7 +2107,7 @@ mod tests_bear_put_spread_probability {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2243,7 +2253,7 @@ mod tests_bear_put_spread_graph {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2286,7 +2296,7 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2431,7 +2441,7 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2576,7 +2586,7 @@ mod tests_bear_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2687,7 +2697,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -127,12 +127,13 @@ impl BullCallSpread {
     ///
     /// Returns a fully configured `BullCallSpread` strategy instance with positions and break-even points calculated.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if:
-    /// - The long call position cannot be added to the strategy
-    /// - The short call position cannot be added to the strategy
-    /// - Break-even points cannot be calculated
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built bull
+    /// call spread and are surfaced only to keep the constructor
+    /// panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -150,7 +151,7 @@ impl BullCallSpread {
         close_fee_long_call: Positive,
         open_fee_short_call: Positive,
         close_fee_short_call: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if long_strike == Positive::ZERO {
             long_strike = underlying_price;
         }
@@ -190,9 +191,7 @@ impl BullCallSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Failed to add long call");
+        strategy.add_position(&long_call)?;
 
         let short_call_option = Options::new(
             OptionType::European,
@@ -217,16 +216,12 @@ impl BullCallSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Failed to add short call");
+        strategy.add_position(&short_call)?;
 
         strategy.validate();
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -244,11 +239,12 @@ impl StrategyConstructor for BullCallSpread {
 
         // Sort options by strike price to identify long and short positions
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lower_strike_option = &sorted_positions[0];
@@ -728,9 +724,16 @@ impl Optimizable for BullCallSpread {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -772,7 +775,7 @@ impl Optimizable for BullCallSpread {
                 "missing call_bid for short leg",
             )
         })?;
-        Ok(BullCallSpread::new(
+        BullCallSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -788,7 +791,7 @@ impl Optimizable for BullCallSpread {
             self.long_call.close_fee,
             self.short_call.open_fee,
             self.short_call.close_fee,
-        ))
+        )
     }
 }
 
@@ -942,7 +945,7 @@ fn bull_call_spread_test() -> BullCallSpread {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    )
+    ).unwrap()
 }
 
 #[cfg(test)]
@@ -1049,7 +1052,7 @@ mod tests_bull_call_spread_strategy {
             pos_or_panic!(0.5), // close_fee_long_call
             pos_or_panic!(0.5), // open_fee_short_call
             pos_or_panic!(0.5), // close_fee_short_call
-        );
+        ).unwrap();
 
         assert_eq!(spread.get_fees().unwrap().to_f64(), 2.0);
     }
@@ -1095,7 +1098,7 @@ mod tests_bull_call_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         assert_eq!(spread.long_call.option.strike_price, Positive::HUNDRED);
         assert_eq!(spread.short_call.option.strike_price, Positive::HUNDRED);
@@ -1119,7 +1122,7 @@ mod tests_bull_call_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         assert!(!spread.validate());
     }
@@ -1451,7 +1454,7 @@ mod tests_bull_call_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1834,7 +1837,7 @@ mod tests_bull_call_spread_profit {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let price = pos_or_panic!(105.0);
         assert_eq!(
@@ -1865,7 +1868,7 @@ mod tests_bull_call_spread_profit {
             pos_or_panic!(0.5), // close_fee_long_call
             pos_or_panic!(0.5), // open_fee_short_call
             pos_or_panic!(0.5), // close_fee_short_call
-        );
+        ).unwrap();
 
         let price = pos_or_panic!(105.0);
         assert_eq!(
@@ -2095,7 +2098,7 @@ mod tests_bull_call_spread_probability {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let result = spread.probability_of_profit(None, None);
         assert!(result.is_ok());
@@ -2122,7 +2125,7 @@ mod tests_bull_call_spread_probability {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let result = spread.probability_of_profit(None, None);
         assert!(result.is_ok());
@@ -2163,7 +2166,7 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2308,7 +2311,7 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2448,7 +2451,7 @@ mod tests_bull_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2559,7 +2562,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -686,10 +686,14 @@ impl Optimizable for BullCallSpread {
                     first: long,
                     second: short,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(long, short)| OptionDataGroup::Two(long, short))
@@ -716,7 +720,13 @@ impl Optimizable for BullCallSpread {
                 first: long,
                 second: short,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -732,14 +742,37 @@ impl Optimizable for BullCallSpread {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `BullCallSpread` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`long.call_ask`, `short.call_bid`) needed to
+    /// price the spread.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (long, short) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
         };
         let implied_volatility = long.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        BullCallSpread::new(
+        let long_call_ask = long.call_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_ask for long leg",
+            )
+        })?;
+        let short_call_bid = short.call_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_bid for short leg",
+            )
+        })?;
+        Ok(BullCallSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -749,13 +782,13 @@ impl Optimizable for BullCallSpread {
             self.long_call.option.risk_free_rate,
             self.long_call.option.dividend_yield,
             self.long_call.option.quantity,
-            long.call_ask.unwrap(),
-            short.call_bid.unwrap(),
+            long_call_ask,
+            short_call_bid,
             self.long_call.open_fee,
             self.long_call.close_fee,
             self.short_call.open_fee,
             self.short_call.close_fee,
-        )
+        ))
     }
 }
 
@@ -1675,7 +1708,7 @@ mod tests_bull_call_spread_optimization {
             first: long_option,
             second: short_option,
         };
-        let new_strategy = spread.create_strategy(&chain, &legs);
+        let new_strategy = spread.create_strategy(&chain, &legs).unwrap();
 
         assert!(new_strategy.validate());
         assert_eq!(

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -683,11 +683,7 @@ impl Optimizable for BullCallSpread {
                     second: short,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -945,7 +941,8 @@ fn bull_call_spread_test() -> BullCallSpread {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    ).unwrap()
+    )
+    .unwrap()
 }
 
 #[cfg(test)]
@@ -1052,7 +1049,8 @@ mod tests_bull_call_spread_strategy {
             pos_or_panic!(0.5), // close_fee_long_call
             pos_or_panic!(0.5), // open_fee_short_call
             pos_or_panic!(0.5), // close_fee_short_call
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(spread.get_fees().unwrap().to_f64(), 2.0);
     }
@@ -1098,7 +1096,8 @@ mod tests_bull_call_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(spread.long_call.option.strike_price, Positive::HUNDRED);
         assert_eq!(spread.short_call.option.strike_price, Positive::HUNDRED);
@@ -1122,7 +1121,8 @@ mod tests_bull_call_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(!spread.validate());
     }
@@ -1454,7 +1454,8 @@ mod tests_bull_call_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1837,7 +1838,8 @@ mod tests_bull_call_spread_profit {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let price = pos_or_panic!(105.0);
         assert_eq!(
@@ -1868,7 +1870,8 @@ mod tests_bull_call_spread_profit {
             pos_or_panic!(0.5), // close_fee_long_call
             pos_or_panic!(0.5), // open_fee_short_call
             pos_or_panic!(0.5), // close_fee_short_call
-        ).unwrap();
+        )
+        .unwrap();
 
         let price = pos_or_panic!(105.0);
         assert_eq!(
@@ -2098,7 +2101,8 @@ mod tests_bull_call_spread_probability {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let result = spread.probability_of_profit(None, None);
         assert!(result.is_ok());
@@ -2125,7 +2129,8 @@ mod tests_bull_call_spread_probability {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let result = spread.probability_of_profit(None, None);
         assert!(result.is_ok());
@@ -2166,7 +2171,8 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2311,7 +2317,8 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2451,7 +2458,8 @@ mod tests_bull_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2562,7 +2570,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -787,11 +787,7 @@ impl Optimizable for BullPutSpread {
                     second: short_option,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1046,7 +1042,8 @@ fn bull_put_spread_test() -> BullPutSpread {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    ).unwrap()
+    )
+    .unwrap()
 }
 
 #[cfg(test)]
@@ -1190,7 +1187,8 @@ mod tests_bull_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(spread.long_put.option.strike_price, Positive::HUNDRED);
         assert_eq!(spread.short_put.option.strike_price, Positive::HUNDRED);
@@ -1214,7 +1212,8 @@ mod tests_bull_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(!spread.validate());
     }
@@ -1526,7 +1525,8 @@ mod tests_bull_put_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1849,7 +1849,8 @@ mod tests_bull_put_spread_profit {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let price = pos_or_panic!(85.0);
         assert_eq!(
@@ -1916,7 +1917,8 @@ mod tests_bull_put_spread_probability {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2066,7 +2068,8 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2209,7 +2212,8 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2349,7 +2353,8 @@ mod tests_bear_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2460,7 +2465,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -783,10 +783,14 @@ impl Optimizable for BullPutSpread {
                     first: long_option,
                     second: short_option,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(long, short)| OptionDataGroup::Two(long, short))
@@ -813,7 +817,13 @@ impl Optimizable for BullPutSpread {
                 first: long_option,
                 second: short_option,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -829,14 +839,37 @@ impl Optimizable for BullPutSpread {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `BullPutSpread` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`long.put_ask`, `short.put_bid`) needed to
+    /// price the spread.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (long, short) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
         };
         let implied_volatility = long.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        BullPutSpread::new(
+        let long_put_ask = long.put_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_ask for long leg",
+            )
+        })?;
+        let short_put_bid = short.put_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_bid for short leg",
+            )
+        })?;
+        Ok(BullPutSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -846,13 +879,13 @@ impl Optimizable for BullPutSpread {
             self.long_put.option.risk_free_rate,
             self.long_put.option.dividend_yield,
             self.long_put.option.quantity,
-            long.put_ask.unwrap(),
-            short.put_bid.unwrap(),
+            long_put_ask,
+            short_put_bid,
             self.long_put.open_fee,
             self.long_put.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        )
+        ))
     }
 }
 
@@ -1686,7 +1719,7 @@ mod tests_bull_put_spread_optimization {
             first: long_option,
             second: short_option,
         };
-        let new_strategy = spread.create_strategy(&chain, &legs);
+        let new_strategy = spread.create_strategy(&chain, &legs).unwrap();
 
         assert!(new_strategy.validate());
         assert_eq!(

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -730,7 +730,7 @@ impl Optimizable for BullPutSpread {
     ///         pos_or_panic!(0.78),   // open_fee_long
     ///         pos_or_panic!(0.73),   // close_fee_long
     ///         pos_or_panic!(0.73),   // close_fee_short
-    ///     );
+    ///     ).expect("valid bull put spread");
     ///
     /// let side = FindOptimalSide::Lower;
     /// let filtered_combinations = bull_put_spread_strategy.filter_combinations(&option_chain, side);

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -138,6 +138,14 @@ impl BullPutSpread {
     /// The created strategy is validated to ensure:
     /// 1. Both positions are valid
     /// 2. The long put strike price is lower than the short put strike price
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built bull
+    /// put spread and are surfaced only to keep the constructor
+    /// panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -155,7 +163,7 @@ impl BullPutSpread {
         close_fee_long_put: Positive,
         open_fee_short_put: Positive,
         close_fee_short_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if long_strike == Positive::ZERO {
             long_strike = underlying_price;
         }
@@ -195,9 +203,7 @@ impl BullPutSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&long_put)
-            .expect("Error adding long put");
+        strategy.add_position(&long_put)?;
 
         let short_put_option = Options::new(
             OptionType::European,
@@ -222,17 +228,13 @@ impl BullPutSpread {
             None,
             None,
         );
-        strategy
-            .add_position(&short_put)
-            .expect("Error adding short put");
+        strategy.add_position(&short_put)?;
 
         strategy.validate();
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
+        strategy.update_break_even_points()?;
 
-        strategy
+        Ok(strategy)
     }
 }
 
@@ -250,11 +252,12 @@ impl StrategyConstructor for BullPutSpread {
 
         // Sort options by strike price to identify short and long positions
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lower_strike_option = &sorted_positions[0];
@@ -825,9 +828,16 @@ impl Optimizable for BullPutSpread {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -869,7 +879,7 @@ impl Optimizable for BullPutSpread {
                 "missing put_bid for short leg",
             )
         })?;
-        Ok(BullPutSpread::new(
+        BullPutSpread::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -885,7 +895,7 @@ impl Optimizable for BullPutSpread {
             self.long_put.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        ))
+        )
     }
 }
 
@@ -1036,7 +1046,7 @@ fn bull_put_spread_test() -> BullPutSpread {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    )
+    ).unwrap()
 }
 
 #[cfg(test)]
@@ -1180,7 +1190,7 @@ mod tests_bull_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         assert_eq!(spread.long_put.option.strike_price, Positive::HUNDRED);
         assert_eq!(spread.short_put.option.strike_price, Positive::HUNDRED);
@@ -1204,7 +1214,7 @@ mod tests_bull_put_spread_strategy {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         assert!(!spread.validate());
     }
@@ -1516,7 +1526,7 @@ mod tests_bull_put_spread_optimization {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1839,7 +1849,7 @@ mod tests_bull_put_spread_profit {
             Positive::ZERO,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let price = pos_or_panic!(85.0);
         assert_eq!(
@@ -1906,7 +1916,7 @@ mod tests_bull_put_spread_probability {
             Positive::ZERO,                            // close_fee_long_put
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2056,7 +2066,7 @@ mod tests_delta {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2199,7 +2209,7 @@ mod tests_delta_size {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2339,7 +2349,7 @@ mod tests_bear_call_spread_position_management {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2450,7 +2460,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.78),  // open_fee_long
             pos_or_panic!(0.73),  // close_fee_long
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -128,6 +128,13 @@ impl CallButterfly {
     /// # Returns
     ///
     /// A fully initialized `CallButterfly` strategy with all positions and break-even points calculated.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if any freshly-constructed leg cannot be added
+    /// to the strategy or if the break-even calculation fails. In practice
+    /// these branches are unreachable for a freshly-built call butterfly and
+    /// are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -149,7 +156,7 @@ impl CallButterfly {
         close_fee_short_low: Positive,
         open_fee_short_high: Positive,
         close_fee_short_high: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = CallButterfly {
             name: underlying_symbol.to_string(),
             kind: StrategyType::CallButterfly,
@@ -182,9 +189,7 @@ impl CallButterfly {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Invalid short call");
+        strategy.add_position(&long_call)?;
         strategy.long_call = long_call;
 
         let short_call_low_option = Options::new(
@@ -210,9 +215,7 @@ impl CallButterfly {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call_low)
-            .expect("Invalid long call itm");
+        strategy.add_position(&short_call_low)?;
         strategy.short_call_low = short_call_low;
 
         let short_call_high_option = Options::new(
@@ -238,15 +241,11 @@ impl CallButterfly {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call_high)
-            .expect("Invalid long call otm");
+        strategy.add_position(&short_call_high)?;
         strategy.short_call_high = short_call_high;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -264,11 +263,12 @@ impl StrategyConstructor for CallButterfly {
 
         // Sort options by strike price
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let low_short_call_position = &sorted_positions[0];
@@ -725,7 +725,7 @@ impl Strategies for CallButterfly {
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
-        let max_loss = match self.get_max_loss().unwrap() {
+        let max_loss = match self.get_max_loss()? {
             value if value == Positive::ZERO => spos!(1.0),
             value if value == Positive::INFINITY => spos!(1.0),
             value => Some(value),
@@ -849,9 +849,16 @@ impl Optimizable for CallButterfly {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -908,7 +915,7 @@ impl Optimizable for CallButterfly {
                 "missing call_bid for short_call_high leg",
             )
         })?;
-        Ok(CallButterfly::new(
+        CallButterfly::new(
             option_chain.symbol.clone(),
             option_chain.underlying_price,
             long_call.strike_price,
@@ -928,7 +935,7 @@ impl Optimizable for CallButterfly {
             self.short_call_low.close_fee,
             self.short_call_high.open_fee,
             self.short_call_high.close_fee,
-        ))
+        )
     }
 }
 
@@ -1117,7 +1124,7 @@ mod tests_call_butterfly {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1200,7 +1207,7 @@ mod tests_call_butterfly_validation {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1250,7 +1257,7 @@ mod tests_call_butterfly_delta {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1421,7 +1428,7 @@ mod tests_call_butterfly_delta_size {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1647,7 +1654,7 @@ mod tests_call_butterfly_optimizable {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1785,7 +1792,7 @@ mod tests_call_butterfly_probability {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.72),  // open_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1997,7 +2004,7 @@ mod tests_call_butterfly_position_management {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.72),  // open_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2180,7 +2187,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.72),  // open_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2488,7 +2495,7 @@ mod tests_call_butterfly_pnl {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        )
+        ).unwrap()
     }
 
     fn create_test_call_butterfly() -> Result<CallButterfly, StrategyError> {

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -805,11 +805,7 @@ impl Optimizable for CallButterfly {
                     third: short_high,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1124,7 +1120,8 @@ mod tests_call_butterfly {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1207,7 +1204,8 @@ mod tests_call_butterfly_validation {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1257,7 +1255,8 @@ mod tests_call_butterfly_delta {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1428,7 +1427,8 @@ mod tests_call_butterfly_delta_size {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1654,7 +1654,8 @@ mod tests_call_butterfly_optimizable {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1792,7 +1793,8 @@ mod tests_call_butterfly_probability {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.72),  // open_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2004,7 +2006,8 @@ mod tests_call_butterfly_position_management {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.72),  // open_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2187,7 +2190,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.73),  // close_fee_short
             pos_or_panic!(0.72),  // open_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2495,7 +2499,8 @@ mod tests_call_butterfly_pnl {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     fn create_test_call_butterfly() -> Result<CallButterfly, StrategyError> {

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -804,10 +804,14 @@ impl Optimizable for CallButterfly {
                     second: short_low,
                     third: short_high,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(long, short_low, short_high)| {
@@ -837,7 +841,13 @@ impl Optimizable for CallButterfly {
                 second: short_low,
                 third: short_high,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -853,7 +863,19 @@ impl Optimizable for CallButterfly {
         }
     }
 
-    fn create_strategy(&self, option_chain: &OptionChain, legs: &StrategyLegs) -> CallButterfly {
+    /// Constructs a `CallButterfly` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`long_call.call_ask`,
+    /// `short_call_low.call_bid`, `short_call_high.call_bid`) needed to
+    /// price the strategy.
+    fn create_strategy(
+        &self,
+        option_chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<CallButterfly, StrategyError> {
         let (long_call, short_call_low, short_call_high) = match legs {
             StrategyLegs::ThreeLegs {
                 first,
@@ -868,7 +890,25 @@ impl Optimizable for CallButterfly {
         }
         let implied_volatility = long_call.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        CallButterfly::new(
+        let long_call_ask = long_call.call_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_ask for long call leg",
+            )
+        })?;
+        let short_call_low_bid = short_call_low.call_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_bid for short_call_low leg",
+            )
+        })?;
+        let short_call_high_bid = short_call_high.call_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_bid for short_call_high leg",
+            )
+        })?;
+        Ok(CallButterfly::new(
             option_chain.symbol.clone(),
             option_chain.underlying_price,
             long_call.strike_price,
@@ -879,16 +919,16 @@ impl Optimizable for CallButterfly {
             self.long_call.option.risk_free_rate,
             self.long_call.option.dividend_yield,
             self.long_call.option.quantity,
-            long_call.call_ask.unwrap(),
-            short_call_low.call_bid.unwrap(),
-            short_call_high.call_bid.unwrap(),
+            long_call_ask,
+            short_call_low_bid,
+            short_call_high_bid,
             self.long_call.open_fee,
             self.long_call.close_fee,
             self.short_call_low.open_fee,
             self.short_call_low.close_fee,
             self.short_call_high.open_fee,
             self.short_call_high.close_fee,
-        )
+        ))
     }
 }
 
@@ -1665,7 +1705,7 @@ mod tests_call_butterfly_optimizable {
             third: chain.options.iter().nth(2).unwrap(),
         };
 
-        let new_strategy = butterfly.create_strategy(&chain, &legs);
+        let new_strategy = butterfly.create_strategy(&chain, &legs).unwrap();
 
         // Verify the new strategy has correct properties
         assert_relative_eq!(
@@ -1687,7 +1727,9 @@ mod tests_call_butterfly_optimizable {
             second: chain.options.iter().nth(1).unwrap(),
         };
 
-        butterfly.create_strategy(&chain, &legs); // Should panic
+        // Wrong number of legs is still a panic (that branch is owned by
+        // issue #292, not panic-free core).
+        let _ = butterfly.create_strategy(&chain, &legs);
     }
 
     #[test]

--- a/src/strategies/collar.rs
+++ b/src/strategies/collar.rs
@@ -177,11 +177,12 @@ impl Collar {
     ///
     /// A fully configured `Collar` strategy instance.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if break-even point calculation fails.
+    /// Returns `StrategyError` if the break-even calculation fails. In
+    /// practice this branch is unreachable for a freshly-built collar and
+    /// is surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
-    #[must_use]
     pub fn new(
         underlying_symbol: String,
         underlying_price: Positive,
@@ -200,7 +201,7 @@ impl Collar {
         put_close_fee: Positive,
         call_open_fee: Positive,
         call_close_fee: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         // Create the spot position (long underlying)
         let spot_leg = SpotPosition::new(
             underlying_symbol.clone(),
@@ -275,11 +276,9 @@ impl Collar {
         };
 
         strategy.validate();
-        strategy
-            .update_break_even_points()
-            .expect("Failed to calculate break-even points");
+        strategy.update_break_even_points()?;
 
-        strategy
+        Ok(strategy)
     }
 
     /// Returns the spot leg as a `Leg` enum.
@@ -859,7 +858,7 @@ mod tests {
             pos_or_panic!(0.65), // put close fee
             pos_or_panic!(0.65), // call open fee
             pos_or_panic!(0.65), // call close fee
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/collar.rs
+++ b/src/strategies/collar.rs
@@ -858,7 +858,8 @@ mod tests {
             pos_or_panic!(0.65), // put close fee
             pos_or_panic!(0.65), // call open fee
             pos_or_panic!(0.65), // call close fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/covered_call.rs
+++ b/src/strategies/covered_call.rs
@@ -692,7 +692,8 @@ mod tests {
             Positive::ONE,
             pos_or_panic!(0.65),
             pos_or_panic!(0.65),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/covered_call.rs
+++ b/src/strategies/covered_call.rs
@@ -149,8 +149,13 @@ impl CoveredCall {
     /// # Returns
     ///
     /// A fully configured `CoveredCall` strategy instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if the break-even calculation fails. In
+    /// practice this branch is unreachable for a freshly-built covered
+    /// call and is surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
-    #[must_use]
     pub fn new(
         underlying_symbol: String,
         underlying_price: Positive,
@@ -165,7 +170,7 @@ impl CoveredCall {
         spot_close_fee: Positive,
         call_open_fee: Positive,
         call_close_fee: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         // Create the spot position (long underlying)
         let spot_leg = SpotPosition::new(
             underlying_symbol.clone(),
@@ -213,11 +218,9 @@ impl CoveredCall {
         };
 
         strategy.validate();
-        strategy
-            .update_break_even_points()
-            .expect("Failed to calculate break-even points");
+        strategy.update_break_even_points()?;
 
-        strategy
+        Ok(strategy)
     }
 
     /// Returns the spot leg as a `Leg` enum.
@@ -689,7 +692,7 @@ mod tests {
             Positive::ONE,
             pos_or_panic!(0.65),
             pos_or_panic!(0.65),
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -108,9 +108,12 @@ impl CustomStrategy {
     /// maximum profit, and maximum loss information.
     ///
     /// # Panics
-    /// Panics if the strategy validation fails or if break-even points cannot be calculated.
-    /// This typically occurs when the strategy has no positions or when the maximum loss point
-    /// cannot be determined.
+    /// Panics if the strategy validation fails (no positions). This is owned
+    /// by issue #292 and will be lifted to a `Result` variant separately.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if the break-even calculation fails.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
@@ -121,7 +124,7 @@ impl CustomStrategy {
         epsilon: Positive,
         max_iterations: u32,
         step_by: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = CustomStrategy {
             name,
             symbol,
@@ -140,10 +143,8 @@ impl CustomStrategy {
         if strategy.positions.is_empty() {
             panic!("Invalid strategy: No positions provided");
         }
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 
     fn update_positions(&mut self, new_positions: Vec<Position>) {
@@ -209,14 +210,17 @@ impl CustomStrategy {
         Ok(prices)
     }
 
-    /// Refine a break-even point guess using Newton-Raphson method
+    /// Refine a break-even point guess using Newton-Raphson method.
+    ///
+    /// Returns `None` instead of panicking if any per-iteration profit
+    /// evaluation or `Decimal -> f64` conversion fails.
     #[allow(dead_code)]
     fn refine_break_even_point(&self, initial_guess: Positive) -> Option<Positive> {
         let mut x = initial_guess;
         let mut iterations = 0;
 
         while iterations < self.max_iterations {
-            let f_x = self.calculate_profit_at(&x).unwrap().to_f64().unwrap();
+            let f_x = self.calculate_profit_at(&x).ok()?.to_f64()?;
 
             // Check if we're close enough to zero
             if f_x.abs() < self.epsilon {
@@ -224,15 +228,9 @@ impl CustomStrategy {
             }
 
             // Calculate derivative numerically with smaller step
-            let f_x = self.calculate_profit_at(&x).unwrap().to_f64().unwrap();
             let h = self.epsilon.sqrt();
-            let derivative = (self
-                .calculate_profit_at(&(x + h))
-                .unwrap()
-                .to_f64()
-                .unwrap()
-                - f_x)
-                / h;
+            let f_x_h = self.calculate_profit_at(&(x + h)).ok()?.to_f64()?;
+            let derivative = (f_x_h - f_x) / h;
 
             // Avoid division by very small numbers
             if derivative.abs() < self.epsilon {
@@ -342,7 +340,7 @@ impl CustomStrategy {
 
 impl StrategyConstructor for CustomStrategy {
     fn get_strategy(vec_options: &[Position]) -> Result<Self, StrategyError> {
-        Ok(Self::new(
+        Self::new(
             "CustomStrategy".to_string(),
             "".to_string(),
             format!("CustomStrategy: {:?}", vec_options),
@@ -351,7 +349,7 @@ impl StrategyConstructor for CustomStrategy {
             Default::default(),
             100,
             Default::default(),
-        ))
+        )
     }
 }
 
@@ -444,7 +442,11 @@ impl Positionable for CustomStrategy {
                 "Position not found: {:?} {:?}",
                 option_style, side
             ))),
-            1 => Ok(matching_positions.into_iter().next().unwrap()),
+            1 => matching_positions.into_iter().next().ok_or_else(|| {
+                PositionError::invalid_position(
+                    "matching_positions length is 1 but iterator yielded none",
+                )
+            }),
             _ => Err(PositionError::invalid_position(&format!(
                 "Multiple positions found: {:?} {:?}",
                 option_style, side
@@ -802,9 +804,16 @@ impl Optimizable for CustomStrategy {
 
             // Evaluate the current combination
             self.update_positions(current_positions.clone());
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => self.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => self.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => self.get_profit_ratio(),
+                OptimizationCriteria::Area => self.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    return best_positions.clone();
+                }
             };
 
             if current_value > best_value {
@@ -814,8 +823,10 @@ impl Optimizable for CustomStrategy {
             }
 
             best_positions.clone()
-        })
-        .unwrap();
+        });
+        if let Err(e) = _result {
+            tracing::warn!(error = ?e, "process_n_times_iter failed during find_optimal");
+        }
 
         if best_value == Decimal::MIN {
             error!("No valid combinations found");
@@ -860,20 +871,18 @@ impl ProbabilityAnalysis for CustomStrategy {
             .first()
             .map(|position| position.option.risk_free_rate);
 
-        profit_ranges.iter_mut().for_each(|range| {
-            range
-                .calculate_probability(
-                    &self.underlying_price,
-                    Some(VolatilityAdjustment {
-                        base_volatility: mean_volatility,
-                        std_dev_adjustment: std_dev,
-                    }),
-                    None, // PriceTrend
-                    &expiration,
-                    risk_free_rate,
-                )
-                .unwrap();
-        });
+        for range in profit_ranges.iter_mut() {
+            range.calculate_probability(
+                &self.underlying_price,
+                Some(VolatilityAdjustment {
+                    base_volatility: mean_volatility,
+                    std_dev_adjustment: std_dev,
+                }),
+                None, // PriceTrend
+                &expiration,
+                risk_free_rate,
+            )?;
+        }
 
         Ok(profit_ranges)
     }
@@ -899,20 +908,18 @@ impl ProbabilityAnalysis for CustomStrategy {
             .first()
             .map(|position| position.option.risk_free_rate);
 
-        loss_ranges.iter_mut().for_each(|range| {
-            range
-                .calculate_probability(
-                    &self.underlying_price,
-                    Some(VolatilityAdjustment {
-                        base_volatility: mean_volatility,
-                        std_dev_adjustment: std_dev,
-                    }),
-                    None, // PriceTrend
-                    &expiration,
-                    risk_free_rate,
-                )
-                .unwrap();
-        });
+        for range in loss_ranges.iter_mut() {
+            range.calculate_probability(
+                &self.underlying_price,
+                Some(VolatilityAdjustment {
+                    base_volatility: mean_volatility,
+                    std_dev_adjustment: std_dev,
+                }),
+                None, // PriceTrend
+                &expiration,
+                risk_free_rate,
+            )?;
+        }
 
         Ok(loss_ranges)
     }
@@ -937,30 +944,23 @@ impl PnLCalculator for CustomStrategy {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .positions
-            .iter()
-            .map(|position| {
-                position
-                    .calculate_pnl(market_price, expiration_date, implied_volatility)
-                    .unwrap()
-            })
-            .sum())
+        let mut total = PnL::default();
+        for position in &self.positions {
+            total = total
+                + position.calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        }
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .positions
-            .iter()
-            .map(|position| {
-                position
-                    .calculate_pnl_at_expiration(underlying_price)
-                    .unwrap()
-            })
-            .sum())
+        let mut total = PnL::default();
+        for position in &self.positions {
+            total = total + position.calculate_pnl_at_expiration(underlying_price)?;
+        }
+        Ok(total)
     }
 
     fn adjustments_pnl(&self, adjustment: &DeltaAdjustment) -> Result<PnL, PricingError> {

--- a/src/strategies/delta_neutral/model.rs
+++ b/src/strategies/delta_neutral/model.rs
@@ -354,17 +354,18 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
             return Err(GreeksError::StdError("No options found".to_string()));
         }
         let underlying_price = *self.get_underlying_price();
-        let individual_deltas: Vec<DeltaPositionInfo> = options
-            .iter()
-            .map(|option| DeltaPositionInfo {
-                delta: option.delta().unwrap(),
-                delta_per_contract: option.delta().unwrap() / option.quantity,
+        let mut individual_deltas: Vec<DeltaPositionInfo> = Vec::with_capacity(options.len());
+        for option in options.iter() {
+            let delta = option.delta()?;
+            individual_deltas.push(DeltaPositionInfo {
+                delta,
+                delta_per_contract: delta / option.quantity,
                 quantity: option.quantity,
                 strike: option.strike_price,
                 option_style: option.option_style,
                 side: option.side,
-            })
-            .collect();
+            });
+        }
 
         Ok(DeltaInfo {
             net_delta: self.delta()?,

--- a/src/strategies/delta_neutral/model.rs
+++ b/src/strategies/delta_neutral/model.rs
@@ -1496,7 +1496,8 @@ mod tests_serialization {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_short_put
             pos_or_panic!(7.01),   // close_fee_short_put
-        );
+        )
+        .unwrap();
         let delta_info = strategy.delta_neutrality().unwrap();
         let adjustments = strategy.delta_adjustments().unwrap();
         let response = DeltaNeutralResponse {

--- a/src/strategies/delta_neutral/optimizer.rs
+++ b/src/strategies/delta_neutral/optimizer.rs
@@ -145,8 +145,10 @@ impl<'a> AdjustmentOptimizer<'a> {
             && let Ok(plan) = self.optimize_with_new_legs(delta_gap, gamma_gap)
         {
             trace!("New legs plan quality: {:.4}", plan.quality_score);
-            if best_plan.is_none() || plan.quality_score < best_plan.as_ref().unwrap().quality_score
-            {
+            let beats_best = best_plan
+                .as_ref()
+                .is_none_or(|cur| plan.quality_score < cur.quality_score);
+            if beats_best {
                 best_plan = Some(plan);
             }
         }
@@ -157,8 +159,10 @@ impl<'a> AdjustmentOptimizer<'a> {
             && let Ok(plan) = self.optimize_with_underlying(delta_gap)
         {
             trace!("Underlying plan quality: {:.4}", plan.quality_score);
-            if best_plan.is_none() || plan.quality_score < best_plan.as_ref().unwrap().quality_score
-            {
+            let beats_best = best_plan
+                .as_ref()
+                .is_none_or(|cur| plan.quality_score < cur.quality_score);
+            if beats_best {
                 best_plan = Some(plan);
             }
         }
@@ -193,7 +197,12 @@ impl<'a> AdjustmentOptimizer<'a> {
             })
             .collect();
 
-        legs_with_delta.sort_by(|a, b| b.2.abs().partial_cmp(&a.2.abs()).unwrap());
+        // SAFETY: total order on Decimal; f64 fallback to Equal is safe for stable sort
+        legs_with_delta.sort_by(|a, b| {
+            b.2.abs()
+                .partial_cmp(&a.2.abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Greedily adjust quantities
         for (idx, _leg_delta, delta_per_contract) in legs_with_delta {
@@ -338,7 +347,8 @@ impl<'a> AdjustmentOptimizer<'a> {
                     .calculate_price_black_scholes()
                     .unwrap_or(dec!(1))
                     .max(dec!(0.01));
-            eff_b.partial_cmp(&eff_a).unwrap()
+            // SAFETY: total order on Decimal; f64 fallback to Equal is safe for stable sort
+            eff_b.partial_cmp(&eff_a).unwrap_or(std::cmp::Ordering::Equal)
         });
 
         Ok(candidates)

--- a/src/strategies/delta_neutral/optimizer.rs
+++ b/src/strategies/delta_neutral/optimizer.rs
@@ -468,10 +468,8 @@ impl<'a> AdjustmentOptimizer<'a> {
                         None,
                     ));
                 }
-                AdjustmentAction::CloseLeg { leg_index } => {
-                    if *leg_index < positions.len() {
-                        positions.remove(*leg_index);
-                    }
+                AdjustmentAction::CloseLeg { leg_index } if *leg_index < positions.len() => {
+                    positions.remove(*leg_index);
                 }
                 _ => {}
             }

--- a/src/strategies/delta_neutral/optimizer.rs
+++ b/src/strategies/delta_neutral/optimizer.rs
@@ -348,7 +348,9 @@ impl<'a> AdjustmentOptimizer<'a> {
                     .unwrap_or(dec!(1))
                     .max(dec!(0.01));
             // SAFETY: total order on Decimal; f64 fallback to Equal is safe for stable sort
-            eff_b.partial_cmp(&eff_a).unwrap_or(std::cmp::Ordering::Equal)
+            eff_b
+                .partial_cmp(&eff_a)
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         Ok(candidates)

--- a/src/strategies/graph.rs
+++ b/src/strategies/graph.rs
@@ -168,9 +168,9 @@ macro_rules! impl_graph_for_payoff_strategy {
                     };
 
                     // Get min and max values for reference lines
-                    if !range.is_empty() {
-                        let min_price = range.first().unwrap().to_dec();
-                        let max_price = range.last().unwrap().to_dec();
+                    if let (Some(first), Some(last)) = (range.first(), range.last()) {
+                        let min_price = first.to_dec();
+                        let max_price = last.to_dec();
 
                         // Add zero line points (horizontal line at y=0)
                         zero_line.x.push(min_price);
@@ -241,9 +241,16 @@ macro_rules! impl_graph_for_payoff_strategy {
 
                     // Calculate profit at each price point and add to the series
                     for price in range {
-                        let profit = self
-                            .calculate_profit_at(&price)
-                            .unwrap();
+                        let profit = match self.calculate_profit_at(&price) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                ::tracing::warn!(
+                                    error = %e,
+                                    "skipping price point with unscorable profit"
+                                );
+                                continue;
+                            }
+                        };
 
                         profit_series.x.push(price.to_dec());
                         profit_series.y.push(profit);
@@ -266,10 +273,16 @@ macro_rules! impl_graph_for_payoff_strategy {
                         };
 
                         // If the sign changes or it's the first point
-                        if current_sign.is_none() || (sign != 0 && current_sign.unwrap() != sign) {
+                        let sign_changed = match current_sign {
+                            None => true,
+                            Some(cur) => sign != 0 && cur != sign,
+                        };
+                        if sign_changed {
                             // If there are already points in the current segment, save it
                             if !current_segment.is_empty() {
-                                segments.push((current_segment, current_sign.unwrap()));
+                                if let Some(cur) = current_sign {
+                                    segments.push((current_segment, cur));
+                                }
                                 current_segment = Vec::new();
                             }
                             current_sign = Some(sign);
@@ -280,8 +293,8 @@ macro_rules! impl_graph_for_payoff_strategy {
                     }
 
                     // Add the last segment if it's not empty
-                    if !current_segment.is_empty() && current_sign.is_some() {
-                        segments.push((current_segment, current_sign.unwrap()));
+                    if let (false, Some(cur)) = (current_segment.is_empty(), current_sign) {
+                        segments.push((current_segment, cur));
                     }
 
                     // Create series for each segment

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -881,11 +881,7 @@ impl Optimizable for IronButterfly {
                     fourth: high,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1210,7 +1206,8 @@ mod tests_iron_butterfly {
             Positive::ONE,       // premium long put
             pos_or_panic!(5.0),  // open fee
             pos_or_panic!(5.0),  // close fee
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.name, "Iron Butterfly");
         assert_eq!(
@@ -1245,7 +1242,8 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.get_max_loss().unwrap(), 49.0);
     }
@@ -1270,7 +1268,8 @@ mod tests_iron_butterfly {
             Positive::TWO,
             pos_or_panic!(0.07),
             pos_or_panic!(0.07),
-        ).unwrap();
+        )
+        .unwrap();
 
         let expected_profit: Positive = butterfly.get_net_premium_received().unwrap();
         assert_eq!(butterfly.get_max_profit().unwrap(), expected_profit);
@@ -1296,7 +1295,8 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             butterfly.get_break_even_points().unwrap()[0],
@@ -1334,7 +1334,8 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         let expected_fees = butterfly.short_call.open_fee
             + butterfly.short_call.close_fee
@@ -1367,7 +1368,8 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         // Test at short strike (maximum profit point)
         let price = butterfly.short_call.option.strike_price;
@@ -1448,7 +1450,8 @@ mod tests_iron_butterfly_validable {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1607,7 +1610,8 @@ mod tests_iron_butterfly_strategies {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1776,7 +1780,8 @@ mod tests_iron_butterfly_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
@@ -1800,7 +1805,8 @@ mod tests_iron_butterfly_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
@@ -1834,7 +1840,8 @@ mod tests_iron_butterfly_optimizable {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     fn create_test_chain() -> OptionChain {
@@ -2064,7 +2071,8 @@ mod tests_iron_butterfly_profit {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2184,7 +2192,8 @@ mod tests_iron_butterfly_profit {
             Positive::ONE,
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        ).unwrap();
+        )
+        .unwrap();
 
         let profit = butterfly
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2214,7 +2223,8 @@ mod tests_iron_butterfly_profit {
             Positive::ONE,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let profit = butterfly
             .calculate_profit_at(&butterfly.short_call.option.strike_price)
@@ -2295,7 +2305,8 @@ mod tests_iron_butterfly_delta {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2488,7 +2499,8 @@ mod tests_iron_butterfly_delta_size {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2680,7 +2692,8 @@ mod tests_iron_butterfly_probability {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2885,7 +2898,8 @@ mod tests_iron_butterfly_position_management {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3079,7 +3093,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -168,6 +168,12 @@ impl IronButterfly {
     ///
     /// - **Ideal Market Outlook**: Neutral, expecting low volatility with the underlying price remaining near the short strike price.
     ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if any freshly-constructed leg cannot be added
+    /// to the strategy or if the break-even calculation fails. In practice
+    /// these branches are unreachable for a freshly-built iron butterfly and
+    /// are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -186,7 +192,7 @@ impl IronButterfly {
         premium_long_put: Positive,
         open_fee: Positive,
         close_fee: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = IronButterfly {
             name: "Iron Butterfly".to_string(),
             kind: StrategyType::IronButterfly,
@@ -222,9 +228,7 @@ impl IronButterfly {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Invalid short call");
+        strategy.add_position(&short_call)?;
 
         // Short Put
         let short_put_option = Options::new(
@@ -250,9 +254,7 @@ impl IronButterfly {
             None,
             None,
         );
-        strategy
-            .add_position(&short_put)
-            .expect("Invalid short put");
+        strategy.add_position(&short_put)?;
 
         // Long Call
         let long_call_option = Options::new(
@@ -278,9 +280,7 @@ impl IronButterfly {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Invalid long call");
+        strategy.add_position(&long_call)?;
 
         // Long Put
         let long_put_option = Options::new(
@@ -306,12 +306,10 @@ impl IronButterfly {
             None,
             None,
         );
-        strategy.add_position(&long_put).expect("Invalid long put");
+        strategy.add_position(&long_put)?;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -329,11 +327,12 @@ impl StrategyConstructor for IronButterfly {
 
         // Sort options by strike price to identify positions
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         // Validate the positions and their structure
@@ -819,7 +818,7 @@ impl Strategies for IronButterfly {
 
         let result =
             (inner_area + outer_triangles) / self.short_call.option.underlying_price.to_f64();
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -925,9 +924,16 @@ impl Optimizable for IronButterfly {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -985,7 +991,8 @@ impl Optimizable for IronButterfly {
                         "missing put_ask for long put leg",
                     )
                 })?;
-                Ok(IronButterfly::new(
+                let fee_per_leg = self.get_fees()? / 8.0;
+                IronButterfly::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     short_strike.strike_price,
@@ -1000,9 +1007,9 @@ impl Optimizable for IronButterfly {
                     short_put_bid,
                     long_call_ask,
                     long_put_ask,
-                    self.get_fees().unwrap() / 8.0,
-                    self.get_fees().unwrap() / 8.0,
-                ))
+                    fee_per_leg,
+                    fee_per_leg,
+                )
             }
             _ => panic!("Invalid number of legs for Iron Butterfly strategy"),
         }
@@ -1203,7 +1210,7 @@ mod tests_iron_butterfly {
             Positive::ONE,       // premium long put
             pos_or_panic!(5.0),  // open fee
             pos_or_panic!(5.0),  // close fee
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.name, "Iron Butterfly");
         assert_eq!(
@@ -1238,7 +1245,7 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.get_max_loss().unwrap(), 49.0);
     }
@@ -1263,7 +1270,7 @@ mod tests_iron_butterfly {
             Positive::TWO,
             pos_or_panic!(0.07),
             pos_or_panic!(0.07),
-        );
+        ).unwrap();
 
         let expected_profit: Positive = butterfly.get_net_premium_received().unwrap();
         assert_eq!(butterfly.get_max_profit().unwrap(), expected_profit);
@@ -1289,7 +1296,7 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         assert_eq!(
             butterfly.get_break_even_points().unwrap()[0],
@@ -1327,7 +1334,7 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         let expected_fees = butterfly.short_call.open_fee
             + butterfly.short_call.close_fee
@@ -1360,7 +1367,7 @@ mod tests_iron_butterfly {
             Positive::ONE,
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         // Test at short strike (maximum profit point)
         let price = butterfly.short_call.option.strike_price;
@@ -1441,7 +1448,7 @@ mod tests_iron_butterfly_validable {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1600,7 +1607,7 @@ mod tests_iron_butterfly_strategies {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1769,7 +1776,7 @@ mod tests_iron_butterfly_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
@@ -1793,7 +1800,7 @@ mod tests_iron_butterfly_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
@@ -1827,7 +1834,7 @@ mod tests_iron_butterfly_optimizable {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        )
+        ).unwrap()
     }
 
     fn create_test_chain() -> OptionChain {
@@ -2057,7 +2064,7 @@ mod tests_iron_butterfly_profit {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2177,7 +2184,7 @@ mod tests_iron_butterfly_profit {
             Positive::ONE,
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        );
+        ).unwrap();
 
         let profit = butterfly
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2207,7 +2214,7 @@ mod tests_iron_butterfly_profit {
             Positive::ONE,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let profit = butterfly
             .calculate_profit_at(&butterfly.short_call.option.strike_price)
@@ -2288,7 +2295,7 @@ mod tests_iron_butterfly_delta {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2481,7 +2488,7 @@ mod tests_iron_butterfly_delta_size {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2673,7 +2680,7 @@ mod tests_iron_butterfly_probability {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2878,7 +2885,7 @@ mod tests_iron_butterfly_position_management {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3072,7 +3079,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -881,10 +881,14 @@ impl Optimizable for IronButterfly {
                     third: mid,
                     fourth: high,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(low, mid, high)| OptionDataGroup::Three(low, mid, high))
@@ -913,7 +917,13 @@ impl Optimizable for IronButterfly {
                 third: mid,
                 fourth: high,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -929,7 +939,19 @@ impl Optimizable for IronButterfly {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs an `IronButterfly` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`short_strike.call_bid`,
+    /// `short_strike.put_bid`, `long_call.call_ask`, `long_put.put_ask`)
+    /// needed to price the strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         match legs {
             StrategyLegs::FourLegs {
                 first: long_put,
@@ -939,7 +961,31 @@ impl Optimizable for IronButterfly {
             } => {
                 let implied_volatility = short_strike.implied_volatility;
                 assert!(implied_volatility <= Positive::ONE);
-                IronButterfly::new(
+                let short_call_bid = short_strike.call_bid.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_bid for short strike leg",
+                    )
+                })?;
+                let short_put_bid = short_strike.put_bid.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing put_bid for short strike leg",
+                    )
+                })?;
+                let long_call_ask = long_call.call_ask.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_ask for long call leg",
+                    )
+                })?;
+                let long_put_ask = long_put.put_ask.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing put_ask for long put leg",
+                    )
+                })?;
+                Ok(IronButterfly::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     short_strike.strike_price,
@@ -950,13 +996,13 @@ impl Optimizable for IronButterfly {
                     self.short_call.option.risk_free_rate,
                     self.short_call.option.dividend_yield,
                     self.short_call.option.quantity,
-                    short_strike.call_bid.unwrap(),
-                    short_strike.put_bid.unwrap(),
-                    long_call.call_ask.unwrap(),
-                    long_put.put_ask.unwrap(),
+                    short_call_bid,
+                    short_put_bid,
+                    long_call_ask,
+                    long_put_ask,
                     self.get_fees().unwrap() / 8.0,
                     self.get_fees().unwrap() / 8.0,
-                )
+                ))
             }
             _ => panic!("Invalid number of legs for Iron Butterfly strategy"),
         }
@@ -1945,7 +1991,7 @@ mod tests_iron_butterfly_optimizable {
             fourth: options[5], // 110.0 strike for long call
         };
 
-        let new_strategy = butterfly.create_strategy(&chain, &legs);
+        let new_strategy = butterfly.create_strategy(&chain, &legs).unwrap();
         assert!(new_strategy.validate());
         assert_eq!(
             new_strategy.long_put.option.strike_price,
@@ -1977,6 +2023,8 @@ mod tests_iron_butterfly_optimizable {
             second: options[1],
         };
 
+        // Wrong number of legs is still a panic (that branch is owned by
+        // issue #292, not panic-free core).
         let _ = butterfly.create_strategy(&chain, &legs);
     }
 }

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -903,11 +903,7 @@ impl Optimizable for IronCondor {
                     fourth: long_call,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1237,7 +1233,8 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(iron_condor.name, "Iron Condor");
         assert_eq!(iron_condor.description, IRON_CONDOR_DESCRIPTION.to_string());
@@ -1270,7 +1267,8 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(iron_condor.get_max_loss().unwrap_or(Positive::ZERO), 51.3);
     }
@@ -1296,7 +1294,8 @@ mod tests_iron_condor {
             pos_or_panic!(2.8),
             pos_or_panic!(0.07),
             pos_or_panic!(0.07),
-        ).unwrap();
+        )
+        .unwrap();
 
         let expected_profit = iron_condor.get_net_premium_received().unwrap().to_f64();
         assert_eq!(
@@ -1326,7 +1325,8 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             iron_condor.get_break_even_points().unwrap()[0],
@@ -1355,7 +1355,8 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         let expected_fees = iron_condor.short_call.open_fee
             + iron_condor.short_call.close_fee
@@ -1389,7 +1390,8 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        ).unwrap();
+        )
+        .unwrap();
 
         let price = pos_or_panic!(150.0);
         let expected_profit = iron_condor
@@ -1473,7 +1475,8 @@ mod tests_iron_condor_validable {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1596,7 +1599,8 @@ mod tests_iron_condor_strategies {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1696,7 +1700,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap();
+        )
+        .unwrap();
         let break_even_points = condor.get_break_even_points().unwrap();
 
         assert_eq!(break_even_points.len(), 2);
@@ -1724,7 +1729,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ZERO,      // open_fee
             Positive::ZERO,      // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         let max_profit = condor.get_max_profit().unwrap();
         assert_eq!(max_profit, pos_or_panic!(ZERO));
     }
@@ -1749,7 +1755,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             pos_or_panic!(0.09), // open_fee
             pos_or_panic!(0.09), // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         let max_profit = condor.get_max_profit().unwrap();
         assert_eq!(max_profit, pos_or_panic!(19.28));
     }
@@ -1774,7 +1781,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(11.1), // premium_long_put
             pos_or_panic!(0.1),  // open_fee
             pos_or_panic!(0.1),  // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         let max_loss = condor.get_max_loss().unwrap();
         assert_eq!(max_loss, pos_or_panic!(7.9999999999999964));
     }
@@ -1799,7 +1807,8 @@ mod tests_iron_condor_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         let max_loss = condor.get_max_loss().unwrap();
         assert_eq!(max_loss, pos_or_panic!(12.0));
@@ -1838,7 +1847,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ZERO,      // open_fee
             Positive::ZERO,      // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), ZERO);
     }
 
@@ -1862,7 +1872,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
 
@@ -1886,7 +1897,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
 
@@ -1910,7 +1922,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 2.0);
     }
 
@@ -1934,7 +1947,8 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(20.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
 
@@ -1980,7 +1994,8 @@ mod tests_iron_condor_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(condor.get_max_profit().is_err());
         assert_eq!(condor.get_max_loss().unwrap(), pos_or_panic!(14.0));
@@ -2028,7 +2043,8 @@ mod tests_iron_condor_optimizable {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     fn create_test_chain() -> OptionChain {
@@ -2260,7 +2276,8 @@ mod tests_iron_condor_profit {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2397,7 +2414,8 @@ mod tests_iron_condor_profit {
             Positive::ONE,
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        ).unwrap();
+        )
+        .unwrap();
 
         let profit = condor
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2429,7 +2447,8 @@ mod tests_iron_condor_profit {
             Positive::ONE,
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        ).unwrap();
+        )
+        .unwrap();
 
         let profit = condor
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2460,7 +2479,8 @@ mod tests_iron_condor_profit {
             Positive::ONE,
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap();
+        )
+        .unwrap();
 
         let profit = condor
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2523,7 +2543,8 @@ mod tests_iron_condor_delta {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2718,7 +2739,8 @@ mod tests_iron_condor_delta_size {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2909,7 +2931,8 @@ mod tests_iron_condor_probability {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3109,7 +3132,8 @@ mod tests_iron_condor_position_management {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3304,7 +3328,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -903,10 +903,14 @@ impl Optimizable for IronCondor {
                     third: short_call,
                     fourth: long_call,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(long_put, short_put, short_call, long_call)| {
@@ -939,7 +943,13 @@ impl Optimizable for IronCondor {
                 third: short_call,
                 fourth: long_call,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -955,7 +965,18 @@ impl Optimizable for IronCondor {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs an `IronCondor` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`short_call.call_bid`, `short_put.put_bid`,
+    /// `long_call.call_ask`, `long_put.put_ask`) needed to price the strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         match legs {
             StrategyLegs::FourLegs {
                 first: long_put,
@@ -966,7 +987,32 @@ impl Optimizable for IronCondor {
                 let implied_volatility = short_call.implied_volatility;
                 assert!(implied_volatility <= Positive::ONE);
 
-                IronCondor::new(
+                let short_call_bid = short_call.call_bid.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_bid for short call leg",
+                    )
+                })?;
+                let short_put_bid = short_put.put_bid.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing put_bid for short put leg",
+                    )
+                })?;
+                let long_call_ask = long_call.call_ask.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_ask for long call leg",
+                    )
+                })?;
+                let long_put_ask = long_put.put_ask.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing put_ask for long put leg",
+                    )
+                })?;
+
+                Ok(IronCondor::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     short_call.strike_price,
@@ -978,13 +1024,13 @@ impl Optimizable for IronCondor {
                     self.short_call.option.risk_free_rate,
                     self.short_call.option.dividend_yield,
                     self.short_call.option.quantity,
-                    short_call.call_bid.unwrap(),
-                    short_put.put_bid.unwrap(),
-                    long_call.call_ask.unwrap(),
-                    long_put.put_ask.unwrap(),
+                    short_call_bid,
+                    short_put_bid,
+                    long_call_ask,
+                    long_put_ask,
                     self.get_fees().unwrap() / 8.0,
                     self.get_fees().unwrap() / 8.0,
-                )
+                ))
             }
             _ => panic!("Invalid number of legs for Iron Condor strategy"),
         }
@@ -2140,7 +2186,7 @@ mod tests_iron_condor_optimizable {
             fourth: options[5], // 110.0 strike for long call
         };
 
-        let new_strategy = condor.create_strategy(&chain, &legs);
+        let new_strategy = condor.create_strategy(&chain, &legs).unwrap();
         assert!(new_strategy.validate());
         assert_eq!(
             new_strategy.long_put.option.strike_price,
@@ -2172,6 +2218,8 @@ mod tests_iron_condor_optimizable {
             second: options[1],
         };
 
+        // Wrong number of legs is still a panic (that branch is owned by
+        // issue #292, not panic-free core).
         let _ = condor.create_strategy(&chain, &legs);
     }
 }

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -173,6 +173,12 @@ impl IronCondor {
     ///
     /// The short options generate income, while the long options limit the potential loss.
     ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if any freshly-constructed leg cannot be added
+    /// to the strategy or if the break-even calculation fails. In practice
+    /// these branches are unreachable for a freshly-built iron condor and
+    /// are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -192,7 +198,7 @@ impl IronCondor {
         premium_long_put: Positive,
         open_fee: Positive,
         close_fee: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = IronCondor {
             name: "Iron Condor".to_string(),
             kind: StrategyType::IronCondor,
@@ -228,9 +234,7 @@ impl IronCondor {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Invalid short call");
+        strategy.add_position(&short_call)?;
 
         // Short Put
         let short_put_option = Options::new(
@@ -256,9 +260,7 @@ impl IronCondor {
             None,
             None,
         );
-        strategy
-            .add_position(&short_put)
-            .expect("Invalid short put");
+        strategy.add_position(&short_put)?;
 
         // Long Call
         let long_call_option = Options::new(
@@ -284,9 +286,7 @@ impl IronCondor {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Invalid long call");
+        strategy.add_position(&long_call)?;
 
         // Long Put
         let long_put_option = Options::new(
@@ -312,12 +312,10 @@ impl IronCondor {
             None,
             None,
         );
-        strategy.add_position(&long_put).expect("Invalid long put");
+        strategy.add_position(&long_put)?;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -335,11 +333,12 @@ impl StrategyConstructor for IronCondor {
 
         // Sort options by strike price to identify each position
         let mut sorted_options = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_options.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lowest_strike = &sorted_options[0];
@@ -842,7 +841,7 @@ impl Strategies for IronCondor {
 
         let result =
             (inner_area + outer_triangles) / self.short_call.option.underlying_price.to_f64();
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -951,9 +950,16 @@ impl Optimizable for IronCondor {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -1012,7 +1018,8 @@ impl Optimizable for IronCondor {
                     )
                 })?;
 
-                Ok(IronCondor::new(
+                let fee_per_leg = self.get_fees()? / 8.0;
+                IronCondor::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     short_call.strike_price,
@@ -1028,9 +1035,9 @@ impl Optimizable for IronCondor {
                     short_put_bid,
                     long_call_ask,
                     long_put_ask,
-                    self.get_fees().unwrap() / 8.0,
-                    self.get_fees().unwrap() / 8.0,
-                ))
+                    fee_per_leg,
+                    fee_per_leg,
+                )
             }
             _ => panic!("Invalid number of legs for Iron Condor strategy"),
         }
@@ -1230,7 +1237,7 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         assert_eq!(iron_condor.name, "Iron Condor");
         assert_eq!(iron_condor.description, IRON_CONDOR_DESCRIPTION.to_string());
@@ -1263,7 +1270,7 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         assert_eq!(iron_condor.get_max_loss().unwrap_or(Positive::ZERO), 51.3);
     }
@@ -1289,7 +1296,7 @@ mod tests_iron_condor {
             pos_or_panic!(2.8),
             pos_or_panic!(0.07),
             pos_or_panic!(0.07),
-        );
+        ).unwrap();
 
         let expected_profit = iron_condor.get_net_premium_received().unwrap().to_f64();
         assert_eq!(
@@ -1319,7 +1326,7 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         assert_eq!(
             iron_condor.get_break_even_points().unwrap()[0],
@@ -1348,7 +1355,7 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         let expected_fees = iron_condor.short_call.open_fee
             + iron_condor.short_call.close_fee
@@ -1382,7 +1389,7 @@ mod tests_iron_condor {
             pos_or_panic!(1.8),
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
-        );
+        ).unwrap();
 
         let price = pos_or_panic!(150.0);
         let expected_profit = iron_condor
@@ -1466,7 +1473,7 @@ mod tests_iron_condor_validable {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1589,7 +1596,7 @@ mod tests_iron_condor_strategies {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1689,7 +1696,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        );
+        ).unwrap();
         let break_even_points = condor.get_break_even_points().unwrap();
 
         assert_eq!(break_even_points.len(), 2);
@@ -1717,7 +1724,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ZERO,      // open_fee
             Positive::ZERO,      // closing fee
-        );
+        ).unwrap();
         let max_profit = condor.get_max_profit().unwrap();
         assert_eq!(max_profit, pos_or_panic!(ZERO));
     }
@@ -1742,7 +1749,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             pos_or_panic!(0.09), // open_fee
             pos_or_panic!(0.09), // closing fee
-        );
+        ).unwrap();
         let max_profit = condor.get_max_profit().unwrap();
         assert_eq!(max_profit, pos_or_panic!(19.28));
     }
@@ -1767,7 +1774,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(11.1), // premium_long_put
             pos_or_panic!(0.1),  // open_fee
             pos_or_panic!(0.1),  // closing fee
-        );
+        ).unwrap();
         let max_loss = condor.get_max_loss().unwrap();
         assert_eq!(max_loss, pos_or_panic!(7.9999999999999964));
     }
@@ -1792,7 +1799,7 @@ mod tests_iron_condor_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         let max_loss = condor.get_max_loss().unwrap();
         assert_eq!(max_loss, pos_or_panic!(12.0));
@@ -1831,7 +1838,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ZERO,      // open_fee
             Positive::ZERO,      // closing fee
-        );
+        ).unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), ZERO);
     }
 
@@ -1855,7 +1862,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        );
+        ).unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
 
@@ -1879,7 +1886,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        );
+        ).unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
 
@@ -1903,7 +1910,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(10.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        );
+        ).unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 2.0);
     }
 
@@ -1927,7 +1934,7 @@ mod tests_iron_condor_strategies {
             pos_or_panic!(20.0), // premium_long_put
             Positive::ONE,       // open_fee
             Positive::ONE,       // closing fee
-        );
+        ).unwrap();
         assert_eq!(condor.get_net_premium_received().unwrap().to_f64(), 0.0);
     }
 
@@ -1973,7 +1980,7 @@ mod tests_iron_condor_strategies {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         assert!(condor.get_max_profit().is_err());
         assert_eq!(condor.get_max_loss().unwrap(), pos_or_panic!(14.0));
@@ -2021,7 +2028,7 @@ mod tests_iron_condor_optimizable {
             Positive::ONE,      // premium_long_put
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        )
+        ).unwrap()
     }
 
     fn create_test_chain() -> OptionChain {
@@ -2253,7 +2260,7 @@ mod tests_iron_condor_profit {
             Positive::ONE,      // premium_long_put
             Positive::ZERO,     // open_fee
             Positive::ZERO,     // closing fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2390,7 +2397,7 @@ mod tests_iron_condor_profit {
             Positive::ONE,
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        );
+        ).unwrap();
 
         let profit = condor
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2422,7 +2429,7 @@ mod tests_iron_condor_profit {
             Positive::ONE,
             pos_or_panic!(0.5), // open_fee
             pos_or_panic!(0.5), // closing fee
-        );
+        ).unwrap();
 
         let profit = condor
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2453,7 +2460,7 @@ mod tests_iron_condor_profit {
             Positive::ONE,
             Positive::ZERO,
             Positive::ZERO,
-        );
+        ).unwrap();
 
         let profit = condor
             .calculate_profit_at(&Positive::HUNDRED)
@@ -2516,7 +2523,7 @@ mod tests_iron_condor_delta {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2711,7 +2718,7 @@ mod tests_iron_condor_delta_size {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2902,7 +2909,7 @@ mod tests_iron_condor_probability {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3102,7 +3109,7 @@ mod tests_iron_condor_position_management {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3297,7 +3304,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(16.8),   // premium_long_put
             pos_or_panic!(0.96),   // open_fee
             pos_or_panic!(0.96),   // close_fee
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -850,11 +850,7 @@ impl Optimizable for LongButterflySpread {
                     third: long_high,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1181,7 +1177,8 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05),                       // close_fee_long_call_low
             pos_or_panic!(0.05),                       // open_fee_long_call_high
             pos_or_panic!(0.05),                       // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1283,7 +1280,8 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_long_call_low
             Positive::ONE,       // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.long_call_low.open_fee, 0.05); // fees / 3
         assert_eq!(butterfly.short_call.open_fee, 1.0); // fees / 3
@@ -1324,7 +1322,8 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.long_call_low.option.quantity, Positive::TWO);
         assert_eq!(butterfly.short_call.option.quantity, pos_or_panic!(4.0)); // 2 * 2
@@ -1379,7 +1378,8 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(1.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert!(check_profit.get_max_profit().is_err());
     }
 }
@@ -1437,7 +1437,8 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert!(butterfly.validate());
     }
 
@@ -1463,7 +1464,8 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
         butterfly.long_call_low =
             create_valid_position(Side::Long, pos_or_panic!(90.0), Positive::ZERO);
         assert!(!butterfly.validate());
@@ -1491,7 +1493,8 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!butterfly.validate());
     }
 
@@ -1517,7 +1520,8 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
         butterfly.short_call = create_valid_position(Side::Short, Positive::HUNDRED, Positive::ONE);
         assert!(!butterfly.validate());
     }
@@ -1544,7 +1548,8 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
         butterfly.long_call_high =
             create_valid_position(Side::Long, pos_or_panic!(110.0), Positive::TWO);
         assert!(!butterfly.validate());
@@ -1585,7 +1590,8 @@ mod tests_long_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1661,7 +1667,8 @@ mod tests_long_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         let scaled_profit = butterfly
             .calculate_profit_at(&Positive::HUNDRED)
@@ -1706,7 +1713,8 @@ mod tests_long_butterfly_delta {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1881,7 +1889,8 @@ mod tests_long_butterfly_delta_size {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2053,7 +2062,8 @@ mod tests_long_butterfly_position_management {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2232,7 +2242,8 @@ mod tests_adjust_option_position_long {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2802,7 +2813,8 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2895,7 +2907,8 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_long_call_low
             Positive::ONE, // open_fee_long_call_high
             Positive::ONE, // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(butterfly.get_fees().unwrap().to_f64(), 8.0);
     }
 
@@ -2921,7 +2934,8 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_long_call_low
             Positive::ONE, // open_fee_long_call_high
             Positive::ONE, // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.get_fees().unwrap(), pos_or_panic!(16.0));
     }
@@ -2967,7 +2981,8 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         let base_butterfly = create_test_long();
         assert_eq!(
@@ -3035,7 +3050,8 @@ mod tests_butterfly_optimizable {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3123,7 +3139,8 @@ mod tests_butterfly_probability {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     mod long_butterfly_tests {
@@ -3235,7 +3252,8 @@ mod tests_butterfly_probability {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         info!("=== DEBUGGING USER CASE ===");
 

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -843,10 +843,14 @@ impl Optimizable for LongButterflySpread {
                     second: short,
                     third: long_high,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(long_low, short, long_high)| {
@@ -876,7 +880,13 @@ impl Optimizable for LongButterflySpread {
                 second: short,
                 third: long_high,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -892,7 +902,19 @@ impl Optimizable for LongButterflySpread {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `LongButterflySpread` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`low_strike.call_ask`,
+    /// `middle_strike.call_bid`, `high_strike.call_ask`) needed to price the
+    /// strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         match legs {
             StrategyLegs::ThreeLegs {
                 first: low_strike,
@@ -902,7 +924,26 @@ impl Optimizable for LongButterflySpread {
                 let implied_volatility = middle_strike.implied_volatility;
                 assert!(implied_volatility <= Positive::ONE);
 
-                LongButterflySpread::new(
+                let low_call_ask = low_strike.call_ask.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_ask for low strike leg",
+                    )
+                })?;
+                let middle_call_bid = middle_strike.call_bid.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_bid for middle strike leg",
+                    )
+                })?;
+                let high_call_ask = high_strike.call_ask.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_ask for high strike leg",
+                    )
+                })?;
+
+                Ok(LongButterflySpread::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     low_strike.strike_price,
@@ -913,16 +954,16 @@ impl Optimizable for LongButterflySpread {
                     self.long_call_low.option.risk_free_rate,
                     self.long_call_low.option.dividend_yield,
                     self.long_call_low.option.quantity,
-                    low_strike.call_ask.unwrap(),
-                    middle_strike.call_bid.unwrap(),
-                    high_strike.call_ask.unwrap(),
+                    low_call_ask,
+                    middle_call_bid,
+                    high_call_ask,
                     self.short_call.open_fee,
                     self.short_call.close_fee,
                     self.long_call_low.open_fee,
                     self.long_call_low.close_fee,
                     self.long_call_high.open_fee,
                     self.long_call_high.close_fee,
-                )
+                ))
             }
             _ => panic!("Invalid number of legs for Long Butterfly strategy"),
         }

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -114,6 +114,13 @@ impl LongButterflySpread {
     ///
     /// # Returns
     /// A fully configured Long Butterfly Spread strategy with positions and break-even points calculated
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if the break-even calculation fails. In
+    /// practice this branch is unreachable for a freshly-built long
+    /// butterfly spread and is surfaced only to keep the constructor
+    /// panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -135,7 +142,7 @@ impl LongButterflySpread {
         close_fee_long_call_low: Positive,
         open_fee_long_call_high: Positive,
         close_fee_long_call_high: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = LongButterflySpread {
             name: "Long Butterfly".to_string(),
             kind: StrategyType::LongButterflySpread,
@@ -223,11 +230,9 @@ impl LongButterflySpread {
 
         strategy.validate();
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
+        strategy.update_break_even_points()?;
 
-        strategy
+        Ok(strategy)
     }
 }
 
@@ -245,11 +250,12 @@ impl StrategyConstructor for LongButterflySpread {
 
         // Sort options by strike price
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lower_strike_position = &sorted_positions[0];
@@ -888,9 +894,16 @@ impl Optimizable for LongButterflySpread {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -943,7 +956,7 @@ impl Optimizable for LongButterflySpread {
                     )
                 })?;
 
-                Ok(LongButterflySpread::new(
+                LongButterflySpread::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     low_strike.strike_price,
@@ -963,7 +976,7 @@ impl Optimizable for LongButterflySpread {
                     self.long_call_low.close_fee,
                     self.long_call_high.open_fee,
                     self.long_call_high.close_fee,
-                ))
+                )
             }
             _ => panic!("Invalid number of legs for Long Butterfly strategy"),
         }
@@ -1168,7 +1181,7 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05),                       // close_fee_long_call_low
             pos_or_panic!(0.05),                       // open_fee_long_call_high
             pos_or_panic!(0.05),                       // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1270,7 +1283,7 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_long_call_low
             Positive::ONE,       // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.long_call_low.open_fee, 0.05); // fees / 3
         assert_eq!(butterfly.short_call.open_fee, 1.0); // fees / 3
@@ -1311,7 +1324,7 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.long_call_low.option.quantity, Positive::TWO);
         assert_eq!(butterfly.short_call.option.quantity, pos_or_panic!(4.0)); // 2 * 2
@@ -1366,7 +1379,7 @@ mod tests_long_butterfly_spread {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(1.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        );
+        ).unwrap();
         assert!(check_profit.get_max_profit().is_err());
     }
 }
@@ -1424,7 +1437,7 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
         assert!(butterfly.validate());
     }
 
@@ -1450,7 +1463,7 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
         butterfly.long_call_low =
             create_valid_position(Side::Long, pos_or_panic!(90.0), Positive::ZERO);
         assert!(!butterfly.validate());
@@ -1478,7 +1491,7 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
         assert!(!butterfly.validate());
     }
 
@@ -1504,7 +1517,7 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
         butterfly.short_call = create_valid_position(Side::Short, Positive::HUNDRED, Positive::ONE);
         assert!(!butterfly.validate());
     }
@@ -1531,7 +1544,7 @@ mod tests_long_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
         butterfly.long_call_high =
             create_valid_position(Side::Long, pos_or_panic!(110.0), Positive::TWO);
         assert!(!butterfly.validate());
@@ -1572,7 +1585,7 @@ mod tests_long_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1648,7 +1661,7 @@ mod tests_long_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
 
         let scaled_profit = butterfly
             .calculate_profit_at(&Positive::HUNDRED)
@@ -1693,7 +1706,7 @@ mod tests_long_butterfly_delta {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1868,7 +1881,7 @@ mod tests_long_butterfly_delta_size {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2040,7 +2053,7 @@ mod tests_long_butterfly_position_management {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2219,7 +2232,7 @@ mod tests_adjust_option_position_long {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2789,7 +2802,7 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2882,7 +2895,7 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_long_call_low
             Positive::ONE, // open_fee_long_call_high
             Positive::ONE, // close_fee_long_call_high
-        );
+        ).unwrap();
         assert_eq!(butterfly.get_fees().unwrap().to_f64(), 8.0);
     }
 
@@ -2908,7 +2921,7 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_long_call_low
             Positive::ONE, // open_fee_long_call_high
             Positive::ONE, // close_fee_long_call_high
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.get_fees().unwrap(), pos_or_panic!(16.0));
     }
@@ -2954,7 +2967,7 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        );
+        ).unwrap();
 
         let base_butterfly = create_test_long();
         assert_eq!(
@@ -3022,7 +3035,7 @@ mod tests_butterfly_optimizable {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3110,7 +3123,7 @@ mod tests_butterfly_probability {
             pos_or_panic!(0.05), // close_fee_long_call_low
             pos_or_panic!(0.05), // open_fee_long_call_high
             pos_or_panic!(0.05), // close_fee_long_call_high
-        )
+        ).unwrap()
     }
 
     mod long_butterfly_tests {
@@ -3222,7 +3235,7 @@ mod tests_butterfly_probability {
             pos_or_panic!(0.05),  // close_fee_long_call_low
             pos_or_panic!(0.05),  // open_fee_long_call_high
             pos_or_panic!(0.05),  // close_fee_long_call_high
-        );
+        ).unwrap();
 
         info!("=== DEBUGGING USER CASE ===");
 

--- a/src/strategies/long_call.rs
+++ b/src/strategies/long_call.rs
@@ -783,7 +783,8 @@ mod tests_simulate {
             pos_or_panic!(5.0),
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     fn create_walk_params(prices: Vec<Positive>) -> WalkParams<Positive, Positive> {

--- a/src/strategies/long_call.rs
+++ b/src/strategies/long_call.rs
@@ -96,9 +96,11 @@ impl LongCall {
     /// # Returns
     /// An initialized instance of `LongCall` strategy configured with the provided parameters.
     ///
-    /// # Panics
-    /// - Panics if adding the long call position to the strategy fails.
-    ///   This typically occurs if the created long call option is invalid.
+    /// # Errors
+    /// Returns `StrategyError` if the freshly-constructed long call leg
+    /// cannot be added to the strategy. In practice this branch is
+    /// unreachable for a freshly-built single-leg strategy and is surfaced
+    /// only to keep the constructor panic-free.
     ///
     /// # Notes
     /// - The function relies on creating a default `LongCall` instance and then populating it with positions.
@@ -117,7 +119,7 @@ impl LongCall {
         premium_long_call: Positive,
         open_fee_long_call: Positive,
         close_fee_long_call: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = LongCall::default();
 
         let long_call_option = Options::new(
@@ -143,11 +145,9 @@ impl LongCall {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Invalid long call option");
+        strategy.add_position(&long_call)?;
 
-        strategy
+        Ok(strategy)
     }
 }
 
@@ -553,7 +553,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .expect("Failed to set progress bar template")
+                .map_err(|e| SimulationError::OtherError {
+                    reason: format!("Failed to set progress bar template: {}", e),
+                })?
                 .progress_chars("#>-"),
         );
 
@@ -642,7 +644,7 @@ where
                 // Calculate expiration premium
                 let mut exp_option = self.long_call.option.clone();
                 exp_option.underlying_price = final_price;
-                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001).unwrap());
+                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001)?);
                 expiration_premium = Some(exp_option.calculate_price_black_scholes()?.abs());
 
                 expired = true;
@@ -781,7 +783,7 @@ mod tests_simulate {
             pos_or_panic!(5.0),
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     fn create_walk_params(prices: Vec<Positive>) -> WalkParams<Positive, Positive> {

--- a/src/strategies/long_put.rs
+++ b/src/strategies/long_put.rs
@@ -97,10 +97,11 @@ impl LongPut {
     ///
     /// A new instance of the `LongPut` strategy initialized with the provided parameters.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if:
-    /// * The `add_position` method fails, which could happen due to invalid configurations of the long put position.
+    /// # Errors
+    /// Returns `StrategyError` if the freshly-constructed long put leg
+    /// cannot be added to the strategy. In practice this branch is
+    /// unreachable for a freshly-built single-leg strategy and is surfaced
+    /// only to keep the constructor panic-free.
     ///
     #[allow(clippy::too_many_arguments, dead_code)]
     fn new(
@@ -115,7 +116,7 @@ impl LongPut {
         premium_long_put: Positive,
         open_fee_long_put: Positive,
         close_fee_long_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = LongPut::default();
 
         let long_put_option = Options::new(
@@ -141,11 +142,9 @@ impl LongPut {
             None,
             None,
         );
-        strategy
-            .add_position(&long_put)
-            .expect("Invalid long put option");
+        strategy.add_position(&long_put)?;
 
-        strategy
+        Ok(strategy)
     }
 }
 
@@ -561,7 +560,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .expect("Failed to set progress bar template")
+                .map_err(|e| SimulationError::OtherError {
+                    reason: format!("Failed to set progress bar template: {}", e),
+                })?
                 .progress_chars("#>-"),
         );
 
@@ -650,7 +651,7 @@ where
                 // Calculate expiration premium
                 let mut exp_option = self.long_put.option.clone();
                 exp_option.underlying_price = final_price;
-                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001).unwrap());
+                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001)?);
                 expiration_premium = Some(exp_option.calculate_price_black_scholes()?.abs());
 
                 expired = true;
@@ -791,7 +792,7 @@ mod tests_simulate {
             pos_or_panic!(5.0),
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     fn create_walk_params(prices: Vec<Positive>) -> WalkParams<Positive, Positive> {

--- a/src/strategies/long_put.rs
+++ b/src/strategies/long_put.rs
@@ -792,7 +792,8 @@ mod tests_simulate {
             pos_or_panic!(5.0),
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     fn create_walk_params(prices: Vec<Positive>) -> WalkParams<Positive, Positive> {

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -674,11 +674,7 @@ impl Optimizable for LongStraddle {
                     second: both,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -948,7 +944,8 @@ mod tests_long_straddle_probability {
             Positive::ZERO,                            // close_fee_long_call
             Positive::ZERO,                            // open_fee_long_put
             Positive::ZERO,                            // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1097,7 +1094,8 @@ mod tests_long_straddle_delta {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1242,7 +1240,8 @@ mod tests_long_straddle_delta_size {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1383,7 +1382,8 @@ mod tests_straddle_position_management {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1492,7 +1492,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -150,6 +150,12 @@ impl LongStraddle {
     /// # Returns
     /// A fully initialized Long Straddle strategy with calculated break-even points
     ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built long
+    /// straddle and are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -166,7 +172,7 @@ impl LongStraddle {
         close_fee_long_call: Positive,
         open_fee_long_put: Positive,
         close_fee_long_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if strike == Positive::ZERO {
             strike = underlying_price;
         }
@@ -203,9 +209,7 @@ impl LongStraddle {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Invalid long call");
+        strategy.add_position(&long_call)?;
 
         let long_put_option = Options::new(
             OptionType::European,
@@ -230,12 +234,10 @@ impl LongStraddle {
             None,
             None,
         );
-        strategy.add_position(&long_put).expect("Invalid long put");
+        strategy.add_position(&long_put)?;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -613,7 +615,7 @@ impl Strategies for LongStraddle {
         let cat = (strike_diff / 2.0_f64.sqrt()).to_f64();
         let loss_area = (cat.powf(2.0)) / (2.0 * 10.0_f64.powf(cat.log10().ceil()));
         let result = (1.0 / loss_area) * 10000.0; // Invert the value to get the profit area: the lower, the better
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -622,7 +624,7 @@ impl Strategies for LongStraddle {
             Ok(max_loss) => ((break_even_diff / max_loss) * 100.0).to_f64(),
             Err(_) => ZERO,
         };
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 }
 
@@ -713,9 +715,16 @@ impl Optimizable for LongStraddle {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -757,7 +766,7 @@ impl Optimizable for LongStraddle {
                 "missing put_ask for long put leg",
             )
         })?;
-        Ok(LongStraddle::new(
+        LongStraddle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -772,7 +781,7 @@ impl Optimizable for LongStraddle {
             self.long_call.close_fee,
             self.long_put.open_fee,
             self.long_put.close_fee,
-        ))
+        )
     }
 }
 
@@ -939,7 +948,7 @@ mod tests_long_straddle_probability {
             Positive::ZERO,                            // close_fee_long_call
             Positive::ZERO,                            // open_fee_long_put
             Positive::ZERO,                            // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1088,7 +1097,7 @@ mod tests_long_straddle_delta {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1233,7 +1242,7 @@ mod tests_long_straddle_delta_size {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1374,7 +1383,7 @@ mod tests_straddle_position_management {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1483,7 +1492,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -671,10 +671,14 @@ impl Optimizable for LongStraddle {
                     first: both,
                     second: both,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(OptionDataGroup::One)
@@ -701,7 +705,13 @@ impl Optimizable for LongStraddle {
                 first: both,
                 second: both,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -717,14 +727,37 @@ impl Optimizable for LongStraddle {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `LongStraddle` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`call.call_ask`, `put.put_ask`) needed to
+    /// price the strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (call, put) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
         };
         let implied_volatility = call.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        LongStraddle::new(
+        let call_ask = call.call_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_ask for long call leg",
+            )
+        })?;
+        let put_ask = put.put_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_ask for long put leg",
+            )
+        })?;
+        Ok(LongStraddle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -733,13 +766,13 @@ impl Optimizable for LongStraddle {
             self.long_call.option.risk_free_rate,
             self.long_call.option.dividend_yield,
             self.long_call.option.quantity,
-            call.call_ask.unwrap(),
-            put.put_ask.unwrap(),
+            call_ask,
+            put_ask,
             self.long_call.open_fee,
             self.long_call.close_fee,
             self.long_put.open_fee,
             self.long_put.close_fee,
-        )
+        ))
     }
 }
 

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -718,10 +718,14 @@ impl Optimizable for LongStrangle {
                     second: long_call,
                 };
 
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(long_put, long_call)| OptionDataGroup::Two(long_put, long_call))
@@ -748,7 +752,13 @@ impl Optimizable for LongStrangle {
                 first: long_put,
                 second: long_call,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -773,14 +783,37 @@ impl Optimizable for LongStrangle {
             && long_put.put_bid.unwrap_or(Positive::ZERO) > Positive::ZERO
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `LongStrangle` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`call.call_ask`, `put.put_ask`) needed to
+    /// price the strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (put, call) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
         };
         let implied_volatility = call.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        LongStrangle::new(
+        let call_ask = call.call_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_ask for long call leg",
+            )
+        })?;
+        let put_ask = put.put_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_ask for long put leg",
+            )
+        })?;
+        Ok(LongStrangle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -790,13 +823,13 @@ impl Optimizable for LongStrangle {
             self.long_call.option.risk_free_rate,
             self.long_call.option.dividend_yield,
             self.long_call.option.quantity,
-            call.call_ask.unwrap(),
-            put.put_ask.unwrap(),
+            call_ask,
+            put_ask,
             self.long_call.open_fee,
             self.long_call.close_fee,
             self.long_put.open_fee,
             self.long_put.close_fee,
-        )
+        ))
     }
 }
 

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -159,6 +159,13 @@ impl LongStrangle {
     ///
     /// Returns a fully initialized `LongStrangle` strategy with properly configured positions and calculated
     /// break-even points.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built
+    /// strangle and are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -176,7 +183,7 @@ impl LongStrangle {
         close_fee_long_call: Positive,
         open_fee_long_put: Positive,
         close_fee_long_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if call_strike == Positive::ZERO {
             call_strike = underlying_price * 1.1;
         }
@@ -215,7 +222,7 @@ impl LongStrangle {
             None,
             None,
         );
-        strategy.add_position(&long_call).expect("Invalid position");
+        strategy.add_position(&long_call)?;
 
         let long_put_option = Options::new(
             OptionType::European,
@@ -240,13 +247,11 @@ impl LongStrangle {
             None,
             None,
         );
-        strategy.add_position(&long_put).expect("Invalid position");
+        strategy.add_position(&long_put)?;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
+        strategy.update_break_even_points()?;
 
-        strategy
+        Ok(strategy)
     }
 }
 
@@ -264,11 +269,12 @@ impl StrategyConstructor for LongStrangle {
 
         // Sort options by option style to identify call and put
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let put_position = &sorted_positions[0]; // Put will be first
@@ -637,7 +643,7 @@ impl Strategies for LongStrangle {
         let loss_area =
             ((inner_square + triangles) / self.long_call.option.underlying_price).to_f64();
         let result = 1.0 / loss_area; // Invert the value to get the profit area: the lower, the better
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
         let max_loss = self.get_max_loss().unwrap_or(Positive::ZERO);
@@ -647,7 +653,7 @@ impl Strategies for LongStrangle {
         let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
         let ratio = max_loss / break_even_diff * 100.0;
         let result = 1.0 / ratio; // Invert the value to get the profit ratio: the lower, the better
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
     fn get_best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
         let (first_option, last_option) = (self.break_even_points[0], self.break_even_points[1]);
@@ -690,10 +696,10 @@ impl Optimizable for LongStrangle {
                 FindOptimalSide::DeltaRange(min, max) => {
                     let (_, delta_put) = long_put.current_deltas();
                     let (delta_call, _) = long_call.current_deltas();
-                    delta_put.unwrap() > min
-                        && delta_put.unwrap() < max
-                        && delta_call.unwrap() > min
-                        && delta_call.unwrap() < max
+                    let (Some(dp), Some(dc)) = (delta_put, delta_call) else {
+                        return false;
+                    };
+                    dp > min && dp < max && dc > min && dc < max
                 }
                 FindOptimalSide::Center => {
                     long_put.is_valid_optimal_side(underlying_price, &FindOptimalSide::Lower)
@@ -760,9 +766,16 @@ impl Optimizable for LongStrangle {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -813,7 +826,7 @@ impl Optimizable for LongStrangle {
                 "missing put_ask for long put leg",
             )
         })?;
-        Ok(LongStrangle::new(
+        LongStrangle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -829,7 +842,7 @@ impl Optimizable for LongStrangle {
             self.long_call.close_fee,
             self.long_put.open_fee,
             self.long_put.close_fee,
-        ))
+        )
     }
 }
 
@@ -990,8 +1003,8 @@ impl PnLCalculator for LongStrangle {
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1003,8 +1016,8 @@ impl PnLCalculator for LongStrangle {
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1020,14 +1033,14 @@ impl PnLCalculator for LongStrangle {
                     match (side, option_style) {
                         (Side::Long, OptionStyle::Call) => {
                             let mut position = self.long_call.clone();
-                            position.option.side = Side::Short; // Sell the call 
+                            position.option.side = Side::Short; // Sell the call
                             position.option.quantity = *quantity;
                             position.option.strike_price = *strike;
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1039,8 +1052,8 @@ impl PnLCalculator for LongStrangle {
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1082,7 +1095,7 @@ mod tests_long_strangle_probability {
             Positive::ZERO,                            // close_fee_long_call
             Positive::ZERO,                            // open_fee_long_put
             Positive::ZERO,                            // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1233,7 +1246,7 @@ mod tests_long_strangle_delta {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1376,7 +1389,7 @@ mod tests_long_strangle_delta_size {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1672,7 +1685,7 @@ mod tests_strangle_position_management {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1782,7 +1795,7 @@ mod tests_adjust_option_position_long {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -725,11 +725,7 @@ impl Optimizable for LongStrangle {
                 };
 
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1095,7 +1091,8 @@ mod tests_long_strangle_probability {
             Positive::ZERO,                            // close_fee_long_call
             Positive::ZERO,                            // open_fee_long_put
             Positive::ZERO,                            // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1246,7 +1243,8 @@ mod tests_long_strangle_delta {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1389,7 +1387,8 @@ mod tests_long_strangle_delta_size {
             pos_or_panic!(7.01),   // close_fee_long_call
             pos_or_panic!(7.01),   // open_fee_long_put
             pos_or_panic!(7.01),   // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1685,7 +1684,8 @@ mod tests_strangle_position_management {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1795,7 +1795,8 @@ mod tests_adjust_option_position_long {
             pos_or_panic!(0.1), // close_fee_long_call
             pos_or_panic!(0.1), // open_fee_long_put
             pos_or_panic!(0.1), // close_fee_long_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -65,7 +65,7 @@
 //!     pos_or_panic!(0.78),   // open_fee_long
 //!     pos_or_panic!(0.73),   // close_fee_long
 //!     pos_or_panic!(0.73),   // close_fee_short
-//! );
+//! ).expect("valid bull call spread");
 //!
 //! let profit = spread.get_max_profit().unwrap_or(Positive::ZERO);
 //! let loss = spread.get_max_loss().unwrap_or(Positive::ZERO);
@@ -180,7 +180,7 @@
 //!     pos_or_panic!(1.8),   // premium_long_put
 //!     pos_or_panic!(5.0),   // open_fee
 //!     pos_or_panic!(5.0),   // close_fee
-//! );
+//! ).expect("valid iron condor");
 //!
 //! let max_profit = condor.get_max_profit().unwrap_or(Positive::ZERO);
 //! let max_loss = condor.get_max_loss().unwrap_or(Positive::ZERO);

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -704,7 +704,17 @@ impl Optimizable for PoorMansCoveredCall {
                     first: long_call_option,
                     second: short_call_option,
                 };
-                let strategy: PoorMansCoveredCall = self.create_strategy(option_chain, &legs);
+                let strategy: PoorMansCoveredCall =
+                    match self.create_strategy(option_chain, &legs) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "skipping invalid strategy combination"
+                            );
+                            continue;
+                        }
+                    };
 
                 if !strategy.validate() {
                     debug!("Invalid strategy");
@@ -724,7 +734,18 @@ impl Optimizable for PoorMansCoveredCall {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `PoorMansCoveredCall` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`long.call_ask`, `short.call_bid`) needed to
+    /// price the strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (long, short) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
@@ -732,7 +753,20 @@ impl Optimizable for PoorMansCoveredCall {
         let implied_volatility = short.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
 
-        PoorMansCoveredCall::new(
+        let long_call_ask = long.call_ask.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_ask for long call leg",
+            )
+        })?;
+        let short_call_bid = short.call_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_bid for short call leg",
+            )
+        })?;
+
+        Ok(PoorMansCoveredCall::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -743,13 +777,13 @@ impl Optimizable for PoorMansCoveredCall {
             self.short_call.option.risk_free_rate,
             self.short_call.option.dividend_yield,
             self.short_call.option.quantity,
-            long.call_ask.unwrap(),
-            short.call_bid.unwrap(),
+            long_call_ask,
+            short_call_bid,
             self.long_call.open_fee,
             self.long_call.close_fee,
             self.short_call.open_fee,
             self.short_call.close_fee,
-        )
+        ))
     }
 }
 

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -705,17 +705,17 @@ impl Optimizable for PoorMansCoveredCall {
                     first: long_call_option,
                     second: short_call_option,
                 };
-                let strategy: PoorMansCoveredCall =
-                    match self.create_strategy(option_chain, &legs) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                "skipping invalid strategy combination"
-                            );
-                            continue;
-                        }
-                    };
+                let strategy: PoorMansCoveredCall = match self.create_strategy(option_chain, &legs)
+                {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "skipping invalid strategy combination"
+                        );
+                        continue;
+                    }
+                };
 
                 if !strategy.validate() {
                     debug!("Invalid strategy");
@@ -927,7 +927,8 @@ mod tests_pmcc_validation {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1096,7 +1097,8 @@ mod tests_pmcc_optimization {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1252,7 +1254,8 @@ mod tests_pmcc_pnl {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1346,7 +1349,8 @@ mod tests_pmcc_best_area {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         Ok((strategy, option_chain))
     }
@@ -1423,7 +1427,8 @@ mod tests_pmcc_best_ratio {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        ).unwrap();
+        )
+        .unwrap();
 
         Ok((strategy, option_chain))
     }
@@ -1499,7 +1504,8 @@ mod tests_short_straddle_delta {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_long_call
             pos_or_panic!(7.01),   // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1644,7 +1650,8 @@ mod tests_short_straddle_delta_size {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_long_call
             pos_or_panic!(7.01),   // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1785,7 +1792,8 @@ mod tests_poor_mans_covered_call_probability {
             pos_or_panic!(1.74),                        // close_fee_short_call
             pos_or_panic!(0.85),                        // open_fee_long_call
             pos_or_panic!(0.85),                        // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1995,7 +2003,8 @@ mod tests_poor_mans_covered_call_position_management {
             pos_or_panic!(1.74),                       // close_fee_short_call
             pos_or_panic!(0.85),                       // open_fee_long_call
             pos_or_panic!(0.85),                       // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2123,7 +2132,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(1.74),                       // close_fee_short_call
             pos_or_panic!(0.85),                       // open_fee_long_call
             pos_or_panic!(0.85),                       // close_fee_long_call
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -174,6 +174,12 @@ impl PoorMansCoveredCall {
     /// * The investor wants to generate income from the short calls while maintaining upside potential
     /// * The investor seeks a capital-efficient alternative to traditional covered calls
     ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built PMCC and
+    /// are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -192,7 +198,7 @@ impl PoorMansCoveredCall {
         close_fee_long_call: Positive,
         open_fee_short_call: Positive,
         close_fee_short_call: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = PoorMansCoveredCall::default();
 
         // Long Call (LEAPS)
@@ -219,9 +225,7 @@ impl PoorMansCoveredCall {
             None,
             None,
         );
-        strategy
-            .add_position(&long_call)
-            .expect("Invalid long call option");
+        strategy.add_position(&long_call)?;
 
         // Short Call
         let short_call_option = Options::new(
@@ -247,14 +251,10 @@ impl PoorMansCoveredCall {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Invalid short call option");
+        strategy.add_position(&short_call)?;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -272,11 +272,12 @@ impl StrategyConstructor for PoorMansCoveredCall {
 
         // Sort options by strike price to identify long and short positions
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lower_strike_position = &sorted_positions[0];
@@ -647,7 +648,7 @@ impl Strategies for PoorMansCoveredCall {
         .to_f64();
         let high = self.get_max_profit().unwrap_or(Positive::ZERO).to_f64();
         let result = base * high / 200.0;
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -655,7 +656,7 @@ impl Strategies for PoorMansCoveredCall {
             (Ok(profit), Ok(loss)) => (profit / loss).to_f64() * 100.0,
             _ => ZERO,
         };
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 }
 
@@ -721,9 +722,16 @@ impl Optimizable for PoorMansCoveredCall {
                     continue;
                 }
 
-                let current_value = match criteria {
-                    OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                    OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+                let metric = match criteria {
+                    OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                    OptimizationCriteria::Area => strategy.get_profit_area(),
+                };
+                let current_value = match metric {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                        continue;
+                    }
                 };
 
                 if current_value > best_value {
@@ -766,7 +774,7 @@ impl Optimizable for PoorMansCoveredCall {
             )
         })?;
 
-        Ok(PoorMansCoveredCall::new(
+        PoorMansCoveredCall::new(
             chain.symbol.clone(),
             chain.underlying_price,
             long.strike_price,
@@ -783,7 +791,7 @@ impl Optimizable for PoorMansCoveredCall {
             self.long_call.close_fee,
             self.short_call.open_fee,
             self.short_call.close_fee,
-        ))
+        )
     }
 }
 
@@ -919,7 +927,7 @@ mod tests_pmcc_validation {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1088,7 +1096,7 @@ mod tests_pmcc_optimization {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1244,7 +1252,7 @@ mod tests_pmcc_pnl {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1338,7 +1346,7 @@ mod tests_pmcc_best_area {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         Ok((strategy, option_chain))
     }
@@ -1415,7 +1423,7 @@ mod tests_pmcc_best_ratio {
             Positive::ONE,
             pos_or_panic!(0.5),
             pos_or_panic!(0.5),
-        );
+        ).unwrap();
 
         Ok((strategy, option_chain))
     }
@@ -1491,7 +1499,7 @@ mod tests_short_straddle_delta {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_long_call
             pos_or_panic!(7.01),   // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1636,7 +1644,7 @@ mod tests_short_straddle_delta_size {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_long_call
             pos_or_panic!(7.01),   // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1777,7 +1785,7 @@ mod tests_poor_mans_covered_call_probability {
             pos_or_panic!(1.74),                        // close_fee_short_call
             pos_or_panic!(0.85),                        // open_fee_long_call
             pos_or_panic!(0.85),                        // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1987,7 +1995,7 @@ mod tests_poor_mans_covered_call_position_management {
             pos_or_panic!(1.74),                       // close_fee_short_call
             pos_or_panic!(0.85),                       // open_fee_long_call
             pos_or_panic!(0.85),                       // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2115,7 +2123,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(1.74),                       // close_fee_short_call
             pos_or_panic!(0.85),                       // open_fee_long_call
             pos_or_panic!(0.85),                       // close_fee_long_call
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/probabilities/core.rs
+++ b/src/strategies/probabilities/core.rs
@@ -150,13 +150,9 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
 
         let step = self.get_underlying_price() / 100.0;
         let range = self.get_best_range_to_show(step)?;
-        let expiration = *self
-            .get_expiration()
-            .values()
-            .next()
-            .ok_or_else(|| {
-                StrategyError::empty_collection("expected_value: no expiration on strategy")
-            })?;
+        let expiration = *self.get_expiration().values().next().ok_or_else(|| {
+            StrategyError::empty_collection("expected_value: no expiration on strategy")
+        })?;
 
         let mut probabilities = Vec::with_capacity(range.len());
         let mut last_prob = Decimal::ZERO;
@@ -390,7 +386,8 @@ mod tests_probability_analysis {
             pos_or_panic!(0.58),  // close_fee_long
             pos_or_panic!(0.55),  // close_fee_short
             pos_or_panic!(0.54),  // open_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -543,7 +540,8 @@ mod tests_expected_value {
             pos_or_panic!(0.58),  // close_fee_long
             pos_or_panic!(0.55),  // close_fee_short
             pos_or_panic!(0.54),  // open_fee_short
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/probabilities/core.rs
+++ b/src/strategies/probabilities/core.rs
@@ -374,7 +374,7 @@ mod tests_probability_analysis {
             pos_or_panic!(0.58),  // close_fee_long
             pos_or_panic!(0.55),  // close_fee_short
             pos_or_panic!(0.54),  // open_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -527,7 +527,7 @@ mod tests_expected_value {
             pos_or_panic!(0.58),  // close_fee_long
             pos_or_panic!(0.55),  // close_fee_short
             pos_or_panic!(0.54),  // open_fee_short
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/probabilities/core.rs
+++ b/src/strategies/probabilities/core.rs
@@ -10,6 +10,7 @@
 use positive::{Positive, pos_or_panic};
 
 use crate::error::probability::ProbabilityError;
+use crate::error::strategies::StrategyError;
 use crate::model::ProfitLossRange;
 use crate::pricing::payoff::Profit;
 use crate::strategies::base::Strategies;
@@ -68,7 +69,7 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
         volatility_adj: Option<VolatilityAdjustment>,
         trend: Option<PriceTrend>,
     ) -> Result<StrategyProbabilityAnalysis, ProbabilityError> {
-        let break_even_points = self.get_break_even_points().unwrap();
+        let break_even_points = self.get_break_even_points()?;
         // If both parameters are None, return default probabilities based on profit ranges
         if volatility_adj.is_none() && trend.is_none() {
             let probability_of_profit = self.probability_of_profit(None, None)?;
@@ -80,7 +81,7 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
                 probability_of_max_loss: Positive::ZERO, // Default value when no volatility adjustment
                 expected_value,
                 break_even_points: break_even_points.to_vec(),
-                risk_reward_ratio: Positive::new_decimal(self.get_profit_ratio().unwrap())
+                risk_reward_ratio: Positive::new_decimal(self.get_profit_ratio()?)
                     .unwrap_or(Positive::ZERO),
             });
         }
@@ -92,7 +93,7 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
         let (prob_max_profit, prob_max_loss) =
             self.calculate_extreme_probabilities(volatility_adj, trend)?;
         let risk_reward_ratio =
-            Positive::new_decimal(self.get_profit_ratio().unwrap()).unwrap_or(Positive::ZERO);
+            Positive::new_decimal(self.get_profit_ratio()?).unwrap_or(Positive::ZERO);
 
         Ok(StrategyProbabilityAnalysis {
             probability_of_profit,
@@ -148,8 +149,14 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
         }
 
         let step = self.get_underlying_price() / 100.0;
-        let range = self.get_best_range_to_show(step).unwrap();
-        let expiration = *self.get_expiration().values().next().unwrap();
+        let range = self.get_best_range_to_show(step)?;
+        let expiration = *self
+            .get_expiration()
+            .values()
+            .next()
+            .ok_or_else(|| {
+                StrategyError::empty_collection("expected_value: no expiration on strategy")
+            })?;
 
         let mut probabilities = Vec::with_capacity(range.len());
         let mut last_prob = Decimal::ZERO;
@@ -169,13 +176,14 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
             last_prob = prob.0.to_dec();
         }
 
-        let expected_value =
-            range
-                .iter()
-                .zip(probabilities.iter())
-                .fold(0.0, |acc, (price, prob)| {
-                    acc + self.calculate_profit_at(price).unwrap().to_f64().unwrap() * *prob
-                });
+        let mut expected_value = 0.0_f64;
+        for (price, prob) in range.iter().zip(probabilities.iter()) {
+            let profit_dec = self.calculate_profit_at(price)?;
+            let profit = profit_dec
+                .to_f64()
+                .ok_or_else(|| StrategyError::numeric_conversion(0.0))?;
+            expected_value += profit * prob.to_f64();
+        }
 
         let total_prob: f64 = probabilities.iter().map(|p| p.to_f64()).sum();
         if (total_prob - 1.0).abs() > 0.05 {
@@ -293,8 +301,16 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
             .find(|range| range.upper_bound.is_none());
 
         let max_loss_range = loss_ranges.iter().find(|range| range.lower_bound.is_none());
-        let expiration = *self.get_expiration().values().next().unwrap();
-        let risk_free_rate = *self.get_risk_free_rate().values().next().unwrap();
+        let expiration = *self.get_expiration().values().next().ok_or_else(|| {
+            StrategyError::empty_collection(
+                "calculate_extreme_probabilities: no expiration on strategy",
+            )
+        })?;
+        let risk_free_rate = *self.get_risk_free_rate().values().next().ok_or_else(|| {
+            StrategyError::empty_collection(
+                "calculate_extreme_probabilities: no risk_free_rate on strategy",
+            )
+        })?;
         let underlying_price = self.get_underlying_price();
 
         let mut max_profit_prob = Positive::ZERO;

--- a/src/strategies/probabilities/mod.rs
+++ b/src/strategies/probabilities/mod.rs
@@ -57,6 +57,7 @@ use positive::pos_or_panic;
 //! ### Basic Strategy Analysis
 //!
 //! ```rust
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! use rust_decimal_macros::dec;
 //! use tracing::info;
 //! use optionstratlib::model::types::{ OptionStyle, OptionType, Side};
@@ -81,15 +82,18 @@ use positive::pos_or_panic;
 //!         pos_or_panic!(0.78),   // open_fee_long
 //!         pos_or_panic!(0.73),   // close_fee_long
 //!         pos_or_panic!(0.73),   // close_fee_short
-//!     );
-//! let analysis = strategy.analyze_probabilities(None, None);
+//!     )?;
+//! let analysis = strategy.analyze_probabilities(None, None)?;
 //!
 //! info!("Analysis: {:?}", analysis);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ### Analysis with Volatility Adjustment
 //!
 //! ```rust
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! use rust_decimal_macros::dec;
 //! use optionstratlib::ExpirationDate;
 //! use optionstratlib::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
@@ -113,19 +117,22 @@ use positive::pos_or_panic;
 //!         pos_or_panic!(0.78),   // open_fee_long
 //!         pos_or_panic!(0.73),   // close_fee_long
 //!         pos_or_panic!(0.73),   // close_fee_short
-//!     );
+//!     )?;
 //!
 //! let vol_adj = Some(VolatilityAdjustment {
 //!     base_volatility: pos_or_panic!(0.20),   // 20% base volatility
 //!     std_dev_adjustment: pos_or_panic!(0.10),   // 10% adjustment
 //! });
 //!
-//! let analysis = strategy.analyze_probabilities(vol_adj, None);
+//! let _analysis = strategy.analyze_probabilities(vol_adj, None)?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ### Analysis with Price Trend
 //!
 //! ```rust
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! use rust_decimal_macros::dec;
 //! use optionstratlib::ExpirationDate;
 //! use positive::Positive;
@@ -148,18 +155,21 @@ use positive::pos_or_panic;
 //!         pos_or_panic!(0.78),   // open_fee_long
 //!         pos_or_panic!(0.73),   // close_fee_long
 //!         pos_or_panic!(0.73),   // close_fee_short
-//!     );
+//!     )?;
 //! let trend = Some(PriceTrend {
 //!     drift_rate: 0.05,   // 5% annual drift
 //!     confidence: 0.95,   // 95% confidence level
 //! });
 //!
-//! let analysis = strategy.analyze_probabilities(None, trend).unwrap();
+//! let _analysis = strategy.analyze_probabilities(None, trend)?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ### Price Range Probability Analysis
 //!
 //! ```rust
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! use tracing::info;
 //! use optionstratlib::strategies::probabilities::calculate_price_probability;
 //! use optionstratlib::ExpirationDate;
@@ -174,8 +184,10 @@ use positive::pos_or_panic;
 //!     None,   // trend
 //!     &ExpirationDate::Days(pos_or_panic!(30.0)),
 //!     None                 // risk-free rate
-//! ).unwrap();
+//! )?;
 //! info!("Probabilities: {}, {}, {}", prob_below, prob_in_range, prob_above);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Mathematical Models

--- a/src/strategies/probabilities/utils.rs
+++ b/src/strategies/probabilities/utils.rs
@@ -110,9 +110,20 @@ pub fn calculate_single_point_probability(
                     },
                 ));
             }
-            risk_free.to_f64().unwrap() + (t.drift_rate * t.confidence)
+            let rf = risk_free.to_f64().ok_or_else(|| {
+                ProbabilityError::StdError(format!(
+                    "calculate_single_point_probability: risk_free Decimal {} not representable as f64",
+                    risk_free
+                ))
+            })?;
+            rf + (t.drift_rate * t.confidence)
         }
-        None => risk_free.to_f64().unwrap(),
+        None => risk_free.to_f64().ok_or_else(|| {
+            ProbabilityError::StdError(format!(
+                "calculate_single_point_probability: risk_free Decimal {} not representable as f64",
+                risk_free
+            ))
+        })?,
     };
 
     // Calculate parameters for the log-normal distribution
@@ -121,11 +132,11 @@ pub fn calculate_single_point_probability(
 
     // Calculate z-score considering drift
     let z_score: Decimal =
-        f2du!((log_ratio.to_f64() - drift_rate * time_to_expiry) / std_dev).unwrap();
+        f2du!((log_ratio.to_f64() - drift_rate * time_to_expiry) / std_dev)?;
 
     // Calculate probabilities using the standard normal distribution
     let prob_below: Positive =
-        Positive::new_decimal(big_n(z_score).unwrap()).unwrap_or(Positive::ZERO);
+        Positive::new_decimal(big_n(z_score)?).unwrap_or(Positive::ZERO);
     let prob_above: Positive = Positive::new(1.0 - prob_below.to_f64()).unwrap_or(Positive::ZERO);
 
     Ok((prob_below, prob_above))

--- a/src/strategies/probabilities/utils.rs
+++ b/src/strategies/probabilities/utils.rs
@@ -131,12 +131,10 @@ pub fn calculate_single_point_probability(
     let std_dev = volatility * time_to_expiry.sqrt();
 
     // Calculate z-score considering drift
-    let z_score: Decimal =
-        f2du!((log_ratio.to_f64() - drift_rate * time_to_expiry) / std_dev)?;
+    let z_score: Decimal = f2du!((log_ratio.to_f64() - drift_rate * time_to_expiry) / std_dev)?;
 
     // Calculate probabilities using the standard normal distribution
-    let prob_below: Positive =
-        Positive::new_decimal(big_n(z_score)?).unwrap_or(Positive::ZERO);
+    let prob_below: Positive = Positive::new_decimal(big_n(z_score)?).unwrap_or(Positive::ZERO);
     let prob_above: Positive = Positive::new(1.0 - prob_below.to_f64()).unwrap_or(Positive::ZERO);
 
     Ok((prob_below, prob_above))

--- a/src/strategies/protective_put.rs
+++ b/src/strategies/protective_put.rs
@@ -61,8 +61,13 @@ pub struct ProtectivePut {
 
 impl ProtectivePut {
     /// Creates a new Protective Put strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if the break-even calculation fails. In
+    /// practice this branch is unreachable for a freshly-built protective
+    /// put and is surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
-    #[must_use]
     pub fn new(
         underlying_symbol: String,
         underlying_price: Positive,
@@ -77,7 +82,7 @@ impl ProtectivePut {
         spot_close_fee: Positive,
         put_open_fee: Positive,
         put_close_fee: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let spot_leg = SpotPosition::new(
             underlying_symbol.clone(),
             quantity,
@@ -123,10 +128,8 @@ impl ProtectivePut {
         };
 
         strategy.validate();
-        strategy
-            .update_break_even_points()
-            .expect("Failed to calculate break-even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 
     /// Returns the spot leg as a Leg enum.
@@ -541,7 +544,7 @@ mod tests {
             Positive::ONE,
             pos_or_panic!(0.65),
             pos_or_panic!(0.65),
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/protective_put.rs
+++ b/src/strategies/protective_put.rs
@@ -544,7 +544,8 @@ mod tests {
             Positive::ONE,
             pos_or_panic!(0.65),
             pos_or_panic!(0.65),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -822,11 +822,7 @@ impl Optimizable for ShortButterflySpread {
                     third: short_high,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1143,7 +1139,8 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05),                       // close_fee_short_call_low
             pos_or_panic!(0.05),                       // open_fee_short_call_high
             pos_or_panic!(0.05),                       // close_fee_short_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1245,7 +1242,8 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_short_call_low
             Positive::ONE,       // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.short_call_low.open_fee, 1.0); // fees / 3
         assert_eq!(butterfly.long_call.open_fee, 1.0); // fees / 3
@@ -1286,7 +1284,8 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.short_call_low.option.quantity, Positive::TWO);
         assert_eq!(butterfly.long_call.option.quantity, pos_or_panic!(4.0)); // 2 * 2
@@ -1360,7 +1359,8 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert!(max_loss.get_max_loss().is_err());
     }
 
@@ -1434,7 +1434,8 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert!(butterfly.validate());
     }
 
@@ -1460,7 +1461,8 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         butterfly.short_call_low =
             create_valid_position(Side::Short, pos_or_panic!(90.0), Positive::ZERO);
         assert!(!butterfly.validate());
@@ -1488,7 +1490,8 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert!(!butterfly.validate());
     }
 
@@ -1514,7 +1517,8 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         butterfly.long_call = create_valid_position(Side::Long, Positive::HUNDRED, Positive::ONE);
         assert!(!butterfly.validate());
     }
@@ -1541,7 +1545,8 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         butterfly.short_call_high =
             create_valid_position(Side::Short, pos_or_panic!(110.0), Positive::TWO);
         assert!(!butterfly.validate());
@@ -1581,7 +1586,8 @@ mod tests_short_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1631,7 +1637,8 @@ mod tests_short_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         let scaled_profit = butterfly
             .calculate_profit_at(&pos_or_panic!(85.0))
             .unwrap()
@@ -1679,7 +1686,8 @@ mod tests_short_butterfly_profit {
             Positive::ZERO, // close_fee_short_call_low
             Positive::ZERO, // open_fee_short_call_high
             Positive::ZERO, // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         let base_butterfly = create_test();
         let profit_without_fees = butterfly
@@ -1730,7 +1738,8 @@ mod tests_short_butterfly_delta {
             pos_or_panic!(0.05),   // close_fee_short_call_low
             pos_or_panic!(0.05),   // open_fee_short_call_high
             pos_or_panic!(0.05),   // close_fee_short_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1902,7 +1911,8 @@ mod tests_short_butterfly_delta_size {
             pos_or_panic!(0.05),   // close_fee_short_call_low
             pos_or_panic!(0.05),   // open_fee_short_call_high
             pos_or_panic!(0.05),   // close_fee_short_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2070,7 +2080,8 @@ mod tests_adjust_option_position_short {
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2194,7 +2205,8 @@ mod tests_short_butterfly_position_management {
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2672,7 +2684,8 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2759,7 +2772,8 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_short_call_low
             Positive::ONE, // open_fee_short_call_high
             Positive::ONE, // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(butterfly.get_fees().unwrap().to_f64(), 8.0);
     }
 
@@ -2785,7 +2799,8 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_short_call_low
             Positive::ONE, // open_fee_short_call_high
             Positive::ONE, // close_fee_short_call_high
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(butterfly.get_fees().unwrap(), pos_or_panic!(16.0));
     }
@@ -2838,7 +2853,8 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             short_butterfly.get_max_profit().unwrap().to_f64(),
             pos_or_panic!(18.106)
@@ -2904,7 +2920,8 @@ mod tests_butterfly_optimizable {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3025,7 +3042,8 @@ mod tests_butterfly_probability {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     mod short_butterfly_tests {
@@ -3069,7 +3087,8 @@ mod tests_butterfly_probability {
                 pos_or_panic!(0.05),
                 pos_or_panic!(0.05),
                 pos_or_panic!(0.05),
-            ).unwrap();
+            )
+            .unwrap();
             let ranges = butterfly.get_profit_ranges().unwrap();
 
             assert!(ranges[0].upper_bound.is_some());

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -815,10 +815,14 @@ impl Optimizable for ShortButterflySpread {
                     second: short,
                     third: short_high,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(short_low, short, short_high)| {
@@ -848,7 +852,13 @@ impl Optimizable for ShortButterflySpread {
                 second: short,
                 third: short_high,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -864,7 +874,19 @@ impl Optimizable for ShortButterflySpread {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `ShortButterflySpread` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`low_strike.call_bid`,
+    /// `middle_strike.call_ask`, `high_strike.call_bid`) needed to price the
+    /// strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         match legs {
             StrategyLegs::ThreeLegs {
                 first: low_strike,
@@ -874,7 +896,26 @@ impl Optimizable for ShortButterflySpread {
                 let implied_volatility = middle_strike.implied_volatility;
                 assert!(implied_volatility <= Positive::ONE);
 
-                ShortButterflySpread::new(
+                let low_call_bid = low_strike.call_bid.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_bid for low strike leg",
+                    )
+                })?;
+                let middle_call_ask = middle_strike.call_ask.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_ask for middle strike leg",
+                    )
+                })?;
+                let high_call_bid = high_strike.call_bid.ok_or_else(|| {
+                    StrategyError::operation_not_supported(
+                        "create_strategy",
+                        "missing call_bid for high strike leg",
+                    )
+                })?;
+
+                Ok(ShortButterflySpread::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     low_strike.strike_price,
@@ -885,16 +926,16 @@ impl Optimizable for ShortButterflySpread {
                     self.short_call_low.option.risk_free_rate,
                     self.short_call_low.option.dividend_yield,
                     self.short_call_low.option.quantity,
-                    low_strike.call_bid.unwrap(),
-                    middle_strike.call_ask.unwrap(),
-                    high_strike.call_bid.unwrap(),
+                    low_call_bid,
+                    middle_call_ask,
+                    high_call_bid,
                     self.long_call.open_fee,
                     self.long_call.close_fee,
                     self.short_call_low.open_fee,
                     self.short_call_low.close_fee,
                     self.short_call_high.open_fee,
                     self.short_call_high.close_fee,
-                )
+                ))
             }
             _ => panic!("Invalid number of legs for Short Butterfly strategy"),
         }

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -107,6 +107,13 @@ impl ShortButterflySpread {
     /// # Returns
     ///
     /// A fully initialized `ShortButterflySpread` strategy with calculated break-even points.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if the break-even calculation fails. In
+    /// practice this branch is unreachable for a freshly-built short
+    /// butterfly spread and is surfaced only to keep the constructor
+    /// panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -128,7 +135,7 @@ impl ShortButterflySpread {
         close_fee_short_call_low: Positive,
         open_fee_short_call_high: Positive,
         close_fee_short_call_high: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = ShortButterflySpread {
             name: "Short Butterfly".to_string(),
             kind: StrategyType::ShortButterflySpread,
@@ -216,10 +223,8 @@ impl ShortButterflySpread {
 
         strategy.validate();
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -237,11 +242,12 @@ impl StrategyConstructor for ShortButterflySpread {
 
         // Sort options by strike price
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let lower_strike_position = &sorted_positions[0];
@@ -860,9 +866,16 @@ impl Optimizable for ShortButterflySpread {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -915,7 +928,7 @@ impl Optimizable for ShortButterflySpread {
                     )
                 })?;
 
-                Ok(ShortButterflySpread::new(
+                ShortButterflySpread::new(
                     chain.symbol.clone(),
                     chain.underlying_price,
                     low_strike.strike_price,
@@ -935,7 +948,7 @@ impl Optimizable for ShortButterflySpread {
                     self.short_call_low.close_fee,
                     self.short_call_high.open_fee,
                     self.short_call_high.close_fee,
-                ))
+                )
             }
             _ => panic!("Invalid number of legs for Short Butterfly strategy"),
         }
@@ -1130,7 +1143,7 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05),                       // close_fee_short_call_low
             pos_or_panic!(0.05),                       // open_fee_short_call_high
             pos_or_panic!(0.05),                       // close_fee_short_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1232,7 +1245,7 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_short_call_low
             Positive::ONE,       // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.short_call_low.open_fee, 1.0); // fees / 3
         assert_eq!(butterfly.long_call.open_fee, 1.0); // fees / 3
@@ -1273,7 +1286,7 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.short_call_low.option.quantity, Positive::TWO);
         assert_eq!(butterfly.long_call.option.quantity, pos_or_panic!(4.0)); // 2 * 2
@@ -1347,7 +1360,7 @@ mod tests_short_butterfly_spread {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
         assert!(max_loss.get_max_loss().is_err());
     }
 
@@ -1421,7 +1434,7 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
         assert!(butterfly.validate());
     }
 
@@ -1447,7 +1460,7 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
         butterfly.short_call_low =
             create_valid_position(Side::Short, pos_or_panic!(90.0), Positive::ZERO);
         assert!(!butterfly.validate());
@@ -1475,7 +1488,7 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
         assert!(!butterfly.validate());
     }
 
@@ -1501,7 +1514,7 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
         butterfly.long_call = create_valid_position(Side::Long, Positive::HUNDRED, Positive::ONE);
         assert!(!butterfly.validate());
     }
@@ -1528,7 +1541,7 @@ mod tests_short_butterfly_validation {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
         butterfly.short_call_high =
             create_valid_position(Side::Short, pos_or_panic!(110.0), Positive::TWO);
         assert!(!butterfly.validate());
@@ -1568,7 +1581,7 @@ mod tests_short_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1618,7 +1631,7 @@ mod tests_short_butterfly_profit {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        );
+        ).unwrap();
         let scaled_profit = butterfly
             .calculate_profit_at(&pos_or_panic!(85.0))
             .unwrap()
@@ -1666,7 +1679,7 @@ mod tests_short_butterfly_profit {
             Positive::ZERO, // close_fee_short_call_low
             Positive::ZERO, // open_fee_short_call_high
             Positive::ZERO, // close_fee_short_call_high
-        );
+        ).unwrap();
 
         let base_butterfly = create_test();
         let profit_without_fees = butterfly
@@ -1717,7 +1730,7 @@ mod tests_short_butterfly_delta {
             pos_or_panic!(0.05),   // close_fee_short_call_low
             pos_or_panic!(0.05),   // open_fee_short_call_high
             pos_or_panic!(0.05),   // close_fee_short_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1889,7 +1902,7 @@ mod tests_short_butterfly_delta_size {
             pos_or_panic!(0.05),   // close_fee_short_call_low
             pos_or_panic!(0.05),   // open_fee_short_call_high
             pos_or_panic!(0.05),   // close_fee_short_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2057,7 +2070,7 @@ mod tests_adjust_option_position_short {
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2181,7 +2194,7 @@ mod tests_short_butterfly_position_management {
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2659,7 +2672,7 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2746,7 +2759,7 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_short_call_low
             Positive::ONE, // open_fee_short_call_high
             Positive::ONE, // close_fee_short_call_high
-        );
+        ).unwrap();
         assert_eq!(butterfly.get_fees().unwrap().to_f64(), 8.0);
     }
 
@@ -2772,7 +2785,7 @@ mod tests_butterfly_strategies {
             Positive::ONE, // close_fee_short_call_low
             Positive::ONE, // open_fee_short_call_high
             Positive::ONE, // close_fee_short_call_high
-        );
+        ).unwrap();
 
         assert_eq!(butterfly.get_fees().unwrap(), pos_or_panic!(16.0));
     }
@@ -2825,7 +2838,7 @@ mod tests_butterfly_strategies {
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
             pos_or_panic!(0.05),
-        );
+        ).unwrap();
         assert_eq!(
             short_butterfly.get_max_profit().unwrap().to_f64(),
             pos_or_panic!(18.106)
@@ -2891,7 +2904,7 @@ mod tests_butterfly_optimizable {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3012,7 +3025,7 @@ mod tests_butterfly_probability {
             pos_or_panic!(0.05), // close_fee_short_call_low
             pos_or_panic!(0.05), // open_fee_short_call_high
             pos_or_panic!(0.05), // close_fee_short_call_high
-        )
+        ).unwrap()
     }
 
     mod short_butterfly_tests {
@@ -3056,7 +3069,7 @@ mod tests_butterfly_probability {
                 pos_or_panic!(0.05),
                 pos_or_panic!(0.05),
                 pos_or_panic!(0.05),
-            );
+            ).unwrap();
             let ranges = butterfly.get_profit_ranges().unwrap();
 
             assert!(ranges[0].upper_bound.is_some());

--- a/src/strategies/short_call.rs
+++ b/src/strategies/short_call.rs
@@ -99,10 +99,11 @@ impl ShortCall {
     /// Returns an initialized `ShortCall` strategy instance. The instance includes the short call
     /// option position with the specified parameters.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if the short call option created using the specified parameters
-    /// fails to meet validity requirements during the `add_position` operation.
+    /// # Errors
+    /// Returns `StrategyError` if the freshly-constructed short call leg
+    /// cannot be added to the strategy. In practice this branch is
+    /// unreachable for a freshly-built single-leg strategy and is surfaced
+    /// only to keep the constructor panic-free.
     ///
     #[allow(clippy::too_many_arguments, dead_code)]
     fn new(
@@ -117,7 +118,7 @@ impl ShortCall {
         premium_short_call: Positive,
         open_fee_short_call: Positive,
         close_fee_short_call: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = ShortCall::default();
 
         let short_call_option = Options::new(
@@ -143,11 +144,9 @@ impl ShortCall {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Invalid short call option");
+        strategy.add_position(&short_call)?;
 
-        strategy
+        Ok(strategy)
     }
 }
 
@@ -570,7 +569,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .expect("Failed to set progress bar template")
+                .map_err(|e| SimulationError::OtherError {
+                    reason: format!("Failed to set progress bar template: {}", e),
+                })?
                 .progress_chars("#>-"),
         );
 
@@ -659,7 +660,7 @@ where
                 // Calculate expiration premium
                 let mut exp_option = self.short_call.option.clone();
                 exp_option.underlying_price = final_price;
-                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001).unwrap());
+                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001)?);
                 expiration_premium = Some(exp_option.calculate_price_black_scholes()?.abs());
 
                 expired = true;
@@ -800,7 +801,7 @@ mod tests_simulate {
             pos_or_panic!(5.0),
             Positive::ZERO,
             Positive::ZERO,
-        )
+        ).unwrap()
     }
 
     fn create_walk_params(prices: Vec<Positive>) -> WalkParams<Positive, Positive> {

--- a/src/strategies/short_call.rs
+++ b/src/strategies/short_call.rs
@@ -801,7 +801,8 @@ mod tests_simulate {
             pos_or_panic!(5.0),
             Positive::ZERO,
             Positive::ZERO,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     fn create_walk_params(prices: Vec<Positive>) -> WalkParams<Positive, Positive> {

--- a/src/strategies/short_put.rs
+++ b/src/strategies/short_put.rs
@@ -801,7 +801,8 @@ mod tests_simulate {
             pos_or_panic!(5.0),  // premium received
             Positive::ZERO,      // open fee
             Positive::ZERO,      // close fee
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     /// Helper to create WalkParams with Historical data

--- a/src/strategies/short_put.rs
+++ b/src/strategies/short_put.rs
@@ -102,10 +102,11 @@ impl ShortPut {
     ///
     /// A new instance of `ShortPut` containing the initialized short put position.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if adding the short put position to the strategy fails,
-    /// which may happen if the position is deemed invalid.
+    /// # Errors
+    /// Returns `StrategyError` if the freshly-constructed short put leg
+    /// cannot be added to the strategy. In practice this branch is
+    /// unreachable for a freshly-built single-leg strategy and is surfaced
+    /// only to keep the constructor panic-free.
     ///
     #[allow(clippy::too_many_arguments, dead_code)]
     pub fn new(
@@ -120,7 +121,7 @@ impl ShortPut {
         premium_short_put: Positive,
         open_fee_short_put: Positive,
         close_fee_short_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         let mut strategy = ShortPut::default();
 
         let short_put_option = Options::new(
@@ -146,11 +147,9 @@ impl ShortPut {
             None,
             None,
         );
-        strategy
-            .add_position(&short_put)
-            .expect("Invalid short put option");
+        strategy.add_position(&short_put)?;
 
-        strategy
+        Ok(strategy)
     }
 }
 
@@ -566,7 +565,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .expect("Failed to set progress bar template")
+                .map_err(|e| SimulationError::OtherError {
+                    reason: format!("Failed to set progress bar template: {}", e),
+                })?
                 .progress_chars("#>-"),
         );
 
@@ -656,7 +657,7 @@ where
                 // Calculate expiration premium (use very small time instead of zero)
                 let mut exp_option = self.short_put.option.clone();
                 exp_option.underlying_price = final_price;
-                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001).unwrap());
+                exp_option.expiration_date = ExpirationDate::Days(Positive::new(0.001)?);
                 expiration_premium = Some(exp_option.calculate_price_black_scholes()?.abs());
 
                 expired = true;
@@ -800,7 +801,7 @@ mod tests_simulate {
             pos_or_panic!(5.0),  // premium received
             Positive::ZERO,      // open fee
             Positive::ZERO,      // close fee
-        )
+        ).unwrap()
     }
 
     /// Helper to create WalkParams with Historical data

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -698,10 +698,14 @@ impl Optimizable for ShortStraddle {
                     first: both,
                     second: both,
                 };
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(OptionDataGroup::One)
@@ -728,7 +732,13 @@ impl Optimizable for ShortStraddle {
                 first: both,
                 second: both,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -744,7 +754,18 @@ impl Optimizable for ShortStraddle {
         }
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `ShortStraddle` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`call.call_bid`, `put.put_bid`) needed to
+    /// price the strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (call, put) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
@@ -760,7 +781,19 @@ impl Optimizable for ShortStraddle {
 
         let implied_volatility = call.implied_volatility;
         assert!(implied_volatility <= Positive::ONE);
-        ShortStraddle::new(
+        let call_bid = call.call_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_bid for short call leg",
+            )
+        })?;
+        let put_bid = put.put_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_bid for short put leg",
+            )
+        })?;
+        Ok(ShortStraddle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -769,13 +802,13 @@ impl Optimizable for ShortStraddle {
             self.short_call.option.risk_free_rate,
             self.short_call.option.dividend_yield,
             self.short_call.option.quantity,
-            call.call_bid.unwrap(),
-            put.put_bid.unwrap(),
+            call_bid,
+            put_bid,
             self.short_call.open_fee,
             self.short_call.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        )
+        ))
     }
 }
 
@@ -1207,7 +1240,7 @@ mod tests_short_straddle {
             first: call_option,
             second: put_option,
         };
-        let new_strategy = strategy.create_strategy(&chain, &legs);
+        let new_strategy = strategy.create_strategy(&chain, &legs).unwrap();
         assert!(new_strategy.validate());
     }
 

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -162,6 +162,12 @@ impl ShortStraddle {
     /// - Calculated break-even points
     /// - Strategy metadata (name, description, etc.)
     ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built short
+    /// straddle and are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -178,7 +184,7 @@ impl ShortStraddle {
         close_fee_short_call: Positive,
         open_fee_short_put: Positive,
         close_fee_short_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if strike == Positive::ZERO {
             strike = underlying_price;
         }
@@ -215,9 +221,7 @@ impl ShortStraddle {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Invalid short call");
+        strategy.add_position(&short_call)?;
 
         let short_put_option = Options::new(
             OptionType::European,
@@ -242,14 +246,10 @@ impl ShortStraddle {
             None,
             None,
         );
-        strategy
-            .add_position(&short_put)
-            .expect("Invalid short put");
+        strategy.add_position(&short_put)?;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -643,13 +643,13 @@ impl Strategies for ShortStraddle {
         let strike_diff = self.break_even_points[1] - self.break_even_points[0];
         let cat = (strike_diff / 2.0_f64.sqrt()).to_f64();
         let result = (cat.powf(2.0)) / (2.0 * 10.0_f64.powf(cat.log10().ceil()));
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
         let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
         let result =
             self.get_max_profit().unwrap_or(Positive::ZERO).to_f64() / break_even_diff * 100.0;
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 }
 
@@ -740,9 +740,16 @@ impl Optimizable for ShortStraddle {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -793,7 +800,7 @@ impl Optimizable for ShortStraddle {
                 "missing put_bid for short put leg",
             )
         })?;
-        Ok(ShortStraddle::new(
+        ShortStraddle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -808,7 +815,7 @@ impl Optimizable for ShortStraddle {
             self.short_call.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        ))
+        )
     }
 }
 
@@ -987,7 +994,7 @@ mod tests_short_straddle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1008,7 +1015,7 @@ mod tests_short_straddle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        );
+        ).unwrap();
 
         assert_eq!(
             strategy.short_call.option.strike_price, underlying_price,
@@ -1062,7 +1069,7 @@ mod tests_short_straddle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        );
+        ).unwrap();
         assert!(valid_strategy.validate());
         assert_eq!(
             valid_strategy.short_call.option.strike_price,
@@ -1296,7 +1303,7 @@ mod tests_short_straddle_probability {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1431,7 +1438,7 @@ mod tests_short_straddle_probability_bis {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1568,7 +1575,7 @@ mod tests_short_straddle_delta {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_short_put
             pos_or_panic!(7.01),   // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1711,7 +1718,7 @@ mod tests_short_straddle_delta_size {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_short_put
             pos_or_panic!(7.01),   // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2148,7 +2155,7 @@ mod tests_straddle_position_management {
             pos_or_panic!(0.1), // close_fee_short_call
             pos_or_panic!(0.1), // open_fee_short_put
             pos_or_panic!(0.1), // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2258,7 +2265,7 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.1), // close_fee_short_call
             pos_or_panic!(0.1), // open_fee_short_put
             pos_or_panic!(0.1), // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -699,11 +699,7 @@ impl Optimizable for ShortStraddle {
                     second: both,
                 };
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -994,7 +990,8 @@ mod tests_short_straddle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1015,7 +1012,8 @@ mod tests_short_straddle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             strategy.short_call.option.strike_price, underlying_price,
@@ -1069,7 +1067,8 @@ mod tests_short_straddle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap();
+        )
+        .unwrap();
         assert!(valid_strategy.validate());
         assert_eq!(
             valid_strategy.short_call.option.strike_price,
@@ -1303,7 +1302,8 @@ mod tests_short_straddle_probability {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1438,7 +1438,8 @@ mod tests_short_straddle_probability_bis {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1575,7 +1576,8 @@ mod tests_short_straddle_delta {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_short_put
             pos_or_panic!(7.01),   // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1718,7 +1720,8 @@ mod tests_short_straddle_delta_size {
             pos_or_panic!(7.01),   // close_fee_short_call
             pos_or_panic!(7.01),   // open_fee_short_put
             pos_or_panic!(7.01),   // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2155,7 +2158,8 @@ mod tests_straddle_position_management {
             pos_or_panic!(0.1), // close_fee_short_call
             pos_or_panic!(0.1), // open_fee_short_put
             pos_or_panic!(0.1), // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2265,7 +2269,8 @@ mod tests_adjust_option_position {
             pos_or_panic!(0.1), // close_fee_short_call
             pos_or_panic!(0.1), // open_fee_short_put
             pos_or_panic!(0.1), // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -912,10 +912,7 @@ impl Optimizable for ShortStrangle {
                         return false;
                     };
                     let delta_put_positive = dp.abs();
-                    delta_put_positive > min
-                        && delta_put_positive < max
-                        && dc > min
-                        && dc < max
+                    delta_put_positive > min && delta_put_positive < max && dc > min && dc < max
                 }
                 FindOptimalSide::Center => {
                     short_put.is_valid_optimal_side(underlying_price, &FindOptimalSide::Lower)
@@ -941,11 +938,7 @@ impl Optimizable for ShortStrangle {
                 };
                 trace!("Legs: {:?}", legs);
                 match strategy.create_strategy(option_chain, &legs) {
-                    Ok(s) => {
-                        s.validate()
-                            && s.get_max_profit().is_ok()
-                            && s.get_max_loss().is_ok()
-                    }
+                    Ok(s) => s.validate() && s.get_max_profit().is_ok() && s.get_max_loss().is_ok(),
                     Err(_) => false,
                 }
             })
@@ -1368,7 +1361,8 @@ mod tests_short_strangle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1613,7 +1607,8 @@ mod tests_short_strangle_probability {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1750,7 +1745,8 @@ mod tests_short_strangle_probability_bis {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1889,7 +1885,8 @@ mod tests_short_strangle_delta {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2078,7 +2075,8 @@ mod tests_short_strangle_delta_size {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2412,7 +2410,8 @@ mod tests_adjust_option_position_short {
             pos_or_panic!(0.1),  // close_fee_short_call
             pos_or_panic!(0.1),  // open_fee_short_put
             pos_or_panic!(0.1),  // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3241,7 +3240,8 @@ mod test_adjustments_pnl {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3381,7 +3381,8 @@ mod test_valid_premium_for_shorts {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3421,7 +3422,8 @@ mod tests_strangle_position_management {
             pos_or_panic!(0.1),  // close_fee_short_call
             pos_or_panic!(0.1),  // open_fee_short_put
             pos_or_panic!(0.1),  // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]
@@ -3532,7 +3534,8 @@ mod tests_generate_delta_adjustments {
             pos_or_panic!(0.1),  // close_fee_short_call
             pos_or_panic!(0.1),  // open_fee_short_put
             pos_or_panic!(0.1),  // close_fee_short_put
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -926,10 +926,14 @@ impl Optimizable for ShortStrangle {
                     second: short_call,
                 };
                 trace!("Legs: {:?}", legs);
-                let strategy = strategy.create_strategy(option_chain, &legs);
-                strategy.validate()
-                    && strategy.get_max_profit().is_ok()
-                    && strategy.get_max_loss().is_ok()
+                match strategy.create_strategy(option_chain, &legs) {
+                    Ok(s) => {
+                        s.validate()
+                            && s.get_max_profit().is_ok()
+                            && s.get_max_loss().is_ok()
+                    }
+                    Err(_) => false,
+                }
             })
             // Map to OptionDataGroup
             .map(move |(short_put, short_call)| OptionDataGroup::Two(short_put, short_call))
@@ -969,7 +973,13 @@ impl Optimizable for ShortStrangle {
                 first: short_put,
                 second: short_call,
             };
-            let strategy = self.create_strategy(option_chain, &legs);
+            let strategy = match self.create_strategy(option_chain, &legs) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "skipping invalid strategy combination");
+                    continue;
+                }
+            };
             // Calculate the current value based on the optimization criteria
             let current_value = match criteria {
                 OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
@@ -994,7 +1004,18 @@ impl Optimizable for ShortStrangle {
             && short_call.call_ask.unwrap_or(Positive::ZERO) > Positive::ZERO
     }
 
-    fn create_strategy(&self, chain: &OptionChain, legs: &StrategyLegs) -> Self::Strategy {
+    /// Constructs a `ShortStrangle` from the supplied chain and legs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError::OperationError` when the supplied legs are
+    /// missing required quotes (`call.call_bid`, `put.put_bid`) needed to
+    /// price the strategy.
+    fn create_strategy(
+        &self,
+        chain: &OptionChain,
+        legs: &StrategyLegs,
+    ) -> Result<Self::Strategy, StrategyError> {
         let (put, call) = match legs {
             StrategyLegs::TwoLegs { first, second } => (first, second),
             _ => panic!("Invalid number of legs for this strategy"),
@@ -1019,7 +1040,20 @@ impl Optimizable for ShortStrangle {
             self.one_option().expiration_date
         };
 
-        ShortStrangle::new(
+        let call_bid = call.call_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing call_bid for short call leg",
+            )
+        })?;
+        let put_bid = put.put_bid.ok_or_else(|| {
+            StrategyError::operation_not_supported(
+                "create_strategy",
+                "missing put_bid for short put leg",
+            )
+        })?;
+
+        Ok(ShortStrangle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -1030,13 +1064,13 @@ impl Optimizable for ShortStrangle {
             self.one_option().risk_free_rate,
             self.one_option().dividend_yield,
             self.one_option().quantity,
-            call.call_bid.unwrap(),
-            put.put_bid.unwrap(),
+            call_bid,
+            put_bid,
             self.short_call.open_fee,
             self.short_call.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        )
+        ))
     }
 }
 
@@ -1501,7 +1535,7 @@ is expected and the underlying asset's price is anticipated to remain stable."
             second: call_option,
         };
 
-        let new_strategy = strategy.create_strategy(&chain, &legs);
+        let new_strategy = strategy.create_strategy(&chain, &legs).unwrap();
         assert!(new_strategy.validate());
     }
     fn create_test_option_chain() -> OptionChain {

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -146,6 +146,13 @@ impl ShortStrangle {
     /// The strategy has two break-even points:
     /// - Lower break-even: Put strike minus the total premium received per contract
     /// - Upper break-even: Call strike plus the total premium received per contract
+    ///
+    /// # Errors
+    ///
+    /// Returns `StrategyError` if either freshly-constructed leg cannot be
+    /// added to the strategy or if the break-even calculation fails. In
+    /// practice these branches are unreachable for a freshly-built
+    /// strangle and are surfaced only to keep the constructor panic-free.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         underlying_symbol: String,
@@ -164,7 +171,7 @@ impl ShortStrangle {
         close_fee_short_call: Positive,
         open_fee_short_put: Positive,
         close_fee_short_put: Positive,
-    ) -> Self {
+    ) -> Result<Self, StrategyError> {
         if call_strike == Positive::ZERO {
             call_strike = underlying_price * 1.1;
         }
@@ -203,9 +210,7 @@ impl ShortStrangle {
             None,
             None,
         );
-        strategy
-            .add_position(&short_call)
-            .expect("Invalid position");
+        strategy.add_position(&short_call)?;
 
         let short_put_option = Options::new(
             OptionType::European,
@@ -230,12 +235,10 @@ impl ShortStrangle {
             None,
             None,
         );
-        strategy.add_position(&short_put).expect("Invalid position");
+        strategy.add_position(&short_put)?;
 
-        strategy
-            .update_break_even_points()
-            .expect("Unable to update break even points");
-        strategy
+        strategy.update_break_even_points()?;
+        Ok(strategy)
     }
 }
 
@@ -253,11 +256,12 @@ impl StrategyConstructor for ShortStrangle {
 
         // Sort options by option style to identify call and put
         let mut sorted_positions = vec_positions.to_vec();
+        // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
         sorted_positions.sort_by(|a, b| {
             a.option
                 .strike_price
                 .partial_cmp(&b.option.strike_price)
-                .unwrap()
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
 
         let put_position = &sorted_positions[0]; // Put will be first
@@ -683,7 +687,7 @@ impl Strategies for ShortStrangle {
     }
 
     fn get_max_profit(&self) -> Result<Positive, StrategyError> {
-        let max_profit = self.get_net_premium_received().unwrap().to_f64();
+        let max_profit = self.get_net_premium_received()?.to_f64();
         if max_profit < ZERO {
             Err(StrategyError::ProfitLossError(
                 ProfitLossErrorKind::MaxProfitError {
@@ -710,7 +714,7 @@ impl Strategies for ShortStrangle {
         let outer_square = break_even_diff * max_profit;
         let triangles = (outer_square - inner_square) / 2.0;
         let result = ((inner_square + triangles) / self.one_option().underlying_price).to_f64();
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -719,7 +723,7 @@ impl Strategies for ShortStrangle {
             Ok(max_profit) => max_profit.to_f64() / break_even_diff * 100.0,
             Err(_) => ZERO,
         };
-        Ok(Decimal::from_f64(result).unwrap())
+        Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
@@ -880,12 +884,19 @@ impl Optimizable for ShortStrangle {
                     let (_, delta_put) = short_put.current_deltas();
                     let (delta_call, _) = short_call.current_deltas();
 
-                    let is_valid = delta_put.unwrap() >= -delta.to_dec()
-                        && delta_call.unwrap() <= delta.to_dec()
-                        && delta_put.unwrap().is_sign_negative()
-                        && delta_call.unwrap().is_sign_positive()
-                        && !delta_call.unwrap().is_zero()
-                        && !delta_put.unwrap().is_zero();
+                    let (Some(dp), Some(dc)) = (delta_put, delta_call) else {
+                        trace!(
+                            "Missing delta on PUT {:?} or CALL {:?}",
+                            delta_put, delta_call
+                        );
+                        return false;
+                    };
+                    let is_valid = dp >= -delta.to_dec()
+                        && dc <= delta.to_dec()
+                        && dp.is_sign_negative()
+                        && dc.is_sign_positive()
+                        && !dc.is_zero()
+                        && !dp.is_zero();
                     if !is_valid {
                         trace!(
                             "Not Valid Delta combination: PUT {:?} and CALL {:?}",
@@ -897,11 +908,14 @@ impl Optimizable for ShortStrangle {
                 FindOptimalSide::DeltaRange(min, max) => {
                     let (_, delta_put) = short_put.current_deltas();
                     let (delta_call, _) = short_call.current_deltas();
-                    let delta_put_positive = delta_put.unwrap().abs();
+                    let (Some(dp), Some(dc)) = (delta_put, delta_call) else {
+                        return false;
+                    };
+                    let delta_put_positive = dp.abs();
                     delta_put_positive > min
                         && delta_put_positive < max
-                        && delta_call.unwrap() > min
-                        && delta_call.unwrap() < max
+                        && dc > min
+                        && dc < max
                 }
                 FindOptimalSide::Center => {
                     short_put.is_valid_optimal_side(underlying_price, &FindOptimalSide::Lower)
@@ -981,9 +995,16 @@ impl Optimizable for ShortStrangle {
                 }
             };
             // Calculate the current value based on the optimization criteria
-            let current_value = match criteria {
-                OptimizationCriteria::Ratio => strategy.get_profit_ratio().unwrap(),
-                OptimizationCriteria::Area => strategy.get_profit_area().unwrap(),
+            let metric = match criteria {
+                OptimizationCriteria::Ratio => strategy.get_profit_ratio(),
+                OptimizationCriteria::Area => strategy.get_profit_area(),
+            };
+            let current_value = match metric {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(error = %e, "skipping candidate with unscorable metric");
+                    continue;
+                }
             };
 
             if current_value > best_value {
@@ -1053,7 +1074,7 @@ impl Optimizable for ShortStrangle {
             )
         })?;
 
-        Ok(ShortStrangle::new(
+        ShortStrangle::new(
             chain.symbol.clone(),
             chain.underlying_price,
             call.strike_price,
@@ -1070,7 +1091,7 @@ impl Optimizable for ShortStrangle {
             self.short_call.close_fee,
             self.short_put.open_fee,
             self.short_put.close_fee,
-        ))
+        )
     }
 }
 
@@ -1241,8 +1262,8 @@ impl PnLCalculator for ShortStrangle {
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1255,8 +1276,8 @@ impl PnLCalculator for ShortStrangle {
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1275,15 +1296,15 @@ impl PnLCalculator for ShortStrangle {
                     match (side, option_style) {
                         (Side::Short, OptionStyle::Call) => {
                             let mut position = self.short_call.clone();
-                            position.option.side = Side::Long; // Sell the short call 
+                            position.option.side = Side::Long; // Sell the short call
                             position.option.quantity = *quantity;
                             position.option.strike_price = *strike;
 
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1296,8 +1317,8 @@ impl PnLCalculator for ShortStrangle {
                             PnL {
                                 realized: None,
                                 unrealized: None,
-                                initial_costs: position.total_cost().unwrap(),
-                                initial_income: position.premium_received().unwrap(),
+                                initial_costs: position.total_cost()?,
+                                initial_income: position.premium_received()?,
                                 date_time: Utc::now(),
                             }
                         }
@@ -1347,7 +1368,7 @@ mod tests_short_strangle {
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
             pos_or_panic!(0.1),
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1592,7 +1613,7 @@ mod tests_short_strangle_probability {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1729,7 +1750,7 @@ mod tests_short_strangle_probability_bis {
             Positive::ZERO,                            // close_fee_short_call
             Positive::ZERO,                            // open_fee_short_put
             Positive::ZERO,                            // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -1868,7 +1889,7 @@ mod tests_short_strangle_delta {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2057,7 +2078,7 @@ mod tests_short_strangle_delta_size {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -2391,7 +2412,7 @@ mod tests_adjust_option_position_short {
             pos_or_panic!(0.1),  // close_fee_short_call
             pos_or_panic!(0.1),  // open_fee_short_put
             pos_or_panic!(0.1),  // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3220,7 +3241,7 @@ mod test_adjustments_pnl {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3360,7 +3381,7 @@ mod test_valid_premium_for_shorts {
             pos_or_panic!(7.01),  // close_fee_short_call
             pos_or_panic!(7.01),  // open_fee_short_put
             pos_or_panic!(7.01),  // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3400,7 +3421,7 @@ mod tests_strangle_position_management {
             pos_or_panic!(0.1),  // close_fee_short_call
             pos_or_panic!(0.1),  // open_fee_short_put
             pos_or_panic!(0.1),  // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]
@@ -3511,7 +3532,7 @@ mod tests_generate_delta_adjustments {
             pos_or_panic!(0.1),  // close_fee_short_call
             pos_or_panic!(0.1),  // open_fee_short_put
             pos_or_panic!(0.1),  // close_fee_short_put
-        )
+        ).unwrap()
     }
 
     #[test]

--- a/tests/unit/strategies/custom_test.rs
+++ b/tests/unit/strategies/custom_test.rs
@@ -84,6 +84,7 @@ fn create_test_custom_strategy() -> CustomStrategy {
         30,                           // Days to expiration
         Positive::new(0.25).unwrap(), // Implied volatility
     )
+    .unwrap()
 }
 
 // Helper function to create a complex Custom Strategy for testing
@@ -208,6 +209,7 @@ fn create_complex_custom_strategy() -> CustomStrategy {
         45,
         Positive::new(0.21).unwrap(),
     )
+    .unwrap()
 }
 
 #[cfg(test)]

--- a/tests/unit/strategies/delta/strategy_bear_call_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bear_call_spread.rs
@@ -30,7 +30,7 @@ fn test_bear_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_bear_put_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bear_put_spread.rs
@@ -30,7 +30,7 @@ fn test_bear_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_bull_call_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bull_call_spread.rs
@@ -30,7 +30,7 @@ fn test_bull_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);
 

--- a/tests/unit/strategies/delta/strategy_bull_put_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bull_put_spread.rs
@@ -30,7 +30,7 @@ fn test_bull_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_call_butterfly.rs
+++ b/tests/unit/strategies/delta/strategy_call_butterfly.rs
@@ -34,7 +34,7 @@ fn test_call_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // open_fee_short
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_iron_butterfly.rs
+++ b/tests/unit/strategies/delta/strategy_iron_butterfly.rs
@@ -31,7 +31,7 @@ fn test_iron_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_iron_condor.rs
+++ b/tests/unit/strategies/delta/strategy_iron_condor.rs
@@ -32,7 +32,7 @@ fn test_iron_condor_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_long_butterfly_spread.rs
+++ b/tests/unit/strategies/delta/strategy_long_butterfly_spread.rs
@@ -34,7 +34,7 @@ fn test_long_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.07),  // fees
         pos_or_panic!(0.05),  // fees
         pos_or_panic!(0.03),  // fees
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_long_straddle.rs
+++ b/tests/unit/strategies/delta/strategy_long_straddle.rs
@@ -29,7 +29,7 @@ fn test_long_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_long_strangle.rs
+++ b/tests/unit/strategies/delta/strategy_long_strangle.rs
@@ -30,7 +30,7 @@ fn test_long_strangle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = DELTA_THRESHOLD;

--- a/tests/unit/strategies/delta/strategy_poor_mans_covered_call.rs
+++ b/tests/unit/strategies/delta/strategy_poor_mans_covered_call.rs
@@ -30,7 +30,7 @@ fn test_poor_mans_covered_call_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(1.74),                       // close_fee_short_call
         pos_or_panic!(0.85),                       // open_fee_short_put
         pos_or_panic!(0.85),                       // close_fee_short_put
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
+++ b/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
@@ -32,7 +32,7 @@ fn test_short_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_short_straddle.rs
+++ b/tests/unit/strategies/delta/strategy_short_straddle.rs
@@ -28,7 +28,7 @@ fn test_short_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = dec!(0.001);

--- a/tests/unit/strategies/delta/strategy_short_strangle.rs
+++ b/tests/unit/strategies/delta/strategy_short_strangle.rs
@@ -31,7 +31,7 @@ fn test_short_strangle_with_greeks_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let greeks = strategy.greeks().unwrap();
     let epsilon = DELTA_THRESHOLD;

--- a/tests/unit/strategies/optimal/strategy_bear_call_spread.rs
+++ b/tests/unit/strategies/optimal/strategy_bear_call_spread.rs
@@ -30,7 +30,7 @@ fn test_bear_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_bear_put_spread.rs
+++ b/tests/unit/strategies/optimal/strategy_bear_put_spread.rs
@@ -31,7 +31,7 @@ fn test_bear_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_bull_call_spread.rs
+++ b/tests/unit/strategies/optimal/strategy_bull_call_spread.rs
@@ -31,7 +31,7 @@ fn test_bull_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_bull_put_spread.rs
+++ b/tests/unit/strategies/optimal/strategy_bull_put_spread.rs
@@ -31,7 +31,7 @@ fn test_bull_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_call_butterfly.rs
+++ b/tests/unit/strategies/optimal/strategy_call_butterfly.rs
@@ -35,7 +35,7 @@ fn test_call_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // open_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_iron_butterfly.rs
+++ b/tests/unit/strategies/optimal/strategy_iron_butterfly.rs
@@ -32,7 +32,7 @@ fn test_iron_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_iron_condor.rs
+++ b/tests/unit/strategies/optimal/strategy_iron_condor.rs
@@ -33,7 +33,7 @@ fn test_iron_condor_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_long_butterfly_spread.rs
+++ b/tests/unit/strategies/optimal/strategy_long_butterfly_spread.rs
@@ -35,7 +35,7 @@ fn test_long_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_long_straddle.rs
+++ b/tests/unit/strategies/optimal/strategy_long_straddle.rs
@@ -30,7 +30,7 @@ fn test_long_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_long_strangle.rs
+++ b/tests/unit/strategies/optimal/strategy_long_strangle.rs
@@ -31,7 +31,7 @@ fn test_long_strangle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_poor_mans_covered_call.rs
+++ b/tests/unit/strategies/optimal/strategy_poor_mans_covered_call.rs
@@ -31,7 +31,7 @@ fn test_poor_mans_covered_call_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(1.74),                       // close_fee_short_call
         pos_or_panic!(0.85),                       // open_fee_short_put
         pos_or_panic!(0.85),                       // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_short_butterfly_spread.rs
+++ b/tests/unit/strategies/optimal/strategy_short_butterfly_spread.rs
@@ -35,7 +35,7 @@ fn test_short_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_short_straddle.rs
+++ b/tests/unit/strategies/optimal/strategy_short_straddle.rs
@@ -30,7 +30,7 @@ fn test_short_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal/strategy_short_strangle.rs
+++ b/tests/unit/strategies/optimal/strategy_short_strangle.rs
@@ -32,7 +32,7 @@ fn test_short_strangle_with_greeks_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_bear_call_spread.rs
+++ b/tests/unit/strategies/optimal_center/strategy_bear_call_spread.rs
@@ -30,7 +30,7 @@ fn test_bear_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_bear_put_spread.rs
+++ b/tests/unit/strategies/optimal_center/strategy_bear_put_spread.rs
@@ -31,7 +31,7 @@ fn test_bear_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_bull_call_spread.rs
+++ b/tests/unit/strategies/optimal_center/strategy_bull_call_spread.rs
@@ -31,7 +31,7 @@ fn test_bull_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_bull_put_spread.rs
+++ b/tests/unit/strategies/optimal_center/strategy_bull_put_spread.rs
@@ -31,7 +31,7 @@ fn test_bull_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_call_butterfly.rs
+++ b/tests/unit/strategies/optimal_center/strategy_call_butterfly.rs
@@ -36,7 +36,7 @@ fn test_call_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // open_fee_short
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_iron_butterfly.rs
+++ b/tests/unit/strategies/optimal_center/strategy_iron_butterfly.rs
@@ -32,7 +32,7 @@ fn test_iron_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_iron_condor.rs
+++ b/tests/unit/strategies/optimal_center/strategy_iron_condor.rs
@@ -33,7 +33,7 @@ fn test_iron_condor_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_long_butterfly_spread.rs
+++ b/tests/unit/strategies/optimal_center/strategy_long_butterfly_spread.rs
@@ -35,7 +35,7 @@ fn test_long_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_long_straddle.rs
+++ b/tests/unit/strategies/optimal_center/strategy_long_straddle.rs
@@ -30,7 +30,7 @@ fn test_long_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_long_strangle.rs
+++ b/tests/unit/strategies/optimal_center/strategy_long_strangle.rs
@@ -31,7 +31,7 @@ fn test_long_strangle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_poor_mans_covered_call.rs
+++ b/tests/unit/strategies/optimal_center/strategy_poor_mans_covered_call.rs
@@ -31,7 +31,7 @@ fn test_poor_mans_covered_call_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(1.74),                       // close_fee_short_call
         pos_or_panic!(0.85),                       // open_fee_short_put
         pos_or_panic!(0.85),                       // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_short_butterfly_spread.rs
+++ b/tests/unit/strategies/optimal_center/strategy_short_butterfly_spread.rs
@@ -35,7 +35,7 @@ fn test_short_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_short_straddle.rs
+++ b/tests/unit/strategies/optimal_center/strategy_short_straddle.rs
@@ -30,7 +30,7 @@ fn test_short_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     let option_chain =
         OptionChain::load_from_json("./examples/Chains/SP500-18-oct-2024-5781.88.json")?;

--- a/tests/unit/strategies/optimal_center/strategy_short_strangle.rs
+++ b/tests/unit/strategies/optimal_center/strategy_short_strangle.rs
@@ -33,7 +33,7 @@ fn test_short_strangle_with_greeks_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.1),    // close_fee_short_call
         pos_or_panic!(0.1),    // open_fee_short_put
         pos_or_panic!(0.1),    // close_fee_short_put
-    );
+    )?;
 
     let option_chain = OptionChain::load_from_json(
         "./examples/Chains/Germany-40-2025-05-27-15-29-00-UTC-24209.json",

--- a/tests/unit/strategies/protective_put_test.rs
+++ b/tests/unit/strategies/protective_put_test.rs
@@ -34,6 +34,7 @@ fn create_test_protective_put() -> ProtectivePut {
         Positive::new(0.65).unwrap(),
         Positive::new(0.65).unwrap(),
     )
+    .unwrap()
 }
 
 #[test]

--- a/tests/unit/strategies/simple/strategy_bear_call_spread.rs
+++ b/tests/unit/strategies/simple/strategy_bear_call_spread.rs
@@ -28,7 +28,7 @@ fn test_bear_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_bear_put_spread.rs
+++ b/tests/unit/strategies/simple/strategy_bear_put_spread.rs
@@ -30,7 +30,7 @@ fn test_bear_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_bull_call_spread.rs
+++ b/tests/unit/strategies/simple/strategy_bull_call_spread.rs
@@ -30,7 +30,7 @@ fn test_bull_call_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_bull_put_spread.rs
+++ b/tests/unit/strategies/simple/strategy_bull_put_spread.rs
@@ -30,7 +30,7 @@ fn test_bull_put_spread_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.78),  // open_fee_long
         pos_or_panic!(0.73),  // close_fee_long
         pos_or_panic!(0.73),  // close_fee_short
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_call_butterfly.rs
+++ b/tests/unit/strategies/simple/strategy_call_butterfly.rs
@@ -34,7 +34,7 @@ fn test_call_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // close_fee_short
         pos_or_panic!(0.73),  // open_fee_short
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_graph.rs
+++ b/tests/unit/strategies/simple/strategy_graph.rs
@@ -27,7 +27,7 @@ fn test_bull_call_spread_basic_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(0.58),  // close_fee_long
         pos_or_panic!(0.55),  // close_fee_short
         pos_or_panic!(0.54),  // open_fee_short
-    );
+    )?;
 
     // Validate strategy properties
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_iron_butterfly.rs
+++ b/tests/unit/strategies/simple/strategy_iron_butterfly.rs
@@ -31,7 +31,7 @@ fn test_iron_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     // Validate strategy
     assert!(strategy.validate(), "Strategy should be valid");

--- a/tests/unit/strategies/simple/strategy_iron_condor.rs
+++ b/tests/unit/strategies/simple/strategy_iron_condor.rs
@@ -32,7 +32,7 @@ fn test_iron_condor_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(16.8),   // premium_long_put
         pos_or_panic!(0.96),   // open_fee
         pos_or_panic!(0.96),   // close_fee
-    );
+    )?;
 
     // Validate strategy
     assert!(strategy.validate(), "Strategy should be valid");

--- a/tests/unit/strategies/simple/strategy_long_butterfly_spread.rs
+++ b/tests/unit/strategies/simple/strategy_long_butterfly_spread.rs
@@ -35,7 +35,7 @@ fn test_long_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(strategy.get_break_even_points().unwrap().len(), 2);

--- a/tests/unit/strategies/simple/strategy_long_straddle.rs
+++ b/tests/unit/strategies/simple/strategy_long_straddle.rs
@@ -31,7 +31,7 @@ fn test_long_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_long_strangle.rs
+++ b/tests/unit/strategies/simple/strategy_long_strangle.rs
@@ -32,7 +32,7 @@ fn test_long_strangle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(

--- a/tests/unit/strategies/simple/strategy_poor_mans_covered_call.rs
+++ b/tests/unit/strategies/simple/strategy_poor_mans_covered_call.rs
@@ -30,7 +30,7 @@ fn test_poor_mans_covered_call_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(1.74),                       // close_fee_short_call
         pos_or_panic!(0.85),                       // open_fee_short_put
         pos_or_panic!(0.85),                       // close_fee_short_put
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(strategy.get_break_even_points().unwrap().len(), 1);

--- a/tests/unit/strategies/simple/strategy_short_butterfly_spread.rs
+++ b/tests/unit/strategies/simple/strategy_short_butterfly_spread.rs
@@ -34,7 +34,7 @@ fn test_short_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
         Positive::ZERO,
         Positive::ZERO,
         Positive::ZERO,
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(strategy.get_break_even_points().unwrap().len(), 1);

--- a/tests/unit/strategies/simple/strategy_short_straddle.rs
+++ b/tests/unit/strategies/simple/strategy_short_straddle.rs
@@ -29,7 +29,7 @@ fn test_short_straddle_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(strategy.get_break_even_points().unwrap().len(), 2);

--- a/tests/unit/strategies/simple/strategy_short_strangle.rs
+++ b/tests/unit/strategies/simple/strategy_short_strangle.rs
@@ -32,7 +32,7 @@ fn test_short_strangle_with_greeks_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(7.01),   // close_fee_short_call
         pos_or_panic!(7.01),   // open_fee_short_put
         pos_or_panic!(7.01),   // close_fee_short_put
-    );
+    )?;
 
     // Assertions to validate strategy properties and computations
     assert_eq!(strategy.get_break_even_points().unwrap().len(), 2);


### PR DESCRIPTION
Closes #316.

## Summary

Remove every production `.unwrap()` and `.expect()` from `src/strategies/` (M1 — Panic-Free Core, 0.16.0). Total: 236 sites across 29 files → 0.

Acceptance grep is clean:
```bash
for f in $(find src/strategies -name '*.rs'); do
  awk '/#\[cfg\(test\)\]/{exit} {print}' "$f" | grep -nE '\.unwrap\(\)|\.expect\('
done
# (no output)
```

## Approach

- Extended `StrategyError` with three typed variants (`NumericConversion { value: f64 }`, `MissingGreek { name: &'static str }`, `EmptyCollection { context: String }`) plus `#[cold]` constructors.
- Tightened `Optimizable::create_strategy(...)` from `-> Self::Strategy` to `-> Result<Self::Strategy, StrategyError>` (default impl now returns `OperationError(NotSupported)` instead of `unimplemented!()`).
- Tightened every leaf strategy `::new(...)` from `Self` to `Result<Self, StrategyError>` for the strategies whose constructors used `.expect("Invalid <leg>")` / `.expect("Unable to update break even points")`. All in-tree callers (tests, examples, benches, dependent strategies) updated.
- Inside Result-returning fns: `?` propagation. `Option` → `.ok_or_else(StrategyError::...)?` mapped to the most specific variant.
- Sort comparators (`partial_cmp(...).unwrap()`): `unwrap_or(Ordering::Equal)` with SAFETY comment.
- F-blocker `is_valid_optimal_option`: rewritten with `is_some_and` so no panic on missing greeks.
- F-blocker `refine_break_even_point() -> Option<Positive>`: short-circuits via `.ok()?`.

`panic!` / `unreachable!` / `unimplemented!` / `assert!` are intentionally left in place — they belong to issue #292.

## Public API impact (intentional)

The following constructors changed return type from `Self` to `Result<Self, StrategyError>`:

`ShortStrangle::new`, `LongStrangle::new`, `IronCondor::new`, `IronButterfly::new`, `CustomStrategy::new`, `CallButterfly::new`, `PoorMansCoveredCall::new`, `ShortStraddle::new`, `LongStraddle::new`, `BullCallSpread::new`, `BearCallSpread::new`, `BullPutSpread::new`, `BearPutSpread::new`, `LongButterflySpread::new`, `ShortButterflySpread::new`, `LongCall::new`, `LongPut::new` (private), `ShortCall::new` (private), `ShortPut::new`, `ProtectivePut::new`, `CoveredCall::new`, `Collar::new`.

Plus trait-level: `Optimizable::create_strategy` is now fallible (covers all impls).

## Verification

- `cargo build --all-targets --all-features` — clean.
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo test --lib` (default features) — 3723 passed; 0 failed; 5 ignored.
- `cargo test --features plotly --lib` — 3719 passed; 0 failed; 5 ignored.
- `cargo build --release` — clean.

`tests/unit/visualization::plotly_render_test::*` PNG/SVG render tests fail in environments without the plotly-static Chrome/Kaleido binary; this is pre-existing and unrelated.

## Commit map

1. `feat(error): add NumericConversion, MissingGreek, EmptyCollection variants`
2. `refactor(strategies): make Optimizable::create_strategy fallible` (40 sites)
3. `refactor(strategies): panic-free base + short/long strangle (58 sites)`
4. `refactor(strategies): panic-free iron condor/butterfly + custom (35 sites)`
5. `refactor(strategies): panic-free butterflies + pmcc + straddles (32 sites)`
6. `refactor(strategies): panic-free spreads + butterfly_spreads + graph (44)`
7. `refactor(strategies): panic-free probabilities, delta_neutral, singletons (27)`
8. `test(strategies): add negative tests for new StrategyError variants + fmt+clippy`

## Test plan

- [x] `cargo test --lib --all-features` clean
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo build --release` clean
- [ ] Reviewer confirms the constructor API changes are acceptable for the 0.16.0 cut