### PR TITLE
fix(strategies): guard Positive boundaries in butterfly/spread P&L (#387)

### DIFF
--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -27,7 +27,6 @@ use super::shared::SpreadStrategy;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
-    constants::ZERO,
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
@@ -612,18 +611,24 @@ impl Strategies for BullPutSpread {
         }
     }
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
-        let width = self.short_put.option.strike_price - self.long_put.option.strike_price;
-        let max_loss =
-            (width * self.short_put.option.quantity) - self.get_net_premium_received()?;
-        if max_loss < ZERO {
-            Err(StrategyError::ProfitLossError(
+        let short_strike = self.short_put.option.strike_price.to_dec();
+        let long_strike = self.long_put.option.strike_price.to_dec();
+        let width = short_strike - long_strike;
+        if width < Decimal::ZERO {
+            return Err(StrategyError::ProfitLossError(
                 ProfitLossErrorKind::MaxLossError {
-                    reason: "Max loss is negative".to_string(),
+                    reason: "Short put strike must be above long put strike".to_string(),
                 },
-            ))
-        } else {
-            Ok(max_loss)
+            ));
         }
+        let qty = self.short_put.option.quantity.to_dec();
+        let net_prem = self.get_net_premium_received()?.to_dec();
+        let max_loss_dec = (width * qty) - net_prem;
+        Positive::new_decimal(max_loss_dec).map_err(|_| {
+            StrategyError::ProfitLossError(ProfitLossErrorKind::MaxLossError {
+                reason: "Max loss is negative".to_string(),
+            })
+        })
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -381,19 +381,21 @@ impl BreakEvenable for CallButterfly {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
-        self.break_even_points.push(
-            (self.long_call.option.strike_price
-                - self.calculate_profit_at(&self.long_call.option.strike_price)?
-                    / self.long_call.option.quantity)
-                .round_to(2),
-        );
+        let long_strike = self.long_call.option.strike_price.to_dec();
+        let long_qty = self.long_call.option.quantity.to_dec();
+        let long_profit = self.calculate_profit_at(&self.long_call.option.strike_price)?;
+        let candidate_low = long_strike - long_profit / long_qty;
+        if let Ok(be) = Positive::new_decimal(candidate_low) {
+            self.break_even_points.push(be.round_to(2));
+        }
 
-        self.break_even_points.push(
-            (self.short_call_high.option.strike_price
-                + self.calculate_profit_at(&self.short_call_high.option.strike_price)?
-                    / self.short_call_high.option.quantity)
-                .round_to(2),
-        );
+        let short_strike = self.short_call_high.option.strike_price.to_dec();
+        let short_qty = self.short_call_high.option.quantity.to_dec();
+        let short_profit = self.calculate_profit_at(&self.short_call_high.option.strike_price)?;
+        let candidate_high = short_strike + short_profit / short_qty;
+        if let Ok(be) = Positive::new_decimal(candidate_high) {
+            self.break_even_points.push(be.round_to(2));
+        }
 
         self.break_even_points.sort();
         Ok(())
@@ -722,10 +724,15 @@ impl Strategies for CallButterfly {
                 BreakEvenErrorKind::NoBreakEvenPoints,
             ));
         }
-        let base_low = break_even[1] - break_even[0];
+        let be0 = break_even[0].to_dec();
+        let be1 = break_even[1].to_dec();
+        let base_low_dec = be1 - be0;
+        let base_low = Positive::new_decimal(base_low_dec).unwrap_or(Positive::ZERO);
         let max_profit = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base_high =
-            self.short_call_high.option.strike_price - self.short_call_low.option.strike_price;
+        let short_high = self.short_call_high.option.strike_price.to_dec();
+        let short_low = self.short_call_low.option.strike_price.to_dec();
+        let base_high_dec = short_high - short_low;
+        let base_high = Positive::new_decimal(base_high_dec).unwrap_or(Positive::ZERO);
         Ok(
             Decimal::from_f64((base_low.to_f64() + base_high.to_f64()) * max_profit.to_f64() / 2.0)
                 .unwrap_or(Decimal::ZERO),

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -379,13 +379,17 @@ impl BreakEvenable for LongButterflySpread {
             / self.long_call_high.option.quantity;
 
         if left_net_value <= Decimal::ZERO {
-            self.break_even_points
-                .push((self.long_call_low.option.strike_price - left_net_value).round_to(2));
+            let candidate = self.long_call_low.option.strike_price.to_dec() - left_net_value;
+            if let Ok(be) = Positive::new_decimal(candidate) {
+                self.break_even_points.push(be.round_to(2));
+            }
         }
 
         if right_net_value <= Decimal::ZERO {
-            self.break_even_points
-                .push((self.long_call_high.option.strike_price + right_net_value).round_to(2));
+            let candidate = self.long_call_high.option.strike_price.to_dec() + right_net_value;
+            if let Ok(be) = Positive::new_decimal(candidate) {
+                self.break_even_points.push(be.round_to(2));
+            }
         }
 
         self.break_even_points.sort();


### PR DESCRIPTION
## Summary

Six example binaries panicked mid-optimizer-scan with \`Positive invariant broken\` because strategy P&L and break-even expressions crossed the \`Positive\` boundary with an unchecked \`Add<Decimal>\` / \`Sub<Positive>\`.

Root-cause fixes:

- **\`CallButterfly::update_break_even_points\`**: \`strike ± profit/qty\` lowered to \`Decimal\` then wrapped via \`Positive::new_decimal(..)\`; out-of-range candidates are silently dropped instead of panicking. The same optimizer then skips that combination cleanly.
- **\`CallButterfly::get_profit_area\`**: \`be[1] - be[0]\` and \`short_high_strike - short_low_strike\` lowered to \`Decimal\` first, then wrapped; non-positive widths fall back to \`Positive::ZERO\`.
- **\`LongButterflySpread::update_break_even_points\`**: same \`Positive ± Decimal\` guard.
- **\`BullPutSpread::get_max_loss\`**: width computed as \`Decimal\`, wrapped with \`Positive::new_decimal(..).map_err\` instead of \`Positive - Positive\`; inverted-strike candidates now return a typed \`MaxLossError\` instead of panicking.

Unblocks: \`strategy_call_butterfly_best_{area,ratio}\`, \`strategy_long_butterfly_spread_best_{area,ratio}\`, \`strategy_call_butterfly_delta\`, \`strategy_bull_put_spread_extended_delta\`.

Closes #387.

## Test plan

- [x] All six example binaries run to completion.
- [x] \`cargo test --lib --all-features\` — 3760 pass, 0 fail.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all --check\`.