### PR TITLE
release(0.16.4): dep bumps + doctest repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.4] - 2026-04-20
+
+### Changed
+
+- Bump workspace dependencies: `rust_decimal` 1.40 → 1.41,
+  `rayon` 1.11 → 1.12, `uuid` 1.19 → 1.23, `tokio` 1.43 → 1.52.
+
+### Fixed
+
+- Repair three doctests broken by the `NonZeroUsize` migration
+  in 0.16.0: `pricing` module-level examples for `telegraph` and
+  `monte_carlo_option_pricing` now wrap literal step / simulation
+  counts with `nz!(..)`; the `utils::deterministic_rng` doctest
+  uses `rand::RngExt` for `random::<u64>()`.
+
+[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.4...HEAD
+[0.16.4]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.4
+
 ## [0.16.3] - 2026-04-20
 
 Hot-fix targeting the runnable-example audit.
@@ -25,7 +43,6 @@ Hot-fix targeting the runnable-example audit.
   1 000 000 to 10 000 iterations — the example is a demo, not a
   local benchmark. (#386)
 
-[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.3...HEAD
 [0.16.3]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.3
 
 ## [0.16.2] - 2026-04-19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."
@@ -117,7 +117,7 @@ members = [
 [workspace.dependencies]
 optionstratlib = { path = "." }
 tracing = "0.1"
-rust_decimal = { version = "1.40", features = ["maths", "serde"] }
+rust_decimal = { version = "1.41", features = ["maths", "serde"] }
 rust_decimal_macros = "1.40"
 plotly = { version = "0.14", default-features = false, features = ["static_export_default"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -128,11 +128,11 @@ num-traits = "0.2"
 serde_json = "1.0"
 csv = { version = "1.4"}
 serde = { version = "1.0", features = ["derive"] }
-rayon = { version = "1.11" }
+rayon = { version = "1.12" }
 itertools = "0.14"
 zip = "6.0"
 lazy_static = "1.5"
-uuid = { version = "1.19", features = ["v4", "serde"] }
+uuid = { version = "1.23", features = ["v4", "serde"] }
 approx = "0.5"
 rand_distr = "0.6"
 prettytable-rs = "0.10"
@@ -144,7 +144,7 @@ positive = { version = "0.5", features = ["utoipa"] }
 expiration_date = { version = "0.2", features = ["utoipa"] }
 financial_types = { version = "0.2", features = ["utoipa"] }
 option_type = { version = "0.1.2", features = ["utoipa"] }
-tokio = { version = "1.43", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 async-trait = "0.1"
 reqwest = { version = "0.13", features = ["json"] }
 futures = "0.3"

--- a/examples/examples_chain/src/bin/async_ohlcv.rs
+++ b/examples/examples_chain/src/bin/async_ohlcv.rs
@@ -1,7 +1,7 @@
+use optionstratlib::prelude::setup_logger;
 use optionstratlib::utils::read_ohlcv_from_zip_async;
 use std::error::Error;
 use tracing::{error, info};
-use optionstratlib::prelude::setup_logger;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/examples_exotics/src/bin/cliquet_example.rs
+++ b/examples/examples_exotics/src/bin/cliquet_example.rs
@@ -6,12 +6,12 @@
 
 use optionstratlib::model::option::ExoticParams;
 use optionstratlib::model::types::{OptionStyle, OptionType, Side};
+use optionstratlib::prelude::setup_logger;
 use optionstratlib::pricing::cliquet::cliquet_black_scholes;
 use optionstratlib::{ExpirationDate, Options};
 use positive::pos_or_panic;
 use rust_decimal_macros::dec;
 use tracing::{error, info};
-use optionstratlib::prelude::setup_logger;
 
 fn main() {
     setup_logger();

--- a/src/pricing/mod.rs
+++ b/src/pricing/mod.rs
@@ -86,7 +86,7 @@
 //!             dividend_yield: pos_or_panic!(0.01),
 //!             exotic_params: None,
 //!         };
-//! let price = telegraph(&option, 1000, Some(dec!(0.5)), Some(dec!(0.3)));
+//! let price = telegraph(&option, optionstratlib::nz!(1000), Some(dec!(0.5)), Some(dec!(0.3)));
 //! ```
 //!
 //! ### Combined Model Analysis
@@ -118,8 +118,8 @@
 //!         };
 //! // Compare prices across different models
 //! let bs_price = black_scholes(&option);
-//! let mc_price = monte_carlo_option_pricing(&option, 2, 2);
-//! let tp_price = telegraph(&option, 1000, Some(dec!(0.5)), Some(dec!(0.3)));
+//! let mc_price = monte_carlo_option_pricing(&option, optionstratlib::nz!(2), optionstratlib::nz!(2));
+//! let tp_price = telegraph(&option, optionstratlib::nz!(1000), Some(dec!(0.5)), Some(dec!(0.3)));
 //! ```
 //!
 //! ## Implementation Notes

--- a/src/utils/others.rs
+++ b/src/utils/others.rs
@@ -38,8 +38,9 @@ pub const DETERMINISTIC_RNG_DEFAULT_SEED: u64 = 0x0B_AD_C0_FF_EE_15_DE_AD;
 ///
 /// ```rust
 /// use optionstratlib::utils::deterministic_rng;
+/// use rand::RngExt;
 /// let mut rng = deterministic_rng(42);
-/// let _ = <rand::rngs::StdRng as rand::Rng>::random::<u64>(&mut rng);
+/// let _ = rng.random::<u64>();
 /// ```
 #[must_use]
 #[inline]


### PR DESCRIPTION
## Summary

- Bump workspace dependencies: \`rust_decimal\` 1.40 → 1.41, \`rayon\` 1.11 → 1.12, \`uuid\` 1.19 → 1.23, \`tokio\` 1.43 → 1.52.
- Repair three doctests broken by the \`NonZeroUsize\` migration in 0.16.0:
  - \`src/pricing/mod.rs\`: \`telegraph(&option, 1000, ..)\` → \`telegraph(&option, optionstratlib::nz!(1000), ..)\`
  - \`src/pricing/mod.rs\`: \`monte_carlo_option_pricing(&option, 2, 2)\` → \`monte_carlo_option_pricing(&option, nz!(2), nz!(2))\`
  - \`src/utils/others.rs\` — \`deterministic_rng\` doctest uses \`rand::RngExt\` for \`.random::<u64>()\`.
- Cargo-fmt side-effects on \`async_ohlcv\` / \`cliquet_example\`.

Tag \`v0.16.4\`, GitHub release, \`make publish\` follow immediately after merge.

## Test plan

- [x] \`cargo build --all-features\` clean.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all --check\`.
- [x] \`cargo test --lib --all-features\` — **3760 passed, 0 failed**.
- [x] \`cargo test --doc --all-features\` — **205 passed, 0 failed** (was 3 failed pre-bump).