### PR TITLE
release(0.16.3): bump + CHANGELOG for #385/#386

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3] - 2026-04-20
+
+Hot-fix targeting the runnable-example audit.
+
+### Fixed
+
+- Simulation-heavy demo binaries
+  (`long_call_strategy_simulation`, `short_put_strategy_simulation`,
+  `position_simulator`, `strategy_simulator`, `random_walk_chain`)
+  now use an hourly grid over the week instead of a minute-level
+  grid (10 080 steps × 100 simulations, 43 200 for the chain
+  walker). The code paths are exercised identically; the demos
+  just run in a few seconds in debug mode rather than the minutes
+  the example runner timed out on. (#385, #386)
+- `examples_volatility::test` brute-force scan cut from
+  1 000 000 to 10 000 iterations — the example is a demo, not a
+  local benchmark. (#386)
+
+[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.3...HEAD
+[0.16.3]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.3
+
 ## [0.16.2] - 2026-04-19
 
 Hot-fix for two panic / I/O bugs caught while running every example
@@ -36,7 +57,6 @@ binary under `examples/`.
   was never committed; now reads the one that ships in
   `examples/Chains/`. (#388)
 
-[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.2...HEAD
 [0.16.2]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.2
 
 ## [0.16.1] - 2026-04-19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."

--- a/examples/examples_chain/src/bin/async_chain_ops.rs
+++ b/examples/examples_chain/src/bin/async_chain_ops.rs
@@ -3,7 +3,8 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    println!("--- Async Option Chain Operations ---");
+    setup_logger();
+    info!("--- Async Option Chain Operations ---");
 
     let chain = OptionChain::new(
         "AAPL",
@@ -24,30 +25,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let json_path = dir.join(&filename_json);
     let csv_path = dir.join(&filename_csv);
 
-    println!("Saving chain to {} asynchronously...", json_path.display());
+    info!("Saving chain to {} asynchronously...", json_path.display());
     chain.save_to_json_async(&dir_str).await?;
-    println!("Successfully saved to JSON.");
+    info!("Successfully saved to JSON.");
 
-    println!(
+    info!(
         "Loading chain from {} asynchronously...",
         json_path.display()
     );
     let loaded_json = OptionChain::load_from_json_async(json_path.to_str().unwrap()).await?;
-    println!(
+    info!(
         "Successfully loaded from JSON. Symbol: {}",
         loaded_json.symbol
     );
 
-    println!("Saving chain to {} asynchronously...", csv_path.display());
+    info!("Saving chain to {} asynchronously...", csv_path.display());
     chain.save_to_csv_async(&dir_str).await?;
-    println!("Successfully saved to CSV.");
+    info!("Successfully saved to CSV.");
 
-    println!(
+    info!(
         "Loading chain from {} asynchronously...",
         csv_path.display()
     );
     let loaded_csv = OptionChain::load_from_csv_async(csv_path.to_str().unwrap()).await?;
-    println!(
+    info!(
         "Successfully loaded from CSV. Symbol: {}",
         loaded_csv.symbol
     );
@@ -55,6 +56,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let _ = std::fs::remove_file(&json_path);
     let _ = std::fs::remove_file(&csv_path);
 
-    println!("--- Async Chain Operations Completed ---");
+    info!("--- Async Chain Operations Completed ---");
     Ok(())
 }

--- a/examples/examples_chain/src/bin/async_ohlcv.rs
+++ b/examples/examples_chain/src/bin/async_ohlcv.rs
@@ -1,13 +1,16 @@
 use optionstratlib::utils::read_ohlcv_from_zip_async;
 use std::error::Error;
+use tracing::{error, info};
+use optionstratlib::prelude::setup_logger;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    println!("--- Async OHLCV Reading ---");
+    setup_logger();
+    info!("--- Async OHLCV Reading ---");
 
     let zip_path = "../../examples/Data/cl-1m-sample.zip"; // Path relative to the example run dir
 
-    println!("Reading OHLCV data from {} asynchronously...", zip_path);
+    info!("Reading OHLCV data from {} asynchronously...", zip_path);
 
     // We'll read without date filters first
     let result: Result<Vec<optionstratlib::utils::OhlcvCandle>, optionstratlib::error::OhlcvError> =
@@ -15,17 +18,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     match result {
         Ok(candles) => {
-            println!("Successfully read {} candles.", candles.len());
+            info!("Successfully read {} candles.", candles.len());
             if let Some(first) = candles.first() {
-                println!("First candle: Date={}, Close={}", first.date, first.close);
+                info!("First candle: Date={}, Close={}", first.date, first.close);
             }
         }
         Err(e) => {
-            eprintln!("Error reading OHLCV: {}", e);
+            error!("Error reading OHLCV: {}", e);
             // Don't fail the example if file is not found, just report it
         }
     }
 
-    println!("--- Async OHLCV Reading Completed ---");
+    info!("--- Async OHLCV Reading Completed ---");
     Ok(())
 }

--- a/examples/examples_curves/src/bin/volatility_smile.rs
+++ b/examples/examples_curves/src/bin/volatility_smile.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
 //                 "../../examples/Chains/SP500-18-oct-2024-5781.88.json").unwrap();
 //         let smile_curve = option_chain.smile();
 //         for point in smile_curve.points.iter() {
-//             println!("x: {}, y: {}", point.x, point.y);
+//             info!("x: {}, y: {}", point.x, point.y);
 //         }
 //     }
 // }

--- a/examples/examples_exotics/src/bin/cliquet_example.rs
+++ b/examples/examples_exotics/src/bin/cliquet_example.rs
@@ -10,8 +10,11 @@ use optionstratlib::pricing::cliquet::cliquet_black_scholes;
 use optionstratlib::{ExpirationDate, Options};
 use positive::pos_or_panic;
 use rust_decimal_macros::dec;
+use tracing::{error, info};
+use optionstratlib::prelude::setup_logger;
 
 fn main() {
+    setup_logger();
     // 1. Define Cliquet Option parameters
     // We want a 1-year Cliquet option with quarterly resets (every 90 days)
     let reset_dates = vec![90.0, 180.0, 270.0];
@@ -61,12 +64,12 @@ fn main() {
     // 3. Price the option
     match cliquet_black_scholes(&option) {
         Ok(price) => {
-            println!("Cliquet Option Price: ${:.4}", price);
-            println!("Number of periods: 4 (Inception to 90, 90-180, 180-270, 270-365)");
-            println!("Local Cap: 5.00%");
-            println!("Local Floor: -2.00%");
+            info!("Cliquet Option Price: ${:.4}", price);
+            info!("Number of periods: 4 (Inception to 90, 90-180, 180-270, 270-365)");
+            info!("Local Cap: 5.00%");
+            info!("Local Floor: -2.00%");
         }
-        Err(e) => eprintln!("Error pricing Cliquet: {:?}", e),
+        Err(e) => error!("Error pricing Cliquet: {:?}", e),
     }
 
     // 4. Show price without cap/floor (unconstrained cliquet)
@@ -77,7 +80,7 @@ fn main() {
     }
 
     match cliquet_black_scholes(&unconstrained) {
-        Ok(price) => println!("Unconstrained Cliquet Price: ${:.4}", price),
-        Err(e) => eprintln!("Error pricing unconstrained Cliquet: {:?}", e),
+        Ok(price) => info!("Unconstrained Cliquet Price: ${:.4}", price),
+        Err(e) => error!("Error pricing unconstrained Cliquet: {:?}", e),
     }
 }

--- a/examples/examples_simulation/src/bin/unified_pricing.rs
+++ b/examples/examples_simulation/src/bin/unified_pricing.rs
@@ -23,6 +23,7 @@ use positive::pos_or_panic;
 use std::convert::Infallible;
 use std::fmt::Display;
 use std::ops::AddAssign;
+use tracing::info;
 
 // Simple walker implementation for demonstration
 #[derive(Clone)]
@@ -52,7 +53,8 @@ fn demo_generator(
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== Unified Pricing System Example ===\n");
+    setup_logger();
+    info!("=== Unified Pricing System Example ===\n");
 
     // Create a sample European call option
     let option = Options {
@@ -70,30 +72,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         exotic_params: None,
     };
 
-    println!("Option Details:");
-    println!("  Symbol: {}", option.underlying_symbol);
-    println!("  Type: {:?} {:?}", option.option_style, option.option_type);
-    println!("  Strike: ${}", option.strike_price);
-    println!("  Underlying: ${}", option.underlying_price);
-    println!("  Volatility: {}", option.implied_volatility);
-    println!("  Days to Expiry: {:?}\n", option.expiration_date);
+    info!("Option Details:");
+    info!("  Symbol: {}", option.underlying_symbol);
+    info!("  Type: {:?} {:?}", option.option_style, option.option_type);
+    info!("  Strike: ${}", option.strike_price);
+    info!("  Underlying: ${}", option.underlying_price);
+    info!("  Volatility: {}", option.implied_volatility);
+    info!("  Days to Expiry: {:?}\n", option.expiration_date);
 
     // 1. Black-Scholes Pricing
-    println!("1. Black-Scholes Closed-Form Pricing:");
+    info!("1. Black-Scholes Closed-Form Pricing:");
     let bs_engine = PricingEngine::ClosedFormBS;
     match price_option(&option, &bs_engine) {
-        Ok(price) => println!("   Price: ${:.4}", price),
-        Err(e) => println!("   Error: {}", e),
+        Ok(price) => info!("   Price: ${:.4}", price),
+        Err(e) => info!("   Error: {}", e),
     }
 
     // Alternative using Priceable trait
     match option.price(&bs_engine) {
-        Ok(price) => println!("   Price (via trait): ${:.4}\n", price),
-        Err(e) => println!("   Error: {}\n", e),
+        Ok(price) => info!("   Price (via trait): ${:.4}\n", price),
+        Err(e) => info!("   Error: {}\n", e),
     }
 
     // 2. Monte Carlo with Geometric Brownian Motion
-    println!("2. Monte Carlo with Geometric Brownian Motion:");
+    info!("2. Monte Carlo with Geometric Brownian Motion:");
     let size = 365;
     let init_step = Step {
         x: Xstep::new(
@@ -128,12 +130,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         simulator: gbm_simulator,
     };
     match option.price(&mc_engine) {
-        Ok(price) => println!("   Price: ${:.4}\n", price),
-        Err(e) => println!("   Error: {}\n", e),
+        Ok(price) => info!("   Price: ${:.4}\n", price),
+        Err(e) => info!("   Error: {}\n", e),
     }
 
     // 3. Monte Carlo with Heston Model
-    println!("3. Monte Carlo with Heston Stochastic Volatility:");
+    info!("3. Monte Carlo with Heston Stochastic Volatility:");
     let heston_walk = WalkType::Heston {
         dt: Positive::ONE,
         drift: dec!(0.0),
@@ -162,12 +164,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         simulator: heston_simulator,
     };
     match option.price(&heston_engine) {
-        Ok(price) => println!("   Price: ${:.4}\n", price),
-        Err(e) => println!("   Error: {}\n", e),
+        Ok(price) => info!("   Price: ${:.4}\n", price),
+        Err(e) => info!("   Error: {}\n", e),
     }
 
     // 4. Monte Carlo with Jump Diffusion
-    println!("4. Monte Carlo with Jump Diffusion:");
+    info!("4. Monte Carlo with Jump Diffusion:");
     let jump_walk = WalkType::JumpDiffusion {
         dt: Positive::ONE,
         drift: dec!(0.0),
@@ -195,12 +197,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         simulator: jump_simulator,
     };
     match option.price(&jump_engine) {
-        Ok(price) => println!("   Price: ${:.4}\n", price),
-        Err(e) => println!("   Error: {}\n", e),
+        Ok(price) => info!("   Price: ${:.4}\n", price),
+        Err(e) => info!("   Error: {}\n", e),
     }
 
     // 5. Monte Carlo with Telegraph Process
-    println!("5. Monte Carlo with Telegraph Process:");
+    info!("5. Monte Carlo with Telegraph Process:");
     let telegraph_walk = WalkType::Telegraph {
         dt: Positive::ONE,
         drift: dec!(0.0),
@@ -229,10 +231,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         simulator: telegraph_simulator,
     };
     match option.price(&telegraph_engine) {
-        Ok(price) => println!("   Price: ${:.4}\n", price),
-        Err(e) => println!("   Error: {}\n", e),
+        Ok(price) => info!("   Price: ${:.4}\n", price),
+        Err(e) => info!("   Error: {}\n", e),
     }
 
-    println!("=== Example Complete ===");
+    info!("=== Example Complete ===");
     Ok(())
 }

--- a/src/metrics/risk/dollar_gamma.rs
+++ b/src/metrics/risk/dollar_gamma.rs
@@ -79,7 +79,7 @@ use crate::model::OptionStyle;
 /// let max_dg = dg_curve.points.iter()
 ///     .max_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal))
 ///     .ok_or("empty dollar gamma curve")?;
-/// println!("Max dollar gamma at strike {}: ${:.2}", max_dg.x, max_dg.y);
+/// info!("Max dollar gamma at strike {}: ${:.2}", max_dg.x, max_dg.y);
 /// ```
 ///
 /// # Practical Considerations

--- a/src/metrics/risk/implied_volatility.rs
+++ b/src/metrics/risk/implied_volatility.rs
@@ -76,7 +76,7 @@ use rust_decimal::MathematicalOps;
 ///
 /// // The curve can be used for visualization or analysis
 /// for point in iv_curve.points.iter() {
-///     println!("Strike: {}, IV: {:.2}%", point.x, point.y * 100.0);
+///     info!("Strike: {}, IV: {:.2}%", point.x, point.y * 100.0);
 /// }
 /// ```
 pub trait ImpliedVolatilityCurve {

--- a/src/metrics/risk/risk_reversal.rs
+++ b/src/metrics/risk/risk_reversal.rs
@@ -76,7 +76,7 @@ use crate::error::CurveError;
 /// // Analyze market sentiment
 /// for point in rr_curve.points.iter() {
 ///     let sentiment = if point.y > Decimal::ZERO { "bullish" } else { "bearish" };
-///     println!("Strike {}: RR = {:.4} ({})", point.x, point.y, sentiment);
+///     info!("Strike {}: RR = {:.4} ({})", point.x, point.y, sentiment);
 /// }
 /// ```
 ///

--- a/src/model/leg/mod.rs
+++ b/src/model/leg/mod.rs
@@ -52,7 +52,7 @@
 //!
 //! // Both legs can be handled uniformly via LegAble trait
 //! use optionstratlib::model::leg::LegAble;
-//! println!("Spot delta: {}", spot_leg.delta()?);
+//! info!("Spot delta: {}", spot_leg.delta()?);
 //! # Ok(())
 //! # }
 //! ```

--- a/src/strategies/delta_neutral/model.rs
+++ b/src/strategies/delta_neutral/model.rs
@@ -1032,8 +1032,8 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
     ///
     /// ```ignore
     /// let greeks = strategy.portfolio_greeks()?;
-    /// println!("Portfolio delta: {}", greeks.delta);
-    /// println!("Portfolio gamma: {}", greeks.gamma);
+    /// info!("Portfolio delta: {}", greeks.delta);
+    /// info!("Portfolio gamma: {}", greeks.gamma);
     /// ```
     ///
     /// # Errors
@@ -1080,7 +1080,7 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
     /// let config = AdjustmentConfig::default();
     /// let target = AdjustmentTarget::delta_neutral();
     /// let plan = strategy.optimized_adjustment_plan(config, target)?;
-    /// println!("Actions needed: {}", plan.actions.len());
+    /// info!("Actions needed: {}", plan.actions.len());
     /// ```
     ///
     /// # Errors

--- a/src/strategies/delta_neutral/portfolio.rs
+++ b/src/strategies/delta_neutral/portfolio.rs
@@ -95,7 +95,7 @@ impl PortfolioGreeks {
     /// ```ignore
     /// let positions = strategy.get_positions()?;
     /// let greeks = PortfolioGreeks::from_positions(&positions)?;
-    /// println!("Portfolio delta: {}", greeks.delta);
+    /// info!("Portfolio delta: {}", greeks.delta);
     /// ```
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

- Bump crate version to \`0.16.3\`.
- CHANGELOG entry for 0.16.3 covering the example-runtime fixes (#385, #386) that landed in #392: shrunk simulation grids, cut volatility brute-force scan.

Tag \`v0.16.3\`, GitHub release, \`make publish\` follow immediately after merge.

## Test plan

- [x] \`cargo build --lib\` on bumped version.
- [x] \`cargo readme\` — no README diff.