### PR TITLE
Convert TransactionError from String-bag struct to typed enum

### DIFF
--- a/src/error/transaction.rs
+++ b/src/error/transaction.rs
@@ -1,19 +1,126 @@
+use crate::OptionType;
 use thiserror::Error;
 
 /// # Transaction Error
 ///
-/// Defines the error type used for transaction-related operations in the financial library.
-/// This error is typically raised when operations involving trades, orders, or financial
-/// transactions encounter issues such as validation failures, execution problems,
-/// or data inconsistencies.
-/// Represents an error that occurred during a financial transaction operation.
+/// Typed errors for operations on financial transactions. Replaces the
+/// previous single-field string carrier so callers can match on the
+/// specific failure mode and include the offending value.
 ///
-/// This struct encapsulates error information for transaction-related operations,
-/// providing a descriptive message that explains the nature of the error.
+/// # Variants
 ///
+/// - `NotImplemented` — a trait default implementation was invoked on a
+///   concrete type that does not support the operation.
+/// - `UnsupportedOptionType` — the requested PnL / settlement path does
+///   not support the supplied `OptionType` (typically any non-`European`).
+/// - `Other` — catch-all for ad-hoc failures that have not yet earned a
+///   dedicated variant.
 #[derive(Error, Debug)]
-#[error("TransactionError: {message}")]
-pub struct TransactionError {
-    /// The error message
-    pub message: String,
+pub enum TransactionError {
+    /// A trait method lacks an override on the concrete implementer.
+    #[error("{method} not implemented for {type_name}")]
+    NotImplemented {
+        /// Trait method that was invoked without an override (e.g.
+        /// `add_transaction`, `get_transactions`).
+        method: &'static str,
+        /// `std::any::type_name` of the implementer that reached the
+        /// default body.
+        type_name: &'static str,
+    },
+
+    /// A downstream calculation does not support the supplied option type.
+    #[error("unsupported option type in transaction: {option_type:?}")]
+    UnsupportedOptionType {
+        /// The offending `OptionType` passed through the transaction.
+        option_type: OptionType,
+    },
+
+    /// Catch-all variant for ad-hoc transaction errors.
+    #[error("transaction error: {reason}")]
+    Other {
+        /// Human-readable description of the failure.
+        reason: String,
+    },
+}
+
+impl TransactionError {
+    /// Builds a `NotImplemented` error for a trait default that has no
+    /// override on the concrete implementer.
+    ///
+    /// # Errors
+    ///
+    /// This is an error constructor — it always returns the variant.
+    #[cold]
+    #[inline(never)]
+    #[must_use]
+    pub fn not_implemented(method: &'static str, type_name: &'static str) -> Self {
+        TransactionError::NotImplemented { method, type_name }
+    }
+
+    /// Builds an `UnsupportedOptionType` error for a transaction carrying
+    /// an option type the current path does not support.
+    ///
+    /// # Errors
+    ///
+    /// This is an error constructor — it always returns the variant.
+    #[cold]
+    #[inline(never)]
+    #[must_use]
+    pub fn unsupported_option_type(option_type: OptionType) -> Self {
+        TransactionError::UnsupportedOptionType { option_type }
+    }
+
+    /// Builds a catch-all `Other` variant.
+    ///
+    /// # Errors
+    ///
+    /// This is an error constructor — it always returns the variant.
+    #[cold]
+    #[inline(never)]
+    #[must_use]
+    pub fn other(reason: impl Into<String>) -> Self {
+        TransactionError::Other {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_not_implemented_display() {
+        let err = TransactionError::not_implemented("add_transaction", "Position");
+        assert!(err.to_string().contains("add_transaction"));
+        assert!(err.to_string().contains("Position"));
+    }
+
+    #[test]
+    fn test_not_implemented_match_fields() {
+        let err = TransactionError::not_implemented("get_transactions", "Position");
+        match err {
+            TransactionError::NotImplemented { method, type_name } => {
+                assert_eq!(method, "get_transactions");
+                assert_eq!(type_name, "Position");
+            }
+            other => panic!("expected NotImplemented, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_unsupported_option_type_display() {
+        let err = TransactionError::unsupported_option_type(OptionType::American);
+        assert!(err.to_string().contains("American"));
+    }
+
+    #[test]
+    fn test_other_constructor_accepts_str_and_string() {
+        let from_str = TransactionError::other("boom");
+        let from_string = TransactionError::other(String::from("kaboom"));
+        assert!(matches!(from_str, TransactionError::Other { .. }));
+        assert!(matches!(from_string, TransactionError::Other { .. }));
+        assert!(from_str.to_string().contains("boom"));
+        assert!(from_string.to_string().contains("kaboom"));
+    }
 }

--- a/src/model/position.rs
+++ b/src/model/position.rs
@@ -756,9 +756,10 @@ impl TransactionAble for Position {
     /// Always returns a `TransactionError` — this operation is
     /// intentionally unsupported on `Position`.
     fn add_transaction(&mut self, _transaction: Transaction) -> Result<(), TransactionError> {
-        Err(TransactionError {
-            message: "add_transaction not implemented for Position".to_string(),
-        })
+        Err(TransactionError::not_implemented(
+            "add_transaction",
+            "Position",
+        ))
     }
 
     /// See [`Self::add_transaction`] — this method is intentionally
@@ -766,12 +767,13 @@ impl TransactionAble for Position {
     ///
     /// # Errors
     ///
-    /// Always returns a `TransactionError` — this operation is
-    /// intentionally unsupported on `Position`.
+    /// Always returns a `TransactionError::NotImplemented` —
+    /// this operation is intentionally unsupported on `Position`.
     fn get_transactions(&self) -> Result<Vec<Transaction>, TransactionError> {
-        Err(TransactionError {
-            message: "get_transactions not implemented for Position".to_string(),
-        })
+        Err(TransactionError::not_implemented(
+            "get_transactions",
+            "Position",
+        ))
     }
 }
 
@@ -818,10 +820,11 @@ mod tests_transaction_able_default {
         let mut position = make_position();
         let result = position.add_transaction(make_transaction());
         match result {
-            Err(TransactionError { message }) => {
-                assert!(message.contains("add_transaction not implemented"));
+            Err(TransactionError::NotImplemented { method, type_name }) => {
+                assert_eq!(method, "add_transaction");
+                assert_eq!(type_name, "Position");
             }
-            Ok(()) => panic!("expected TransactionError, got Ok"),
+            other => panic!("expected NotImplemented, got {other:?}"),
         }
     }
 
@@ -830,10 +833,11 @@ mod tests_transaction_able_default {
         let position = make_position();
         let result = position.get_transactions();
         match result {
-            Err(TransactionError { message }) => {
-                assert!(message.contains("get_transactions not implemented"));
+            Err(TransactionError::NotImplemented { method, type_name }) => {
+                assert_eq!(method, "get_transactions");
+                assert_eq!(type_name, "Position");
             }
-            Ok(_) => panic!("expected TransactionError, got Ok"),
+            other => panic!("expected NotImplemented, got {other:?}"),
         }
     }
 }

--- a/src/pnl/transaction.rs
+++ b/src/pnl/transaction.rs
@@ -205,9 +205,9 @@ impl Transaction {
     /// A Result containing the PnL with unrealized values or an error
     fn calculate_open_pnl(&self) -> Result<PnL, TransactionError> {
         if self.option_type != OptionType::European {
-            return Err(TransactionError {
-                message: "Unsupported option type in Transaction".to_string(),
-            });
+            return Err(TransactionError::unsupported_option_type(
+                self.option_type.clone(),
+            ));
         }
 
         let realized = match self.side {
@@ -235,9 +235,9 @@ impl Transaction {
     /// A Result containing the PnL with realized values or an error
     fn calculate_closed_pnl(&self) -> Result<PnL, TransactionError> {
         if self.option_type != OptionType::European {
-            return Err(TransactionError {
-                message: "Unsupported option type in Transaction".to_string(),
-            });
+            return Err(TransactionError::unsupported_option_type(
+                self.option_type.clone(),
+            ));
         }
 
         let realized = match self.side {
@@ -965,11 +965,12 @@ mod tests_transaction_status_pnl {
         );
 
         let result = transaction.pnl();
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().message,
-            "Unsupported option type in Transaction"
-        );
+        match result {
+            Err(TransactionError::UnsupportedOptionType { option_type }) => {
+                assert_eq!(option_type, OptionType::American);
+            }
+            other => panic!("expected UnsupportedOptionType, got {other:?}"),
+        }
     }
 
     #[test]
@@ -989,10 +990,11 @@ mod tests_transaction_status_pnl {
         );
 
         let result = transaction.pnl();
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().message,
-            "Unsupported option type in Transaction"
-        );
+        match result {
+            Err(TransactionError::UnsupportedOptionType { option_type }) => {
+                assert_eq!(option_type, OptionType::American);
+            }
+            other => panic!("expected UnsupportedOptionType, got {other:?}"),
+        }
     }
 }

--- a/tests/unit/error/transaction_test.rs
+++ b/tests/unit/error/transaction_test.rs
@@ -1,39 +1,43 @@
+use optionstratlib::OptionType;
 use optionstratlib::error::TransactionError;
 use std::error::Error;
 
 #[test]
-fn test_transaction_error_display() {
-    // Create a new TransactionError with a test message
-    let error = TransactionError {
-        message: "Test error message".to_string(),
-    };
+fn test_transaction_error_not_implemented_display() {
+    let error = TransactionError::not_implemented("add_transaction", "Position");
+    assert_eq!(
+        format!("{error}"),
+        "add_transaction not implemented for Position"
+    );
+}
 
-    // Verify that the Display implementation works correctly
-    assert_eq!(format!("{error}"), "TransactionError: Test error message");
+#[test]
+fn test_transaction_error_unsupported_option_type_display() {
+    let error = TransactionError::unsupported_option_type(OptionType::American);
+    assert!(
+        format!("{error}")
+            .to_lowercase()
+            .contains("unsupported option type")
+    );
+    assert!(format!("{error}").contains("American"));
+}
+
+#[test]
+fn test_transaction_error_other_display() {
+    let error = TransactionError::other("boom");
+    assert_eq!(format!("{error}"), "transaction error: boom");
 }
 
 #[test]
 fn test_transaction_error_debug() {
-    // Create a new TransactionError with a test message
-    let error = TransactionError {
-        message: "Test error message".to_string(),
-    };
-
-    // Verify that the Debug implementation works correctly
-    assert!(format!("{error:?}").contains("Test error message"));
+    let error = TransactionError::not_implemented("get_transactions", "Position");
+    assert!(format!("{error:?}").contains("get_transactions"));
+    assert!(format!("{error:?}").contains("Position"));
 }
 
 #[test]
-fn test_transaction_error_as_error() {
-    // Create a new TransactionError
-    let error = TransactionError {
-        message: "Test error message".to_string(),
-    };
-
-    // Verify that it can be used as a Box<dyn Error>
+fn test_transaction_error_as_error_trait_object() {
+    let error = TransactionError::other("boxed");
     let boxed_error: Box<dyn Error> = Box::new(error);
-    assert_eq!(
-        boxed_error.to_string(),
-        "TransactionError: Test error message"
-    );
+    assert_eq!(boxed_error.to_string(), "transaction error: boxed");
 }


### PR DESCRIPTION
Closes #332.

## Summary

Replaces the single-field `TransactionError { message: String }` with a
proper thiserror enum that captures the three distinct failure modes
seen in the crate:

- `NotImplemented { method, type_name }` — a trait default was invoked
  on a concrete type that does not override it (e.g.
  `TransactionAble::add_transaction` / `get_transactions` on `Position`).
- `UnsupportedOptionType { option_type }` — a transaction carries a
  non-`European` `OptionType` on a path that only supports European
  (used by `Transaction::calculate_{open,closed}_pnl`).
- `Other { reason }` — catch-all for ad-hoc string-backed errors so
  downstream callers that still want a free-form message aren't
  punished.

Helper constructors `not_implemented`, `unsupported_option_type`, and
`other` are marked `#[cold] #[inline(never)] #[must_use]` per
§Error Handling.

Also resolves the concrete acceptance criterion of #332: grep shows
zero public `fn` returns of `Result<_, Box<dyn Error>>` or
`Result<_, String>` in production code (all remaining `Box<dyn Error>`
matches are in doc examples or test fn signatures; the last
String-carrier public error was this one).

## Breaking change

`TransactionError` is a `pub` type re-exported from `prelude`. Anyone
pattern-matching on `TransactionError { message }` now needs to match
on one of `NotImplemented { method, type_name }`,
`UnsupportedOptionType { option_type }`, or `Other { reason }`. Both
in-tree pattern-matching tests are updated in this PR.

## Test plan

- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check`
- [x] `cargo build --release`
- [x] `cargo test --all-features --workspace` — 3733 lib (4 new) +
      418 integration (2 new) + 12 property tests green.
- [x] Pattern-match tests in `model/position.rs` and
      `pnl/transaction.rs` plus dedicated `tests/unit/error/transaction_test.rs`
      exercise every variant.