### PR TITLE
Replace production pos_or_panic! in model and risk with checked constructors

### DIFF
--- a/src/model/leg/future.rs
+++ b/src/model/leg/future.rs
@@ -47,6 +47,7 @@ use crate::model::types::Side;
 use chrono::{DateTime, Utc};
 use positive::Positive;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -412,7 +413,13 @@ impl Default for FuturePosition {
             quantity: Positive::ZERO,
             entry_price: Positive::ZERO,
             side: Side::Long,
-            expiration_date: ExpirationDate::Days(positive::pos_or_panic!(30.0)),
+            // `dec!(30.0)` is a compile-time positive literal; the checked
+            // constructor never fails, so the `Positive::ZERO` fallback is
+            // unreachable and only exists to keep the call site free of
+            // `.unwrap()`/`.expect()`.
+            expiration_date: ExpirationDate::Days(
+                Positive::new_decimal(dec!(30.0)).unwrap_or(Positive::ZERO),
+            ),
             contract_size: positive::Positive::ONE,
             initial_margin_req: Positive::ZERO,
             maintenance_margin_req: Positive::ZERO,

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -18,7 +18,9 @@ use crate::visualization::{
     ColorScheme, Graph, GraphConfig, GraphData, LineStyle, Series2D, TraceMode,
 };
 use num_traits::FromPrimitive;
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
@@ -677,8 +679,8 @@ impl Options {
             market_price
         };
 
-        // Initialize high and low bounds for volatility
-        let mut high = pos_or_panic!(5.0); // 500% max volatility
+        // Initialize high and low bounds for volatility (500% max).
+        let mut high = Positive::new(5.0)?;
         let mut low = Positive::ZERO;
 
         // Binary search through volatilities until we find one that gives us our target price

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -8,10 +8,21 @@ use crate::model::Position;
 use crate::model::types::{OptionStyle, OptionType, Side};
 use crate::{ExpirationDate, Options};
 use chrono::{NaiveDateTime, TimeZone, Utc};
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 use std::ops::Mul;
+
+/// Build a `Positive` from a compile-time non-negative `Decimal` literal.
+///
+/// All call sites in this module pass `dec!(X.X)` with a statically
+/// non-negative value, so the checked constructor is total; the
+/// `Positive::ZERO` branch is unreachable and only exists to keep the
+/// call site free of `.unwrap()`/`.expect()`.
+#[inline]
+fn pos_lit(value: Decimal) -> Positive {
+    Positive::new_decimal(value).unwrap_or(Positive::ZERO)
+}
 
 /// Converts a vector of `Positive` values to a vector of `f64` values.
 ///
@@ -79,13 +90,13 @@ pub fn create_sample_option(
         side,
         "AAPL".to_string(),
         strike_price,
-        ExpirationDate::Days(pos_or_panic!(30.0)),
+        ExpirationDate::Days(pos_lit(dec!(30.0))),
         volatility,
         quantity,
         underlying_price,
         dec!(0.05),
         option_style,
-        pos_or_panic!(0.01),
+        pos_lit(dec!(0.01)),
         None,
     )
 }
@@ -147,19 +158,19 @@ pub fn create_sample_position(
             side,
             underlying_symbol: "AAPL".to_string(),
             strike_price,
-            expiration_date: ExpirationDate::Days(pos_or_panic!(30.0)),
+            expiration_date: ExpirationDate::Days(pos_lit(dec!(30.0))),
             implied_volatility,
             quantity,
             underlying_price,
             risk_free_rate: dec!(0.05),
             option_style,
-            dividend_yield: pos_or_panic!(0.01),
+            dividend_yield: pos_lit(dec!(0.01)),
             exotic_params: None,
         },
-        premium: pos_or_panic!(5.0),
+        premium: pos_lit(dec!(5.0)),
         date: Utc::now(),
-        open_fee: pos_or_panic!(0.5),
-        close_fee: pos_or_panic!(0.5),
+        open_fee: pos_lit(dec!(0.5)),
+        close_fee: pos_lit(dec!(0.5)),
         epic: Some("Epic123".to_string()),
         extra_fields: None,
     }
@@ -205,7 +216,7 @@ pub fn create_sample_option_with_date(
         underlying_price,
         dec!(0.05),
         option_style,
-        pos_or_panic!(0.01),
+        pos_lit(dec!(0.01)),
         None,
     )
 }
@@ -251,7 +262,7 @@ pub fn create_sample_option_with_days(
         underlying_price,
         dec!(0.05),
         option_style,
-        pos_or_panic!(0.01),
+        pos_lit(dec!(0.01)),
         None,
     )
 }
@@ -296,13 +307,13 @@ pub fn create_sample_option_simplest(option_style: OptionStyle, side: Side) -> O
         side,
         "AAPL".to_string(),
         Positive::HUNDRED,
-        ExpirationDate::Days(pos_or_panic!(30.0)),
-        pos_or_panic!(0.2),
+        ExpirationDate::Days(pos_lit(dec!(30.0))),
+        pos_lit(dec!(0.2)),
         Positive::ONE,
         Positive::HUNDRED,
         dec!(0.05),
         option_style,
-        pos_or_panic!(0.01),
+        pos_lit(dec!(0.01)),
         None,
     )
 }
@@ -349,13 +360,13 @@ pub fn create_sample_option_simplest_strike(
         side,
         "AAPL".to_string(),
         strike,
-        ExpirationDate::Days(pos_or_panic!(30.0)),
-        pos_or_panic!(0.2),
+        ExpirationDate::Days(pos_lit(dec!(30.0))),
+        pos_lit(dec!(0.2)),
         Positive::ONE,
         Positive::HUNDRED,
         dec!(0.05),
         option_style,
-        pos_or_panic!(0.01),
+        pos_lit(dec!(0.01)),
         None,
     )
 }
@@ -402,13 +413,17 @@ pub fn create_sample_option_simplest_strike(
 /// Note: The `Positive` type and associated operations are defined in the `crate::model::types` module.
 pub fn mean_and_std(vec: Vec<Positive>) -> (Positive, Positive) {
     let mean = vec.iter().sum::<Positive>() / vec.len() as f64;
+    // `(x - mean).powi(2)` is mathematically non-negative, and so is
+    // `sqrt(variance)`. The `Positive::ZERO` fallback on the checked
+    // constructors is therefore unreachable and only exists to keep these
+    // call sites free of `.unwrap()`/`.expect()`.
     let variance = vec
         .iter()
-        .map(|x| pos_or_panic!((x.to_f64() - mean.to_f64()).powi(2)))
+        .map(|x| Positive::new((x.to_f64() - mean.to_f64()).powi(2)).unwrap_or(Positive::ZERO))
         .sum::<Positive>()
         / vec.len() as f64;
     let std = variance.to_f64().sqrt();
-    (mean, pos_or_panic!(std))
+    (mean, Positive::new(std).unwrap_or(Positive::ZERO))
 }
 
 /// Trait for rounding operations on numeric types, specifically for financial calculations.

--- a/src/risk/model.rs
+++ b/src/risk/model.rs
@@ -3,7 +3,9 @@
    Email: jb@taunais.com
    Date: 26/2/25
 ******************************************************************************/
-use positive::{Positive, pos_or_panic};
+use positive::Positive;
+#[cfg(test)]
+use positive::pos_or_panic;
 
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -34,12 +36,17 @@ pub struct RiskMetricsSimulation {
 
 impl Default for RiskMetricsSimulation {
     fn default() -> Self {
+        // `dec!(0.01)` is a compile-time positive literal; the checked
+        // constructor never fails, so the `Positive::ZERO` fallback is
+        // unreachable and only exists to keep the call site free of
+        // `.unwrap()`/`.expect()`.
+        let one_pct = Positive::new_decimal(dec!(0.01)).unwrap_or(Positive::ZERO);
         Self {
             var_95: dec!(0.0),
             var_99: dec!(0.0),
             cvar_95: dec!(0.0),
-            severe_loss_probability: pos_or_panic!(0.01),
-            max_drawdown: pos_or_panic!(0.01),
+            severe_loss_probability: one_pct,
+            max_drawdown: one_pct,
             sharpe_ratio: dec!(0.0),
         }
     }


### PR DESCRIPTION
Closes #328.

## Summary

Drops 21 production `pos_or_panic!` call sites across `src/model/` and
`src/risk/`:

- `model/option.rs::calculate_implied_volatility` — swaps the 500% IV
  upper bound to `Positive::new(5.0)?` so the error propagates through
  the existing `Result<_, VolatilityError>` (`VolatilityError:
  From<PositiveError>` already exists).
- `model/leg/future.rs::FuturePosition::Default` — swaps the 30-day
  default expiration to
  `Positive::new_decimal(dec!(30.0)).unwrap_or(Positive::ZERO)`. The
  `dec!()` literal is compile-time non-negative so the fallback branch
  is unreachable and only exists to keep the call site free of
  `.unwrap()` / `.expect()` per §Error Handling.
- `model/utils.rs` — 17 sites spanning the seven `create_sample_*`
  helpers and `mean_and_std`. Introduces a module-private
  `pos_lit(value: Decimal) -> Positive` helper (same pattern used in
  `chains/utils.rs` and `strategies/custom.rs` from PRs #360/#361).
  `mean_and_std`'s two runtime sites use
  `Positive::new(...).unwrap_or(Positive::ZERO)` — a squared real and
  `sqrt` of a non-negative are mathematically non-negative, so the
  fallback is unreachable.
- `risk/model.rs::RiskMetricsSimulation::Default` — same
  `Positive::new_decimal(dec!(0.01)).unwrap_or(Positive::ZERO)` pattern
  for the two non-fallible default fields.

`pos_or_panic!` imports gated behind `#[cfg(test)]` in the files where
the macro only remains in tests.

## Test plan

- [x] `grep -rn "pos_or_panic!" src/model/ src/risk/ src/metrics/ src/backtesting/`
      outside tests and doc comments returns **0** matches.
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean.
- [x] `cargo fmt --all --check`
- [x] `cargo build --release`
- [x] `cargo test --all-features --workspace` — 3728 lib + 416 integration
      + 12 property tests green.