### PR TITLE
feat(observability): add #[tracing::instrument] on hot paths (#342)

### DIFF
--- a/src/pricing/binomial_model.rs
+++ b/src/pricing/binomial_model.rs
@@ -12,6 +12,7 @@ use crate::{d2f, f2d};
 use positive::Positive;
 use rust_decimal::{Decimal, MathematicalOps};
 use std::num::NonZeroUsize;
+use tracing::instrument;
 
 #[cfg(test)]
 use positive::pos_or_panic;
@@ -110,6 +111,13 @@ pub struct BinomialPricingParams<'a> {
 /// when the induction step cannot read an intermediate node, and
 /// [`PricingError::Positive`] when any `Positive` construction
 /// downstream (e.g. strike × discount factor) underflows below zero.
+#[instrument(skip(params), fields(
+    strike = %params.strike,
+    asset = %params.asset,
+    steps = params.no_steps.get(),
+    style = ?*params.option_style,
+    side = ?*params.side,
+))]
 pub fn price_binomial(params: BinomialPricingParams) -> Result<Decimal, PricingError> {
     let mut info = PayoffInfo {
         spot: params.asset,

--- a/src/pricing/black_scholes_model.rs
+++ b/src/pricing/black_scholes_model.rs
@@ -9,7 +9,7 @@ use crate::greeks::{big_n, calculate_d_values};
 use crate::model::decimal::{d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
 use rust_decimal::{Decimal, MathematicalOps};
-use tracing::trace;
+use tracing::{instrument, trace};
 
 /// Computes the price of an option using the Black-Scholes model.
 ///
@@ -66,6 +66,11 @@ use tracing::trace;
 /// numerical wall (e.g. zero volatility or non-finite intermediate
 /// value), and [`PricingError::UnsupportedOptionType`] for exotic
 /// option types not handled by the closed form.
+#[instrument(skip(option), fields(
+    strike = %option.strike_price,
+    style = ?option.option_style,
+    side = ?option.side,
+))]
 pub fn black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let (d1, d2, expiry_time) = calculate_d1_d2_and_time(option)?;
     match option.option_type {

--- a/src/pricing/monte_carlo.rs
+++ b/src/pricing/monte_carlo.rs
@@ -6,6 +6,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use positive::Positive;
 use rust_decimal::{Decimal, MathematicalOps};
 use std::num::NonZeroUsize;
+use tracing::instrument;
 
 /// This function performs Monte Carlo simulation to price an option.
 ///
@@ -42,6 +43,13 @@ use std::num::NonZeroUsize;
 /// encounters a non-finite value (e.g. volatility overflow) or when
 /// the terminal payoff averaging produces a non-representable
 /// `Decimal`.
+#[instrument(skip(option), fields(
+    steps = steps.get(),
+    simulations = simulations.get(),
+    strike = %option.strike_price,
+    style = ?option.option_style,
+    side = ?option.side,
+))]
 pub fn monte_carlo_option_pricing(
     option: &Options,
     steps: NonZeroUsize,       // Number of time steps per path

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
-use tracing::{error, warn};
+use tracing::{error, instrument, warn};
 use utoipa::ToSchema;
 
 /// Represents basic information about a trading strategy.
@@ -1309,6 +1309,7 @@ pub trait Optimizable: Validable + Strategies {
     /// # Arguments
     /// * `option_chain` - A reference to the `OptionChain` containing option data.
     /// * `side` - A `FindOptimalSide` value specifying the filtering strategy.
+    #[instrument(skip(self, option_chain), fields(side = ?side, criteria = "Ratio"))]
     fn get_best_ratio(&mut self, option_chain: &OptionChain, side: FindOptimalSide) {
         self.find_optimal(option_chain, side, OptimizationCriteria::Ratio);
     }
@@ -1318,6 +1319,7 @@ pub trait Optimizable: Validable + Strategies {
     /// # Arguments
     /// * `option_chain` - A reference to the `OptionChain` containing option data.
     /// * `side` - A `FindOptimalSide` value specifying the filtering strategy.
+    #[instrument(skip(self, option_chain), fields(side = ?side, criteria = "Area"))]
     fn get_best_area(&mut self, option_chain: &OptionChain, side: FindOptimalSide) {
         self.find_optimal(option_chain, side, OptimizationCriteria::Area);
     }

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -21,6 +21,7 @@ use positive::Positive;
 use rand::random;
 use rayon::prelude::*;
 use rust_decimal::{Decimal, MathematicalOps};
+use tracing::instrument;
 
 #[cfg(test)]
 use positive::pos_or_panic;
@@ -219,6 +220,11 @@ pub fn ewma_volatility(
 /// `VolatilityError::PositiveError` when the boundary `Positive`
 /// conversion fails. Black–Scholes errors on individual candidates
 /// are discarded by the parallel filter rather than propagated.
+#[instrument(skip(options), fields(
+    market_price = %market_price,
+    strike = %options.strike_price,
+    max_iterations,
+))]
 pub fn implied_volatility(
     market_price: Positive,
     options: &mut Options,


### PR DESCRIPTION
Add structured tracing instrumentation to pricing and strategy hot paths.