### PR TITLE
M4 #333: Eliminate Box<dyn Error> and String errors from public surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ use positive::{pos_or_panic,Positive};
 use rust_decimal_macros::dec;
 use optionstratlib::greeks::Greeks;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), optionstratlib::error::Error> {
     // Create a European call option
     let option = Options::new(
         OptionType::European,
@@ -787,7 +787,7 @@ use optionstratlib::visualization::Graph;
 use rust_decimal_macros::dec;
 use std::error::Error;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), optionstratlib::error::Error> {
     use optionstratlib::pricing::Profit;
 let underlying_price = Positive::HUNDRED;
 
@@ -837,7 +837,7 @@ let underlying_price = Positive::HUNDRED;
 ```rust
 use optionstratlib::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), optionstratlib::error::Error> {
     // Create an option for implied volatility calculation
     let mut option = Options::new(
         OptionType::European,
@@ -867,7 +867,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```rust
 use optionstratlib::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), optionstratlib::error::Error> {
     // Define common parameters
     let underlying_symbol = "DAX".to_string();
     let underlying_price = pos_or_panic!(24000.0);

--- a/examples/examples_chain/src/bin/creator.rs
+++ b/examples/examples_chain/src/bin/creator.rs
@@ -19,9 +19,12 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     info!("{}", option_chain);
 
     let underlying_price = option_chain.underlying_price;
-    let expiration_date = option_chain
-        .get_expiration()
-        .ok_or("No expiration date found")?;
+    let expiration_date =
+        option_chain
+            .get_expiration()
+            .ok_or(optionstratlib::error::ChainError::AtmNotFound {
+                symbol: option_chain.symbol.clone(),
+            })?;
     let symbol = option_chain.symbol.clone();
 
     info!("Underlying Price: {}", underlying_price);

--- a/examples/examples_chain/src/bin/creator.rs
+++ b/examples/examples_chain/src/bin/creator.rs
@@ -19,12 +19,12 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     info!("{}", option_chain);
 
     let underlying_price = option_chain.underlying_price;
-    let expiration_date =
-        option_chain
-            .get_expiration()
-            .ok_or(optionstratlib::error::ChainError::AtmNotFound {
-                symbol: option_chain.symbol.clone(),
-            })?;
+    let expiration_date = option_chain.get_expiration().ok_or_else(|| {
+        optionstratlib::error::ChainError::invalid_parameters(
+            "expiration_date",
+            "missing on option chain",
+        )
+    })?;
     let symbol = option_chain.symbol.clone();
 
     info!("Underlying Price: {}", underlying_price);

--- a/examples/examples_strategies/src/bin/strategy_iron_butterfly.rs
+++ b/examples/examples_strategies/src/bin/strategy_iron_butterfly.rs
@@ -24,7 +24,9 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.96),   // close_fee
     )?;
     if !strategy.validate() {
-        return Err("Invalid strategy".into());
+        return Err(optionstratlib::error::Error::EmptyCollection {
+            context: "iron_butterfly_validation",
+        });
     }
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];
 

--- a/examples/examples_strategies/src/bin/strategy_iron_condor.rs
+++ b/examples/examples_strategies/src/bin/strategy_iron_condor.rs
@@ -25,7 +25,9 @@ fn main() -> Result<(), Error> {
         pos_or_panic!(0.1),  // close_fee
     )?;
     if !strategy.validate() {
-        return Err("Invalid strategy".into());
+        return Err(optionstratlib::error::Error::EmptyCollection {
+            context: "iron_condor_validation",
+        });
     }
 
     let range = strategy.break_even_points[1] - strategy.break_even_points[0];

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -2815,7 +2815,7 @@ impl OptionChain {
     pub fn get_optiondata_with_strike(&self, price: &Positive) -> Result<&OptionData, ChainError> {
         // Check for empty option chain
         if self.options.is_empty() {
-            return Err(ChainError::EmptyChainAtm {
+            return Err(ChainError::EmptyChain {
                 symbol: self.symbol.clone(),
             });
         }
@@ -11951,10 +11951,14 @@ mod tests_get_strikes_and_optiondata {
         assert!(result.is_err(), "Should return error for empty chain");
 
         let error = result.unwrap_err();
+        assert!(
+            matches!(error, ChainError::EmptyChain { ref symbol } if symbol == "EMPTY"),
+            "Should return ChainError::EmptyChain for EMPTY symbol, got: {error:?}"
+        );
         let error_msg = format!("{error}");
         assert!(
-            error_msg.contains("empty option chain"),
-            "Error should mention empty chain"
+            error_msg.contains("option chain is empty"),
+            "Error should mention empty chain, got: {error_msg}"
         );
         assert!(
             error_msg.contains("EMPTY"),

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -328,7 +328,7 @@ impl OptionChain {
     /// # Examples
     ///
     /// ```
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), optionstratlib::error::Error> {
     /// use rust_decimal_macros::dec;
     /// use optionstratlib::chains::utils::{OptionChainBuildParams, OptionDataPriceParams};
     /// use positive::{pos_or_panic, spos, Positive};
@@ -909,11 +909,9 @@ impl OptionChain {
     pub fn atm_option_data(&self) -> Result<&OptionData, ChainError> {
         // Check for empty option chain
         if self.options.is_empty() {
-            return Err(format!(
-                "Cannot find ATM OptionData for empty option chain: {}",
-                self.symbol
-            )
-            .into());
+            return Err(ChainError::EmptyChainAtm {
+                symbol: self.symbol.clone(),
+            });
         }
 
         // First check for exact match
@@ -936,11 +934,9 @@ impl OptionChain {
 
         match option_data {
             Some(opt) => Ok(opt),
-            None => Err(format!(
-                "Failed to find ATM OptionData for option chain: {}",
-                self.symbol
-            )
-            .into()),
+            None => Err(ChainError::AtmNotFound {
+                symbol: self.symbol.clone(),
+            }),
         }
     }
 
@@ -1185,7 +1181,9 @@ impl OptionChain {
             let record = result?;
             debug!("To CSV: {:?}", record);
             let mut option_data = OptionData {
-                strike_price: record[0].parse()?,
+                strike_price: record[0].parse::<Positive>().map_err(|e| {
+                    ChainError::invalid_strike(record[0].parse::<f64>().unwrap_or(f64::NAN), &e)
+                })?,
                 call_bid: parse(&record[1]),
                 call_ask: parse(&record[2]),
                 put_bid: parse(&record[3]),
@@ -2817,11 +2815,9 @@ impl OptionChain {
     pub fn get_optiondata_with_strike(&self, price: &Positive) -> Result<&OptionData, ChainError> {
         // Check for empty option chain
         if self.options.is_empty() {
-            return Err(format!(
-                "Cannot find option data for empty option chain: {}",
-                self.symbol
-            )
-            .into());
+            return Err(ChainError::EmptyChainAtm {
+                symbol: self.symbol.clone(),
+            });
         }
 
         // Find the option with strike price closest to the price parameter
@@ -2835,11 +2831,7 @@ impl OptionChain {
 
         match option_data {
             Some(opt) => Ok(opt),
-            None => Err(format!(
-                "Failed to find option data for price {} in chain: {}",
-                price, self.symbol
-            )
-            .into()),
+            None => Err(ChainError::StrikeNotFound { strike: *price }),
         }
     }
 
@@ -2943,17 +2935,16 @@ impl RNDAnalysis for OptionChain {
 
         // Step 1: Validate parameters
         if h == Positive::ZERO {
-            return Err("Derivative tolerance must be greater than zero"
-                .to_string()
-                .into());
+            return Err(ChainError::invalid_parameters(
+                "derivative_tolerance",
+                "must be greater than zero",
+            ));
         }
 
         // Step 2: Get all available strikes
         let strikes: Vec<Positive> = self.options.iter().map(|opt| opt.strike_price).collect();
         if strikes.is_empty() {
-            return Err("No strikes available for RND calculation"
-                .to_string()
-                .into());
+            return Err(ChainError::EmptyDensities);
         }
 
         // Calculate minimum strike interval
@@ -2961,7 +2952,12 @@ impl RNDAnalysis for OptionChain {
             .windows(2)
             .map(|w| w[1] - w[0])
             .min()
-            .ok_or("Cannot determine strike interval")?;
+            .ok_or_else(|| {
+                ChainError::invalid_parameters(
+                    "strike_interval",
+                    "cannot determine minimum strike interval",
+                )
+            })?;
 
         if h < min_interval.to_dec() {
             h = min_interval.to_dec();
@@ -2970,7 +2966,12 @@ impl RNDAnalysis for OptionChain {
         // Step 3: Calculate time to expiry
         let expiry_date = NaiveDate::parse_from_str(&self.expiration_date, "%Y-%m-%d")?
             .and_hms_opt(23, 59, 59)
-            .ok_or("Invalid expiry date time")?;
+            .ok_or_else(|| {
+                ChainError::invalid_parameters(
+                    "expiration_date",
+                    "invalid expiration date/time components",
+                )
+            })?;
 
         let now = Utc::now().naive_utc();
         let time_to_expiry =
@@ -3031,7 +3032,7 @@ impl RNDAnalysis for OptionChain {
 
         // Step 6: Validate and normalize densities
         if densities.is_empty() {
-            return Err("Failed to calculate valid densities".to_string().into());
+            return Err(ChainError::EmptyDensities);
         }
 
         let total: Decimal = densities.values().sum();
@@ -3070,7 +3071,7 @@ impl RNDAnalysis for OptionChain {
         }
 
         if skew.is_empty() {
-            return Err("No valid data for skew calculation".to_string().into());
+            return Err(ChainError::EmptySkewData);
         }
 
         Ok(skew)
@@ -7471,7 +7472,7 @@ mod rnd_analysis_tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Derivative tolerance must be greater than zero")
+                    .contains("derivative_tolerance")
             );
         }
 
@@ -7489,7 +7490,7 @@ mod rnd_analysis_tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Derivative tolerance must be greater than zero")
+                    .contains("derivative_tolerance")
             );
         }
 
@@ -7556,7 +7557,7 @@ mod rnd_analysis_tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Cannot find ATM OptionData for empty option chain: TEST")
+                    .contains("cannot find ATM option for empty option chain: TEST")
             );
         }
 

--- a/src/chains/mod.rs
+++ b/src/chains/mod.rs
@@ -21,7 +21,7 @@
 //! ## Example Usage
 //!
 //! ```rust
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal::Decimal;
 //! use rust_decimal_macros::dec;
 //! use optionstratlib::chains::OptionChain;
@@ -116,7 +116,7 @@
 //! ## Usage Example
 //!
 //! ```rust
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal_macros::dec;
 //! use tracing::info;
 //! use optionstratlib::chains::{RNDParameters, RNDAnalysis};

--- a/src/chains/options.rs
+++ b/src/chains/options.rs
@@ -93,7 +93,7 @@ impl OptionsInStrike {
     ///
     /// # Returns
     ///
-    /// * `Result<DeltasInStrike, Box<dyn Error>>` - A Result containing delta values for all
+    /// * `Result<DeltasInStrike, ChainError>` - A Result containing delta values for all
     ///   four option positions if successful, or an error if any delta calculation fails.
     ///
     /// # Errors

--- a/src/chains/rnd.rs
+++ b/src/chains/rnd.rs
@@ -32,7 +32,7 @@
 //! ## Usage Example
 //!
 //! ```rust
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal::Decimal;
 //! use rust_decimal_macros::dec;
 //! use tracing::info;
@@ -601,7 +601,7 @@ mod tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Failed to calculate valid densities")
+                    .contains("failed to calculate any valid risk-neutral density value")
             );
         }
 
@@ -616,7 +616,7 @@ mod tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Derivative tolerance must be greater than zero")
+                    .contains("derivative_tolerance")
             );
         }
 
@@ -634,7 +634,7 @@ mod tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Derivative tolerance must be greater than zero")
+                    .contains("derivative_tolerance")
             );
         }
 
@@ -654,7 +654,7 @@ mod tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Failed to calculate valid densities")
+                    .contains("failed to calculate any valid risk-neutral density value")
             );
         }
     }
@@ -687,7 +687,7 @@ mod tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Cannot find ATM OptionData for empty option chain: TEST")
+                    .contains("cannot find ATM option for empty option chain: TEST")
             );
         }
 
@@ -767,7 +767,7 @@ mod tests {
                 rnd_result
                     .unwrap_err()
                     .to_string()
-                    .contains("Failed to calculate valid densities")
+                    .contains("failed to calculate any valid risk-neutral density value")
             );
         }
 
@@ -824,7 +824,7 @@ mod tests {
                 rnd_result
                     .unwrap_err()
                     .to_string()
-                    .contains("Failed to calculate valid densities")
+                    .contains("failed to calculate any valid risk-neutral density value")
             );
         }
     }
@@ -1001,7 +1001,7 @@ mod additional_tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Failed to calculate valid densities")
+                    .contains("failed to calculate any valid risk-neutral density value")
             );
         }
 
@@ -1020,7 +1020,7 @@ mod additional_tests {
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Failed to calculate valid densities")
+                    .contains("failed to calculate any valid risk-neutral density value")
             );
         }
 
@@ -1048,7 +1048,7 @@ mod additional_tests {
                     result
                         .unwrap_err()
                         .to_string()
-                        .contains("Failed to calculate valid densities")
+                        .contains("failed to calculate any valid risk-neutral density value")
                 );
             }
         }

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -2507,9 +2507,10 @@ mod tests_extended {
     #[test]
     fn test_construct_parametric_invalid_function() {
         let f = |_t: Decimal| -> Result<Point2D, ChainError> {
-            Err(ChainError::DynError {
-                message: "Function evaluation failed".to_string(),
-            })
+            Err(ChainError::invalid_parameters(
+                "parametric_f",
+                "Function evaluation failed",
+            ))
         };
         let params = ConstructionParams::D2 {
             t_start: Decimal::ZERO,
@@ -2535,13 +2536,15 @@ mod tests_extended {
     #[test]
     fn test_segment_not_found_error() {
         let segment: Option<Point2D> = None;
-        let result: Result<Point2D, CurveError> = segment.ok_or_else(|| CurveError::StdError {
-            reason: "Could not find valid segment for interpolation".to_string(),
+        let result: Result<Point2D, CurveError> = segment.ok_or_else(|| {
+            CurveError::ConstructionError(
+                "Could not find valid segment for interpolation".to_string(),
+            )
         });
         assert!(result.is_err());
         let error = result.unwrap_err();
         match error {
-            CurveError::StdError { reason } => {
+            CurveError::ConstructionError(reason) => {
                 assert_eq!(reason, "Could not find valid segment for interpolation");
             }
             _ => {
@@ -3538,7 +3541,12 @@ mod tests_curve_len_and_geometric {
     fn test_construct_method_error() {
         // Test ConstructionMethod errors (lines 168-175, 179, 181, 189)
         let result = Curve::construct(ConstructionMethod::Parametric {
-            f: Box::new(|_| Err("Test error".into())),
+            f: Box::new(|_| {
+                Err(crate::error::ChainError::invalid_parameters(
+                    "parametric_f",
+                    "Test error",
+                ))
+            }),
             params: ConstructionParams::D2 {
                 t_start: dec!(0.0),
                 t_end: dec!(1.0),

--- a/src/curves/visualization/mod.rs
+++ b/src/curves/visualization/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Usage Examples
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! // Plot a single curve
 //! use std::fs;
 //! use std::path::{Path, PathBuf};

--- a/src/curves/visualization/plotters.rs
+++ b/src/curves/visualization/plotters.rs
@@ -10,7 +10,7 @@
 //!
 //! ## Usage Examples
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! // Plot a single curve
 //! use std::fs;
 //! use std::path::{Path, PathBuf};
@@ -409,16 +409,18 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_map_err_to_std_error() {
+    fn test_map_err_to_render_error() {
         let result: Result<(), CurveError> =
-            Err(std::io::Error::other("Test error")).map_err(|e| CurveError::StdError {
+            Err(std::io::Error::other("Test error")).map_err(|e| CurveError::RenderError {
+                backend: "plotters",
                 reason: e.to_string(),
             });
 
         assert!(result.is_err());
         let error = result.unwrap_err();
         match error {
-            CurveError::StdError { reason } => {
+            CurveError::RenderError { backend, reason } => {
+                assert_eq!(backend, "plotters");
                 assert_eq!(reason, "Test error");
             }
             _ => panic!("Unexpected error type"),
@@ -440,13 +442,13 @@ mod tests_extended {
 
     #[test]
     fn test_draw_series_error() {
-        let result: Result<(), CurveError> =
-            Err("Draw error".to_string()).map_err(|e| CurveError::StdError { reason: e });
-
-        assert!(result.is_err());
-        let error = result.unwrap_err();
+        let error = CurveError::RenderError {
+            backend: "plotters",
+            reason: "Draw error".to_string(),
+        };
         match error {
-            CurveError::StdError { reason } => {
+            CurveError::RenderError { backend, reason } => {
+                assert_eq!(backend, "plotters");
                 assert_eq!(reason, "Draw error");
             }
             _ => panic!("Unexpected error type"),

--- a/src/error/chains.rs
+++ b/src/error/chains.rs
@@ -85,8 +85,10 @@ use thiserror::Error;
 /// * `StrategyError` - Errors related to option trading strategies, including issues
 ///   with leg validation or invalid combinations of options.
 ///
+/// * `EmptyChain` - The option chain for the given symbol is empty (generic empty-chain
+///   condition, independent of ATM selection).
 /// * `EmptyChainAtm` - The option chain for the given symbol is empty and has no ATM option
-///   to select.
+///   to select. Reserved for ATM-selection paths; prefer `EmptyChain` for non-ATM lookups.
 /// * `AtmNotFound` - The option chain has options but none could be selected as the ATM
 ///   contract for the given symbol.
 /// * `EmptyDensities` - No valid risk-neutral densities could be produced.
@@ -133,8 +135,16 @@ pub enum ChainError {
     #[error("Strategy error: {0}")]
     StrategyError(StrategyErrorKind),
 
+    /// The option chain for the given symbol is empty. Generic empty-chain
+    /// condition, emitted by non-ATM lookups (e.g. strike-based selection).
+    #[error("option chain is empty: {symbol}")]
+    EmptyChain {
+        /// Ticker symbol of the chain that is empty.
+        symbol: String,
+    },
+
     /// The option chain for the given symbol is empty and has no ATM option
-    /// to select.
+    /// to select. Reserved for ATM-selection paths.
     #[error("cannot find ATM option for empty option chain: {symbol}")]
     EmptyChainAtm {
         /// Ticker symbol of the chain that is empty.

--- a/src/error/chains.rs
+++ b/src/error/chains.rs
@@ -46,15 +46,20 @@
 //!
 //! ## Conversions
 //!
-//! The module implements various conversion traits:
+//! The module implements the following conversion traits, all typed:
 //!
-//! * `From<io::Error>` - Converts IO errors to chain errors
-//! * `From<String>` - Converts string messages to price calculation errors
+//! * `From<io::Error>` via `#[from]` (to `FileErrorKind::IOError`)
+//! * `From<csv::Error>` and `From<serde_json::Error>` to `FileErrorKind::ParseError`
+//! * `From<DecimalError>`, `From<GreeksError>`, `From<OptionsError>` to the
+//!   appropriate `OptionDataErrorKind` variant
+//! * `From<CurveError>`, `From<VolatilityError>`, `From<SimulationError>`,
+//!   `From<ExpirationDateError>` with typed wrapping (see variants below)
 //!
-//! All error types implement `std::error::Error` and `std::fmt::Display` for proper error
-//! handling and formatting.
+//! All error types implement `std::error::Error` and `std::fmt::Display` for proper
+//! error handling and formatting.
 
 use crate::error::{DecimalError, GreeksError, OptionsError};
+use positive::Positive;
 use std::io;
 use thiserror::Error;
 
@@ -80,8 +85,18 @@ use thiserror::Error;
 /// * `StrategyError` - Errors related to option trading strategies, including issues
 ///   with leg validation or invalid combinations of options.
 ///
-/// * `DynError` - A generic error variant for capturing dynamic error messages that
-///   don't fit into the other specific categories.
+/// * `EmptyChainAtm` - The option chain for the given symbol is empty and has no ATM option
+///   to select.
+/// * `AtmNotFound` - The option chain has options but none could be selected as the ATM
+///   contract for the given symbol.
+/// * `EmptyDensities` - No valid risk-neutral densities could be produced.
+/// * `EmptySkewData` - No strikes produced valid data points to build a volatility skew.
+/// * `StrikeNotFound` - A requested strike was not present in the current chain.
+/// * `Curve` - A curve-layer error surfaced during chain construction or analytics.
+/// * `Volatility` - A volatility-layer error surfaced during chain construction or analytics.
+/// * `Simulation` - A simulation-layer error surfaced during chain construction.
+/// * `ExpirationDate` - Expiration-date conversion error.
+/// * `PositiveError` - Positive value errors
 ///
 /// # Usage
 ///
@@ -118,15 +133,52 @@ pub enum ChainError {
     #[error("Strategy error: {0}")]
     StrategyError(StrategyErrorKind),
 
-    /// Dynamic error with custom message
-    ///
-    /// This variant provides flexibility for error conditions that don't
-    /// fit into the other specific categories.
-    #[error("{message}")]
-    DynError {
-        /// A descriptive message explaining the error
-        message: String,
+    /// The option chain for the given symbol is empty and has no ATM option
+    /// to select.
+    #[error("cannot find ATM option for empty option chain: {symbol}")]
+    EmptyChainAtm {
+        /// Ticker symbol of the chain that is empty.
+        symbol: String,
     },
+
+    /// The option chain has options but none could be selected as the ATM
+    /// contract for the given symbol.
+    #[error("failed to find ATM option for option chain: {symbol}")]
+    AtmNotFound {
+        /// Ticker symbol of the chain for which no ATM contract was found.
+        symbol: String,
+    },
+
+    /// No valid risk-neutral densities could be produced.
+    #[error("failed to calculate any valid risk-neutral density value")]
+    EmptyDensities,
+
+    /// No strikes produced valid data points to build a volatility skew.
+    #[error("no valid data points available for volatility skew calculation")]
+    EmptySkewData,
+
+    /// A requested strike was not present in the current chain.
+    #[error("strike {strike} not found in option chain")]
+    StrikeNotFound {
+        /// The strike price that was requested but missing.
+        strike: Positive,
+    },
+
+    /// A curve-layer error surfaced during chain construction or analytics.
+    #[error(transparent)]
+    Curve(Box<crate::error::CurveError>),
+
+    /// A volatility-layer error surfaced during chain construction or analytics.
+    #[error(transparent)]
+    Volatility(Box<crate::error::VolatilityError>),
+
+    /// A simulation-layer error surfaced during chain construction.
+    #[error(transparent)]
+    Simulation(Box<crate::error::SimulationError>),
+
+    /// Expiration-date conversion error.
+    #[error(transparent)]
+    ExpirationDate(#[from] expiration_date::error::ExpirationDateError),
 
     /// Positive value errors
     #[error(transparent)]
@@ -564,29 +616,10 @@ impl ChainError {
     }
 }
 
-impl From<String> for ChainError {
-    fn from(msg: String) -> Self {
-        ChainError::OptionDataError(OptionDataErrorKind::PriceCalculationError(msg))
-    }
-}
-
-impl From<&str> for ChainError {
-    fn from(msg: &str) -> Self {
-        ChainError::OptionDataError(OptionDataErrorKind::PriceCalculationError(msg.to_string()))
-    }
-}
-
 impl From<GreeksError> for ChainError {
+    #[inline]
     fn from(err: GreeksError) -> Self {
         ChainError::OptionDataError(OptionDataErrorKind::Other(err.to_string()))
-    }
-}
-
-impl From<Box<dyn std::error::Error>> for ChainError {
-    fn from(error: Box<dyn std::error::Error>) -> Self {
-        ChainError::DynError {
-            message: error.to_string(),
-        }
     }
 }
 
@@ -623,30 +656,23 @@ impl From<std::num::ParseIntError> for ChainError {
 }
 
 impl From<crate::error::CurveError> for ChainError {
+    #[inline]
     fn from(err: crate::error::CurveError) -> Self {
-        ChainError::OptionDataError(OptionDataErrorKind::Other(err.to_string()))
-    }
-}
-
-impl From<expiration_date::error::ExpirationDateError> for ChainError {
-    fn from(err: expiration_date::error::ExpirationDateError) -> Self {
-        ChainError::OptionDataError(OptionDataErrorKind::PriceCalculationError(err.to_string()))
+        ChainError::Curve(Box::new(err))
     }
 }
 
 impl From<crate::error::SimulationError> for ChainError {
+    #[inline]
     fn from(err: crate::error::SimulationError) -> Self {
-        ChainError::DynError {
-            message: format!("simulation error: {err}"),
-        }
+        ChainError::Simulation(Box::new(err))
     }
 }
 
 impl From<crate::error::VolatilityError> for ChainError {
+    #[inline]
     fn from(err: crate::error::VolatilityError) -> Self {
-        ChainError::DynError {
-            message: format!("volatility error: {err}"),
-        }
+        ChainError::Volatility(Box::new(err))
     }
 }
 
@@ -770,13 +796,6 @@ mod tests_extended {
 
     #[test]
     fn test_error_conversions() {
-        // Test de String a ChainError
-        let string_error: ChainError = "test error".to_string().into();
-        assert!(matches!(
-            string_error,
-            ChainError::OptionDataError(OptionDataErrorKind::PriceCalculationError(_))
-        ));
-
         // Test de io::Error a ChainError
         let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let chain_error = ChainError::from(io_error);
@@ -784,11 +803,6 @@ mod tests_extended {
             chain_error,
             ChainError::FileError(FileErrorKind::IOError(_))
         ));
-
-        let std_error: Box<dyn std::error::Error> =
-            Box::new(std::io::Error::other("dynamic error"));
-        let chain_error = ChainError::from(std_error);
-        assert!(matches!(chain_error, ChainError::DynError { .. }));
     }
 
     #[test]
@@ -825,11 +839,34 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_chain_error_dyn_error() {
-        let error = ChainError::DynError {
-            message: "Dynamic error occurred".to_string(),
+    fn test_chain_error_empty_chain_atm() {
+        let error = ChainError::EmptyChainAtm {
+            symbol: "SPX".to_string(),
         };
-        assert_eq!(format!("{error}"), "Dynamic error occurred");
+        assert_eq!(
+            format!("{error}"),
+            "cannot find ATM option for empty option chain: SPX"
+        );
+    }
+
+    #[test]
+    fn test_chain_error_atm_not_found() {
+        let error = ChainError::AtmNotFound {
+            symbol: "SPX".to_string(),
+        };
+        assert_eq!(
+            format!("{error}"),
+            "failed to find ATM option for option chain: SPX"
+        );
+    }
+
+    #[test]
+    fn test_chain_error_empty_densities() {
+        let error = ChainError::EmptyDensities;
+        assert_eq!(
+            format!("{error}"),
+            "failed to calculate any valid risk-neutral density value"
+        );
     }
 
     #[test]

--- a/src/error/csv.rs
+++ b/src/error/csv.rs
@@ -99,12 +99,17 @@ pub enum OhlcvError {
         reason: String,
     },
 
-    /// General error
-    ///
-    /// This variant is used for errors that don't fit into other categories.
-    #[error("Error: {reason}")]
-    OtherError {
-        /// Reason for the error
+    /// A required column was missing from the CSV payload.
+    #[error("required column `{column}` is missing")]
+    MissingColumn {
+        /// Name of the column that was expected but not found.
+        column: &'static str,
+    },
+
+    /// Row-level parsing failure, with a descriptive reason bound to the row.
+    #[error("failed to parse row: {reason}")]
+    RowParsing {
+        /// Human-readable description of why the row could not be parsed.
         reason: String,
     },
 }

--- a/src/error/csv.rs
+++ b/src/error/csv.rs
@@ -112,6 +112,21 @@ pub enum OhlcvError {
         /// Human-readable description of why the row could not be parsed.
         reason: String,
     },
+
+    /// No file with the expected extension was found inside the ZIP archive.
+    #[error("no file with extension `{extension}` found in ZIP archive")]
+    MissingZipEntry {
+        /// Extension that was expected inside the ZIP payload (e.g. `"csv"`).
+        extension: &'static str,
+    },
+
+    /// An asynchronous background task (`tokio::task::spawn_blocking`) failed to
+    /// complete — typically a panic or cancellation of the worker thread.
+    #[error("async task failed: {reason}")]
+    AsyncTask {
+        /// Human-readable description of the underlying join failure.
+        reason: String,
+    },
 }
 
 impl From<std::io::Error> for OhlcvError {

--- a/src/error/curves.rs
+++ b/src/error/curves.rs
@@ -106,10 +106,14 @@ pub enum CurveError {
         OperationErrorKind,
     ),
 
-    /// Standard error with additional context
-    #[error("Error: {reason}")]
-    StdError {
-        /// Detailed explanation of the error
+    /// A rendering operation failed. Preserves the backend discriminator so
+    /// callers can distinguish plotters output paths from other backends
+    /// without resorting to a `String` catch-all.
+    #[error("rendering failed ({backend}): {reason}")]
+    RenderError {
+        /// Identifier of the rendering backend that failed (e.g. `"plotters"`).
+        backend: &'static str,
+        /// Detailed, human-readable reason for the failure.
         reason: String,
     },
 
@@ -292,53 +296,6 @@ impl From<GraphError> for CurveError {
     }
 }
 
-impl From<Box<dyn std::error::Error>> for CurveError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        CurveError::StdError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-/// Implements the `From` trait to enable seamless conversion from a boxed `dyn Error`
-/// into a `CurvesError`. This is particularly useful for integrating standard error
-/// handling mechanisms with the custom `CurvesError` type.
-///
-/// # Behavior
-///
-/// When constructing a `CurveError` from a `Box<dyn std::error::Error>`, the `StdError` variant
-/// is utilized. The boxed error is unwrapped, and its string representation
-/// (via `to_string`) is used to populate the `reason` field of the `StdError` variant.
-///
-/// # Parameters
-///
-/// - `err`: A boxed standard error (`Box<dyn std::error::Error>`). Represents the error to be
-///   wrapped within a `CurveError` variant.
-///
-/// # Returns
-///
-/// - `CurvesError::StdError`: The custom error type with a detailed `reason`
-///   string derived from the provided error.
-///
-/// # Usage
-///
-/// This implementation is commonly employed when you need to bridge standard Rust
-/// errors with the specific error handling system provided by the `curves` module.
-/// It facilitates scenarios where standard error contexts need to be preserved
-/// in a flexible, string-based `reason` for debugging or logging purposes.
-///
-/// # Example Scenario
-///
-/// Instead of handling standard errors separately, you can propagate them as `CurvesError`
-/// within the larger error system of the `curves` module, ensuring consistent error
-/// wrapping and management.
-///
-/// # Notes
-///
-/// - This implementation assumes that all input errors (`Box<dyn std::error::Error>`) are stringifiable
-///   using the `to_string()` method.
-/// - This conversion is particularly useful for libraries integrating generalized errors
-///   (e.g., I/O errors, or third-party library errors) into a standardized error system.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -351,10 +308,14 @@ mod tests {
         };
         assert_eq!(error.to_string(), "Error: Invalid coordinates");
 
-        let error = CurveError::StdError {
-            reason: "Standard error".to_string(),
+        let error = CurveError::RenderError {
+            backend: "plotters",
+            reason: "rendering failed".to_string(),
         };
-        assert_eq!(error.to_string(), "Error: Standard error");
+        assert_eq!(
+            error.to_string(),
+            "rendering failed (plotters): rendering failed"
+        );
 
         let error = CurveError::operation_not_supported("calculate", "Strategy");
         assert_eq!(
@@ -403,11 +364,16 @@ mod tests {
     }
 
     #[test]
-    fn test_from_box_dyn_error() {
-        let boxed_error: Box<dyn std::error::Error> = Box::new(std::io::Error::other("io error"));
-        let curves_error = CurveError::from(boxed_error);
-        match curves_error {
-            CurveError::StdError { reason } => assert_eq!(reason, "io error"),
+    fn test_render_error_constructor() {
+        let error = CurveError::RenderError {
+            backend: "plotters",
+            reason: "Draw error".to_string(),
+        };
+        match error {
+            CurveError::RenderError { backend, reason } => {
+                assert_eq!(backend, "plotters");
+                assert_eq!(reason, "Draw error");
+            }
             _ => panic!("Wrong error variant"),
         }
     }
@@ -432,7 +398,8 @@ mod tests {
         };
         assert!(format!("{error:?}").contains("test debug"));
 
-        let error = CurveError::StdError {
+        let error = CurveError::RenderError {
+            backend: "plotters",
             reason: "test debug".to_string(),
         };
         assert!(format!("{error:?}").contains("test debug"));

--- a/src/error/decimal.rs
+++ b/src/error/decimal.rs
@@ -125,9 +125,9 @@ pub enum DecimalError {
         reason: String,
     },
 
-    /// Catch-all error for other decimal errors
-    #[error("Other decimal error: {0}")]
-    Other(String),
+    /// Expiration-date conversion error surfaced during decimal operations.
+    #[error(transparent)]
+    ExpirationDate(expiration_date::error::ExpirationDateError),
 }
 
 /// A specialized `Result` type for decimal calculation operations.
@@ -287,15 +287,10 @@ impl DecimalError {
     }
 }
 
-impl From<&str> for DecimalError {
-    fn from(s: &str) -> Self {
-        DecimalError::Other(s.to_string())
-    }
-}
-
 impl From<expiration_date::error::ExpirationDateError> for DecimalError {
+    #[inline]
     fn from(err: expiration_date::error::ExpirationDateError) -> Self {
-        DecimalError::Other(err.to_string())
+        DecimalError::ExpirationDate(err)
     }
 }
 

--- a/src/error/graph.rs
+++ b/src/error/graph.rs
@@ -38,9 +38,3 @@ impl From<SurfaceError> for GraphError {
         GraphError::Surface(err)
     }
 }
-
-impl From<Box<dyn std::error::Error>> for GraphError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        GraphError::Render(err.to_string())
-    }
-}

--- a/src/error/greeks.rs
+++ b/src/error/greeks.rs
@@ -35,6 +35,7 @@
 
 use crate::error::VolatilityError;
 use crate::error::decimal;
+use expiration_date::error::ExpirationDateError;
 use positive::Positive;
 use thiserror::Error;
 
@@ -64,14 +65,79 @@ pub enum GreeksError {
     #[error("Greek calculation error: {0}")]
     CalculationError(CalculationErrorKind),
 
-    /// Errors originating from standard Rust error types, wrapped as strings
-    /// for consistent error handling.
-    #[error("Standard error: {0}")]
-    StdError(String),
+    /// Errors specific to delta-neutrality calculations and adjustments.
+    #[error("Delta neutrality error: {0}")]
+    DeltaNeutrality(DeltaNeutralityErrorKind),
+
+    /// Expiration-date conversion error surfaced during Greeks calculations.
+    #[error(transparent)]
+    ExpirationDate(#[from] ExpirationDateError),
+
+    /// Pricing-layer error surfaced during Greeks calculations (e.g. numerical
+    /// Greeks falling back to a pricing engine).
+    #[error(transparent)]
+    Pricing(Box<crate::error::PricingError>),
 
     /// Positive value errors
     #[error(transparent)]
     PositiveError(#[from] positive::PositiveError),
+}
+
+impl From<crate::error::PricingError> for GreeksError {
+    #[inline]
+    fn from(err: crate::error::PricingError) -> Self {
+        GreeksError::Pricing(Box::new(err))
+    }
+}
+
+/// Errors raised by delta-neutrality sizing and adjustment helpers.
+///
+/// These variants replace the former `GreeksError::StdError(String)` catch-all for
+/// the `greeks::calculate_delta_neutral_sizes` and strategy delta-neutrality flows,
+/// providing a precise, typed description of why a neutral size could not be
+/// produced.
+#[derive(Error, Debug)]
+pub enum DeltaNeutralityErrorKind {
+    /// One (or both) of the input deltas is zero, which makes neutrality impossible.
+    #[error("deltas cannot be zero for delta neutrality")]
+    ZeroDelta,
+
+    /// The two deltas are equal, so their linear combination cannot produce a zero delta.
+    #[error("deltas cannot be equal for delta neutrality")]
+    EqualDeltas,
+
+    /// The two deltas share the same sign, so they cannot offset each other.
+    #[error("deltas must have opposite signs for delta neutrality")]
+    SameSignDeltas,
+
+    /// A candidate sizing would require negative contract counts.
+    #[error("delta neutrality would require negative position sizes")]
+    NegativePositionSize,
+
+    /// The delta residual after sizing exceeds the neutrality threshold.
+    #[error("could not achieve delta neutrality: residual above threshold")]
+    NotAchievable,
+
+    /// The sum of the calculated sizes does not match the requested total size.
+    #[error("calculated sizes {calculated} do not match requested total size {expected}")]
+    SizeMismatch {
+        /// Sum of the sizes produced by the neutrality solver.
+        calculated: Positive,
+        /// Total size originally requested by the caller.
+        expected: Positive,
+    },
+
+    /// The strategy has no options to evaluate, so delta neutrality is undefined.
+    #[error("no options found for delta-neutral calculation")]
+    EmptyOptions,
+
+    /// An option's delta-per-contract is zero, which prevents neutral sizing.
+    #[error("option delta per contract cannot be zero")]
+    OptionDeltaZero,
+
+    /// The strategy does not hold enough contracts to perform the required sell adjustment.
+    #[error("insufficient contracts to perform the requested delta adjustment")]
+    InsufficientContracts,
 }
 
 /// Represents various types of mathematical errors that can occur during calculations.
@@ -480,32 +546,10 @@ impl From<VolatilityError> for GreeksError {
     }
 }
 
-/// Implements conversion from `Box<dyn std::error::Error>` to `GreeksError`.
-///
-/// This implementation serves as a catch-all for converting any type that implements
-/// the standard Error trait into a `GreeksError`. This is useful for integrating with
-/// libraries or functions that return boxed standard error types for compatibility.
-impl From<Box<dyn std::error::Error>> for GreeksError {
-    fn from(error: Box<dyn std::error::Error>) -> Self {
-        GreeksError::StdError(error.to_string())
-    }
-}
-
-impl From<String> for GreeksError {
-    fn from(s: String) -> Self {
-        GreeksError::StdError(s)
-    }
-}
-
-impl From<&str> for GreeksError {
-    fn from(s: &str) -> Self {
-        GreeksError::StdError(s.to_string())
-    }
-}
-
-impl From<expiration_date::error::ExpirationDateError> for GreeksError {
-    fn from(err: expiration_date::error::ExpirationDateError) -> Self {
-        GreeksError::StdError(err.to_string())
+impl From<DeltaNeutralityErrorKind> for GreeksError {
+    #[inline]
+    fn from(kind: DeltaNeutralityErrorKind) -> Self {
+        GreeksError::DeltaNeutrality(kind)
     }
 }
 
@@ -635,9 +679,12 @@ mod tests_error_greeks_extended {
     use positive::pos_or_panic;
 
     #[test]
-    fn test_greeks_error_std_error() {
-        let error = GreeksError::StdError("An error occurred".to_string());
-        assert_eq!(format!("{error}"), "Standard error: An error occurred");
+    fn test_greeks_error_delta_neutrality() {
+        let error = GreeksError::DeltaNeutrality(DeltaNeutralityErrorKind::ZeroDelta);
+        assert_eq!(
+            format!("{error}"),
+            "Delta neutrality error: deltas cannot be zero for delta neutrality"
+        );
     }
 
     #[test]
@@ -793,10 +840,11 @@ mod tests_error_greeks_extended {
     }
 
     #[test]
-    fn test_boxed_error_conversion() {
-        let boxed_error: Box<dyn std::error::Error> =
-            Box::new(std::io::Error::other("Some IO error"));
-        let error: GreeksError = boxed_error.into();
-        assert_eq!(format!("{error}"), "Standard error: Some IO error");
+    fn test_delta_neutrality_zero_delta() {
+        let error = GreeksError::DeltaNeutrality(DeltaNeutralityErrorKind::ZeroDelta);
+        assert_eq!(
+            format!("{error}"),
+            "Delta neutrality error: deltas cannot be zero for delta neutrality"
+        );
     }
 }

--- a/src/error/interpolation.rs
+++ b/src/error/interpolation.rs
@@ -57,23 +57,25 @@ pub enum InterpolationError {
     #[error(transparent)]
     Surface(#[from] SurfaceError),
 
-    /// Standard errors not specific to a particular interpolation method.
-    ///
-    /// These represent general errors that may occur during interpolation
-    /// operations, such as memory allocation failures or system errors.
-    #[error("Standard error: {0}")]
-    StdError(String),
+    /// Input data set was empty so interpolation could not proceed.
+    #[error("interpolation input has no data points")]
+    EmptyData,
+
+    /// Requested point falls outside the valid interpolation range.
+    #[error("interpolation target {target} is outside the supported range")]
+    OutOfRange {
+        /// The offending coordinate (stringified for flexibility across axes).
+        target: String,
+    },
+
+    /// Interval degenerated into a point (two consecutive knots coincide).
+    #[error("interpolation interval is degenerate: knots collapse to a single point")]
+    DegenerateInterval,
 }
 
 impl From<CurveError> for InterpolationError {
     fn from(err: CurveError) -> Self {
         InterpolationError::Curve(err)
-    }
-}
-
-impl From<Box<dyn std::error::Error>> for InterpolationError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        InterpolationError::StdError(err.to_string())
     }
 }
 
@@ -83,18 +85,6 @@ mod tests {
     use crate::error::position::PositionValidationErrorKind;
     use std::error::Error as StdError;
     use std::fmt;
-
-    // Mock errors for testing the From implementations
-    #[derive(Debug)]
-    struct MockError(String);
-
-    impl fmt::Display for MockError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
-
-    impl StdError for MockError {}
 
     // Mock implementations of the error types used in From implementations
     #[derive(Debug)]
@@ -161,7 +151,11 @@ mod tests {
         let bilinear_err = InterpolationError::Bilinear("out of grid boundary".to_string());
         let cubic_err = InterpolationError::Cubic("numerical instability".to_string());
         let spline_err = InterpolationError::Spline("invalid knot placement".to_string());
-        let std_err = InterpolationError::StdError("general error".to_string());
+        let empty_err = InterpolationError::EmptyData;
+        let out_of_range = InterpolationError::OutOfRange {
+            target: "1.23".to_string(),
+        };
+        let degenerate = InterpolationError::DegenerateInterval;
 
         // Verify the variants are created correctly
         match linear_err {
@@ -184,10 +178,12 @@ mod tests {
             _ => panic!("Expected Spline variant"),
         }
 
-        match std_err {
-            InterpolationError::StdError(msg) => assert_eq!(msg, "general error"),
-            _ => panic!("Expected StdError variant"),
-        }
+        assert!(matches!(empty_err, InterpolationError::EmptyData));
+        assert!(matches!(
+            out_of_range,
+            InterpolationError::OutOfRange { .. }
+        ));
+        assert!(matches!(degenerate, InterpolationError::DegenerateInterval));
     }
 
     #[test]
@@ -197,7 +193,7 @@ mod tests {
         let bilinear_err = InterpolationError::Bilinear("test error".to_string());
         let cubic_err = InterpolationError::Cubic("test error".to_string());
         let spline_err = InterpolationError::Spline("test error".to_string());
-        let std_err = InterpolationError::StdError("test error".to_string());
+        let empty_err = InterpolationError::EmptyData;
 
         assert_eq!(
             format!("{linear_err}"),
@@ -215,20 +211,10 @@ mod tests {
             format!("{spline_err}"),
             "Spline interpolation error: test error"
         );
-        assert_eq!(format!("{std_err}"), "Standard error: test error");
-    }
-
-    #[test]
-    fn test_from_box_dyn_error() {
-        // Create a Box<dyn Error> and convert it to an InterpolationError
-        let mock_error = Box::new(MockError("boxed error".to_string())) as Box<dyn StdError>;
-
-        let interpolation_err = InterpolationError::from(mock_error);
-
-        match interpolation_err {
-            InterpolationError::StdError(msg) => assert!(msg.contains("boxed error")),
-            _ => panic!("Expected StdError variant"),
-        }
+        assert_eq!(
+            format!("{empty_err}"),
+            "interpolation input has no data points"
+        );
     }
 
     #[test]

--- a/src/error/metrics.rs
+++ b/src/error/metrics.rs
@@ -21,7 +21,6 @@ use thiserror::Error;
 /// * `RiskError` - Errors in risk metrics calculations (like VaR, Sharpe ratio, etc.)
 /// * `Curve` - Errors related to curve-fitting or curve-based calculations
 /// * `Surface` - Errors in surface modeling or multi-dimensional metrics
-/// * `StdError` - Standard error conditions with additional context
 ///
 /// # Examples
 ///
@@ -66,19 +65,4 @@ pub enum MetricsError {
     /// such as volatility surfaces or correlation matrices.
     #[error(transparent)]
     Surface(#[from] SurfaceError),
-
-    /// Standard error with additional contextual information.
-    #[error("Standard Error: {reason}")]
-    StdError {
-        /// Detailed explanation of the error cause
-        reason: String,
-    },
-}
-
-impl From<Box<dyn std::error::Error>> for MetricsError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        MetricsError::StdError {
-            reason: err.to_string(),
-        }
-    }
 }

--- a/src/error/options.rs
+++ b/src/error/options.rs
@@ -37,10 +37,11 @@
 //!
 //! ## Error Conversion
 //!
-//! The module supports conversion from:
-//! - `String`
-//! - `&str`
-//! - `Box<dyn std::error::Error>` (for compatibility)
+//! The module converts from typed domain errors:
+//! - `DecimalError` via `#[from]`
+//! - `GreeksError` via `#[from]`
+//! - `ExpirationDateError` via `#[from]`
+//! - `PricingError` via a manual `From` impl
 //!
 //! ## Examples
 //!
@@ -59,6 +60,7 @@
 //! ```
 
 use crate::error::{DecimalError, GreeksError, PricingError};
+use expiration_date::error::ExpirationDateError;
 use thiserror::Error;
 
 /// Custom errors that can occur during Options operations
@@ -88,8 +90,8 @@ use thiserror::Error;
 /// * `UpdateError` - Errors that occur when attempting to update option data
 ///   or parameters in an existing option object.
 ///
-/// * `OtherError` - A catch-all for errors that don't fit into other categories
-///   but still need to be represented in the options domain.
+/// * `InvalidStepCount` - Invalid pricing step count (typed replacement for the former `OtherError`).
+/// * `ImpliedVolatilityInvariant` - Implied-volatility invariant breach.
 ///
 /// # Usage
 ///
@@ -162,12 +164,19 @@ pub enum OptionsError {
         reason: String,
     },
 
-    /// Error when performing other operations
-    ///
-    /// A general-purpose error for cases not covered by other variants.
-    #[error("Other error: {reason}")]
-    OtherError {
-        /// Detailed explanation of the error
+    /// The caller requested a pricing operation with zero tree steps, which
+    /// is structurally invalid.
+    #[error("invalid step count: {operation} requires at least one step")]
+    InvalidStepCount {
+        /// Name of the operation that rejected the step count (e.g. `"binomial"`).
+        operation: &'static str,
+    },
+
+    /// A numerical invariant was breached while constructing a valid implied
+    /// volatility value from two non-negative bounds.
+    #[error("implied volatility invariant breached: {reason}")]
+    ImpliedVolatilityInvariant {
+        /// Detailed explanation of which invariant was breached.
         reason: String,
     },
 
@@ -178,6 +187,10 @@ pub enum OptionsError {
     /// Error when GreeksError occurs
     #[error(transparent)]
     Greeks(#[from] GreeksError),
+
+    /// Expiration-date conversion error surfaced during options operations.
+    #[error(transparent)]
+    ExpirationDate(#[from] ExpirationDateError),
 }
 
 /// A specialized result type for operations related to Options calculations and processing.
@@ -364,41 +377,8 @@ impl OptionsError {
     }
 }
 
-impl From<Box<dyn std::error::Error>> for OptionsError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        OptionsError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<&str> for OptionsError {
-    fn from(err: &str) -> Self {
-        OptionsError::ValidationError {
-            field: "unknown".to_string(),
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<String> for OptionsError {
-    fn from(err: String) -> Self {
-        OptionsError::ValidationError {
-            field: "unknown".to_string(),
-            reason: err,
-        }
-    }
-}
-
-impl From<expiration_date::error::ExpirationDateError> for OptionsError {
-    fn from(err: expiration_date::error::ExpirationDateError) -> Self {
-        OptionsError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
 impl From<PricingError> for OptionsError {
+    #[inline]
     fn from(value: PricingError) -> Self {
         Self::PricingError {
             method: "unknown".to_string(),
@@ -498,57 +478,25 @@ mod tests {
     }
 
     #[test]
-    fn test_from_str_conversion() {
-        let error: OptionsError = "test error".into();
-        match error {
-            OptionsError::ValidationError { field, reason } => {
-                assert_eq!(field, "unknown");
-                assert_eq!(reason, "test error");
-            }
-            _ => panic!("Expected ValidationError"),
-        }
+    fn test_invalid_step_count_variant() {
+        let error = OptionsError::InvalidStepCount {
+            operation: "binomial",
+        };
+        assert_eq!(
+            format!("{error}"),
+            "invalid step count: binomial requires at least one step"
+        );
     }
 
     #[test]
-    fn test_from_string_conversion() {
-        let error: OptionsError = String::from("test error").into();
-        match error {
-            OptionsError::ValidationError { field, reason } => {
-                assert_eq!(field, "unknown");
-                assert_eq!(reason, "test error");
-            }
-            _ => panic!("Expected ValidationError"),
-        }
-    }
-
-    #[test]
-    fn test_from_box_dyn_error_conversion() {
-        struct TestError(String);
-
-        impl std::fmt::Display for TestError {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "{}", self.0)
-            }
-        }
-
-        impl std::fmt::Debug for TestError {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "TestError({})", self.0)
-            }
-        }
-
-        impl std::error::Error for TestError {}
-
-        let original_error: Box<dyn std::error::Error> =
-            Box::new(TestError("test error".to_string()));
-        let error: OptionsError = original_error.into();
-
-        match error {
-            OptionsError::OtherError { reason } => {
-                assert_eq!(reason, "test error");
-            }
-            _ => panic!("Expected OtherError"),
-        }
+    fn test_implied_volatility_invariant_variant() {
+        let error = OptionsError::ImpliedVolatilityInvariant {
+            reason: "mid_vol must be non-negative".to_string(),
+        };
+        assert!(
+            format!("{error}")
+                .contains("implied volatility invariant breached: mid_vol must be non-negative")
+        );
     }
 
     #[test]
@@ -582,37 +530,18 @@ mod tests_extended {
     use super::*;
 
     #[test]
-    fn test_error_chaining() {
+    fn test_error_chaining_via_display() {
         let error1 = OptionsError::validation_error("strike", "invalid value");
-        let error2: OptionsError = error1.to_string().into();
-
-        match error2 {
-            OptionsError::ValidationError { field, reason } => {
-                assert!(reason.contains("invalid value"));
-                assert_eq!(field, "unknown");
-            }
-            _ => panic!("Expected ValidationError"),
-        }
-
-        // Segunda forma: usando From<&str>
-        let error3 = OptionsError::validation_error("price", "must be positive");
-        let error4: OptionsError = error3.to_string().as_str().into();
-
-        match error4 {
-            OptionsError::ValidationError { field, reason } => {
-                assert!(reason.contains("must be positive"));
-                assert_eq!(field, "unknown");
-            }
-            _ => panic!("Expected ValidationError"),
-        }
+        let rendered = error1.to_string();
+        assert!(rendered.contains("invalid value"));
+        assert!(rendered.contains("strike"));
     }
 
     #[test]
-    fn test_multiple_conversions() {
-        let io_error = std::io::Error::other("test error");
-        let boxed: Box<dyn std::error::Error> = Box::new(io_error);
-        let error: OptionsError = boxed.into();
-        assert!(matches!(error, OptionsError::OtherError { .. }));
+    fn test_pricing_error_conversion() {
+        let pricing = PricingError::invalid_engine("bad engine");
+        let error: OptionsError = pricing.into();
+        assert!(matches!(error, OptionsError::PricingError { .. }));
     }
 
     #[test]
@@ -664,12 +593,10 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_error_conversion_preservation() {
+    fn test_error_display_preserves_message() {
         let original = "preserve this message";
-        let error1: OptionsError = original.into();
-        let error2: OptionsError = error1.to_string().into();
-
-        assert!(error2.to_string().contains(original));
+        let error = OptionsError::validation_error("field", original);
+        assert!(error.to_string().contains(original));
     }
 
     #[test]

--- a/src/error/position.rs
+++ b/src/error/position.rs
@@ -195,7 +195,6 @@ pub enum StrategyErrorKind {
 ///
 /// * `InvalidPosition` - The position is invalid for other specific reasons.
 ///
-/// * `StdError` - Standard error from external systems or libraries.
 ///
 /// # Usage
 ///
@@ -257,15 +256,6 @@ pub enum PositionValidationErrorKind {
     #[error("Invalid position: {reason}")]
     InvalidPosition {
         /// Explanation of why the position is invalid
-        reason: String,
-    },
-
-    /// Standard error from external systems
-    ///
-    /// Wraps standard errors from external libraries or systems.
-    #[error("Standard error: {reason}")]
-    StdError {
-        /// Description of the standard error
         reason: String,
     },
 }
@@ -476,30 +466,6 @@ impl PositionError {
     }
 }
 
-impl From<Box<dyn std::error::Error>> for PositionError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        PositionError::ValidationError(PositionValidationErrorKind::StdError {
-            reason: err.to_string(),
-        })
-    }
-}
-
-impl From<&str> for PositionError {
-    fn from(err: &str) -> Self {
-        PositionError::ValidationError(PositionValidationErrorKind::StdError {
-            reason: err.to_string(),
-        })
-    }
-}
-
-impl From<String> for PositionError {
-    fn from(err: String) -> Self {
-        PositionError::ValidationError(PositionValidationErrorKind::StdError {
-            reason: err.to_string(),
-        })
-    }
-}
-
 // Implement conversion from StrategyError to PositionError
 impl From<StrategyError> for PositionError {
     fn from(error: StrategyError) -> Self {
@@ -587,28 +553,11 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_error_conversions() {
-        // Test de str a PositionError
-        let str_error: PositionError = "test error".into();
+    fn test_invalid_position_constructor() {
+        let error = PositionError::invalid_position("bad position");
         assert!(matches!(
-            str_error,
-            PositionError::ValidationError(PositionValidationErrorKind::StdError { .. })
-        ));
-
-        // Test de String a PositionError
-        let string_error: PositionError = "test error".to_string().into();
-        assert!(matches!(
-            string_error,
-            PositionError::ValidationError(PositionValidationErrorKind::StdError { .. })
-        ));
-
-        // Test de Box<dyn Error> a PositionError
-        let std_error: Box<dyn std::error::Error> =
-            Box::new(std::io::Error::other("dynamic error"));
-        let position_error = PositionError::from(std_error);
-        assert!(matches!(
-            position_error,
-            PositionError::ValidationError(PositionValidationErrorKind::StdError { .. })
+            error,
+            PositionError::ValidationError(PositionValidationErrorKind::InvalidPosition { .. })
         ));
     }
 
@@ -723,14 +672,6 @@ mod tests_extended {
             format!("{error}"),
             "Incompatible option style OptionStyle::Call: Unsupported for Call options"
         );
-    }
-
-    #[test]
-    fn test_position_validation_error_std_error() {
-        let error = PositionValidationErrorKind::StdError {
-            reason: "Unexpected null value".to_string(),
-        };
-        assert_eq!(format!("{error}"), "Standard error: Unexpected null value");
     }
 
     #[test]

--- a/src/error/pricing.rs
+++ b/src/error/pricing.rs
@@ -1,5 +1,6 @@
 use crate::error::{DecimalError, GreeksError, OptionsError, PositionError};
-use positive::PositiveError;
+use expiration_date::error::ExpirationDateError;
+use positive::{Positive, PositiveError};
 use thiserror::Error;
 
 /// Error type for option pricing operations.
@@ -47,11 +48,32 @@ pub enum PricingError {
     #[error(transparent)]
     Decimal(#[from] DecimalError),
 
-    /// Generic pricing error.
-    #[error("Pricing error: {reason}")]
-    OtherError {
-        /// Detailed reason for the error
-        reason: String,
+    /// Expiration-date conversion error surfaced during pricing.
+    #[error(transparent)]
+    ExpirationDate(#[from] ExpirationDateError),
+
+    /// A delta adjustment was requested on a strategy that does not support it.
+    #[error("delta adjustments are not applicable to single-leg {strategy} strategy")]
+    DeltaAdjustmentNotApplicable {
+        /// Name of the strategy, e.g. `"LongCall"`, `"ShortPut"`.
+        strategy: &'static str,
+    },
+
+    /// A required intermediate value on a binomial lattice or pricing kernel
+    /// was missing (typically a node that should have been populated by an
+    /// earlier induction step).
+    #[error("binomial pricing node `{node}` is missing")]
+    BinomialNodeMissing {
+        /// Identifier of the missing node, e.g. `"S_k"`, `"b"`.
+        node: &'static str,
+    },
+
+    /// A square-root computation inside a pricing kernel failed (the operand
+    /// was negative or not representable).
+    #[error("pricing sqrt failed for value {value}")]
+    SqrtFailure {
+        /// The value for which the square root could not be computed.
+        value: Positive,
     },
 
     /// Error from Positive operations.
@@ -101,12 +123,14 @@ impl PricingError {
         }
     }
 
-    /// Creates a new `OtherError` variant.
-    ///
-    /// # Arguments
-    /// * `reason` - Detailed reason for the error
+    /// Creates a typed `MethodError` with `method = "pricing"` as a lightweight
+    /// replacement for the former `OtherError` catch-all. Prefer
+    /// [`PricingError::method_error`] with a specific method name when known.
+    #[must_use]
+    #[inline]
     pub fn other(reason: &str) -> Self {
-        PricingError::OtherError {
+        PricingError::MethodError {
+            method: "pricing".to_string(),
             reason: reason.to_string(),
         }
     }
@@ -120,36 +144,6 @@ impl PricingError {
         PricingError::UnsupportedOptionType {
             option_type: option_type.to_string(),
             method: method.to_string(),
-        }
-    }
-}
-
-impl From<Box<dyn std::error::Error>> for PricingError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        PricingError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<String> for PricingError {
-    fn from(s: String) -> Self {
-        PricingError::OtherError { reason: s }
-    }
-}
-
-impl From<expiration_date::error::ExpirationDateError> for PricingError {
-    fn from(err: expiration_date::error::ExpirationDateError) -> Self {
-        PricingError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<&str> for PricingError {
-    fn from(s: &str) -> Self {
-        PricingError::OtherError {
-            reason: s.to_string(),
         }
     }
 }

--- a/src/error/pricing.rs
+++ b/src/error/pricing.rs
@@ -1,6 +1,7 @@
 use crate::error::{DecimalError, GreeksError, OptionsError, PositionError};
 use expiration_date::error::ExpirationDateError;
-use positive::{Positive, PositiveError};
+use positive::PositiveError;
+use rust_decimal::Decimal;
 use thiserror::Error;
 
 /// Error type for option pricing operations.
@@ -69,11 +70,14 @@ pub enum PricingError {
     },
 
     /// A square-root computation inside a pricing kernel failed (the operand
-    /// was negative or not representable).
+    /// was negative or not representable — e.g. a negative discriminant in a
+    /// closed-form solver).
     #[error("pricing sqrt failed for value {value}")]
     SqrtFailure {
         /// The value for which the square root could not be computed.
-        value: Positive,
+        ///
+        /// Stored as `Decimal` so negative operands are representable.
+        value: Decimal,
     },
 
     /// Error from Positive operations.

--- a/src/error/probability.rs
+++ b/src/error/probability.rs
@@ -94,7 +94,8 @@ use thiserror::Error;
 /// * `PriceError` - Errors related to price parameters, such as invalid underlying
 ///   prices or invalid price ranges.
 ///
-/// * `StdError` - Standard errors from external systems or libraries, wrapped as strings.
+/// * `NoPositions` - No positions available for probability analysis.
+/// * `MissingMetric` - A required metric is missing from the strategy evaluation.
 ///
 /// * `NoPositions` - Error indicating that no positions were available for analysis.
 ///
@@ -133,19 +134,19 @@ pub enum ProbabilityError {
     #[error("Price error: {0}")]
     PriceError(PriceErrorKind),
 
-    /// Standard error from an external system or library
-    ///
-    /// Contains a string description of an error from a standard library
-    /// or external dependency.
-    #[error("Standard error: {0}")]
-    StdError(String),
-
     /// Error indicating no positions are available for analysis
     ///
     /// Contains a string description explaining why positions are missing
     /// or why they cannot be analyzed.
     #[error("No positions available: {0}")]
     NoPositions(String),
+
+    /// A required metric is missing from the strategy evaluation.
+    #[error("missing metric `{metric}` for probability analysis")]
+    MissingMetric {
+        /// Identifier of the missing metric (e.g. `"max_profit"`).
+        metric: &'static str,
+    },
 
     /// Positive value errors
     #[error(transparent)]
@@ -375,108 +376,98 @@ pub enum PriceErrorKind {
     },
 }
 
-impl From<Box<dyn std::error::Error>> for ProbabilityError {
-    fn from(error: Box<dyn std::error::Error>) -> Self {
-        ProbabilityError::StdError(error.to_string())
-    }
-}
-
 impl From<GreeksError> for ProbabilityError {
+    #[inline]
     fn from(error: GreeksError) -> Self {
-        ProbabilityError::StdError(error.to_string())
+        ProbabilityError::CalculationError(ProbabilityCalculationErrorKind::ExpectedValueError {
+            reason: error.to_string(),
+        })
     }
 }
 
 impl From<crate::error::PricingError> for ProbabilityError {
+    #[inline]
     fn from(error: crate::error::PricingError) -> Self {
-        ProbabilityError::StdError(error.to_string())
+        ProbabilityError::CalculationError(ProbabilityCalculationErrorKind::ExpectedValueError {
+            reason: error.to_string(),
+        })
     }
 }
 
 impl From<crate::error::DecimalError> for ProbabilityError {
+    #[inline]
     fn from(error: crate::error::DecimalError) -> Self {
-        ProbabilityError::StdError(error.to_string())
+        ProbabilityError::CalculationError(ProbabilityCalculationErrorKind::ExpectedValueError {
+            reason: error.to_string(),
+        })
     }
 }
 
 /// Convenient type alias for Results with ProbabilityError
 pub type ProbabilityResult<T> = Result<T, ProbabilityError>;
 
-// Implementation of From<String> for compatibility with existing code
-impl From<String> for ProbabilityError {
-    fn from(msg: String) -> Self {
-        ProbabilityError::CalculationError(ProbabilityCalculationErrorKind::ExpectedValueError {
-            reason: msg,
-        })
-    }
-}
-
-impl From<&str> for ProbabilityError {
-    fn from(msg: &str) -> Self {
-        ProbabilityError::CalculationError(ProbabilityCalculationErrorKind::ExpectedValueError {
-            reason: msg.to_string(),
-        })
-    }
-}
-
 impl From<StrategyError> for ProbabilityError {
     fn from(error: StrategyError) -> Self {
+        let reason = |r: String| {
+            ProbabilityError::CalculationError(
+                ProbabilityCalculationErrorKind::ExpectedValueError { reason: r },
+            )
+        };
         match error {
             StrategyError::ProfitLossError(kind) => match kind {
-                ProfitLossErrorKind::MaxProfitError { reason }
-                | ProfitLossErrorKind::MaxLossError { reason }
-                | ProfitLossErrorKind::ProfitRangeError { reason } => {
-                    ProbabilityError::from(reason)
-                }
+                ProfitLossErrorKind::MaxProfitError { reason: r }
+                | ProfitLossErrorKind::MaxLossError { reason: r }
+                | ProfitLossErrorKind::ProfitRangeError { reason: r } => reason(r),
             },
             StrategyError::PriceError(kind) => match kind {
-                crate::error::strategies::PriceErrorKind::InvalidUnderlyingPrice { reason }
+                crate::error::strategies::PriceErrorKind::InvalidUnderlyingPrice { reason: r }
                 | crate::error::strategies::PriceErrorKind::InvalidPriceRange {
                     start: _,
                     end: _,
-                    reason,
-                } => ProbabilityError::from(reason),
+                    reason: r,
+                } => reason(r),
             },
             StrategyError::BreakEvenError(kind) => match kind {
-                BreakEvenErrorKind::CalculationError { reason } => ProbabilityError::from(reason),
+                BreakEvenErrorKind::CalculationError { reason: r } => reason(r),
                 BreakEvenErrorKind::NoBreakEvenPoints => {
-                    ProbabilityError::from("No break-even points found".to_string())
+                    reason("No break-even points found".to_string())
                 }
             },
             StrategyError::OperationError(kind) => match kind {
                 OperationErrorKind::NotSupported {
                     operation,
                     reason: strategy_type,
-                } => ProbabilityError::from(format!(
+                } => reason(format!(
                     "Operation '{operation}' not supported for strategy '{strategy_type}'"
                 )),
-                OperationErrorKind::InvalidParameters { operation, reason } => {
-                    ProbabilityError::from(format!(
-                        "Invalid parameters for operation '{operation}': {reason}"
-                    ))
-                }
+                OperationErrorKind::InvalidParameters {
+                    operation,
+                    reason: r,
+                } => reason(format!(
+                    "Invalid parameters for operation '{operation}': {r}"
+                )),
             },
-            StrategyError::StdError { reason: msg } => ProbabilityError::StdError(msg),
-            StrategyError::NotImplemented => {
-                ProbabilityError::StdError("Strategy not implemented".to_string())
-            }
-            StrategyError::GreeksError(err) => ProbabilityError::StdError(err.to_string()),
-            StrategyError::PositiveError(err) => ProbabilityError::StdError(err.to_string()),
-            StrategyError::NumericConversion { value } => ProbabilityError::StdError(format!(
+            StrategyError::NotImplemented => reason("Strategy not implemented".to_string()),
+            StrategyError::GreeksError(err) => reason(err.to_string()),
+            StrategyError::PositiveError(err) => reason(err.to_string()),
+            StrategyError::Simulation(err) => reason(err.to_string()),
+            StrategyError::NumericConversion { value } => reason(format!(
                 "numeric conversion failed: {value} is not a finite Decimal"
             )),
-            StrategyError::MissingGreek { name } => {
-                ProbabilityError::StdError(format!("missing greek `{name}`"))
-            }
+            StrategyError::MissingGreek { name } => reason(format!("missing greek `{name}`")),
             StrategyError::EmptyCollection { context } => {
-                ProbabilityError::StdError(format!("empty collection: {context}"))
+                reason(format!("empty collection: {context}"))
             }
         }
     }
 }
+
 impl From<expiration_date::error::ExpirationDateError> for ProbabilityError {
+    #[inline]
     fn from(err: expiration_date::error::ExpirationDateError) -> Self {
-        ProbabilityError::StdError(err.to_string())
+        ProbabilityError::CalculationError(ProbabilityCalculationErrorKind::ExpectedValueError {
+            reason: err.to_string(),
+        })
     }
 }
 
@@ -543,14 +534,14 @@ mod tests {
     }
 
     #[test]
-    fn test_string_conversion() {
-        let error = ProbabilityError::from("Test error message".to_string());
-        assert!(matches!(
-            error,
-            ProbabilityError::CalculationError(
-                ProbabilityCalculationErrorKind::ExpectedValueError { .. }
-            )
-        ));
+    fn test_missing_metric_variant() {
+        let error = ProbabilityError::MissingMetric {
+            metric: "max_profit",
+        };
+        assert_eq!(
+            error.to_string(),
+            "missing metric `max_profit` for probability analysis"
+        );
     }
 
     #[test]
@@ -579,17 +570,6 @@ mod tests {
         assert!(error.to_string().contains("Price cannot be negative"));
         assert!(error.to_string().contains("-10"));
     }
-
-    #[test]
-    fn test_str_conversion() {
-        let error = ProbabilityError::from("Test error message");
-        assert!(matches!(
-            error,
-            ProbabilityError::CalculationError(
-                ProbabilityCalculationErrorKind::ExpectedValueError { .. }
-            )
-        ));
-    }
 }
 
 #[cfg(test)]
@@ -604,17 +584,6 @@ mod tests_extended {
             error,
             ProbabilityError::CalculationError(
                 ProbabilityCalculationErrorKind::InvalidProbability { .. }
-            )
-        ));
-    }
-
-    #[test]
-    fn test_string_conversion() {
-        let error = ProbabilityError::from("Test error message".to_string());
-        assert!(matches!(
-            error,
-            ProbabilityError::CalculationError(
-                ProbabilityCalculationErrorKind::ExpectedValueError { .. }
             )
         ));
     }
@@ -712,11 +681,15 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_box_dyn_error_conversion() {
-        let io_error = std::io::Error::other("test error");
-        let boxed_error: Box<dyn std::error::Error> = Box::new(io_error);
-        let prob_error = ProbabilityError::from(boxed_error);
-        assert!(matches!(prob_error, ProbabilityError::StdError(..)));
+    fn test_greeks_error_conversion() {
+        let greeks_error = GreeksError::invalid_volatility(-0.5, "negative");
+        let prob_error: ProbabilityError = greeks_error.into();
+        assert!(matches!(
+            prob_error,
+            ProbabilityError::CalculationError(
+                ProbabilityCalculationErrorKind::ExpectedValueError { .. }
+            )
+        ));
     }
 
     #[test]
@@ -736,9 +709,14 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_probability_error_std_error() {
-        let error = ProbabilityError::StdError("Calculation failed".to_string());
-        assert_eq!(format!("{error}"), "Standard error: Calculation failed");
+    fn test_probability_error_missing_metric() {
+        let error = ProbabilityError::MissingMetric {
+            metric: "max_profit",
+        };
+        assert_eq!(
+            format!("{error}"),
+            "missing metric `max_profit` for probability analysis"
+        );
     }
 
     #[test]
@@ -812,17 +790,17 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_strategy_error_std_error() {
-        let error = StrategyError::StdError {
-            reason: "General strategy failure".to_string(),
-        };
-
-        let converted_error: ProbabilityError = error.into();
-
-        assert_eq!(
-            format!("{converted_error}"),
-            "Standard error: General strategy failure"
-        );
+    fn test_strategy_error_simulation_conversion() {
+        let strategy_error = StrategyError::Simulation(Box::new(
+            crate::error::SimulationError::walk_error("simulation failed"),
+        ));
+        let converted_error: ProbabilityError = strategy_error.into();
+        assert!(matches!(
+            converted_error,
+            ProbabilityError::CalculationError(
+                ProbabilityCalculationErrorKind::ExpectedValueError { .. }
+            )
+        ));
     }
 
     #[test]
@@ -901,12 +879,13 @@ mod tests_extended {
             operation: "Calculate P/L".to_string(),
             reason: "Invalid input values".to_string(),
         };
-        let converted_error: ProbabilityError =
-            ProbabilityError::from(format!("Invalid parameters for operation {error}"));
-        assert_eq!(
-            format!("{converted_error}"),
-            "Probability calculation error: Expected value calculation error: Invalid parameters for operation Invalid parameters for operation 'Calculate P/L': Invalid input values"
-        );
+        let converted_error: ProbabilityError = error.into();
+        assert!(matches!(
+            converted_error,
+            ProbabilityError::CalculationError(
+                ProbabilityCalculationErrorKind::ExpectedValueError { .. }
+            )
+        ));
     }
 
     #[test]

--- a/src/error/simulation.rs
+++ b/src/error/simulation.rs
@@ -1,5 +1,8 @@
-use crate::error::{DecimalError, StrategyError};
+use crate::error::{ChainError, DecimalError, OptionsError, PricingError, StrategyError};
 use crate::prelude::GraphError;
+use expiration_date::error::ExpirationDateError;
+use positive::Positive;
+use rust_decimal::Decimal;
 use thiserror::Error;
 
 /// Error type for simulation operations.
@@ -29,12 +32,80 @@ pub enum SimulationError {
         reason: String,
     },
 
-    /// Generic simulation error.
-    #[error("Simulation error: {reason}")]
-    OtherError {
-        /// Detailed reason for the error
-        reason: String,
+    /// The walk type in the parameters does not match the generator being invoked.
+    ///
+    /// Raised from inside each `WalkTypeAble` implementation when the supplied
+    /// `walk_type` discriminator is not the one expected by the method.
+    #[error("invalid walk type: expected {expected}")]
+    InvalidWalkType {
+        /// Human-readable description of the expected walk type, e.g. `"Brownian"`.
+        expected: &'static str,
     },
+
+    /// Autocorrelation parameter is outside the required `[-1, 1]` interval.
+    #[error("autocorrelation {value} must lie in [-1, 1]")]
+    InvalidAutocorrelation {
+        /// The offending autocorrelation value.
+        value: Decimal,
+    },
+
+    /// GARCH stationarity constraint `alpha + beta < 1` violated.
+    #[error("GARCH stationarity violated: alpha ({alpha}) + beta ({beta}) must be < 1")]
+    GarchStationarity {
+        /// The GARCH alpha coefficient.
+        alpha: Positive,
+        /// The GARCH beta coefficient.
+        beta: Positive,
+    },
+
+    /// Heston correlation `rho` is outside the valid `[-1, 1]` interval.
+    #[error("Heston correlation rho {rho} must lie in [-1, 1]")]
+    InvalidCorrelation {
+        /// The offending correlation value.
+        rho: Decimal,
+    },
+
+    /// Not enough historical price observations to generate the requested walk.
+    #[error("historical walk requires at least {required} observations, found {found}")]
+    InsufficientHistoricalData {
+        /// Minimum number of observations required.
+        required: usize,
+        /// Number of observations actually available.
+        found: usize,
+    },
+
+    /// Failed to convert the x-axis step index into a `Decimal`.
+    #[error("cannot convert x-axis step index to Decimal")]
+    IndexConversion,
+
+    /// The simulated expiration has already been reached, no further steps
+    /// can be generated.
+    #[error("cannot generate next step: expiration date already reached")]
+    ExpirationReached,
+
+    /// Decimal arithmetic error surfaced from pricing or Greek calculations.
+    #[error(transparent)]
+    Decimal(#[from] DecimalError),
+
+    /// Options domain error surfaced during simulation.
+    #[error(transparent)]
+    Options(#[from] OptionsError),
+
+    /// Pricing error surfaced during simulation.
+    #[error(transparent)]
+    Pricing(#[from] PricingError),
+
+    /// Expiration-date conversion error.
+    #[error(transparent)]
+    ExpirationDate(#[from] ExpirationDateError),
+
+    /// Strategy-layer error surfaced during simulation.
+    #[error(transparent)]
+    Strategy(Box<StrategyError>),
+
+    /// Chain domain error surfaced during simulation.
+    #[error(transparent)]
+    Chain(Box<ChainError>),
 
     /// Error during graph generation.
     #[error(transparent)]
@@ -50,6 +121,8 @@ impl SimulationError {
     ///
     /// # Arguments
     /// * `reason` - Detailed reason for the walk generation failure
+    #[must_use]
+    #[inline]
     pub fn walk_error(reason: &str) -> Self {
         SimulationError::WalkError {
             reason: reason.to_string(),
@@ -60,6 +133,8 @@ impl SimulationError {
     ///
     /// # Arguments
     /// * `reason` - Detailed reason for the invalid parameters
+    #[must_use]
+    #[inline]
     pub fn invalid_parameters(reason: &str) -> Self {
         SimulationError::InvalidParameters {
             reason: reason.to_string(),
@@ -70,90 +145,26 @@ impl SimulationError {
     ///
     /// # Arguments
     /// * `reason` - Detailed reason for the step calculation failure
+    #[must_use]
+    #[inline]
     pub fn step_error(reason: &str) -> Self {
         SimulationError::StepError {
             reason: reason.to_string(),
         }
     }
-
-    /// Creates a new `OtherError` variant.
-    ///
-    /// # Arguments
-    /// * `reason` - Detailed reason for the error
-    pub fn other(reason: &str) -> Self {
-        SimulationError::OtherError {
-            reason: reason.to_string(),
-        }
-    }
-}
-
-impl From<Box<dyn std::error::Error>> for SimulationError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        SimulationError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<String> for SimulationError {
-    fn from(s: String) -> Self {
-        SimulationError::OtherError { reason: s }
-    }
-}
-
-impl From<&str> for SimulationError {
-    fn from(s: &str) -> Self {
-        SimulationError::OtherError {
-            reason: s.to_string(),
-        }
-    }
-}
-
-impl From<DecimalError> for SimulationError {
-    fn from(err: DecimalError) -> Self {
-        SimulationError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<crate::error::OptionsError> for SimulationError {
-    fn from(err: crate::error::OptionsError) -> Self {
-        SimulationError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<crate::error::PricingError> for SimulationError {
-    fn from(err: crate::error::PricingError) -> Self {
-        SimulationError::OtherError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-impl From<expiration_date::error::ExpirationDateError> for SimulationError {
-    fn from(err: expiration_date::error::ExpirationDateError) -> Self {
-        SimulationError::OtherError {
-            reason: err.to_string(),
-        }
-    }
 }
 
 impl From<StrategyError> for SimulationError {
+    #[inline]
     fn from(err: StrategyError) -> Self {
-        SimulationError::OtherError {
-            reason: err.to_string(),
-        }
+        SimulationError::Strategy(Box::new(err))
     }
 }
 
-impl From<crate::error::ChainError> for SimulationError {
-    fn from(err: crate::error::ChainError) -> Self {
-        SimulationError::OtherError {
-            reason: err.to_string(),
-        }
+impl From<ChainError> for SimulationError {
+    #[inline]
+    fn from(err: ChainError) -> Self {
+        SimulationError::Chain(Box::new(err))
     }
 }
 

--- a/src/error/strategies.rs
+++ b/src/error/strategies.rs
@@ -68,7 +68,7 @@
 //!
 //! Provides `StrategyResult<T>` for convenient error handling in strategy operations.
 use crate::error::common::OperationErrorKind;
-use crate::error::{GreeksError, OptionsError, PositionError, SimulationError, TradeError};
+use crate::error::{GreeksError, OptionsError, PositionError, TradeError};
 use thiserror::Error;
 
 /// Represents the different types of errors that can occur in options trading strategies.
@@ -84,8 +84,8 @@ use thiserror::Error;
 /// * `BreakEvenError` - Errors encountered when calculating strategy break-even points
 /// * `ProfitLossError` - Errors related to profit/loss calculations including maximum values
 /// * `OperationError` - General strategy operation errors including unsupported operations
-/// * `StdError` - Standard errors with a descriptive reason
 /// * `NotImplemented` - For features or operations that are not yet implemented
+/// * `Simulation` - Simulation-layer errors surfaced while evaluating a strategy
 ///
 /// # Usage
 ///
@@ -110,16 +110,13 @@ pub enum StrategyError {
     #[error("Operation error: {0}")]
     OperationError(OperationErrorKind),
 
-    /// Standard error with descriptive reason
-    #[error("Standard error: {reason}")]
-    StdError {
-        /// Detailed explanation of the standard error
-        reason: String,
-    },
-
     /// Indicates a feature or operation that has not been implemented yet
     #[error("Not implemented")]
     NotImplemented,
+
+    /// A simulation-layer error surfaced while evaluating a strategy.
+    #[error(transparent)]
+    Simulation(Box<crate::error::SimulationError>),
 
     /// Greeks errors
     #[error(transparent)]
@@ -429,11 +426,10 @@ impl From<OptionsError> for StrategyError {
     }
 }
 
-impl From<Box<dyn std::error::Error>> for StrategyError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        StrategyError::StdError {
-            reason: err.to_string(),
-        }
+impl From<crate::error::SimulationError> for StrategyError {
+    #[inline]
+    fn from(err: crate::error::SimulationError) -> Self {
+        StrategyError::Simulation(Box::new(err))
     }
 }
 
@@ -442,15 +438,6 @@ impl From<crate::error::PricingError> for StrategyError {
         StrategyError::OperationError(OperationErrorKind::InvalidParameters {
             operation: "Pricing".to_string(),
             reason: err.to_string(),
-        })
-    }
-}
-
-impl From<SimulationError> for StrategyError {
-    fn from(value: SimulationError) -> Self {
-        StrategyError::OperationError(OperationErrorKind::InvalidParameters {
-            operation: "Simulation".to_string(),
-            reason: value.to_string(),
         })
     }
 }
@@ -610,11 +597,10 @@ mod tests_extended {
     use super::*;
 
     #[test]
-    fn test_strategy_error_std_error() {
-        let error = StrategyError::StdError {
-            reason: "General failure".to_string(),
-        };
-        assert_eq!(format!("{error}"), "Standard error: General failure");
+    fn test_strategy_error_simulation() {
+        let sim_error = crate::error::SimulationError::walk_error("simulation failure");
+        let error = StrategyError::from(sim_error);
+        assert!(matches!(error, StrategyError::Simulation(_)));
     }
 
     #[test]
@@ -668,14 +654,6 @@ mod tests_extended {
             format!("{error}"),
             "Operation error: Invalid parameters for operation 'Open position': Margin insufficient"
         );
-    }
-
-    #[test]
-    fn test_strategy_error_from_boxed_error() {
-        let boxed_error: Box<dyn std::error::Error> =
-            Box::new(std::io::Error::other("Underlying failure"));
-        let error: StrategyError = boxed_error.into();
-        assert_eq!(format!("{error}"), "Standard error: Underlying failure");
     }
 
     #[test]

--- a/src/error/surfaces.rs
+++ b/src/error/surfaces.rs
@@ -45,13 +45,14 @@ pub enum SurfaceError {
     #[error("Operation error: {0}")]
     OperationError(OperationErrorKind),
 
-    /// Error originating from the standard library or external dependencies.
-    ///
-    /// Encapsulates errors that were generated outside of the surface module,
-    /// providing a clear transition between external and internal error handling.
-    #[error("Error: {reason}")]
-    StdError {
-        /// A reference to a static string that explains the reason for an error or a condition.
+    /// A rendering operation failed. Preserves the backend discriminator so
+    /// callers can distinguish plotters output paths from other backends
+    /// without resorting to a `String` catch-all.
+    #[error("rendering failed ({backend}): {reason}")]
+    RenderError {
+        /// Identifier of the rendering backend that failed (e.g. `"plotters"`).
+        backend: &'static str,
+        /// Detailed, human-readable reason for the failure.
         reason: String,
     },
 
@@ -177,9 +178,7 @@ impl SurfaceError {
 /// straightforward to trace and debug the underlying issue.
 impl From<InterpolationError> for SurfaceError {
     fn from(err: InterpolationError) -> Self {
-        SurfaceError::StdError {
-            reason: err.to_string(),
-        }
+        SurfaceError::AnalysisError(err.to_string())
     }
 }
 
@@ -189,75 +188,12 @@ impl From<GraphError> for SurfaceError {
     }
 }
 
-impl From<Box<dyn std::error::Error>> for SurfaceError {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        SurfaceError::StdError {
-            reason: err.to_string(),
-        }
-    }
-}
-
-/// Implements the `From` trait to enable seamless conversion from a boxed `dyn Error`
-/// into a `SurfaceError`. This is particularly useful for integrating standard error
-/// handling mechanisms with the custom `SurfaceError` type.
-///
-/// # Behavior
-///
-/// When constructing a `SurfaceError` from a `Box<dyn std::error::Error>`, the `StdError` variant
-/// is utilized. The boxed error is unwrapped, and its string representation
-/// (via `to_string`) is used to populate the `reason` field of the `StdError` variant.
-///
-/// # Parameters
-///
-/// - `err`: A boxed standard error (`Box<dyn std::error::Error>`). Represents the error to be
-///   wrapped within a `SurfaceError` variant.
-///
-/// # Returns
-///
-/// - `SurfaceError::StdError`: The custom error type with a detailed `reason`
-///   string derived from the provided error.
-///
-/// # Usage
-///
-/// This implementation is commonly employed when you need to bridge standard Rust
-/// errors with the specific error handling system provided by the `curves` module.
-/// It facilitates scenarios where standard error contexts need to be preserved
-/// in a flexible, string-based `reason` for debugging or logging purposes.
-///
-/// # Example Scenario
-///
-/// Instead of handling standard errors separately, you can propagate them as `SurfaceError`
-/// within the larger error system of the `curves` module, ensuring consistent error
-/// wrapping and management.
-///
-/// # Notes
-///
-/// - This implementation assumes that all input errors (`Box<dyn std::error::Error>`) are stringifiable
-///   using the `to_string()` method.
-/// - This conversion is particularly useful for libraries integrating generalized errors
-///   (e.g., I/O errors, or third-party library errors) into a standardized error system.
-///
-/// # Module Context
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::error::CurveError;
     use crate::error::curves::CurvesResult;
     use crate::error::position::PositionValidationErrorKind;
-
-    // Custom error type for testing From<Box<dyn Error>>
-    #[derive(Debug)]
-    struct TestError {
-        message: String,
-    }
-
-    impl std::fmt::Display for TestError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.message)
-        }
-    }
-
-    impl std::error::Error for TestError {}
 
     #[test]
     fn test_operation_not_supported() {
@@ -306,11 +242,15 @@ mod tests {
     }
 
     #[test]
-    fn test_display_std_error() {
-        let error = SurfaceError::StdError {
-            reason: "Standard error test".to_string(),
+    fn test_display_render_error() {
+        let error = SurfaceError::RenderError {
+            backend: "plotters",
+            reason: "rendering failed".to_string(),
         };
-        assert_eq!(error.to_string(), "Error: Standard error test");
+        assert_eq!(
+            error.to_string(),
+            "rendering failed (plotters): rendering failed"
+        );
     }
 
     #[test]
@@ -350,19 +290,10 @@ mod tests {
     }
 
     #[test]
-    fn test_from_box_dyn_error() {
-        let test_error = TestError {
-            message: "Test box error".to_string(),
-        };
-        let boxed_error: Box<dyn std::error::Error> = Box::new(test_error);
-        let surface_error = SurfaceError::from(boxed_error);
-
-        match surface_error {
-            SurfaceError::StdError { reason } => {
-                assert_eq!(reason, "Test box error");
-            }
-            _ => panic!("Wrong error variant"),
-        }
+    fn test_from_interpolation_error_surfaces() {
+        let interpolation_err = InterpolationError::EmptyData;
+        let surface_err = SurfaceError::from(interpolation_err);
+        assert!(matches!(surface_err, SurfaceError::AnalysisError(_)));
     }
 
     #[test]

--- a/src/error/unified.rs
+++ b/src/error/unified.rs
@@ -106,25 +106,15 @@ pub enum Error {
     #[error(transparent)]
     Trade(#[from] crate::error::TradeError),
 
-    /// Generic error with a custom message.
-    #[error("{0}")]
-    Other(String),
-}
+    /// Empty input collection supplied to a utility that requires at least one element.
+    #[error("empty collection: {context}")]
+    EmptyCollection {
+        /// Description of the collection that was empty (e.g. `"positions"`).
+        context: &'static str,
+    },
 
-impl From<Box<dyn std::error::Error>> for Error {
-    fn from(err: Box<dyn std::error::Error>) -> Self {
-        Error::Other(err.to_string())
-    }
-}
-
-impl From<String> for Error {
-    fn from(msg: String) -> Self {
-        Error::Other(msg)
-    }
-}
-
-impl From<&str> for Error {
-    fn from(msg: &str) -> Self {
-        Error::Other(msg.to_string())
-    }
+    /// I/O error surfaced during file or network operations invoked from examples
+    /// and documentation snippets (plot saving, chain loading, etc.).
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }

--- a/src/error/volatility.rs
+++ b/src/error/volatility.rs
@@ -90,23 +90,34 @@ pub enum VolatilityError {
         last_volatility: Positive,
     },
 
+    /// No implied-volatility candidate produced a price match after the grid search.
+    #[error("implied volatility not found within search grid")]
+    IvNotFound,
+
+    /// None of the generated volatility samples produced a valid price.
+    #[error("no valid volatility sample produced a finite price")]
+    NoValidVolatility,
+
+    /// A numerical precision or representation failure inside a Heston-style
+    /// volatility simulation kernel (e.g. `sqrt` overflow, `f64`/`Decimal` bridge).
+    #[error("volatility simulation numerical failure: {reason}")]
+    NumericalFailure {
+        /// Human-readable description of which numerical step failed.
+        reason: String,
+    },
+
+    /// The ATM implied volatility is unavailable; the boxed inner source
+    /// describes the failing lookup.
+    #[error("ATM implied volatility is not available: {source}")]
+    AtmIvUnavailable {
+        /// Underlying error that explains why the ATM IV could not be retrieved.
+        #[source]
+        source: Box<VolatilityError>,
+    },
+
     /// Positive value errors
     #[error(transparent)]
     PositiveError(#[from] positive::PositiveError),
-}
-
-impl From<&str> for VolatilityError {
-    fn from(s: &str) -> Self {
-        VolatilityError::OptionError {
-            reason: s.to_string(),
-        }
-    }
-}
-
-impl From<String> for VolatilityError {
-    fn from(s: String) -> Self {
-        VolatilityError::OptionError { reason: s }
-    }
 }
 
 #[cfg(test)]
@@ -199,11 +210,9 @@ mod tests_volatility_errors {
 
     #[test]
     fn test_from_options_error() {
-        let greeks_error = OptionsError::OtherError {
-            reason: "Invalid option parameters".to_string(),
-        };
+        let options_error = OptionsError::validation_error("strike", "Invalid option parameters");
 
-        let implied_vol_error: VolatilityError = greeks_error.into();
+        let implied_vol_error: VolatilityError = options_error.into();
 
         match implied_vol_error {
             VolatilityError::Options(_) => {
@@ -211,6 +220,36 @@ mod tests_volatility_errors {
             }
             _ => panic!("Wrong error variant"),
         }
+    }
+
+    #[test]
+    fn test_iv_not_found() {
+        let error = VolatilityError::IvNotFound;
+        assert_eq!(
+            error.to_string(),
+            "implied volatility not found within search grid"
+        );
+    }
+
+    #[test]
+    fn test_no_valid_volatility() {
+        let error = VolatilityError::NoValidVolatility;
+        assert_eq!(
+            error.to_string(),
+            "no valid volatility sample produced a finite price"
+        );
+    }
+
+    #[test]
+    fn test_atm_iv_unavailable() {
+        let error = VolatilityError::AtmIvUnavailable {
+            source: Box::new(VolatilityError::IvNotFound),
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("ATM implied volatility is not available")
+        );
     }
 
     #[test]

--- a/src/error/volatility.rs
+++ b/src/error/volatility.rs
@@ -115,9 +115,23 @@ pub enum VolatilityError {
         source: Box<VolatilityError>,
     },
 
+    /// A chain-layer error surfaced while retrieving volatility data
+    /// (e.g. empty option chain, ATM lookup failure on a chain).
+    ///
+    /// Boxed to avoid infinite enum size through the `ChainError::Volatility`
+    /// cycle.
+    #[error(transparent)]
+    Chain(Box<crate::error::ChainError>),
+
     /// Positive value errors
     #[error(transparent)]
     PositiveError(#[from] positive::PositiveError),
+}
+
+impl From<crate::error::ChainError> for VolatilityError {
+    fn from(error: crate::error::ChainError) -> Self {
+        Self::Chain(Box::new(error))
+    }
 }
 
 #[cfg(test)]

--- a/src/geometrics/interpolation/traits.rs
+++ b/src/geometrics/interpolation/traits.rs
@@ -111,14 +111,12 @@ where
         let points: Vec<&Point> = self.get_points().into_iter().collect();
         // Edge cases
         if points.len() < 2 {
-            return Err(InterpolationError::StdError(
-                "Need at least two points for interpolation".to_string(),
-            ));
+            return Err(InterpolationError::EmptyData);
         }
         if x.get_x() < points[0].get_x() || x.get_x() > points[points.len() - 1].get_x() {
-            return Err(InterpolationError::StdError(
-                "x is outside the range of points".to_string(),
-            ));
+            return Err(InterpolationError::OutOfRange {
+                target: x.get_x().to_string(),
+            });
         }
         // Find points that bracket x
         for i in 0..points.len() - 1 {
@@ -126,9 +124,7 @@ where
                 return Ok((i, i + 1));
             }
         }
-        Err(InterpolationError::StdError(
-            "Could not find bracketing points".to_string(),
-        ))
+        Err(InterpolationError::DegenerateInterval)
     }
 }
 

--- a/src/greeks/numerical.rs
+++ b/src/greeks/numerical.rs
@@ -31,12 +31,8 @@ pub fn numerical_delta(option: &Options) -> Result<Decimal, GreeksError> {
     opt_minus.underlying_price =
         Positive::new_decimal((option.underlying_price.to_dec() - H).abs())?;
 
-    let p_plus = opt_plus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
-    let p_minus = opt_minus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
+    let p_plus = opt_plus.price(&PricingEngine::ClosedFormBS)?;
+    let p_minus = opt_minus.price(&PricingEngine::ClosedFormBS)?;
 
     Ok((p_plus.to_dec() - p_minus.to_dec()) / (dec!(2.0) * H))
 }
@@ -54,15 +50,9 @@ pub fn numerical_gamma(option: &Options) -> Result<Decimal, GreeksError> {
     opt_minus.underlying_price =
         Positive::new_decimal((option.underlying_price.to_dec() - H).abs())?;
 
-    let p_plus = opt_plus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
-    let p_minus = opt_minus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
-    let p = option
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
+    let p_plus = opt_plus.price(&PricingEngine::ClosedFormBS)?;
+    let p_minus = opt_minus.price(&PricingEngine::ClosedFormBS)?;
+    let p = option.price(&PricingEngine::ClosedFormBS)?;
 
     Ok((p_plus.to_dec() - dec!(2.0) * p.to_dec() + p_minus.to_dec()) / (H * H))
 }
@@ -80,12 +70,8 @@ pub fn numerical_vega(option: &Options) -> Result<Decimal, GreeksError> {
     opt_minus.implied_volatility =
         Positive::new_decimal((option.implied_volatility.to_dec() - H).abs())?;
 
-    let p_plus = opt_plus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
-    let p_minus = opt_minus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
+    let p_plus = opt_plus.price(&PricingEngine::ClosedFormBS)?;
+    let p_minus = opt_minus.price(&PricingEngine::ClosedFormBS)?;
 
     Ok((p_plus.to_dec() - p_minus.to_dec()) / (dec!(2.0) * H))
 }
@@ -118,12 +104,8 @@ pub fn numerical_rho(option: &Options) -> Result<Decimal, GreeksError> {
     let mut opt_minus = option.clone();
     opt_minus.risk_free_rate -= H;
 
-    let p_plus = opt_plus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
-    let p_minus = opt_minus
-        .price(&PricingEngine::ClosedFormBS)
-        .map_err(|e| GreeksError::StdError(e.to_string()))?;
+    let p_plus = opt_plus.price(&PricingEngine::ClosedFormBS)?;
+    let p_minus = opt_minus.price(&PricingEngine::ClosedFormBS)?;
 
     Ok((p_plus.to_dec() - p_minus.to_dec()) / (dec!(2.0) * H))
 }

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -6,7 +6,7 @@
 
 use crate::Options;
 use crate::error::decimal::DecimalError;
-use crate::error::greeks::{GreeksError, InputErrorKind, MathErrorKind};
+use crate::error::greeks::{DeltaNeutralityErrorKind, GreeksError, InputErrorKind, MathErrorKind};
 use crate::model::decimal::f64_to_decimal;
 use crate::strategies::DELTA_THRESHOLD;
 use core::f64;
@@ -176,7 +176,7 @@ pub fn d1(
 /// # Example
 ///
 /// ```rust
-/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn run() -> Result<(), optionstratlib::error::Error> {
 /// use rust_decimal_macros::dec;
 /// use tracing::{error, info};
 /// use optionstratlib::greeks::d2;
@@ -457,7 +457,7 @@ pub(crate) fn calculate_d_values(option: &Options) -> Result<(Decimal, Decimal),
 ///
 /// # Example
 /// ```rust
-/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn run() -> Result<(), optionstratlib::error::Error> {
 /// use rust_decimal_macros::dec;
 /// use optionstratlib::greeks::calculate_delta_neutral_sizes;
 /// use positive::pos_or_panic;
@@ -479,47 +479,40 @@ pub fn calculate_delta_neutral_sizes(
     // size1 + size2 = total_size
 
     if delta1.is_zero() || delta2.is_zero() {
-        return Err("Deltas cannot be zero for delta neutrality"
-            .to_string()
-            .into());
+        return Err(DeltaNeutralityErrorKind::ZeroDelta.into());
     }
 
     // Validate inputs
     if delta1 == delta2 {
-        return Err("Deltas cannot be equal for delta neutrality"
-            .to_string()
-            .into());
+        return Err(DeltaNeutralityErrorKind::EqualDeltas.into());
     }
 
     if delta1.is_sign_positive() == delta2.is_sign_positive() {
-        return Err("Deltas must have opposite signs for delta neutrality"
-            .to_string()
-            .into());
+        return Err(DeltaNeutralityErrorKind::SameSignDeltas.into());
     }
 
     let size1: Positive =
-        Positive::new_decimal((-total_size.to_dec() * delta2) / (delta1 - delta2))
-            .map_err(|e| e.to_string())?;
+        Positive::new_decimal((-total_size.to_dec() * delta2) / (delta1 - delta2))?;
     let size2 = total_size - size1;
 
     // Validate results
     if size1 < Decimal::ZERO || size2 < Decimal::ZERO {
-        return Err("Solution would require negative position sizes"
-            .to_string()
-            .into());
+        return Err(DeltaNeutralityErrorKind::NegativePositionSize.into());
     }
 
     // Verify the solution
     let total_delta: Decimal = size1.to_dec() * delta1 + size2.to_dec() * delta2;
     if total_delta.abs() > DELTA_THRESHOLD {
         // Allow small numerical errors
-        return Err("Could not achieve delta neutrality".to_string().into());
+        return Err(DeltaNeutralityErrorKind::NotAchievable.into());
     }
-    let toral_size_check = size1 + size2;
-    if (toral_size_check.to_dec() - total_size.to_dec()).abs() > DELTA_THRESHOLD {
-        return Err(format!(
-            "Calculated sizes {toral_size_check} do not match the total desired size of {total_size} "
-        ).into());
+    let total_size_check = size1 + size2;
+    if (total_size_check.to_dec() - total_size.to_dec()).abs() > DELTA_THRESHOLD {
+        return Err(DeltaNeutralityErrorKind::SizeMismatch {
+            calculated: total_size_check,
+            expected: total_size,
+        }
+        .into());
     }
 
     Ok((size1, size2))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,7 +722,7 @@
 //! use rust_decimal_macros::dec;
 //! use optionstratlib::greeks::Greeks;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! fn main() -> Result<(), optionstratlib::error::Error> {
 //!     // Create a European call option
 //!     let option = Options::new(
 //!         OptionType::European,
@@ -773,7 +773,7 @@
 //! use rust_decimal_macros::dec;
 //! use std::error::Error;
 //!
-//! fn main() -> Result<(), Box<dyn Error>> {
+//! fn main() -> Result<(), optionstratlib::error::Error> {
 //!     use optionstratlib::pricing::Profit;
 //! let underlying_price = Positive::HUNDRED;
 //!
@@ -823,7 +823,7 @@
 //! ```rust
 //! use optionstratlib::prelude::*;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! fn main() -> Result<(), optionstratlib::error::Error> {
 //!     // Create an option for implied volatility calculation
 //!     let mut option = Options::new(
 //!         OptionType::European,
@@ -853,7 +853,7 @@
 //! ```rust
 //! use optionstratlib::prelude::*;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! fn main() -> Result<(), optionstratlib::error::Error> {
 //!     // Define common parameters
 //!     let underlying_symbol = "DAX".to_string();
 //!     let underlying_price = pos_or_panic!(24000.0);

--- a/src/model/leg/mod.rs
+++ b/src/model/leg/mod.rs
@@ -37,7 +37,7 @@
 //! ## Example: Covered Call Strategy
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! use optionstratlib::model::leg::{Leg, SpotPosition};
 //! use optionstratlib::model::Position;
 //! use optionstratlib::model::types::Side;
@@ -60,7 +60,7 @@
 //! ## Example: Cash & Carry Arbitrage (Crypto)
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! use optionstratlib::model::leg::{Leg, SpotPosition, PerpetualPosition, MarginType};
 //! use optionstratlib::model::types::Side;
 //! use positive::{Positive, pos_or_panic};

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -316,8 +316,8 @@ impl Options {
     /// * The binomial price calculation fails
     pub fn calculate_price_binomial(&self, no_steps: usize) -> OptionsResult<Decimal> {
         if no_steps == 0 {
-            return Err(OptionsError::OtherError {
-                reason: "Number of steps cannot be zero".to_string(),
+            return Err(OptionsError::InvalidStepCount {
+                operation: "binomial",
             });
         }
         let expiry = self.time_to_expiration()?;
@@ -691,10 +691,11 @@ impl Options {
             // mid_vol is the average of two non-negative bounds, so it is
             // structurally non-negative; a None here would indicate a
             // breached invariant on the bounds themselves.
-            let volatility =
-                Positive::new_decimal(mid_vol).map_err(|e| OptionsError::OtherError {
+            let volatility = Positive::new_decimal(mid_vol).map_err(|e| {
+                OptionsError::ImpliedVolatilityInvariant {
                     reason: format!("mid_vol invariant breached: {e}"),
-                })?;
+                }
+            })?;
 
             // Calculate option price at this volatility
             let mut option_copy = self.clone();

--- a/src/model/position.rs
+++ b/src/model/position.rs
@@ -38,7 +38,7 @@ use utoipa::ToSchema;
 /// # Examples
 ///
 /// ```rust
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), optionstratlib::error::Error> {
 /// use optionstratlib::{Options, Side, OptionStyle};
 /// use positive::pos_or_panic;
 /// use chrono::Utc;
@@ -267,7 +267,7 @@ impl Position {
     /// # Examples
     ///
     /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), optionstratlib::error::Error> {
     /// use optionstratlib::{ Side, OptionStyle};
     /// use positive::pos_or_panic;
     /// use optionstratlib::model::Position;
@@ -354,7 +354,7 @@ impl Position {
     /// # Examples
     ///
     /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), optionstratlib::error::Error> {
     /// // Assuming position is a properly initialized Position
     /// use chrono::Utc;
     /// use optionstratlib::model::utils::create_sample_option_simplest;
@@ -414,7 +414,7 @@ impl Position {
     /// # Example
     ///
     /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), optionstratlib::error::Error> {
     /// use chrono::Utc;
     /// use tracing::info;
     /// use optionstratlib::model::Position;
@@ -1120,14 +1120,24 @@ impl PnLCalculator for Position {
         let income_diff = self_pnl.initial_income.to_dec() - other_pnl.initial_income.to_dec();
 
         let initial_costs = Positive::new(cost_diff.abs().to_f64().ok_or_else(|| {
-            PricingError::other("initial_costs: cost_diff Decimal cannot be represented as f64")
+            PricingError::method_error(
+                "pnl_diff",
+                "initial_costs: cost_diff Decimal cannot be represented as f64",
+            )
         })?)
-        .map_err(|_| PricingError::other("initial_costs value is not strictly positive"))?;
+        .map_err(|_| {
+            PricingError::method_error("pnl_diff", "initial_costs value is not strictly positive")
+        })?;
 
         let initial_income = Positive::new(income_diff.abs().to_f64().ok_or_else(|| {
-            PricingError::other("initial_income: income_diff Decimal cannot be represented as f64")
+            PricingError::method_error(
+                "pnl_diff",
+                "initial_income: income_diff Decimal cannot be represented as f64",
+            )
         })?)
-        .map_err(|_| PricingError::other("initial_income value is not strictly positive"))?;
+        .map_err(|_| {
+            PricingError::method_error("pnl_diff", "initial_income value is not strictly positive")
+        })?;
 
         Ok(PnL {
             realized: realized_diff,

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -387,7 +387,7 @@ pub fn create_sample_option_simplest_strike(
 /// # Example
 ///
 /// ```rust
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), optionstratlib::error::Error> {
 /// use positive::Positive;
 /// use optionstratlib::model::utils::mean_and_std;
 ///

--- a/src/pnl/model.rs
+++ b/src/pnl/model.rs
@@ -75,7 +75,7 @@ impl PnLRange {
     /// # Example
     ///
     /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), optionstratlib::error::Error> {
     /// use rust_decimal_macros::dec;
     /// use optionstratlib::pnl::model::PnLRange;
     ///

--- a/src/pricing/american.rs
+++ b/src/pricing/american.rs
@@ -24,7 +24,7 @@
 //! use optionstratlib::pricing::american::barone_adesi_whaley;
 //! use optionstratlib::model::types::OptionStyle;
 //! use positive::Positive;
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! let price = barone_adesi_whaley(
 //!     Positive::HUNDRED,      // underlying price
 //!     Positive::HUNDRED,      // strike price
@@ -94,7 +94,7 @@ const TOLERANCE: f64 = 1e-6;
 /// use optionstratlib::pricing::american::barone_adesi_whaley;
 /// use optionstratlib::model::types::OptionStyle;
 /// use positive::Positive;
-/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn run() -> Result<(), optionstratlib::error::Error> {
 /// // Price an American call option
 /// let call_price = barone_adesi_whaley(
 ///     Positive::HUNDRED,           // spot = 100
@@ -170,11 +170,12 @@ pub fn barone_adesi_whaley(
     match option_style {
         OptionStyle::Call => {
             let discriminant = (n - dec!(1)).powi(2) + dec!(4) * m / k_factor;
-            let sqrt_disc = discriminant
-                .sqrt()
-                .ok_or_else(|| PricingError::OtherError {
-                    reason: "Cannot calculate square root of negative discriminant".to_string(),
-                })?;
+            let sqrt_disc = discriminant.sqrt().ok_or_else(|| {
+                PricingError::method_error(
+                    "baw",
+                    "cannot calculate square root of negative discriminant",
+                )
+            })?;
             let q2 = (-(n - dec!(1)) + sqrt_disc) / dec!(2);
 
             // Find critical price S*
@@ -194,11 +195,12 @@ pub fn barone_adesi_whaley(
         }
         OptionStyle::Put => {
             let discriminant = (n - dec!(1)).powi(2) + dec!(4) * m / k_factor;
-            let sqrt_disc = discriminant
-                .sqrt()
-                .ok_or_else(|| PricingError::OtherError {
-                    reason: "Cannot calculate square root of negative discriminant".to_string(),
-                })?;
+            let sqrt_disc = discriminant.sqrt().ok_or_else(|| {
+                PricingError::method_error(
+                    "baw",
+                    "cannot calculate square root of negative discriminant",
+                )
+            })?;
             let q1 = (-(n - dec!(1)) - sqrt_disc) / dec!(2);
 
             // Find critical price S**
@@ -232,8 +234,8 @@ fn black_scholes_european(
     option_style: &OptionStyle,
 ) -> Result<Decimal, PricingError> {
     let d1_val = d1(s, k, t, r, q, sigma)?;
-    let sqrt_t = t.sqrt().ok_or_else(|| PricingError::OtherError {
-        reason: "Cannot calculate square root of time".to_string(),
+    let sqrt_t = t.sqrt().ok_or_else(|| {
+        PricingError::method_error("black_scholes", "cannot calculate square root of time")
     })?;
     let d2_val = d1_val - sigma * sqrt_t;
 
@@ -261,13 +263,14 @@ fn d1(
     sigma: Decimal,
 ) -> Result<Decimal, PricingError> {
     if t <= Decimal::ZERO || sigma <= Decimal::ZERO {
-        return Err(PricingError::OtherError {
-            reason: "Time and volatility must be positive".to_string(),
-        });
+        return Err(PricingError::method_error(
+            "d1",
+            "time and volatility must be positive",
+        ));
     }
-    let sqrt_t = t.sqrt().ok_or_else(|| PricingError::OtherError {
-        reason: "Cannot calculate square root of time".to_string(),
-    })?;
+    let sqrt_t = t
+        .sqrt()
+        .ok_or_else(|| PricingError::method_error("d1", "cannot calculate square root of time"))?;
     let ln_s_k = (s / k).ln();
     Ok((ln_s_k + (r - q + sigma * sigma / dec!(2)) * t) / (sigma * sqrt_t))
 }

--- a/src/pricing/binomial_model.rs
+++ b/src/pricing/binomial_model.rs
@@ -195,7 +195,7 @@ pub fn price_binomial(params: BinomialPricingParams) -> Result<Decimal, PricingE
 /// use positive::pos_or_panic;
 /// use optionstratlib::pricing::binomial_model::{BinomialPricingParams, generate_binomial_tree};
 /// use positive::Positive;
-/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn run() -> Result<(), optionstratlib::error::Error> {
 /// let params = BinomialPricingParams {
 ///             asset: Positive::HUNDRED,
 ///             volatility: pos_or_panic!(0.2),

--- a/src/pricing/monte_carlo.rs
+++ b/src/pricing/monte_carlo.rs
@@ -425,7 +425,7 @@ mod tests_price_option_monte_carlo {
     //
     //     // Create a custom implementation for get_years that returns an error
     //     impl ExpirationDate for MockOptions {
-    //         fn get_years(&self) -> Result<f64, Box<dyn Error>> {
+    //         fn get_years(&self) -> Result<f64, ExpirationDateError> {
     //             Err("Invalid expiration date".unwrap_or(Positive::ZERO))
     //         }
     //     }

--- a/src/pricing/payoff.rs
+++ b/src/pricing/payoff.rs
@@ -125,7 +125,7 @@ impl PayoffInfo {
     /// use optionstratlib::pricing::PayoffInfo;
     /// use positive::Positive;
     /// use optionstratlib::model::types::{OptionStyle, Side};
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), optionstratlib::error::Error> {
     /// let payoff_info = PayoffInfo {
     ///     spot: Positive::new(100.0)?,
     ///     strike: Positive::new(105.0)?,

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -55,7 +55,7 @@ use positive::pos_or_panic;
 //! use rust_decimal_macros::dec;
 //! use optionstratlib::risk::SPANMargin;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! fn main() -> Result<(), optionstratlib::error::Error> {
 //!     // Create an option position
 //!     let option = Options::new(
 //!         OptionType::European,
@@ -108,7 +108,7 @@ use positive::pos_or_panic;
 //! use positive::pos_or_panic;
 //! use optionstratlib::risk::SPANMargin;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! fn main() -> Result<(), optionstratlib::error::Error> {
 //!     let option = Options {
 //!         option_type: OptionType::European,
 //!         side: Side::Long,

--- a/src/risk/span.rs
+++ b/src/risk/span.rs
@@ -300,7 +300,7 @@ mod tests_span {
     use tracing::info;
 
     #[test]
-    fn test_span_margin() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_span_margin() -> Result<(), crate::error::Error> {
         let option = create_sample_option(
             OptionStyle::Call,
             Side::Short,

--- a/src/series/model.rs
+++ b/src/series/model.rs
@@ -216,7 +216,10 @@ impl OptionSeries {
         let chain_params = match chain_params {
             Some((_, option_chain)) => option_chain.to_build_params()?,
             None => {
-                return Err("No chains found".into());
+                return Err(ChainError::invalid_parameters(
+                    "chains",
+                    "no chains available to derive build parameters",
+                ));
             }
         };
 
@@ -646,7 +649,7 @@ mod tests_option_series {
 
             // Verify the error message
             let error = result.unwrap_err();
-            assert!(error.to_string().contains("No chains found"));
+            assert!(error.to_string().contains("chains"));
         }
     }
 

--- a/src/simulation/steps/step.rs
+++ b/src/simulation/steps/step.rs
@@ -111,10 +111,9 @@ where
         let next_x = match self.x.next() {
             Ok(x_step) => x_step,
             Err(e) => {
-                return Err(format!(
+                return Err(SimulationError::step_error(&format!(
                     "Cannot generate next step. Expiration date is already reached: {e}"
-                )
-                .into());
+                )));
             }
         };
         Ok(Self {
@@ -139,10 +138,9 @@ where
         let previous_x = match self.x.previous() {
             Ok(x_step) => x_step,
             Err(e) => {
-                return Err(format!(
+                return Err(SimulationError::step_error(&format!(
                     "Cannot generate previous step. Expiration date is already reached: {e}"
-                )
-                .into());
+                )));
             }
         };
         Ok(Self {
@@ -162,7 +160,7 @@ where
     pub fn get_graph_x_value(&self) -> Result<Decimal, SimulationError> {
         match Decimal::from_i32(*self.x.index()) {
             Some(x) => Ok(x),
-            None => Err("Cannot convert x-axis index to decimal".into()),
+            None => Err(SimulationError::IndexConversion),
         }
     }
 

--- a/src/simulation/steps/x.rs
+++ b/src/simulation/steps/x.rs
@@ -194,7 +194,7 @@ where
     pub fn next(&self) -> Result<Self, SimulationError> {
         let days = self.datetime.get_days()?;
         if days == Positive::ZERO {
-            return Err("Cannot generate next step. Expiration date is already reached.".into());
+            return Err(SimulationError::ExpirationReached);
         }
         let days_to_rest = convert_time_frame(
             self.step_size_in_time.try_into().map_err(|_| {

--- a/src/simulation/traits.rs
+++ b/src/simulation/traits.rs
@@ -130,7 +130,9 @@ where
 
                 Ok(values)
             }
-            _ => Err("Invalid walk type for Brownian motion".into()),
+            _ => Err(SimulationError::InvalidWalkType {
+                expected: "Brownian",
+            }),
         }
     }
 
@@ -173,7 +175,9 @@ where
                 }
                 Ok(values)
             }
-            _ => Err("Invalid walk type for Geometric Brownian motion".into()),
+            _ => Err(SimulationError::InvalidWalkType {
+                expected: "GeometricBrownian",
+            }),
         }
     }
 
@@ -215,10 +219,7 @@ where
 
                     if let Some(ac) = autocorrelation {
                         if !(-Decimal::ONE..=Decimal::ONE).contains(&ac) {
-                            return Err(format!(
-                                "LogReturns: autocorrelation {ac} must lie in [-1, 1]"
-                            )
-                            .into());
+                            return Err(SimulationError::InvalidAutocorrelation { value: ac });
                         }
                         log_ret += ac * prev_log_ret;
                     }
@@ -231,7 +232,9 @@ where
                 }
                 Ok(values)
             }
-            _ => Err("Invalid walk type for Log Returns motion".into()),
+            _ => Err(SimulationError::InvalidWalkType {
+                expected: "LogReturns",
+            }),
         }
     }
 
@@ -269,7 +272,9 @@ where
                 ))
             }
 
-            _ => Err("Invalid walk type for Mean Reverting motion".into()),
+            _ => Err(SimulationError::InvalidWalkType {
+                expected: "MeanReverting",
+            }),
         }
     }
 
@@ -325,7 +330,9 @@ where
 
                 Ok(values)
             }
-            _ => Err("Invalid walk type for Jump Diffusion motion".into()),
+            _ => Err(SimulationError::InvalidWalkType {
+                expected: "JumpDiffusion",
+            }),
         }
     }
 
@@ -356,7 +363,7 @@ where
                 beta,
             } => {
                 if alpha + beta >= Decimal::ONE {
-                    return Err("alpha + beta must be < 1 for stationarity".into());
+                    return Err(SimulationError::GarchStationarity { alpha, beta });
                 }
 
                 let mut path = Vec::with_capacity(params.size + 1);
@@ -392,7 +399,7 @@ where
                 }
                 Ok(path)
             }
-            _ => Err("Invalid walk type for GARCH model".into()),
+            _ => Err(SimulationError::InvalidWalkType { expected: "GARCH" }),
         }
     }
 
@@ -453,7 +460,7 @@ where
             } => {
                 // Validate parameters
                 if rho < -Decimal::ONE || rho > Decimal::ONE {
-                    return Err("Correlation rho must be between -1 and 1".into());
+                    return Err(SimulationError::InvalidCorrelation { rho });
                 }
 
                 let mut values = Vec::with_capacity(params.size);
@@ -464,14 +471,13 @@ where
 
                 values.push(price); // Add initial value
 
-                let dt_sqrt = dt
-                    .to_dec()
-                    .sqrt()
-                    .ok_or_else(|| SimulationError::other("Heston: sqrt(dt) failed (overflow)"))?;
+                let dt_sqrt = dt.to_dec().sqrt().ok_or_else(|| {
+                    SimulationError::walk_error("Heston: sqrt(dt) failed (overflow)")
+                })?;
                 // sqrt(1 - rho^2) depends only on `rho`, hoist out of the
                 // hot loop so we don't recompute it per step.
                 let one_minus_rho_sq_sqrt = (Decimal::ONE - rho * rho).sqrt().ok_or_else(|| {
-                    SimulationError::other(
+                    SimulationError::walk_error(
                         "Heston: sqrt(1 - rho^2) failed (rho out of range or overflow)",
                     )
                 })?;
@@ -482,7 +488,7 @@ where
 
                     // Ensure variance stays positive (modified Euler scheme with truncation)
                     let variance_sqrt = variance.sqrt().ok_or_else(|| {
-                        SimulationError::other("Heston: sqrt(variance) failed (overflow)")
+                        SimulationError::walk_error("Heston: sqrt(variance) failed (overflow)")
                     })?;
                     let variance_new = (variance
                         + kappa.to_dec() * (theta.to_dec() - variance) * dt.to_dec()
@@ -492,7 +498,7 @@ where
                     // Update price using the average variance over the step
                     let avg_variance = (variance + variance_new) / Decimal::TWO;
                     let avg_variance_sqrt = avg_variance.sqrt().ok_or_else(|| {
-                        SimulationError::other("Heston: sqrt(avg_variance) failed (overflow)")
+                        SimulationError::walk_error("Heston: sqrt(avg_variance) failed (overflow)")
                     })?;
                     let price_change = drift * dt.to_dec() + avg_variance_sqrt * z1 * dt_sqrt;
 
@@ -504,7 +510,7 @@ where
 
                 Ok(values)
             }
-            _ => Err("Invalid walk type for Heston model".into()),
+            _ => Err(SimulationError::InvalidWalkType { expected: "Heston" }),
         }
     }
 
@@ -554,7 +560,7 @@ where
 
                 Ok(path)
             }
-            _ => Err("Invalid walk type for Custom motion".into()),
+            _ => Err(SimulationError::InvalidWalkType { expected: "Custom" }),
         }
     }
 
@@ -637,7 +643,9 @@ where
 
                 Ok(values)
             }
-            _ => Err("Invalid walk type for Telegraph process".into()),
+            _ => Err(SimulationError::InvalidWalkType {
+                expected: "Telegraph",
+            }),
         }
     }
 
@@ -676,10 +684,15 @@ where
                 if prices.len() >= params.size {
                     Ok(prices[0..params.size].to_vec())
                 } else {
-                    Err("Historical prices are not enough to generate the walk".into())
+                    Err(SimulationError::InsufficientHistoricalData {
+                        required: params.size,
+                        found: prices.len(),
+                    })
                 }
             }
-            _ => Err("Invalid walk type for Historical motion".into()),
+            _ => Err(SimulationError::InvalidWalkType {
+                expected: "Historical",
+            }),
         }
     }
 }
@@ -773,7 +786,6 @@ mod tests_walk_type_able {
     use crate::utils::TimeFrame;
     use positive::pos_or_panic;
     use rust_decimal::Decimal;
-    use std::error::Error;
     use std::fmt::Display;
     use std::ops::AddAssign;
 
@@ -813,7 +825,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_brownian_walk() -> Result<(), Box<dyn Error>> {
+    fn test_brownian_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             5,
             10.0,
@@ -833,7 +845,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_geometric_brownian_walk() -> Result<(), Box<dyn Error>> {
+    fn test_geometric_brownian_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             5,
             10.0,
@@ -853,7 +865,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_log_returns_walk() -> Result<(), Box<dyn Error>> {
+    fn test_log_returns_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             5,
             10.0,
@@ -874,7 +886,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_mean_reverting_walk() -> Result<(), Box<dyn Error>> {
+    fn test_mean_reverting_walk() -> Result<(), SimulationError> {
         let mean_value = pos_or_panic!(150.0);
         let params = create_test_params(
             5,
@@ -897,7 +909,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_jump_diffusion_walk() -> Result<(), Box<dyn Error>> {
+    fn test_jump_diffusion_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             6,
             10.0,
@@ -920,7 +932,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_garch_walk() -> Result<(), Box<dyn Error>> {
+    fn test_garch_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             5,
             10.0,
@@ -942,7 +954,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_heston_walk() -> Result<(), Box<dyn Error>> {
+    fn test_heston_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             5,
             10.0,
@@ -966,7 +978,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_custom_walk() -> Result<(), Box<dyn Error>> {
+    fn test_custom_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             5,
             10.0,
@@ -989,7 +1001,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_telegraph_walk() -> Result<(), Box<dyn Error>> {
+    fn test_telegraph_walk() -> Result<(), SimulationError> {
         let params = create_test_params(
             5,
             10.0,
@@ -1014,7 +1026,7 @@ mod tests_walk_type_able {
     }
 
     #[test]
-    fn test_with_different_types() -> Result<(), Box<dyn Error>> {
+    fn test_with_different_types() -> Result<(), SimulationError> {
         #[derive(Debug, Copy, Clone, PartialEq)]
         struct XType(f64);
 
@@ -1083,7 +1095,7 @@ mod tests_walk_type_able {
                 &self,
                 _params: &WalkParams<X, Y>,
             ) -> Result<Vec<Positive>, SimulationError> {
-                Err("Error simulado para prueba".into())
+                Err(SimulationError::walk_error("Error simulado para prueba"))
             }
 
             fn geometric_brownian(

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -703,7 +703,7 @@ impl Optimizable for BullPutSpread {
     /// # Examples
     ///
     /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), optionstratlib::error::Error> {
     /// use rust_decimal_macros::dec;
     /// use tracing::info;
     /// use optionstratlib::chains::chain::OptionChain;

--- a/src/strategies/collar.rs
+++ b/src/strategies/collar.rs
@@ -753,11 +753,13 @@ impl crate::strategies::StrategyConstructor for Collar {}
 
 impl ProbabilityAnalysis for Collar {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self
-            .break_even_points
-            .first()
-            .copied()
-            .ok_or_else(|| ProbabilityError::from("No break-even point found"))?;
+        let break_even_point =
+            self.break_even_points
+                .first()
+                .copied()
+                .ok_or(ProbabilityError::MissingMetric {
+                    metric: "break_even_point",
+                })?;
 
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
@@ -785,11 +787,13 @@ impl ProbabilityAnalysis for Collar {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self
-            .break_even_points
-            .first()
-            .copied()
-            .ok_or_else(|| ProbabilityError::from("No break-even point found"))?;
+        let break_even_point =
+            self.break_even_points
+                .first()
+                .copied()
+                .ok_or(ProbabilityError::MissingMetric {
+                    metric: "break_even_point",
+                })?;
 
         let option = &self.long_put.option;
         let expiration_date = &option.expiration_date;

--- a/src/strategies/covered_call.rs
+++ b/src/strategies/covered_call.rs
@@ -596,11 +596,13 @@ impl crate::strategies::StrategyConstructor for CoveredCall {}
 
 impl ProbabilityAnalysis for CoveredCall {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self
-            .break_even_points
-            .first()
-            .copied()
-            .ok_or_else(|| ProbabilityError::from("No break-even point found"))?;
+        let break_even_point =
+            self.break_even_points
+                .first()
+                .copied()
+                .ok_or(ProbabilityError::MissingMetric {
+                    metric: "break_even_point",
+                })?;
 
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
@@ -628,11 +630,13 @@ impl ProbabilityAnalysis for CoveredCall {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self
-            .break_even_points
-            .first()
-            .copied()
-            .ok_or_else(|| ProbabilityError::from("No break-even point found"))?;
+        let break_even_point =
+            self.break_even_points
+                .first()
+                .copied()
+                .ok_or(ProbabilityError::MissingMetric {
+                    metric: "break_even_point",
+                })?;
 
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;

--- a/src/strategies/delta_neutral/model.rs
+++ b/src/strategies/delta_neutral/model.rs
@@ -6,6 +6,7 @@
 use super::adjustment::{AdjustmentConfig, AdjustmentPlan};
 use super::optimizer::AdjustmentOptimizer;
 use super::portfolio::{AdjustmentTarget, PortfolioGreeks};
+use crate::error::greeks::DeltaNeutralityErrorKind;
 use crate::error::position::PositionValidationErrorKind;
 use crate::error::{GreeksError, PositionError, StrategyError};
 /// # Delta Neutrality Management Module
@@ -351,7 +352,7 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
     fn delta_neutrality(&self) -> Result<DeltaInfo, GreeksError> {
         let options = self.get_options()?;
         if options.is_empty() {
-            return Err(GreeksError::StdError("No options found".to_string()));
+            return Err(DeltaNeutralityErrorKind::EmptyOptions.into());
         }
         let underlying_price = *self.get_underlying_price();
         let mut individual_deltas: Vec<DeltaPositionInfo> = Vec::with_capacity(options.len());
@@ -484,9 +485,7 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
             return Ok(DeltaAdjustment::NoAdjustmentNeeded);
         }
         if option_delta_per_contract.is_zero() {
-            return Err(GreeksError::StdError(
-                "Option delta per contract cannot be zero".to_string(),
-            ));
+            return Err(DeltaNeutralityErrorKind::OptionDeltaZero.into());
         }
 
         // Calculate how many contracts are needed to neutralize the net delta
@@ -516,9 +515,7 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
             // We have fewer contracts than needed, but since we need to sell,
             // we can't sell what we don't have, so no adjustment is possible
             (true, true, false) => {
-                return Err(GreeksError::StdError(
-                    "we can't sell what we don't have, so no adjustment is possible".to_string(),
-                ));
+                return Err(DeltaNeutralityErrorKind::InsufficientContracts.into());
             }
             // If net_delta is positive and option_delta is negative, we need to buy options
             // This means we have too much positive delta and need to add negative delta
@@ -576,9 +573,7 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
             // We have fewer contracts than needed, but since we need to sell,
             // we can't sell what we don't have, so no adjustment is possible
             (false, false, false) => {
-                return Err(GreeksError::StdError(
-                    "we can't sell what we don't have, so no adjustment is possible".to_string(),
-                ));
+                return Err(DeltaNeutralityErrorKind::InsufficientContracts.into());
             }
         };
 
@@ -1001,12 +996,17 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
     fn portfolio_greeks(&self) -> Result<PortfolioGreeks, GreeksError> {
         let positions: Vec<_> = self
             .get_positions()
-            .map_err(|e| GreeksError::StdError(e.to_string()))?
+            .map_err(|e| {
+                GreeksError::CalculationError(
+                    crate::error::greeks::CalculationErrorKind::DeltaError {
+                        reason: e.to_string(),
+                    },
+                )
+            })?
             .into_iter()
             .cloned()
             .collect();
         PortfolioGreeks::from_positions(&positions)
-            .map_err(|e| GreeksError::StdError(e.to_string()))
     }
 
     /// Generates an optimized adjustment plan to achieve target Greeks.

--- a/src/strategies/long_call.rs
+++ b/src/strategies/long_call.rs
@@ -504,7 +504,9 @@ impl PnLCalculator for LongCall {
         // Single-leg strategies like LongCall don't typically require delta adjustments
         // as they are directional strategies. Delta adjustments are more relevant for
         // complex multi-leg strategies aiming for delta neutrality.
-        Err("Delta adjustments are not applicable to single-leg LongCall strategy".into())
+        Err(PricingError::DeltaAdjustmentNotApplicable {
+            strategy: "LongCall",
+        })
     }
 }
 
@@ -556,9 +558,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .map_err(|e| SimulationError::OtherError {
-                    reason: format!("Failed to set progress bar template: {}", e),
-                })?
+                .map_err(|e| SimulationError::walk_error(&format!(
+                    "Failed to set progress bar template: {e}"
+                )))?
                 .progress_chars("#>-"),
         );
 

--- a/src/strategies/long_put.rs
+++ b/src/strategies/long_put.rs
@@ -511,7 +511,9 @@ impl PnLCalculator for LongPut {
         // Single-leg strategies like LongPut don't typically require delta adjustments
         // as they are directional strategies. Delta adjustments are more relevant for
         // complex multi-leg strategies aiming for delta neutrality.
-        Err("Delta adjustments are not applicable to single-leg LongPut strategy".into())
+        Err(PricingError::DeltaAdjustmentNotApplicable {
+            strategy: "LongPut",
+        })
     }
 }
 
@@ -563,9 +565,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .map_err(|e| SimulationError::OtherError {
-                    reason: format!("Failed to set progress bar template: {}", e),
-                })?
+                .map_err(|e| SimulationError::walk_error(&format!(
+                    "Failed to set progress bar template: {e}"
+                )))?
                 .progress_chars("#>-"),
         );
 

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -41,7 +41,7 @@
 //! Example usage of the Bull Call Spread strategy:
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal_macros::dec;
 //! use tracing::info;
 //! use optionstratlib::ExpirationDate;
@@ -157,7 +157,7 @@
 //! //! Example usage of the Iron Condor strategy:
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal_macros::dec;
 //! use tracing::info;
 //! use optionstratlib::ExpirationDate;

--- a/src/strategies/probabilities/mod.rs
+++ b/src/strategies/probabilities/mod.rs
@@ -56,7 +56,7 @@
 //! ### Basic Strategy Analysis
 //!
 //! ```rust
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal_macros::dec;
 //! use tracing::info;
 //! use optionstratlib::model::types::{ OptionStyle, OptionType, Side};
@@ -92,7 +92,7 @@
 //! ### Analysis with Volatility Adjustment
 //!
 //! ```rust
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal_macros::dec;
 //! use optionstratlib::ExpirationDate;
 //! use optionstratlib::strategies::probabilities::{ProbabilityAnalysis, VolatilityAdjustment};
@@ -131,7 +131,7 @@
 //! ### Analysis with Price Trend
 //!
 //! ```rust
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! use rust_decimal_macros::dec;
 //! use optionstratlib::ExpirationDate;
 //! use positive::Positive;
@@ -168,7 +168,7 @@
 //! ### Price Range Probability Analysis
 //!
 //! ```rust
-//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn run() -> Result<(), optionstratlib::error::Error> {
 //! use tracing::info;
 //! use optionstratlib::strategies::probabilities::calculate_price_probability;
 //! use optionstratlib::ExpirationDate;

--- a/src/strategies/probabilities/utils.rs
+++ b/src/strategies/probabilities/utils.rs
@@ -114,18 +114,24 @@ pub fn calculate_single_point_probability(
                 ));
             }
             let rf = risk_free.to_f64().ok_or_else(|| {
-                ProbabilityError::StdError(format!(
-                    "calculate_single_point_probability: risk_free Decimal {} not representable as f64",
-                    risk_free
-                ))
+                ProbabilityError::CalculationError(
+                    ProbabilityCalculationErrorKind::ExpectedValueError {
+                        reason: format!(
+                            "calculate_single_point_probability: risk_free Decimal {risk_free} not representable as f64"
+                        ),
+                    },
+                )
             })?;
             rf + (t.drift_rate * t.confidence)
         }
         None => risk_free.to_f64().ok_or_else(|| {
-            ProbabilityError::StdError(format!(
-                "calculate_single_point_probability: risk_free Decimal {} not representable as f64",
-                risk_free
-            ))
+            ProbabilityError::CalculationError(
+                ProbabilityCalculationErrorKind::ExpectedValueError {
+                    reason: format!(
+                        "calculate_single_point_probability: risk_free Decimal {risk_free} not representable as f64"
+                    ),
+                },
+            )
         })?,
     };
 

--- a/src/strategies/protective_put.rs
+++ b/src/strategies/protective_put.rs
@@ -448,11 +448,13 @@ impl crate::strategies::StrategyConstructor for ProtectivePut {}
 
 impl ProbabilityAnalysis for ProtectivePut {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self
-            .break_even_points
-            .first()
-            .copied()
-            .ok_or_else(|| ProbabilityError::from("No break-even point found"))?;
+        let break_even_point =
+            self.break_even_points
+                .first()
+                .copied()
+                .ok_or(ProbabilityError::MissingMetric {
+                    metric: "break_even_point",
+                })?;
         let option = &self.long_put.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -471,11 +473,13 @@ impl ProbabilityAnalysis for ProtectivePut {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self
-            .break_even_points
-            .first()
-            .copied()
-            .ok_or_else(|| ProbabilityError::from("No break-even point found"))?;
+        let break_even_point =
+            self.break_even_points
+                .first()
+                .copied()
+                .ok_or(ProbabilityError::MissingMetric {
+                    metric: "break_even_point",
+                })?;
         let option = &self.long_put.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;

--- a/src/strategies/short_call.rs
+++ b/src/strategies/short_call.rs
@@ -516,7 +516,9 @@ impl PnLCalculator for ShortCall {
         // Single-leg strategies like ShortCall don't typically require delta adjustments
         // as they are directional strategies. Delta adjustments are more relevant for
         // complex multi-leg strategies aiming for delta neutrality.
-        Err("Delta adjustments are not applicable to single-leg ShortCall strategy".into())
+        Err(PricingError::DeltaAdjustmentNotApplicable {
+            strategy: "ShortCall",
+        })
     }
 }
 
@@ -572,9 +574,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .map_err(|e| SimulationError::OtherError {
-                    reason: format!("Failed to set progress bar template: {}", e),
-                })?
+                .map_err(|e| SimulationError::walk_error(&format!(
+                    "Failed to set progress bar template: {e}"
+                )))?
                 .progress_chars("#>-"),
         );
 

--- a/src/strategies/short_put.rs
+++ b/src/strategies/short_put.rs
@@ -516,7 +516,9 @@ impl PnLCalculator for ShortPut {
         // Single-leg strategies like ShortPut don't typically require delta adjustments
         // as they are directional strategies. Delta adjustments are more relevant for
         // complex multi-leg strategies aiming for delta neutrality.
-        Err("Delta adjustments are not applicable to single-leg ShortPut strategy".into())
+        Err(PricingError::DeltaAdjustmentNotApplicable {
+            strategy: "ShortPut",
+        })
     }
 }
 
@@ -568,9 +570,9 @@ where
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} simulations ({eta})",
                 )
-                .map_err(|e| SimulationError::OtherError {
-                    reason: format!("Failed to set progress bar template: {}", e),
-                })?
+                .map_err(|e| SimulationError::walk_error(&format!(
+                    "Failed to set progress bar template: {e}"
+                )))?
                 .progress_chars("#>-"),
         );
 

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -446,7 +446,7 @@ impl GeometricObject<Point3D, Point2D> for Surface {
     ///
     /// ## Creating from existing points
     /// ```rust
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), optionstratlib::error::Error> {
     /// use std::collections::BTreeSet;
     /// use optionstratlib::geometrics::{ConstructionMethod, GeometricObject};
     /// use optionstratlib::surfaces::{Point3D, Surface};
@@ -462,7 +462,7 @@ impl GeometricObject<Point3D, Point2D> for Surface {
     ///
     /// ## Creating from a parametric function
     /// ```rust,no_run
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn run() -> Result<(), optionstratlib::error::Error> {
     /// use rust_decimal_macros::dec;
     /// use optionstratlib::curves::Point2D;
     /// use optionstratlib::geometrics::{ConstructionMethod, ConstructionParams, GeometricObject, ResultPoint};
@@ -1989,7 +1989,10 @@ mod tests_surface_geometric_object {
         let parametric_func: Box<dyn Fn(Point2D) -> ResultPoint<Point3D> + Send + Sync> =
             Box::new(move |t: Point2D| -> ResultPoint<Point3D> {
                 if t.x > dec!(0.5) && t.y > dec!(0.5) {
-                    Err("Test error".into())
+                    Err(crate::error::ChainError::invalid_parameters(
+                        "parametric_f",
+                        "Test error",
+                    ))
                 } else {
                     Ok(Point3D::new(t.x, t.y, t.x * t.y))
                 }

--- a/src/surfaces/traits.rs
+++ b/src/surfaces/traits.rs
@@ -18,8 +18,8 @@ use crate::surfaces::Surface;
 /// Potential errors could include:
 /// - Invalid inputs or parameters leading to a [`SurfaceError::Point3DError`] or [`SurfaceError::ConstructionError`].
 /// - Failures during surface computation due to invalid operations (e.g., [`SurfaceError::OperationError`]).
-/// - General-purpose errors, such as I/O or analysis issues, represented as [`SurfaceError::StdError`]
-///   or [`SurfaceError::AnalysisError`].
+/// - General-purpose errors, such as I/O or analysis issues, represented as
+///   [`SurfaceError::RenderError`] or [`SurfaceError::AnalysisError`].
 ///
 /// # Implementors
 ///  of this trait should define how their specific type generates a [`Surface`].

--- a/src/surfaces/visualization/plotters.rs
+++ b/src/surfaces/visualization/plotters.rs
@@ -16,7 +16,7 @@
 //! # Example Usage
 //!
 //! ```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! # use std::fs;
 //! use std::path::PathBuf;
 //! use rust_decimal_macros::dec;
@@ -147,16 +147,18 @@ mod tests_extended {
     }
 
     #[test]
-    fn test_map_err_to_std_error() {
+    fn test_map_err_to_render_error() {
         let result: Result<(), SurfaceError> =
-            Err(std::io::Error::other("Test error")).map_err(|e| SurfaceError::StdError {
+            Err(std::io::Error::other("Test error")).map_err(|e| SurfaceError::RenderError {
+                backend: "plotters",
                 reason: e.to_string(),
             });
 
         assert!(result.is_err());
         let error = result.unwrap_err();
         match error {
-            SurfaceError::StdError { reason } => {
+            SurfaceError::RenderError { backend, reason } => {
+                assert_eq!(backend, "plotters");
                 assert_eq!(reason, "Test error");
             }
             _ => panic!("Unexpected error type"),
@@ -231,13 +233,13 @@ mod tests_extended {
 
     #[test]
     fn test_draw_series_error() {
-        let result: Result<(), SurfaceError> =
-            Err("Draw error".to_string()).map_err(|e| SurfaceError::StdError { reason: e });
-
-        assert!(result.is_err());
-        let error = result.unwrap_err();
+        let error = SurfaceError::RenderError {
+            backend: "plotters",
+            reason: "Draw error".to_string(),
+        };
         match error {
-            SurfaceError::StdError { reason } => {
+            SurfaceError::RenderError { backend, reason } => {
+                assert_eq!(backend, "plotters");
                 assert_eq!(reason, "Draw error");
             }
             _ => panic!("Unexpected error type"),

--- a/src/utils/csv.rs
+++ b/src/utils/csv.rs
@@ -87,7 +87,7 @@ pub fn read_ohlcv_from_zip(
         }
     }
 
-    let csv_index = csv_index.ok_or(OhlcvError::MissingColumn { column: "csv" })?;
+    let csv_index = csv_index.ok_or(OhlcvError::MissingZipEntry { extension: "csv" })?;
     let file = archive.by_index(csv_index)?;
     let reader = BufReader::new(file);
 
@@ -159,8 +159,8 @@ pub async fn read_ohlcv_from_zip_async(
         read_ohlcv_from_zip(&zip_path, start_date.as_deref(), end_date.as_deref())
     })
     .await
-    .map_err(|e| OhlcvError::RowParsing {
-        reason: format!("async task error: {e}"),
+    .map_err(|e| OhlcvError::AsyncTask {
+        reason: e.to_string(),
     })?
 }
 

--- a/src/utils/csv.rs
+++ b/src/utils/csv.rs
@@ -87,9 +87,7 @@ pub fn read_ohlcv_from_zip(
         }
     }
 
-    let csv_index = csv_index.ok_or(OhlcvError::OtherError {
-        reason: "No CSV file found in ZIP archive".to_string(),
-    })?;
+    let csv_index = csv_index.ok_or(OhlcvError::MissingColumn { column: "csv" })?;
     let file = archive.by_index(csv_index)?;
     let reader = BufReader::new(file);
 
@@ -161,8 +159,8 @@ pub async fn read_ohlcv_from_zip_async(
         read_ohlcv_from_zip(&zip_path, start_date.as_deref(), end_date.as_deref())
     })
     .await
-    .map_err(|e| OhlcvError::OtherError {
-        reason: format!("Async task error: {}", e),
+    .map_err(|e| OhlcvError::RowParsing {
+        reason: format!("async task error: {e}"),
     })?
 }
 
@@ -530,11 +528,18 @@ mod ohlcv_tests {
         };
         assert_eq!(format!("{param_error}"), "Invalid parameter: test reason");
 
-        // Test OtherError display
-        let other_error = OhlcvError::OtherError {
+        // Test MissingColumn display
+        let missing_column = OhlcvError::MissingColumn { column: "csv" };
+        assert_eq!(
+            format!("{missing_column}"),
+            "required column `csv` is missing"
+        );
+
+        // Test RowParsing display
+        let row_parsing = OhlcvError::RowParsing {
             reason: "test reason".to_string(),
         };
-        assert_eq!(format!("{other_error}"), "Error: test reason");
+        assert_eq!(format!("{row_parsing}"), "failed to parse row: test reason");
     }
 
     #[test]

--- a/src/utils/others.rs
+++ b/src/utils/others.rs
@@ -135,7 +135,7 @@ pub fn random_decimal(rng: &mut impl Rng) -> Result<Decimal, DecimalError> {
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), optionstratlib::error::Error> {
 /// use optionstratlib::utils::others::process_n_times_iter;
 ///
 /// let numbers = vec![1, 2, 3];
@@ -159,7 +159,9 @@ where
     Y: Send,
 {
     if positions.is_empty() {
-        return Err(Error::Other("Vector empty".to_string()));
+        return Err(Error::EmptyCollection {
+            context: "positions",
+        });
     }
 
     let combinations: Vec<_> = positions.iter().combinations_with_replacement(n).collect();
@@ -391,7 +393,10 @@ mod tests_process_n_times_iter {
         let empty_vec: Vec<i32> = vec![];
         let result = process_n_times_iter(&empty_vec, 1, |_| vec![42]);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "Vector empty");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "empty collection: positions"
+        );
     }
 
     #[test]

--- a/src/visualization/mod.rs
+++ b/src/visualization/mod.rs
@@ -61,7 +61,7 @@
 //! ## Example: Simple Line Chart
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! use std::fs;
 //! use std::path::{Path, PathBuf};
 //! use rust_decimal::Decimal;

--- a/src/volatility/mod.rs
+++ b/src/volatility/mod.rs
@@ -133,7 +133,7 @@ use positive::pos_or_panic;
 //! The module includes utilities for converting between different time frames:
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! use positive::pos_or_panic;
 //! use optionstratlib::utils::time::TimeFrame;
 //! use optionstratlib::volatility::{annualized_volatility, de_annualized_volatility};

--- a/src/volatility/traits.rs
+++ b/src/volatility/traits.rs
@@ -109,7 +109,11 @@ impl AtmIvProvider for OptionChain {
     fn atm_iv(&self) -> Result<&Positive, VolatilityError> {
         match self.get_atm_implied_volatility() {
             Ok(iv) => Ok(iv),
-            Err(e) => Err(format!("ATM IV not available: {e}").into()),
+            Err(e) => Err(VolatilityError::AtmIvUnavailable {
+                source: Box::new(VolatilityError::NumericalFailure {
+                    reason: e.to_string(),
+                }),
+            }),
         }
     }
 }
@@ -240,7 +244,9 @@ mod tests_volatility_traits {
 
         impl AtmIvProvider for ErrorIvProvider {
             fn atm_iv(&self) -> Result<&Positive, VolatilityError> {
-                Err("ATM IV not available: test error".into())
+                Err(VolatilityError::AtmIvUnavailable {
+                    source: Box::new(VolatilityError::IvNotFound),
+                })
             }
         }
 
@@ -249,7 +255,11 @@ mod tests_volatility_traits {
 
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("ATM IV not available"));
+        assert!(
+            error
+                .to_string()
+                .contains("ATM implied volatility is not available")
+        );
     }
 
     #[test]
@@ -364,7 +374,11 @@ mod tests_volatility_traits {
         let result = chain.atm_iv();
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("ATM IV not available"));
+        assert!(
+            error
+                .to_string()
+                .contains("ATM implied volatility is not available")
+        );
     }
 
     #[test]

--- a/src/volatility/traits.rs
+++ b/src/volatility/traits.rs
@@ -110,9 +110,7 @@ impl AtmIvProvider for OptionChain {
         match self.get_atm_implied_volatility() {
             Ok(iv) => Ok(iv),
             Err(e) => Err(VolatilityError::AtmIvUnavailable {
-                source: Box::new(VolatilityError::NumericalFailure {
-                    reason: e.to_string(),
-                }),
+                source: Box::new(VolatilityError::from(e)),
             }),
         }
     }

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -27,12 +27,13 @@ use positive::pos_or_panic;
 ///
 /// The calculated volatility as a Decimal.
 pub fn constant_volatility(returns: &[Decimal]) -> Result<Positive, VolatilityError> {
-    let n_dec = Decimal::from_usize(returns.len()).ok_or_else(|| {
-        VolatilityError::from(format!(
-            "constant_volatility: returns.len() {} not representable as Decimal",
-            returns.len()
-        ))
-    })?;
+    let n_dec =
+        Decimal::from_usize(returns.len()).ok_or_else(|| VolatilityError::NumericalFailure {
+            reason: format!(
+                "constant_volatility: returns.len() {} not representable as Decimal",
+                returns.len()
+            ),
+        })?;
     let n = Positive::new_decimal(n_dec).unwrap_or(Positive::ZERO);
 
     if n < Decimal::TWO {
@@ -43,9 +44,11 @@ pub fn constant_volatility(returns: &[Decimal]) -> Result<Positive, VolatilityEr
     let variance =
         returns.iter().map(|&r| (r - mean).powi(2)).sum::<Decimal>() / (n - Decimal::ONE);
 
-    let std_dev = variance.sqrt().ok_or_else(|| {
-        VolatilityError::from("constant_volatility: sqrt(variance) failed (overflow)")
-    })?;
+    let std_dev = variance
+        .sqrt()
+        .ok_or_else(|| VolatilityError::NumericalFailure {
+            reason: "constant_volatility: sqrt(variance) failed (overflow)".to_string(),
+        })?;
     Ok(Positive::new_decimal(std_dev).unwrap_or(Positive::ZERO))
 }
 
@@ -85,18 +88,24 @@ pub fn ewma_volatility(
 ) -> Result<Vec<Positive>, VolatilityError> {
     let first_return = returns
         .first()
-        .ok_or_else(|| VolatilityError::from("ewma_volatility: returns slice is empty"))?;
+        .ok_or_else(|| VolatilityError::NumericalFailure {
+            reason: "ewma_volatility: returns slice is empty".to_string(),
+        })?;
     let mut variance = first_return.powi(2);
-    let initial_std_dev = variance.sqrt().ok_or_else(|| {
-        VolatilityError::from("ewma_volatility: sqrt(initial variance) failed (overflow)")
-    })?;
+    let initial_std_dev = variance
+        .sqrt()
+        .ok_or_else(|| VolatilityError::NumericalFailure {
+            reason: "ewma_volatility: sqrt(initial variance) failed (overflow)".to_string(),
+        })?;
     let mut volatilities = vec![Positive::new_decimal(initial_std_dev).unwrap_or(Positive::ZERO)];
 
     for &return_value in &returns[1..] {
         variance = lambda * variance + (Decimal::ONE - lambda) * return_value.powi(2);
-        let std_dev = variance.sqrt().ok_or_else(|| {
-            VolatilityError::from("ewma_volatility: sqrt(variance) failed (overflow)")
-        })?;
+        let std_dev = variance
+            .sqrt()
+            .ok_or_else(|| VolatilityError::NumericalFailure {
+                reason: "ewma_volatility: sqrt(variance) failed (overflow)".to_string(),
+            })?;
         volatilities.push(Positive::new_decimal(std_dev).unwrap_or(Positive::ZERO));
     }
 
@@ -153,12 +162,12 @@ pub fn implied_volatility(
         Some((best_iv, _)) => {
             let iv = best_iv.clamp(*MIN_VOLATILITY, MAX_VOLATILITY);
             if iv == Positive::new(1f64 / iterations as f64)? {
-                Err("Implied volatility not found".into())
+                Err(VolatilityError::IvNotFound)
             } else {
                 Ok(iv)
             }
         }
-        None => Err("No valid volatility found".into()),
+        None => Err(VolatilityError::NoValidVolatility),
     }
 }
 
@@ -270,16 +279,18 @@ pub fn simulate_heston_volatility(
     let mut volatilities = vec![v_pos.sqrt()];
     let dt_sqrt_f64 = dt
         .sqrt()
-        .ok_or_else(|| {
-            VolatilityError::from("simulate_heston_volatility: sqrt(dt) failed (overflow)")
+        .ok_or_else(|| VolatilityError::NumericalFailure {
+            reason: "simulate_heston_volatility: sqrt(dt) failed (overflow)".to_string(),
         })?
         .to_f64()
-        .ok_or_else(|| {
-            VolatilityError::from("simulate_heston_volatility: sqrt(dt) not representable as f64")
+        .ok_or_else(|| VolatilityError::NumericalFailure {
+            reason: "simulate_heston_volatility: sqrt(dt) not representable as f64".to_string(),
         })?;
     for _ in 1..steps {
         let dw = Decimal::from_f64(random::<f64>() * dt_sqrt_f64).ok_or_else(|| {
-            VolatilityError::from("simulate_heston_volatility: dw not representable as Decimal")
+            VolatilityError::NumericalFailure {
+                reason: "simulate_heston_volatility: dw not representable as Decimal".to_string(),
+            }
         })?;
         let sqrt_v = v_pos.sqrt().to_dec();
         v += kappa * (theta - v) * dt + xi * sqrt_v * dw;
@@ -405,7 +416,7 @@ pub fn de_annualized_volatility(
 ///
 /// # Example
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), optionstratlib::error::Error> {
 /// use positive::pos_or_panic;
 /// use optionstratlib::utils::TimeFrame;
 /// use optionstratlib::volatility::adjust_volatility;
@@ -481,7 +492,7 @@ pub fn adjust_volatility(
 /// # Examples
 ///
 /// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), optionstratlib::error::Error> {
 /// use positive::{pos_or_panic, Positive};
 /// use optionstratlib::utils::time::{TimeFrame, convert_time_frame};
 /// use optionstratlib::volatility::volatility_for_dt;

--- a/tests/unit/error/curves_test.rs
+++ b/tests/unit/error/curves_test.rs
@@ -2,14 +2,11 @@ use optionstratlib::error::{
     CurveError, GraphError, GreeksError, InterpolationError, MetricsError, OperationErrorKind,
     OptionsError,
 };
-use std::error::Error;
 
 #[test]
 fn test_curve_error_from_options_error() {
     // Create an OptionsError
-    let options_error = OptionsError::OtherError {
-        reason: "options error test".to_string(),
-    };
+    let options_error = OptionsError::validation_error("field", "options error test");
 
     // Convert to CurveError using From trait
     let curve_error: CurveError = options_error.into();
@@ -26,7 +23,7 @@ fn test_curve_error_from_options_error() {
 #[test]
 fn test_curve_error_from_greeks_error() {
     // Create a GreeksError
-    let greeks_error = GreeksError::StdError("greeks error test".to_string());
+    let greeks_error = GreeksError::invalid_volatility(-1.0, "greeks error test");
 
     // Convert to CurveError using From trait
     let curve_error: CurveError = greeks_error.into();
@@ -43,7 +40,7 @@ fn test_curve_error_from_greeks_error() {
 #[test]
 fn test_curve_error_from_interpolation_error() {
     // Create an InterpolationError
-    let interpolation_error = InterpolationError::StdError("interpolation error test".to_string());
+    let interpolation_error = InterpolationError::Linear("interpolation error test".to_string());
 
     // Convert to CurveError using From trait
     let curve_error: CurveError = interpolation_error.into();
@@ -173,19 +170,16 @@ fn test_curve_error_point2d_error() {
 }
 
 #[test]
-fn test_curve_error_from_box_dyn_error() {
-    // Create a standard error and box it
-    let std_error = std::io::Error::other("io error test");
-    let boxed_error: Box<dyn Error> = Box::new(std_error);
-
-    // Convert to CurveError
-    let curve_error = CurveError::from(boxed_error);
-
-    // Verify the conversion was successful
-    match curve_error {
-        CurveError::StdError { reason } => {
+fn test_curve_error_render_error() {
+    let error = CurveError::RenderError {
+        backend: "plotters",
+        reason: "io error test".to_string(),
+    };
+    match error {
+        CurveError::RenderError { backend, reason } => {
+            assert_eq!(backend, "plotters");
             assert!(reason.contains("io error test"));
         }
-        _ => panic!("Expected StdError variant, got something else"),
+        _ => panic!("Expected RenderError variant, got something else"),
     }
 }

--- a/tests/unit/error/graph_test.rs
+++ b/tests/unit/error/graph_test.rs
@@ -58,7 +58,8 @@ fn test_graph_error_from_box_dyn_error() {
 #[test]
 fn test_graph_error_from_curve_error() {
     // Create a CurveError
-    let curve_error = CurveError::StdError {
+    let curve_error = CurveError::RenderError {
+        backend: "plotters",
         reason: "Invalid curve data".to_string(),
     };
 
@@ -77,7 +78,8 @@ fn test_graph_error_from_curve_error() {
 #[test]
 fn test_graph_error_from_surface_error() {
     // Create a SurfaceError
-    let surface_error = SurfaceError::StdError {
+    let surface_error = SurfaceError::RenderError {
+        backend: "plotters",
         reason: "Invalid surface data".to_string(),
     };
 

--- a/tests/unit/error/metrics_test.rs
+++ b/tests/unit/error/metrics_test.rs
@@ -30,14 +30,6 @@ fn test_metrics_error_display() {
         reason: "surface modeling error",
     });
     assert!(format!("{surface_err}").contains("surface modeling error"));
-
-    let std_err = MetricsError::StdError {
-        reason: "standard error occurred".to_string(),
-    };
-    assert_eq!(
-        format!("{std_err}"),
-        "Standard Error: standard error occurred"
-    );
 }
 
 #[test]
@@ -47,11 +39,9 @@ fn test_metrics_error_debug() {
     assert!(format!("{basic_err:?}").contains("BasicError"));
     assert!(format!("{basic_err:?}").contains("test message"));
 
-    let std_err = MetricsError::StdError {
-        reason: "debug test".to_string(),
-    };
-    assert!(format!("{std_err:?}").contains("StdError"));
-    assert!(format!("{std_err:?}").contains("debug test"));
+    let range_err = MetricsError::RangeError("debug test".to_string());
+    assert!(format!("{range_err:?}").contains("RangeError"));
+    assert!(format!("{range_err:?}").contains("debug test"));
 }
 
 #[test]
@@ -93,21 +83,9 @@ fn test_metrics_error_from_surface_error() {
 }
 
 #[test]
-fn test_metrics_error_from_box_dyn_error() {
-    // Create a simple error that implements Error trait
-    let std_err = std::io::Error::other("IO error occurred");
-    let boxed_err: Box<dyn std::error::Error> = Box::new(std_err);
-
-    // Convert to MetricsError using From trait
-    let metrics_err: MetricsError = boxed_err.into();
-
-    // Verify the conversion was successful
-    match metrics_err {
-        MetricsError::StdError { reason } => {
-            assert!(reason.contains("IO error occurred"));
-        }
-        _ => panic!("Expected StdError variant, got something else"),
-    }
+fn test_metrics_error_basic_error_display() {
+    let error = MetricsError::BasicError("basic calc failed".to_string());
+    assert_eq!(format!("{error}"), "Basic Error: basic calc failed");
 }
 
 #[test]
@@ -120,12 +98,7 @@ fn test_metrics_error_as_error() {
     assert_eq!(boxed_error.to_string(), "Basic Error: test error");
 
     // Test another variant
-    let error = MetricsError::StdError {
-        reason: "standard error test".to_string(),
-    };
+    let error = MetricsError::RangeError("out of range".to_string());
     let boxed_error: Box<dyn std::error::Error> = Box::new(error);
-    assert_eq!(
-        boxed_error.to_string(),
-        "Standard Error: standard error test"
-    );
+    assert_eq!(boxed_error.to_string(), "Range Error: out of range");
 }

--- a/tests/unit/error/surfaces_test.rs
+++ b/tests/unit/error/surfaces_test.rs
@@ -3,7 +3,6 @@ use optionstratlib::error::{
     GraphError, GreeksError, InterpolationError, OptionsError, PositionError, SurfaceError,
 };
 use std::error::Error;
-use std::io;
 
 // MockGraphError struct removed as it was unused.
 #[test]
@@ -16,19 +15,17 @@ fn test_from_interpolation_error() {
 
     // Verify the conversion was successful
     match surface_error {
-        SurfaceError::StdError { reason } => {
+        SurfaceError::AnalysisError(reason) => {
             assert!(reason.contains("interpolation error test"));
         }
-        _ => panic!("Expected StdError variant, got something else"),
+        _ => panic!("Expected AnalysisError variant, got something else"),
     }
 }
 
 #[test]
 fn test_from_options_error() {
     // Create an options error
-    let options_error = OptionsError::OtherError {
-        reason: "options error test".to_string(),
-    };
+    let options_error = OptionsError::validation_error("field", "options error test");
 
     // Convert to SurfaceError
     let surface_error = SurfaceError::from(options_error);
@@ -45,7 +42,7 @@ fn test_from_options_error() {
 #[test]
 fn test_from_greeks_error() {
     // Create a Greeks error
-    let greeks_error = GreeksError::StdError("greeks error test".to_string());
+    let greeks_error = GreeksError::invalid_volatility(-1.0, "greeks error test");
 
     // Convert to SurfaceError
     let surface_error = SurfaceError::from(greeks_error);
@@ -89,11 +86,12 @@ fn test_surface_error_debug() {
     let debug_str = format!("{op_error:?}");
     assert!(debug_str.contains("OperationError"));
 
-    let std_error = SurfaceError::StdError {
+    let render_error = SurfaceError::RenderError {
+        backend: "plotters",
         reason: "std debug test".to_string(),
     };
-    let debug_str = format!("{std_error:?}");
-    assert!(debug_str.contains("StdError"));
+    let debug_str = format!("{render_error:?}");
+    assert!(debug_str.contains("RenderError"));
 
     let construction_error = SurfaceError::ConstructionError("construction debug test".to_string());
     let debug_str = format!("{construction_error:?}");
@@ -114,20 +112,17 @@ fn test_error_trait_implementation() {
 }
 
 #[test]
-fn test_from_io_error() {
-    // Create an IO error
-    let io_error = io::Error::new(io::ErrorKind::NotFound, "file not found");
-    let boxed_error: Box<dyn Error> = Box::new(io_error);
-
-    // Convert to SurfaceError
-    let surface_error = SurfaceError::from(boxed_error);
-
-    // Verify the conversion was successful
-    match surface_error {
-        SurfaceError::StdError { reason } => {
+fn test_surface_error_render_error_variant() {
+    let error = SurfaceError::RenderError {
+        backend: "plotters",
+        reason: "file not found".to_string(),
+    };
+    match error {
+        SurfaceError::RenderError { backend, reason } => {
+            assert_eq!(backend, "plotters");
             assert!(reason.contains("file not found"));
         }
-        _ => panic!("Expected StdError variant, got something else"),
+        _ => panic!("Expected RenderError variant, got something else"),
     }
 }
 


### PR DESCRIPTION
## Summary

Eliminates every `String`, `&str` and `Box<dyn Error>` based error path in OptionStratLib and replaces them with concrete `thiserror` variants. Removes all catch-all variants (`StdError`, `OtherError`, `Other`, `DynError`) from every error enum under `src/error/`, so the library now exposes a fully typed error surface end-to-end.

## Changes

- Removed every `impl From<String>`, `impl From<&str>` and `impl From<Box<dyn std::error::Error>>` on every typed error enum.
- Removed every catch-all variant (`StdError(String)`, `StdError { reason }`, `OtherError { reason }`, `Other(String)`, `DynError { message }`) from all 15 error files under `src/error/`.
- Added typed variants to cover the production call sites that previously used the catch-alls, including: `SimulationError::{InvalidWalkType, InvalidAutocorrelation, GarchStationarity, InvalidCorrelation, InsufficientHistoricalData, IndexConversion, ExpirationReached}`, `GreeksError::DeltaNeutrality(DeltaNeutralityErrorKind)` with nine typed sub-variants, `PricingError::{DeltaAdjustmentNotApplicable, BinomialNodeMissing, SqrtFailure}`, `OptionsError::{InvalidStepCount, ImpliedVolatilityInvariant}`, `VolatilityError::{IvNotFound, NoValidVolatility, AtmIvUnavailable, NumericalFailure}`, `ChainError::{EmptyChainAtm, AtmNotFound, EmptyDensities, EmptySkewData, StrikeNotFound}`, `InterpolationError::{EmptyData, OutOfRange, DegenerateInterval}`, `CurveError::RenderError`, `SurfaceError::RenderError`, `ProbabilityError::MissingMetric`, `OhlcvError::{MissingColumn, RowParsing}`, `Error::{EmptyCollection, Io}`.
- Promoted cross-module conversions to typed `#[from]` where unambiguous (e.g. `SimulationError::Decimal`, `SimulationError::Options`, `SimulationError::Pricing`, `SimulationError::ExpirationDate`, `ChainError::ExpirationDate`, `OptionsError::ExpirationDate`, `PricingError::ExpirationDate`, `GreeksError::ExpirationDate`, `GreeksError::Pricing`).
- Boxed sub-errors where needed to avoid infinitely-sized enums: `SimulationError::{Strategy, Chain}`, `StrategyError::Simulation`, `VolatilityError::AtmIvUnavailable { source: Box<VolatilityError> }`, `ChainError::{Curve, Volatility, Simulation}`, `GreeksError::Pricing`.
- Replaced every `.into()` / `Err("...".to_string().into())` in production code with the new typed variants across `simulation/`, `greeks/`, `strategies/`, `chains/`, `volatility/`, `geometrics/`, `pricing/`, `model/`, `utils/`, `series/`, `surfaces/`, `curves/`.
- Retyped 10 test helpers in `src/simulation/traits.rs` and 1 in `src/risk/span.rs` from `Result<(), Box<dyn Error>>` to typed errors (`SimulationError` / `crate::error::Error`).
- Retyped every doc-example `fn main() -> Result<(), Box<dyn std::error::Error>>` to `Result<(), optionstratlib::error::Error>`.
- Updated integration tests in `tests/unit/error/{curves,graph,metrics,surfaces}_test.rs` to use the new typed variants.

## Technical Decisions

- `PricingError::other(reason: &str)` is **retained as a typed constructor** that builds a `MethodError { method: "pricing", reason }`. This keeps the pricing module's ergonomic `ok_or_else(|| PricingError::other(...))` pattern while still landing in a named, non-catch-all variant.
- `OptionDataErrorKind::Other(String)` inside `ChainError::OptionDataError` is retained as a sub-enum variant. The acceptance grep targets public `Result<_, Box<dyn ...>>` / `Result<_, String>` shapes, and this nested variant is not directly reachable from that pattern.
- `Error::Io(#[from] std::io::Error)` was added to the unified error enum so doctest `?`-propagation of `fs::remove_file`, plot saves and chain loads keeps working after removing `Other(String)`.
- Boxing selected sub-error variants (`SimulationError::Strategy`, `ChainError::Curve`, etc.) avoids a 3-deep cyclic enum size explosion without losing type information.

## Testing

- [x] Unit tests added/updated
- [ ] Property-based tests added/updated (N/A for this refactor)
- [x] Integration tests added/updated
- [ ] Benchmark tests added/updated (N/A for this refactor)
- [x] Manual testing performed (`cargo test --all-features`)

Test counts (all passing):
- Lib tests: **3732 passed** / 0 failed / 5 ignored
- Integration tests: **418 passed** / 0 failed
- Doctests: **203 passed** / 0 failed / 61 ignored

## Checklist

- [x] Code follows `.windsurfrules`
- [x] All public items have `///` documentation (new variants all carry full doc comments)
- [x] No warnings from `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No new `.unwrap()`, `.expect()`, or panics in library code
- [x] Uses rust_decimal for monetary calculations (unchanged, untouched)
- [x] Minimal dependencies — no new crates added

Closes #333
