### PR TITLE
fix(examples): async_chain_ops tempdir + creator chain path (#388)

### DIFF
--- a/examples/examples_chain/src/bin/async_chain_ops.rs
+++ b/examples/examples_chain/src/bin/async_chain_ops.rs
@@ -5,7 +5,6 @@ use std::error::Error;
 async fn main() -> Result<(), Box<dyn Error>> {
     println!("--- Async Option Chain Operations ---");
 
-    // 1. Create a dummy chain
     let chain = OptionChain::new(
         "AAPL",
         pos_or_panic!(150.0),
@@ -14,37 +13,41 @@ async fn main() -> Result<(), Box<dyn Error>> {
         None,
     );
 
-    // 2. Save it asynchronously to JSON
-    let json_path = "async_chain.json";
-    println!("Saving chain to {} asynchronously...", json_path);
-    chain.save_to_json_async(json_path).await?;
+    // `save_to_json_async` / `save_to_csv_async` take a *directory* and append
+    // `{title}.{ext}` from the chain's metadata. Use a scratch subdir under
+    // the OS temp dir so the example never collides with other processes.
+    let dir = std::env::temp_dir().join("optionstratlib-async-chain-ops");
+    std::fs::create_dir_all(&dir)?;
+    let dir_str = dir.to_string_lossy().to_string();
+    let filename_json = format!("{}.json", chain.get_title());
+    let filename_csv = format!("{}.csv", chain.get_title());
+    let json_path = dir.join(&filename_json);
+    let csv_path = dir.join(&filename_csv);
+
+    println!("Saving chain to {} asynchronously...", json_path.display());
+    chain.save_to_json_async(&dir_str).await?;
     println!("Successfully saved to JSON.");
 
-    // 3. Load it asynchronously from JSON
-    println!("Loading chain from {} asynchronously...", json_path);
-    let loaded_json = OptionChain::load_from_json_async(json_path).await?;
+    println!("Loading chain from {} asynchronously...", json_path.display());
+    let loaded_json = OptionChain::load_from_json_async(json_path.to_str().unwrap()).await?;
     println!(
         "Successfully loaded from JSON. Symbol: {}",
         loaded_json.symbol
     );
 
-    // 4. Save it asynchronously to CSV
-    let csv_path = "async_chain.csv";
-    println!("Saving chain to {} asynchronously...", csv_path);
-    chain.save_to_csv_async(csv_path).await?;
+    println!("Saving chain to {} asynchronously...", csv_path.display());
+    chain.save_to_csv_async(&dir_str).await?;
     println!("Successfully saved to CSV.");
 
-    // 5. Load it asynchronously from CSV
-    println!("Loading chain from {} asynchronously...", csv_path);
-    let loaded_csv = OptionChain::load_from_csv_async(csv_path).await?;
+    println!("Loading chain from {} asynchronously...", csv_path.display());
+    let loaded_csv = OptionChain::load_from_csv_async(csv_path.to_str().unwrap()).await?;
     println!(
         "Successfully loaded from CSV. Symbol: {}",
         loaded_csv.symbol
     );
 
-    // Clean up
-    std::fs::remove_file(json_path)?;
-    std::fs::remove_file(csv_path)?;
+    let _ = std::fs::remove_file(&json_path);
+    let _ = std::fs::remove_file(&csv_path);
 
     println!("--- Async Chain Operations Completed ---");
     Ok(())

--- a/examples/examples_chain/src/bin/creator.rs
+++ b/examples/examples_chain/src/bin/creator.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     let symbol = "GER400";
     setup_logger();
     let option_chain = OptionChain::load_from_json(
-        "examples/Chains/Germany-40-2025-06-13-16:00:00-UTC-23794.5.json",
+        "examples/Chains/Germany-40-2025-05-27-15-29-00-UTC-24209.json",
     )?;
     info!("Successfully retrieved option chain for {}", symbol);
     info!("{}", option_chain);


### PR DESCRIPTION
## Summary

- \`async_chain_ops\`: \`save_to_json_async\`/\`save_to_csv_async\` take a *directory* and internally append \`{title}.{ext}\`. The example previously passed \`async_chain.json\` as the directory, which made the inner \`File::create\` fail with ENOENT. Route the paths through \`std::env::temp_dir().join(\"optionstratlib-async-chain-ops\")\` and create it up front.
- \`creator\`: point the hard-coded JSON path at \`Germany-40-2025-05-27-15-29-00-UTC-24209.json\` that actually ships in \`examples/Chains/\` instead of \`2025-06-13-16:00:00-UTC-23794.5.json\` which was never committed.

Both example binaries now run to completion.

Closes #388.

## Test plan

- [x] \`cargo run --manifest-path=examples/examples_chain/Cargo.toml --bin async_chain_ops\` — clean run + round-trips.
- [x] \`cargo run --manifest-path=examples/examples_chain/Cargo.toml --bin creator\` — clean run with best-area + delta adjustment.