### PR TITLE
refactor(docs): enable missing_docs and broken_intra_doc_links denials (#343)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unknown_lints)]
 #![allow(clippy::literal_string_with_formatting_args)]
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 // Per rules/global_rules.md §Error Handling, unchecked `[]` / slicing is
 // banned in production code. Enforced crate-wide; individual modules that
 // need a transitional escape hatch carry a scoped `#![allow(..)]` with a

--- a/src/model/decimal.rs
+++ b/src/model/decimal.rs
@@ -524,6 +524,7 @@ macro_rules! f2d {
     };
 }
 
+/// Conversion helpers' sanity tests (public module to support doctest wiring).
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -157,6 +157,9 @@ fn pos_lit(d: rust_decimal::Decimal) -> Positive {
     Positive::new_decimal(d).unwrap_or(Positive::ZERO)
 }
 
+/// Returns how many units of the given `TimeFrame` fit into a calendar year
+/// as a `Positive`. Used by annualisation helpers (volatility, yield
+/// curves) to scale per-period values to a standardised annual basis.
 #[must_use]
 pub fn units_per_year(time_frame: &TimeFrame) -> Positive {
     match time_frame {

--- a/src/visualization/plotly.rs
+++ b/src/visualization/plotly.rs
@@ -14,6 +14,13 @@ use plotly::plotly_static::ImageFormat;
 #[cfg(feature = "static_export")]
 use tracing::debug;
 
+/// Trait implemented by every strategy / chain / surface that can
+/// render itself as a Plotly figure.
+///
+/// Provides the data-only `graph_data()` / `graph_config()` hooks plus
+/// the feature-gated `to_plot` / `write_html` / `write_png` renderers.
+/// Implementers need only supply `graph_data`; the rest have safe
+/// defaults under the `plotly` (and `static_export`) features.
 pub trait Graph {
     /// Return the raw data ready for plotting.
     fn graph_data(&self) -> GraphData;

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -326,7 +326,7 @@ pub fn calculate_iv(
 ///
 /// # Errors
 ///
-/// - Propagates [`DecimalError::Overflow`] from the underlying
+/// - Propagates [`crate::error::DecimalError::Overflow`] from the underlying
 ///   checked arithmetic helpers (`d_mul`, `d_add`) wrapped as
 ///   [`VolatilityError::DecimalError`] via the `#[from]` cascade.
 ///   This happens when any of the four monetary products


### PR DESCRIPTION
Enable crate-level missing_docs and rustdoc::broken_intra_doc_links denials to enforce comprehensive documentation. Closes #343