### PR TITLE
fix(tests,docs): chain fixtures + doc link (0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-04-19
+
+Hot-fix for CI flakiness introduced by sub-day `ExpirationDate`
+arithmetic in test fixtures, plus a doc-link warning.
+
+### Fixed
+
+- Chain test fixtures (`create_test_option_chain`) now use
+  `get_x_days_formatted(30)` instead of `get_tomorrow_formatted()`.
+  `Actual365Fixed::day_count` in `expiration_date 0.2.0` truncates
+  to integer days, so tomorrow's fixed 18:30 UTC expiry evaluated
+  after that time collapsed to `t = 0` and broke every
+  Black-Scholes-driven axis on the chain curve/surface tests
+  (`test_curve_multiple_axes`, `test_curve_price_short_put`,
+  `test_surface_different_greeks`, `test_vanna_surface`). 30 days
+  puts every test well above the integer-truncation boundary.
+- `constants.rs`: `MAX_NEWTON_ITER` no longer links to the private
+  `MAX_ITERATIONS_IV` — the doc just names the crate-private
+  counterpart in prose, so `cargo doc` emits zero warnings again.
+
+[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.1
+
 ## [0.16.0] - 2026-04-19
 
 Breaking release. Focus: panic-free core, arithmetic discipline,
@@ -82,5 +105,4 @@ attributes, docs, and test hygiene.
 - `#[must_use]` applied across the pure / builder public
   surface to catch discarded results at compile time.
 
-[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.0...HEAD
 [0.16.0]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -8064,13 +8064,13 @@ mod tests_basic_curves {
     use positive::spos;
 
     use crate::model::types::{OptionStyle, Side};
-    use crate::utils::time::get_tomorrow_formatted;
+    use crate::utils::time::get_x_days_formatted;
 
     use rust_decimal_macros::dec;
 
     // Helper function to create a sample OptionChain for testing
     fn create_test_option_chain() -> OptionChain {
-        let tomorrow_date = get_tomorrow_formatted();
+        let tomorrow_date = get_x_days_formatted(30);
         let mut chain = OptionChain::new("TEST", Positive::HUNDRED, tomorrow_date, None, None);
 
         // Add some test options
@@ -8258,12 +8258,12 @@ mod tests_option_chain_surfaces {
     use super::*;
     use positive::spos;
 
-    use crate::utils::time::get_tomorrow_formatted;
+    use crate::utils::time::get_x_days_formatted;
 
     use rust_decimal_macros::dec;
 
     fn create_test_option_chain() -> OptionChain {
-        let tomorrow_date = get_tomorrow_formatted();
+        let tomorrow_date = get_x_days_formatted(30);
         let mut chain = OptionChain::new("TEST", Positive::HUNDRED, tomorrow_date, None, None);
 
         // Add some test options
@@ -8516,12 +8516,12 @@ mod tests_option_chain_time_surfaces {
     use super::*;
     use positive::spos;
 
-    use crate::utils::time::get_tomorrow_formatted;
+    use crate::utils::time::get_x_days_formatted;
 
     use rust_decimal_macros::dec;
 
     fn create_test_option_chain() -> OptionChain {
-        let tomorrow_date = get_tomorrow_formatted();
+        let tomorrow_date = get_x_days_formatted(30);
         let mut chain = OptionChain::new("TEST", Positive::HUNDRED, tomorrow_date, None, None);
 
         // Add some test options
@@ -9267,14 +9267,14 @@ mod tests_gamma_calculations {
     use positive::spos;
 
     use crate::assert_decimal_eq;
-    use crate::utils::time::get_tomorrow_formatted;
+    use crate::utils::time::get_x_days_formatted;
     use rust_decimal_macros::dec;
 
     // Helper function to create a test chain with predefined gamma values
     fn create_test_chain_with_gamma() -> OptionChain {
         let mut option_chain =
             OptionChain::load_from_json("examples/Chains/SP500-18-oct-2024-5781.88.json").unwrap();
-        option_chain.expiration_date = get_tomorrow_formatted();
+        option_chain.expiration_date = get_x_days_formatted(30);
         option_chain
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -152,8 +152,9 @@ pub const DEFAULT_MC_STEPS: NonZeroUsize = match NonZeroUsize::new(252) {
 
 /// Maximum Newton-Raphson iterations used by implied-volatility solvers.
 ///
-/// Typed as `NonZeroUsize`; see [`MAX_ITERATIONS_IV`] for the `u32`
-/// diagnostic counterpart surfaced through `VolatilityError`.
+/// Typed as `NonZeroUsize`; the crate-private `MAX_ITERATIONS_IV` constant
+/// holds the `u32` diagnostic counterpart surfaced through
+/// `VolatilityError`.
 pub const MAX_NEWTON_ITER: NonZeroUsize = match NonZeroUsize::new(100) {
     Some(n) => n,
     None => unreachable!(),


### PR DESCRIPTION
## Summary

- Replace \`get_tomorrow_formatted()\` with \`get_x_days_formatted(30)\` in the three \`create_test_option_chain\` helpers in \`src/chains/chain.rs\`. \`Actual365Fixed::day_count\` in \`expiration_date 0.2.0\` truncates to integer days, so tomorrow's fixed 18:30 UTC expiry evaluated after that time of day collapsed to \`t = 0\` and broke every Black-Scholes-driven chain axis. 30 days puts every fixture well above the integer-truncation boundary regardless of execution time.
- \`constants.rs\`: \`MAX_NEWTON_ITER\` no longer intra-doc-links the crate-private \`MAX_ITERATIONS_IV\`; prose mention only — \`cargo doc --no-deps\` now emits zero warnings.
- Bump to \`0.16.1\`, update \`CHANGELOG.md\`.

### Root cause

\`cargo test --lib chains::chain::tests_basic_curves::test_curve_price_short_put\` was failing depending on time of day:
\`\`\`
[0] strike=90, iv=0.2, expiration=DateTime(2026-04-20T18:30:00Z), t2e=Ok(0)
[0] bs err: Pricing error using method 'unknown': Input validation error: Invalid time 0: Expiration date cannot be zero
\`\`\`

Upstream \`Actual365Fixed::day_count\`:
\`\`\`rust
Ok(duration.num_days() as f64)  // integer truncation → 0 for sub-24h
\`\`\`

Previous fixtures built a chain with tomorrow 18:30 UTC expiry, which is <24h away after 18:30 UTC today, yielding \`t = 0\` and breaking every BS-driven axis. Also fires up the 4 persistent failures on the coverage job.

## Test plan

- [x] \`cargo test --lib --all-features\` — **3760 passed, 0 failed**.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all --check\`.
- [x] \`cargo doc --no-deps --lib --all-features\` — 0 warnings.