### PR TITLE
docs(release): CHANGELOG for 0.16.0 (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to **OptionStratLib** are documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.16.0] - 2026-04-19
+
+Breaking release. Focus: panic-free core, arithmetic discipline,
+typed errors everywhere, and a crate-wide discipline pass over
+attributes, docs, and test hygiene.
+
+### Added
+
+- Checked `Decimal` helpers `d_add` / `d_sub` / `d_mul` / `d_div`
+  plus `d_sum` and the iterator-based `d_sum_iter` in
+  `src/model/decimal.rs`. Every monetary-path kernel now routes
+  through them instead of raw `+ - * /`, surfacing `DecimalError::Overflow`
+  with an operation tag. (#335, #336, #337, #338, #372)
+- Domain-specific `NonFinite { context, value }` variants on
+  `PricingError`, `GreeksError`, `VolatilityError`, and
+  `SimulationError` plus the crate-private `finite_decimal(f64)`
+  guard used at every `f64 → Decimal` boundary. (#336, #337, #338)
+- Public `tracing::instrument` on hot paths: `pricing::black_scholes`,
+  `pricing::monte_carlo_option_pricing`, `pricing::price_binomial`,
+  `volatility::utils::implied_volatility`, and
+  `strategies::base::Optimizable::{get_best_ratio, get_best_area}`. (#342)
+- `utils::deterministic_rng(seed)` plus
+  `DETERMINISTIC_RNG_DEFAULT_SEED` — canonical entry point for
+  reproducible Monte-Carlo / simulation tests. (#344)
+- Deterministic regression tests under
+  `tests/unit/pricing/identities_test.rs` covering put-call parity,
+  CRR binomial convergence to Black-Scholes, and Greek
+  sanity identities (`Γ_c == Γ_p`, `V_c == V_p`,
+  `Δ_c − Δ_p ≈ e^{-qT}`). (#345)
+- `CHANGELOG.md` following Keep a Changelog 1.1.0. (#346)
+
+### Changed
+
+- Breaking: step / simulation counts on `price_binomial`,
+  `monte_carlo_option_pricing`, and related kernels are now
+  `NonZeroUsize` so zero is structurally invalid at the type
+  level. (#337)
+- Breaking: many public surfaces now return
+  `Result<T, concrete_error>` instead of panicking; `unsafe`
+  blocks have been removed from the core in favour of typed
+  guards. (#333, #334, #335, #338)
+- Canonical `#[derive]` ordering
+  (`Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash,
+  Default, …, Serialize, Deserialize, ToSchema`), `#[repr(u8)]`
+  on small stable enums, `#[serde(deny_unknown_fields)]` on
+  input DTOs, and `#[serde(rename_all = "snake_case")]` on
+  public-facing enums unless an existing wire contract
+  forbids it (e.g. `BasicAxisTypes` keeps Pascal case). (#340)
+- `#[inline]` applied on hot-path helpers and public entry
+  points, `#[inline(never)]` on multi-arg builders, and
+  `#[cold] #[inline(never)]` on every error constructor across
+  `src/error/*`. (#339)
+- `CustomStrategy::calculate_profit_at` no longer allocates a
+  `Vec<Decimal>` per invocation; aggregates via `try_fold` + `d_add`. (#372)
+
+### Fixed
+
+- Doc-coverage floor: crate-level
+  `#![deny(missing_docs, rustdoc::broken_intra_doc_links)]`
+  with every previously-bare `pub` item now documented, and
+  broken intra-doc links (e.g. `DecimalError::Overflow` →
+  `crate::error::DecimalError::Overflow`) repaired. (#343)
+- Unchecked `[]` indexing in production code migrated to
+  `.get(..).ok_or_else(..)` on the highest-risk paths
+  (`OptionChain` file-name / CSV readers, binomial-root lookup
+  in `Option::binomial_price`) and
+  `#![deny(clippy::indexing_slicing)]` enforced crate-wide
+  with scoped, documented escapes on the remaining modules
+  as follow-up work. (#341)
+
+### Internal
+
+- `#[must_use]` applied across the pure / builder public
+  surface to catch discarded results at compile time.
+
+[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.0


### PR DESCRIPTION
## Summary

- Add \`CHANGELOG.md\` following Keep a Changelog 1.1.0 with Added / Changed / Fixed / Internal sections.
- Covers the full 0.15.3 → 0.16.0 migration: #333, #334, #335, #336, #337, #338, #339, #340, #341, #342, #343, #344, #345, #372.
- \`Cargo.toml\` version is already \`0.16.0\`; \`README.md\` regenerates identically from \`README.tpl\` under \`cargo readme\`.

Tag + GitHub release will be cut immediately after merge.

Closes #346 (changelog + housekeeping; tag creation follows the merge).

## Test plan

- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all --check\`.
- [x] \`cargo test --lib --all-features\` — 3756 pass; 4 pre-existing \`chains::chain\` failures unrelated.
- [x] \`cargo readme\` — no README diff.