### PR TITLE
Replace pos_or_panic! in strategies with checked constructors (#326)

### DIFF
--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -1,4 +1,6 @@
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 /*
 Bear Put Spread Strategy
 
@@ -825,7 +827,7 @@ impl ProbabilityAnalysis for BearPutSpread {
         let mut profit_range = ProfitLossRange::new(
             Some(self.short_put.option.strike_price), // Price below short strike is max profit
             Some(break_even_point),                   // Upper bound is break even point
-            pos_or_panic!(self.get_max_profit()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         profit_range.calculate_probability(
@@ -855,7 +857,7 @@ impl ProbabilityAnalysis for BearPutSpread {
         let mut loss_range = ProfitLossRange::new(
             Some(break_even_point), // Lower bound is break even point
             None,                   // No upper bound (theoretically)
-            pos_or_panic!(self.get_max_loss()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         loss_range.calculate_probability(

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -46,7 +46,9 @@ use crate::{
 };
 use chrono::Utc;
 use num_traits::FromPrimitive;
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -834,7 +836,7 @@ impl ProbabilityAnalysis for BullCallSpread {
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_point),
             Some(self.short_call.option.strike_price),
-            pos_or_panic!(self.get_max_profit()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         profit_range.calculate_probability(
@@ -865,7 +867,7 @@ impl ProbabilityAnalysis for BullCallSpread {
         let mut loss_range = ProfitLossRange::new(
             Some(self.long_call.option.strike_price),
             Some(break_even_point),
-            pos_or_panic!(self.get_max_loss()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         loss_range.calculate_probability(

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -47,7 +47,9 @@ use crate::{
 };
 use chrono::Utc;
 use num_traits::FromPrimitive;
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -935,11 +937,7 @@ impl ProbabilityAnalysis for BullPutSpread {
             self.long_put.option.implied_volatility,
         ]);
 
-        let mut profit_range = ProfitLossRange::new(
-            Some(break_even_point),
-            None,
-            pos_or_panic!(self.get_max_profit()?.to_f64()),
-        )?;
+        let mut profit_range = ProfitLossRange::new(Some(break_even_point), None, Positive::ZERO)?;
 
         profit_range.calculate_probability(
             self.get_underlying_price(),
@@ -969,7 +967,7 @@ impl ProbabilityAnalysis for BullPutSpread {
         let mut loss_range = ProfitLossRange::new(
             Some(self.long_put.option.strike_price),
             Some(break_even_point),
-            pos_or_panic!(self.get_max_loss()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         loss_range.calculate_probability(

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -31,12 +31,24 @@ use crate::{
     utils::process_n_times_iter,
 };
 use num_traits::ToPrimitive;
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, error};
 use utoipa::ToSchema;
+
+/// Build a `Positive` from a compile-time non-negative `Decimal` literal.
+///
+/// All call sites in this module pass `dec!(X.X)` with a statically
+/// non-negative value, so the checked constructor is total; the
+/// `Positive::ZERO` branch is unreachable and only exists to keep the
+/// call site free of `.unwrap()`/`.expect()` per §Error Handling.
+#[inline]
+fn pos_lit(value: Decimal) -> Positive {
+    Positive::new_decimal(value).unwrap_or(Positive::ZERO)
+}
 
 /// Represents a custom options trading strategy with user-defined positions and characteristics.
 ///
@@ -187,9 +199,9 @@ impl CustomStrategy {
         let strike_range = *max_strike - *min_strike;
 
         // For strategies with small strike ranges, use a very focused approach
-        let base_extension = if strike_range < self.underlying_price * pos_or_panic!(0.05) {
+        let base_extension = if strike_range < self.underlying_price * pos_lit(dec!(0.05)) {
             // Very tight strikes (< 5% of underlying) - use minimal extension
-            strike_range * pos_or_panic!(1.5) // 150% of strike range
+            strike_range * pos_lit(dec!(1.5)) // 150% of strike range
         } else {
             // Wider strikes - use moderate extension
             strike_range * Positive::ONE // 100% of strike range
@@ -207,8 +219,8 @@ impl CustomStrategy {
     #[allow(dead_code)]
     fn best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
         let mut prices = Vec::new();
-        let mut current_price = self.underlying_price * pos_or_panic!(0.5);
-        let max_price = self.underlying_price * pos_or_panic!(1.5);
+        let mut current_price = self.underlying_price * pos_lit(dec!(0.5));
+        let max_price = self.underlying_price * pos_lit(dec!(1.5));
 
         while current_price <= max_price {
             prices.push(current_price);
@@ -285,7 +297,7 @@ impl CustomStrategy {
 
         if break_even_points.len() == 1 {
             let break_even = break_even_points[0];
-            let test_point = break_even - pos_or_panic!(0.01);
+            let test_point = break_even - pos_lit(dec!(0.01));
             let is_profit_below = self.calculate_profit_at(&test_point)? > Decimal::ZERO;
 
             if is_profit_below {
@@ -313,7 +325,7 @@ impl CustomStrategy {
             }
         } else {
             // Multiple break-even points
-            let test_point = break_even_points[0] - pos_or_panic!(0.01);
+            let test_point = break_even_points[0] - pos_lit(dec!(0.01));
             let is_profit_below = self.calculate_profit_at(&test_point)? > Decimal::ZERO;
             let is_first_zone_profit = is_profit_below;
 
@@ -371,9 +383,9 @@ impl BreakEvenable for CustomStrategy {
         self.break_even_points.clear();
 
         // Get a reasonable price range
-        let min_price = self.underlying_price * pos_or_panic!(0.5);
-        let max_price = self.underlying_price * pos_or_panic!(1.5);
-        let step = pos_or_panic!(0.01);
+        let min_price = self.underlying_price * pos_lit(dec!(0.5));
+        let max_price = self.underlying_price * pos_lit(dec!(1.5));
+        let step = pos_lit(dec!(0.01));
 
         let mut current_price = min_price;
         while current_price <= max_price {
@@ -624,7 +636,7 @@ impl Strategies for CustomStrategy {
         }
 
         let (min_price, max_price) = self.range_to_show()?;
-        let step = (max_price - min_price) / pos_or_panic!(50.0); // Use 50 steps max
+        let step = (max_price - min_price) / pos_lit(dec!(50.0)); // Use 50 steps max
         let mut max_profit = Decimal::ZERO;
         let mut current_price = min_price;
 
@@ -656,7 +668,7 @@ impl Strategies for CustomStrategy {
         }
 
         let (min_price, max_price) = self.range_to_show()?;
-        let step = (max_price - min_price) / pos_or_panic!(50.0); // Use 50 steps max
+        let step = (max_price - min_price) / pos_lit(dec!(50.0)); // Use 50 steps max
         let mut max_loss = Decimal::ZERO;
         let mut current_price = min_price;
 
@@ -688,7 +700,7 @@ impl Strategies for CustomStrategy {
         }
 
         let (min_price, max_price) = self.range_to_show()?;
-        let step = (max_price - min_price) / pos_or_panic!(50.0); // Use 50 steps max
+        let step = (max_price - min_price) / pos_lit(dec!(50.0)); // Use 50 steps max
         let mut total_profit = Decimal::ZERO;
         let mut current_price = min_price;
 

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -30,7 +30,9 @@ use crate::{
 };
 use chrono::Utc;
 use num_traits::FromPrimitive;
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -1020,7 +1022,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_points[0]),
             Some(break_even_points[1]),
-            pos_or_panic!(self.get_max_profit()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         profit_range.calculate_probability(
@@ -1060,7 +1062,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
         let mut lower_loss_range = ProfitLossRange::new(
             None, // No lower bound (losses extend to zero)
             Some(break_even_points[0]),
-            pos_or_panic!(self.get_max_loss()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         lower_loss_range.calculate_probability(
@@ -1078,7 +1080,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
         let mut upper_loss_range = ProfitLossRange::new(
             Some(break_even_points[1]),
             None, // No upper bound (losses extend to infinity)
-            pos_or_panic!(self.get_max_loss()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         upper_loss_range.calculate_probability(

--- a/src/strategies/probabilities/core.rs
+++ b/src/strategies/probabilities/core.rs
@@ -7,7 +7,9 @@
 //! The `ProbabilityAnalysis` trait extends the `Strategies` and `Profit` traits to provide
 //! comprehensive probability analysis capabilities for option strategies.
 
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::StrategyError;
@@ -192,7 +194,7 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
             Ok(Positive::ZERO)
         } else {
             let trend_adjustment = trend.map_or(1.0, |t| 1.0 / (1.0 + t.drift_rate.abs()));
-            Ok(pos_or_panic!(expected_value * trend_adjustment))
+            Positive::new(expected_value * trend_adjustment).map_err(ProbabilityError::from)
         }
     }
 

--- a/src/strategies/probabilities/mod.rs
+++ b/src/strategies/probabilities/mod.rs
@@ -1,5 +1,4 @@
 /******************************************************************************
-use positive::pos_or_panic;
    Author: Joaquín Béjar García
    Email: jb@taunais.com
    Date: 30/11/24

--- a/src/strategies/probabilities/utils.rs
+++ b/src/strategies/probabilities/utils.rs
@@ -11,8 +11,11 @@ use crate::f2du;
 use crate::greeks::big_n;
 use crate::model::ExpirationDate;
 use num_traits::ToPrimitive;
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 
 /// Struct to hold volatility adjustment parameters
 #[derive(Debug, Clone)]
@@ -97,7 +100,7 @@ pub fn calculate_single_point_probability(
             }
             adj.base_volatility * (1.0 + adj.std_dev_adjustment)
         }
-        None => pos_or_panic!(0.2), // Default volatility if not provided
+        None => Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO), // Default volatility if not provided
     };
 
     // Adjust drift rate based on trend if provided

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -30,7 +30,9 @@ use crate::{
 };
 use chrono::Utc;
 use num_traits::FromPrimitive;
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -1039,7 +1041,7 @@ impl ProbabilityAnalysis for ShortButterflySpread {
         let mut loss_range = ProfitLossRange::new(
             Some(break_even_points[0]),
             Some(break_even_points[1]),
-            pos_or_panic!(self.get_max_loss()?.to_f64()),
+            Positive::ZERO,
         )?;
 
         loss_range.calculate_probability(


### PR DESCRIPTION
Replace 24 production sites across spreads, custom, and probabilities modules:
- bull_call_spread, bull_put_spread, bear_put_spread, short_butterfly_spread, long_butterfly_spread: swap throwaway probability arguments from pos_or_panic!(max_profit/loss) to Positive::ZERO (recomputed by calculate_probability).
- probabilities/core.rs: expected_value returns Result, use Positive::new().map_err() for trend-adjusted computation.
- probabilities/utils.rs: default volatility (0.2) via Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO).
- custom.rs: 12 literal multipliers (0.05, 0.5, 1.5, 0.01, 50.0) replaced with Positive::new_decimal(dec!(X.X)).unwrap_or(Positive::ZERO).
- Gate pos_or_panic! imports behind #[cfg(test)] in all modified files so test modules retain access.

All 3725 lib + 416 integration + 12 property tests green; clippy -D warnings clean; full release build clean.
