### PR TITLE
Implement object-safe clone_box for WalkTypeAble trait objects

### DIFF
--- a/examples/examples_simulation/src/bin/historical_build_chain.rs
+++ b/examples/examples_simulation/src/bin/historical_build_chain.rs
@@ -2,6 +2,7 @@ use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
 #[warn(dead_code)]
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/long_call_strategy_simulation.rs
+++ b/examples/examples_simulation/src/bin/long_call_strategy_simulation.rs
@@ -42,6 +42,7 @@ use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
 /// Walker implementation for the simulation.
+#[derive(Clone)]
 struct Walker;
 
 impl WalkTypeAble<Positive, Positive> for Walker {}

--- a/examples/examples_simulation/src/bin/position_simulator.rs
+++ b/examples/examples_simulation/src/bin/position_simulator.rs
@@ -1,6 +1,7 @@
 use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/random_walk.rs
+++ b/examples/examples_simulation/src/bin/random_walk.rs
@@ -2,6 +2,7 @@ use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
 #[warn(dead_code)]
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/random_walk_build_chain.rs
+++ b/examples/examples_simulation/src/bin/random_walk_build_chain.rs
@@ -2,6 +2,7 @@ use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
 #[warn(dead_code)]
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/random_walk_build_series.rs
+++ b/examples/examples_simulation/src/bin/random_walk_build_series.rs
@@ -2,6 +2,7 @@ use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
 #[warn(dead_code)]
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/random_walk_chain.rs
+++ b/examples/examples_simulation/src/bin/random_walk_chain.rs
@@ -2,6 +2,7 @@ use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
 #[warn(dead_code)]
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/short_put_simulation.rs
+++ b/examples/examples_simulation/src/bin/short_put_simulation.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 
 /// Walker implementation for the simulation.
 #[warn(dead_code)]
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/short_put_strategy_simulation.rs
+++ b/examples/examples_simulation/src/bin/short_put_strategy_simulation.rs
@@ -43,6 +43,7 @@ use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
 /// Walker implementation for the simulation.
+#[derive(Clone)]
 struct Walker;
 
 impl WalkTypeAble<Positive, Positive> for Walker {}

--- a/examples/examples_simulation/src/bin/simulator.rs
+++ b/examples/examples_simulation/src/bin/simulator.rs
@@ -1,6 +1,7 @@
 use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/strategy_simulator.rs
+++ b/examples/examples_simulation/src/bin/strategy_simulator.rs
@@ -1,6 +1,7 @@
 use optionstratlib::prelude::*;
 use positive::pos_or_panic;
 
+#[derive(Clone)]
 struct Walker {}
 
 impl Walker {

--- a/examples/examples_simulation/src/bin/unified_pricing.rs
+++ b/examples/examples_simulation/src/bin/unified_pricing.rs
@@ -25,6 +25,7 @@ use std::fmt::Display;
 use std::ops::AddAssign;
 
 // Simple walker implementation for demonstration
+#[derive(Clone)]
 struct SimpleWalker;
 
 impl<X, Y> WalkTypeAble<X, Y> for SimpleWalker

--- a/src/chains/generators.rs
+++ b/src/chains/generators.rs
@@ -280,6 +280,7 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
     struct WalkerOptionChain {}
     impl WalkerOptionChain {
         fn new() -> Self {
@@ -321,6 +322,7 @@ mod tests {
         assert_eq!(random_walk.len(), n_steps);
     }
 
+    #[derive(Clone)]
     struct Walker {}
     impl Walker {
         fn new() -> Self {
@@ -370,6 +372,7 @@ mod generators_coverage_tests {
     use crate::utils::time::get_tomorrow_formatted;
     use rust_decimal_macros::dec;
 
+    #[derive(Clone)]
     struct TestWalker {}
     impl TestWalker {
         fn new() -> Self {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -124,7 +124,8 @@ pub use std::path::Path;
 
 // Simulation types and functions
 pub use crate::simulation::{
-    ExitPolicy, Simulate, SimulationStats, WalkParams, WalkType, WalkTypeAble, check_exit_policy,
+    ExitPolicy, Simulate, SimulationStats, WalkParams, WalkType, WalkTypeAble, WalkTypeAbleClone,
+    check_exit_policy,
     randomwalk::RandomWalk,
     simulator::Simulator,
     steps::{Step, Xstep, Ystep},

--- a/src/pricing/monte_carlo.rs
+++ b/src/pricing/monte_carlo.rs
@@ -295,6 +295,7 @@ mod tests_price_option_monte_carlo {
 
     #[test]
     fn test_simulation() {
+        #[derive(Clone)]
         struct TestWalker;
         impl WalkTypeAble<Positive, Positive> for TestWalker {}
         let walker = Box::new(TestWalker);

--- a/src/series/generators.rs
+++ b/src/series/generators.rs
@@ -307,6 +307,7 @@ mod tests_generator_optionseries {
 
     #[test]
     fn test_generator_optionseries_empty_result() {
+        #[derive(Clone)]
         struct TestWalker {}
         // Create a walk with empty y_steps to test early return
         let initial_series = create_test_option_series();

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -134,4 +134,4 @@ pub use exit::{ExitPolicy, check_exit_policy};
 pub use model::WalkType;
 pub use params::WalkParams;
 pub use stats::SimulationStats;
-pub use traits::{Simulate, WalkTypeAble};
+pub use traits::{Simulate, WalkTypeAble, WalkTypeAbleClone};

--- a/src/simulation/params.rs
+++ b/src/simulation/params.rs
@@ -141,6 +141,7 @@ mod tests {
     use std::fmt::Display;
     use std::ops::AddAssign;
 
+    #[derive(Clone)]
     struct MockWalker;
 
     impl<X, Y> WalkTypeAble<X, Y> for MockWalker

--- a/src/simulation/randomwalk.rs
+++ b/src/simulation/randomwalk.rs
@@ -370,6 +370,7 @@ mod tests_random_walk {
     use std::ops::AddAssign;
 
     // Mock implementation of WalkTypeAble for testing
+    #[derive(Clone)]
     struct TestWalker {}
 
     impl<X, Y> WalkTypeAble<X, Y> for TestWalker

--- a/src/simulation/simulator.rs
+++ b/src/simulation/simulator.rs
@@ -478,6 +478,7 @@ mod tests {
     use {std::fs, std::path::Path};
 
     // Helper structs and functions for testing
+    #[derive(Clone)]
     struct TestWalker;
 
     impl TestWalker {

--- a/src/simulation/traits.rs
+++ b/src/simulation/traits.rs
@@ -11,6 +11,40 @@ use std::convert::TryInto;
 use std::fmt::{Debug, Display};
 use std::ops::AddAssign;
 
+/// Object-safe helper trait that exposes a `Clone`-compatible operation for
+/// [`WalkTypeAble`] trait objects.
+///
+/// `Clone::clone` requires `Self: Sized`, so it cannot be invoked through
+/// `dyn WalkTypeAble<X, Y>` directly. `WalkTypeAbleClone::clone_box` returns an
+/// owned `Box<dyn WalkTypeAble<X, Y>>` instead, which lets the generic
+/// `Clone for Box<dyn WalkTypeAble<X, Y>>` implementation work uniformly for
+/// any concrete walker that is `Clone + 'static`.
+///
+/// You should never implement this trait by hand: a blanket impl covers every
+/// `T: WalkTypeAble<X, Y> + Clone + 'static`. Just `#[derive(Clone)]` on your
+/// concrete walker and the trait object gains `Clone` for free.
+pub trait WalkTypeAbleClone<X, Y>
+where
+    X: Copy + TryInto<Positive> + AddAssign + Display,
+    Y: TryInto<Positive> + Display + Clone,
+{
+    /// Returns a boxed clone of this walker as a trait object.
+    #[must_use]
+    fn clone_box(&self) -> Box<dyn WalkTypeAble<X, Y>>;
+}
+
+impl<T, X, Y> WalkTypeAbleClone<X, Y> for T
+where
+    T: 'static + WalkTypeAble<X, Y> + Clone,
+    X: Copy + TryInto<Positive> + AddAssign + Display,
+    Y: TryInto<Positive> + Display + Clone,
+{
+    #[inline]
+    fn clone_box(&self) -> Box<dyn WalkTypeAble<X, Y>> {
+        Box::new(self.clone())
+    }
+}
+
 /// Trait for implementing various random walk models and stochastic processes.
 ///
 /// This trait provides methods to generate different types of stochastic processes commonly
@@ -38,7 +72,19 @@ use std::ops::AddAssign;
 /// - GARCH (Generalized Autoregressive Conditional Heteroskedasticity)
 /// - Heston stochastic volatility model
 /// - Custom stochastic process with mean-reverting volatility
-pub trait WalkTypeAble<X, Y>
+///
+/// # Object safety and cloning
+///
+/// `WalkTypeAble` is object-safe: you can hold it behind `Box<dyn WalkTypeAble<X, Y>>`
+/// (e.g., inside [`WalkParams`]). The super-trait [`WalkTypeAbleClone`] provides an
+/// object-safe `clone_box` hook that forwards to `Clone` on the concrete walker, which
+/// is how `Box<dyn WalkTypeAble<X, Y>>` implements `Clone`. Any concrete walker you
+/// want to store behind a trait object must therefore be `Clone + 'static` — in
+/// practice that means adding `#[derive(Clone)]` to your walker struct.
+///
+/// The blanket implementation of `WalkTypeAbleClone` is automatic; you never
+/// implement `clone_box` by hand.
+pub trait WalkTypeAble<X, Y>: WalkTypeAbleClone<X, Y>
 where
     X: Copy + TryInto<Positive> + AddAssign + Display,
     Y: TryInto<Positive> + Display + Clone,
@@ -643,19 +689,16 @@ impl<X, Y> Debug for Box<dyn WalkTypeAble<X, Y>> {
     }
 }
 
-impl<X, Y> Clone for Box<dyn WalkTypeAble<X, Y>> {
+impl<X, Y> Clone for Box<dyn WalkTypeAble<X, Y>>
+where
+    X: Copy + TryInto<Positive> + AddAssign + Display,
+    Y: TryInto<Positive> + Display + Clone,
+{
     fn clone(&self) -> Self {
-        // INVARIANT: a trait object cannot be cloned through `Clone::clone`
-        // because that requires `Self: Sized`, which `dyn WalkTypeAble` is
-        // not. This impl exists only so containers like `WalkParams` can
-        // still `#[derive(Clone)]`; the concrete walkers used in the crate
-        // live as `Box<ConcreteWalker>` (not `Box<dyn ...>`), so the
-        // derived clone paths never reach this branch. Calling it directly
-        // on a `Box<dyn WalkTypeAble>` is a programmer error — tracked by
-        // issue #358 as a follow-up to add a proper object-safe clone hook.
-        panic!(
-            "Box<dyn WalkTypeAble<X, Y>> cannot be cloned directly; keep walkers as Box<ConcreteWalker> or track the follow-up in issue #358."
-        )
+        // Delegate to the object-safe `clone_box` hook on `WalkTypeAbleClone`.
+        // The blanket impl for `T: WalkTypeAble<X, Y> + Clone + 'static`
+        // forwards to `Clone::clone` on the concrete walker.
+        self.clone_box()
     }
 }
 
@@ -733,7 +776,7 @@ mod tests_walk_type_able {
     use std::fmt::Display;
     use std::ops::AddAssign;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     struct TestWalker {}
 
     impl<X, Y> WalkTypeAble<X, Y> for TestWalker
@@ -1027,6 +1070,7 @@ mod tests_walk_type_able {
 
     #[test]
     fn test_error_handling() {
+        #[derive(Clone)]
         struct ErrorWalker {}
 
         impl<X, Y> WalkTypeAble<X, Y> for ErrorWalker
@@ -1095,5 +1139,56 @@ mod tests_walk_type_able {
 
         let error_walker = ErrorWalker {};
         assert!(error_walker.brownian(&params).is_err());
+    }
+
+    /// Regression for issue #358: cloning through `Box<dyn WalkTypeAble>`
+    /// delegates to `clone_box`, which forwards to the concrete walker's
+    /// `Clone::clone`. Calling `.clone()` must not panic and must produce a
+    /// walker that behaves identically to the original.
+    #[test]
+    fn test_box_dyn_walktypeable_clone_roundtrip() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct CountingWalker {
+            label: &'static str,
+        }
+        impl<X, Y> WalkTypeAble<X, Y> for CountingWalker
+        where
+            X: Copy + TryInto<Positive> + AddAssign + Display,
+            Y: Copy + TryInto<Positive> + Display,
+        {
+        }
+
+        let original: Box<dyn WalkTypeAble<Positive, Positive>> =
+            Box::new(CountingWalker { label: "seed" });
+        // Would previously panic; now forwards through clone_box to
+        // CountingWalker::clone.
+        let cloned = original.clone();
+
+        // We cannot compare trait objects directly, so verify via downcast-ish
+        // behaviour: both walkers expose the same `brownian` result for the
+        // same WalkParams input.
+        let params = create_test_params(
+            3,
+            pos_or_panic!(1.0),
+            Positive::HUNDRED,
+            WalkType::Brownian {
+                dt: pos_or_panic!(0.01),
+                drift: Decimal::ZERO,
+                volatility: pos_or_panic!(0.2),
+            },
+        );
+        let original_len = original
+            .brownian(&params)
+            .map(|v| v.len())
+            .unwrap_or(usize::MAX);
+        let cloned_len = cloned
+            .brownian(&params)
+            .map(|v| v.len())
+            .unwrap_or(usize::MAX);
+        assert_eq!(original_len, cloned_len);
+
+        // The default `brownian` returns `Ok(Vec::new())` for
+        // `WalkType::Brownian` when ystep cannot be coerced, which is fine —
+        // we are asserting parity, not a specific length.
     }
 }

--- a/src/simulation/traits.rs
+++ b/src/simulation/traits.rs
@@ -77,13 +77,14 @@ where
 ///
 /// `WalkTypeAble` is object-safe: you can hold it behind `Box<dyn WalkTypeAble<X, Y>>`
 /// (e.g., inside [`WalkParams`]). The super-trait [`WalkTypeAbleClone`] provides an
-/// object-safe `clone_box` hook that forwards to `Clone` on the concrete walker, which
-/// is how `Box<dyn WalkTypeAble<X, Y>>` implements `Clone`. Any concrete walker you
-/// want to store behind a trait object must therefore be `Clone + 'static` — in
-/// practice that means adding `#[derive(Clone)]` to your walker struct.
+/// object-safe `clone_box` hook that `Box<dyn WalkTypeAble<X, Y>>: Clone` delegates
+/// to. Concrete walkers must therefore implement `WalkTypeAbleClone` — a blanket
+/// impl covers every `T: WalkTypeAble<X, Y> + Clone + 'static`, so in practice it
+/// is enough to add `#[derive(Clone)]` to your walker struct and the object-safe
+/// clone path works automatically.
 ///
-/// The blanket implementation of `WalkTypeAbleClone` is automatic; you never
-/// implement `clone_box` by hand.
+/// Walkers that cannot be `Clone` may implement `WalkTypeAbleClone::clone_box`
+/// by hand, but doing so is rarely necessary.
 pub trait WalkTypeAble<X, Y>: WalkTypeAbleClone<X, Y>
 where
     X: Copy + TryInto<Positive> + AddAssign + Display,
@@ -1144,31 +1145,44 @@ mod tests_walk_type_able {
     /// Regression for issue #358: cloning through `Box<dyn WalkTypeAble>`
     /// delegates to `clone_box`, which forwards to the concrete walker's
     /// `Clone::clone`. Calling `.clone()` must not panic and must produce a
-    /// walker that behaves identically to the original.
+    /// walker that produces byte-identical output on the same input.
     #[test]
     fn test_box_dyn_walktypeable_clone_roundtrip() {
+        // Deterministic walker so we can compare the full `Vec<Positive>`
+        // output rather than just its length. `brownian` returns a ramp
+        // seeded with the struct's `seed` field, which survives `Clone`.
         #[derive(Clone, Debug, PartialEq)]
         struct CountingWalker {
-            label: &'static str,
+            seed: u32,
         }
         impl<X, Y> WalkTypeAble<X, Y> for CountingWalker
         where
             X: Copy + TryInto<Positive> + AddAssign + Display,
             Y: Copy + TryInto<Positive> + Display,
         {
+            fn brownian(
+                &self,
+                params: &WalkParams<X, Y>,
+            ) -> Result<Vec<Positive>, SimulationError> {
+                let start = params.ystep_as_positive()?;
+                let mut out = Vec::with_capacity(params.size);
+                out.push(start);
+                for i in 1..params.size {
+                    let offset = Positive::new(f64::from(self.seed) + i as f64)?;
+                    out.push(start + offset);
+                }
+                Ok(out)
+            }
         }
 
         let original: Box<dyn WalkTypeAble<Positive, Positive>> =
-            Box::new(CountingWalker { label: "seed" });
+            Box::new(CountingWalker { seed: 42 });
         // Would previously panic; now forwards through clone_box to
         // CountingWalker::clone.
         let cloned = original.clone();
 
-        // We cannot compare trait objects directly, so verify via downcast-ish
-        // behaviour: both walkers expose the same `brownian` result for the
-        // same WalkParams input.
         let params = create_test_params(
-            3,
+            4,
             pos_or_panic!(1.0),
             Positive::HUNDRED,
             WalkType::Brownian {
@@ -1177,18 +1191,10 @@ mod tests_walk_type_able {
                 volatility: pos_or_panic!(0.2),
             },
         );
-        let original_len = original
+        let original_out = original
             .brownian(&params)
-            .map(|v| v.len())
-            .unwrap_or(usize::MAX);
-        let cloned_len = cloned
-            .brownian(&params)
-            .map(|v| v.len())
-            .unwrap_or(usize::MAX);
-        assert_eq!(original_len, cloned_len);
-
-        // The default `brownian` returns `Ok(Vec::new())` for
-        // `WalkType::Brownian` when ystep cannot be coerced, which is fine —
-        // we are asserting parity, not a specific length.
+            .expect("deterministic walker succeeds");
+        let cloned_out = cloned.brownian(&params).expect("cloned walker succeeds");
+        assert_eq!(original_out, cloned_out);
     }
 }

--- a/src/strategies/long_call.rs
+++ b/src/strategies/long_call.rs
@@ -794,6 +794,7 @@ mod tests_simulate {
     use crate::utils::TimeFrame;
     use rust_decimal_macros::dec;
 
+    #[derive(Clone)]
     struct TestWalker;
     impl WalkTypeAble<Positive, Positive> for TestWalker {}
 

--- a/src/strategies/long_put.rs
+++ b/src/strategies/long_put.rs
@@ -779,6 +779,7 @@ mod tests_simulate {
     use crate::utils::TimeFrame;
     use rust_decimal_macros::dec;
 
+    #[derive(Clone)]
     struct TestWalker;
     impl WalkTypeAble<Positive, Positive> for TestWalker {}
 

--- a/src/strategies/short_call.rs
+++ b/src/strategies/short_call.rs
@@ -788,6 +788,7 @@ mod tests_simulate {
     use crate::utils::TimeFrame;
     use rust_decimal_macros::dec;
 
+    #[derive(Clone)]
     struct TestWalker;
     impl WalkTypeAble<Positive, Positive> for TestWalker {}
 

--- a/src/strategies/short_put.rs
+++ b/src/strategies/short_put.rs
@@ -786,6 +786,7 @@ mod tests_simulate {
     use rust_decimal_macros::dec;
 
     /// Helper struct to implement WalkTypeAble for tests
+    #[derive(Clone)]
     struct TestWalker;
 
     impl WalkTypeAble<Positive, Positive> for TestWalker {}

--- a/tests/unit/chain/random_walk_chain.rs
+++ b/tests/unit/chain/random_walk_chain.rs
@@ -15,6 +15,7 @@ use rust_decimal_macros::dec;
 use std::error::Error;
 use tracing::info;
 
+#[derive(Clone)]
 struct MockWalker {}
 impl MockWalker {
     fn new() -> Self {

--- a/tests/unit/pricing/unified_pricing_test.rs
+++ b/tests/unit/pricing/unified_pricing_test.rs
@@ -19,6 +19,7 @@ use std::fmt::Display;
 use std::ops::AddAssign;
 
 // A minimal walker for testing
+#[derive(Clone)]
 struct TestWalker;
 
 impl<X, Y> WalkTypeAble<X, Y> for TestWalker


### PR DESCRIPTION
Closes #358.

## Summary

- Adds a `WalkTypeAbleClone<X, Y>` super-trait on `WalkTypeAble` with an
  object-safe `clone_box() -> Box<dyn WalkTypeAble<X, Y>>` hook.
- Provides a blanket impl for every `T: WalkTypeAble<X, Y> + Clone + 'static`,
  so you never implement `clone_box` by hand — just `#[derive(Clone)]`
  on your concrete walker.
- `Clone for Box<dyn WalkTypeAble<X, Y>>` now forwards to `self.clone_box()`
  instead of panicking. `WalkParams: Clone` therefore works uniformly for
  `Box<ConcreteWalker>` and `Box<dyn WalkTypeAble<...>>` walker types.
- `WalkTypeAbleClone` is re-exported from `src/simulation/mod.rs` and
  `src/prelude.rs` alongside `WalkTypeAble`.

## Breaking change (scope: tests + examples)

Every existing `WalkTypeAble` implementer must be `Clone + 'static`. All
in-tree implementers are test/example walkers (no production walkers
exist). This PR adds `#[derive(Clone)]` to 13 test walkers and 12
example binaries under `examples_simulation/`.

## Test plan

- [x] New unit test `test_box_dyn_walktypeable_clone_roundtrip` in
      `simulation/traits.rs` exercises the trait-object clone path and
      verifies the cloned walker produces the same `brownian` output as
      the original.
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean.
- [x] `cargo fmt --all --check`
- [x] `cargo build --release`
- [x] `cargo test --all-features --workspace` — 3728 lib + 416 integration
      + 12 property tests green.