### PR TITLE
feat(greeks): Black-76 Greeks (delta/gamma/vega/theta/rho)

### DIFF
--- a/examples/examples_pricing/Cargo.toml
+++ b/examples/examples_pricing/Cargo.toml
@@ -17,5 +17,9 @@ name = "black_76"
 path = "src/bin/black_76.rs"
 
 [[bin]]
+name = "black_76_greeks"
+path = "src/bin/black_76_greeks.rs"
+
+[[bin]]
 name = "garman_kohlhagen"
 path = "src/bin/garman_kohlhagen.rs"

--- a/examples/examples_pricing/src/bin/black_76_greeks.rs
+++ b/examples/examples_pricing/src/bin/black_76_greeks.rs
@@ -1,0 +1,115 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 2026-04-27
+******************************************************************************/
+
+//! Black-76 Greeks example — commodity futures scenario.
+//!
+//! Computes delta, gamma, vega, theta, and rho for ATM, ITM, and OTM calls and
+//! puts on a 6-month crude-oil futures contract. Prints the values together
+//! with the Hull-style sanity identity `Δ_call − Δ_put = e^(-rT)` and shows
+//! both free-function and trait-based usage.
+
+use optionstratlib::error::greeks::GreeksError;
+use optionstratlib::greeks::{Black76Greeks, delta_b76, gamma_b76, rho_b76, theta_b76, vega_b76};
+use optionstratlib::model::types::{OptionStyle, OptionType, Side};
+use optionstratlib::pricing::black_76;
+use optionstratlib::{ExpirationDate, Options};
+use positive::{Positive, pos_or_panic};
+use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal_macros::dec;
+use tracing::info;
+
+fn build_option(f: f64, k: f64, style: OptionStyle) -> Options {
+    Options::new(
+        OptionType::European,
+        Side::Long,
+        "CL".to_string(),
+        pos_or_panic!(k),
+        ExpirationDate::Days(pos_or_panic!(180.0)),
+        pos_or_panic!(0.30),
+        Positive::ONE,
+        pos_or_panic!(f),
+        dec!(0.045),
+        style,
+        pos_or_panic!(0.0),
+        None,
+    )
+}
+
+fn print_greeks(label: &str, opt: &Options) -> Result<(), Box<dyn std::error::Error>> {
+    let price = black_76(opt)?;
+    let delta = delta_b76(opt)?;
+    let gamma = gamma_b76(opt)?;
+    let vega = vega_b76(opt)?;
+    let theta = theta_b76(opt)?;
+    let rho = rho_b76(opt)?;
+    info!(
+        "{label:<6} F={F:>6} K={K:>6} | price={price:>9.4} Δ={delta:>8.4} Γ={gamma:>9.6} ν={vega:>8.4} Θ={theta:>9.4} ρ={rho:>9.4}",
+        label = label,
+        F = opt.underlying_price.to_dec(),
+        K = opt.strike_price.to_dec(),
+        price = price,
+        delta = delta,
+        gamma = gamma,
+        vega = vega,
+        theta = theta,
+        rho = rho,
+    );
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .without_time()
+        .init();
+
+    info!("=== Black-76 Greeks (6-month CL futures, σ=30%, r=4.5%) ===");
+    info!("");
+    info!("Calls");
+    print_greeks("OTM", &build_option(70.0, 80.0, OptionStyle::Call))?;
+    print_greeks("ATM", &build_option(75.0, 75.0, OptionStyle::Call))?;
+    print_greeks("ITM", &build_option(80.0, 70.0, OptionStyle::Call))?;
+    info!("");
+    info!("Puts");
+    print_greeks("ITM", &build_option(70.0, 80.0, OptionStyle::Put))?;
+    print_greeks("ATM", &build_option(75.0, 75.0, OptionStyle::Put))?;
+    print_greeks("OTM", &build_option(80.0, 70.0, OptionStyle::Put))?;
+
+    // ---- Identity: Δ_call − Δ_put = e^(-rT) at any strike --------------
+    info!("");
+    let call = build_option(75.0, 75.0, OptionStyle::Call);
+    let put = build_option(75.0, 75.0, OptionStyle::Put);
+    let dc = delta_b76(&call)?;
+    let dp = delta_b76(&put)?;
+    let years = call.expiration_date.get_years()?.to_dec();
+    let df = (-call.risk_free_rate * years).exp();
+    let diff = dc - dp;
+    info!(
+        "Identity check: Δ_call − Δ_put = {diff:.10}, e^(-rT) = {df:.10}, |err| = {err:.2e}",
+        diff = diff,
+        df = df,
+        err = (diff - df).abs(),
+    );
+
+    // ---- Trait usage ----------------------------------------------------
+    struct FutureContract(Options);
+    impl Black76Greeks for FutureContract {
+        fn get_option(&self) -> Result<&Options, GreeksError> {
+            Ok(&self.0)
+        }
+    }
+    let contract = FutureContract(build_option(75.0, 75.0, OptionStyle::Call));
+    info!("");
+    info!(
+        "Trait usage on wrapper type: Δ={delta} Γ={gamma}",
+        delta = contract.delta_b76()?,
+        gamma = contract.gamma_b76()?,
+    );
+
+    // Suppress unused-import warning on Decimal in case formatting changes.
+    let _: Decimal = df;
+    Ok(())
+}

--- a/src/greeks/black_76.rs
+++ b/src/greeks/black_76.rs
@@ -1,0 +1,742 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 2026-04-27
+******************************************************************************/
+
+//! # Black-76 Greeks
+//!
+//! Closed-form Greeks (delta, gamma, vega, theta, rho) for the Black-76 (Black 1976)
+//! pricing model on options on futures, forwards, swaptions, caps/floors, and
+//! commodity futures.
+//!
+//! Black-76 differs from Black–Scholes–Merton in that the input is the forward
+//! price `F` (with the cost of carry already baked in) rather than the spot
+//! price `S`. The drift in `d1`/`d2` is therefore zero and the dividend yield is
+//! irrelevant. Both legs of every Greek share the single discount factor
+//! `e^(-rT)`.
+//!
+//! Greek units mirror the BSM module:
+//!
+//! * `delta_b76` — per unit move in `F`, applies long/short sign.
+//! * `gamma_b76` — per unit move in `F` (second order).
+//! * `vega_b76`  — per **1%** change in volatility.
+//! * `theta_b76` — per **calendar day** (annual figure divided by 365).
+//! * `rho_b76`   — per **1%** change in the risk-free rate.
+//!
+//! All quantities are returned as `Decimal` and scale linearly with
+//! `option.quantity`.
+//!
+//! See `src/pricing/black_76.rs` for the matching pricing kernel.
+
+use crate::Options;
+use crate::error::PricingError;
+use crate::error::greeks::GreeksError;
+use crate::greeks::utils::{big_n, calculate_d_values_black_76, n};
+use crate::model::decimal::{d_div, d_mul, d_sub};
+use crate::model::types::{OptionStyle, OptionType, Side};
+use rust_decimal::{Decimal, MathematicalOps};
+use tracing::{instrument, trace};
+
+/// Reject any option type that is not European; Black-76 only prices European
+/// futures/forward options.
+#[cold]
+fn reject_non_european(label: &str) -> GreeksError {
+    GreeksError::Pricing(Box::new(PricingError::unsupported_option_type(
+        label, "Black-76",
+    )))
+}
+
+fn ensure_european(option: &Options) -> Result<(), GreeksError> {
+    match option.option_type {
+        OptionType::European => Ok(()),
+        OptionType::American => Err(reject_non_european("American")),
+        OptionType::Bermuda { .. } => Err(reject_non_european("Bermuda")),
+        _ => Err(reject_non_european("exotic")),
+    }
+}
+
+fn side_sign(option: &Options) -> Decimal {
+    if matches!(option.side, Side::Long) {
+        Decimal::ONE
+    } else {
+        Decimal::NEGATIVE_ONE
+    }
+}
+
+fn discount_factor(option: &Options, t: Decimal) -> Decimal {
+    (-option.risk_free_rate * t).exp()
+}
+
+/// Computes the delta of an option under the Black-76 model.
+///
+/// # Formulas
+///
+/// - Call: `Δ_call = e^(-rT) · N(d1)`
+/// - Put:  `Δ_put  = -e^(-rT) · N(-d1)`
+///
+/// The result is multiplied by `+1` for `Side::Long` and `-1` for `Side::Short`,
+/// then by `option.quantity`.
+///
+/// # Errors
+///
+/// - `GreeksError::Pricing(UnsupportedOptionType)` for non-European options.
+/// - Propagates `GreeksError` from `calculate_d_values_black_76` when expiration
+///   or volatility are non-positive.
+#[instrument(skip(option), fields(
+    strike = %option.strike_price,
+    style = ?option.option_style,
+    side = ?option.side,
+))]
+pub fn delta_b76(option: &Options) -> Result<Decimal, GreeksError> {
+    ensure_european(option)?;
+    let t = option.expiration_date.get_years()?.to_dec();
+    let (d1, _d2) = calculate_d_values_black_76(option)?;
+
+    let df = discount_factor(option, t);
+    let raw = match option.option_style {
+        OptionStyle::Call => d_mul(df, big_n(d1)?, "greeks::black_76::delta::call")?,
+        OptionStyle::Put => -d_mul(df, big_n(-d1)?, "greeks::black_76::delta::put")?,
+    };
+
+    let signed = d_mul(side_sign(option), raw, "greeks::black_76::delta::sign")?;
+    let result = d_mul(
+        signed,
+        option.quantity.to_dec(),
+        "greeks::black_76::delta::quantity",
+    )?;
+
+    trace!(
+        "Black-76 Delta: F={}, K={}, e^(-rT)={}, d1={}, raw={}, result={}",
+        option.underlying_price, option.strike_price, df, d1, raw, result
+    );
+    Ok(result)
+}
+
+/// Computes the gamma of an option under the Black-76 model.
+///
+/// # Formula
+///
+/// `Γ = e^(-rT) · n(d1) / (F · σ · √T)`
+///
+/// Gamma is identical for calls and puts and does not flip with `Side`. Result
+/// is multiplied by `option.quantity`.
+///
+/// # Errors
+///
+/// - `GreeksError::Pricing(UnsupportedOptionType)` for non-European options.
+/// - Propagates `GreeksError` from `calculate_d_values_black_76` when expiration
+///   or volatility are non-positive.
+#[instrument(skip(option), fields(strike = %option.strike_price))]
+pub fn gamma_b76(option: &Options) -> Result<Decimal, GreeksError> {
+    ensure_european(option)?;
+    let t = option.expiration_date.get_years()?;
+    let (d1, _d2) = calculate_d_values_black_76(option)?;
+
+    let df = discount_factor(option, t.to_dec());
+    let f = option.underlying_price.to_dec();
+    let sigma = option.implied_volatility.to_dec();
+    let sqrt_t = t.sqrt().to_dec();
+
+    let denom = d_mul(
+        f,
+        d_mul(sigma, sqrt_t, "greeks::black_76::gamma::sigma_sqrt_t")?,
+        "greeks::black_76::gamma::denom",
+    )?;
+    let numer = d_mul(df, n(d1)?, "greeks::black_76::gamma::numer")?;
+    let raw = d_div(numer, denom, "greeks::black_76::gamma::raw")?;
+
+    let result = d_mul(
+        raw,
+        option.quantity.to_dec(),
+        "greeks::black_76::gamma::quantity",
+    )?;
+    trace!(
+        "Black-76 Gamma: F={}, K={}, d1={}, df={}, result={}",
+        option.underlying_price, option.strike_price, d1, df, result
+    );
+    Ok(result)
+}
+
+/// Computes the vega of an option under the Black-76 model, per 1% change in
+/// volatility.
+///
+/// # Formula
+///
+/// `ν = F · e^(-rT) · n(d1) · √T`, divided by 100 to express the sensitivity per
+/// 1 percentage point of volatility, then multiplied by `option.quantity`.
+///
+/// Vega is identical for calls and puts and does not flip with `Side`.
+///
+/// # Errors
+///
+/// - `GreeksError::Pricing(UnsupportedOptionType)` for non-European options.
+/// - Propagates `GreeksError` from `calculate_d_values_black_76` when expiration
+///   or volatility are non-positive.
+#[instrument(skip(option), fields(strike = %option.strike_price))]
+pub fn vega_b76(option: &Options) -> Result<Decimal, GreeksError> {
+    ensure_european(option)?;
+    let t = option.expiration_date.get_years()?;
+    let (d1, _d2) = calculate_d_values_black_76(option)?;
+
+    let df = discount_factor(option, t.to_dec());
+    let f = option.underlying_price.to_dec();
+    let sqrt_t = t.sqrt().to_dec();
+
+    // F * e^(-rT) * n(d1) * √T
+    let leg1 = d_mul(f, df, "greeks::black_76::vega::f_df")?;
+    let leg2 = d_mul(leg1, n(d1)?, "greeks::black_76::vega::times_n")?;
+    let raw = d_mul(leg2, sqrt_t, "greeks::black_76::vega::times_sqrt_t")?;
+
+    let weighted = d_mul(
+        raw,
+        option.quantity.to_dec(),
+        "greeks::black_76::vega::quantity",
+    )?;
+    let result = d_div(
+        weighted,
+        Decimal::ONE_HUNDRED,
+        "greeks::black_76::vega::per_pct",
+    )?;
+    trace!(
+        "Black-76 Vega: F={}, K={}, d1={}, df={}, result={}",
+        option.underlying_price, option.strike_price, d1, df, result
+    );
+    Ok(result)
+}
+
+/// Computes the theta of an option under the Black-76 model, per calendar day.
+///
+/// # Formulas (annual)
+///
+/// - `Θ_call_year = -F·e^(-rT)·n(d1)·σ/(2√T) + r·F·e^(-rT)·N(d1) - r·K·e^(-rT)·N(d2)`
+/// - `Θ_put_year  = -F·e^(-rT)·n(d1)·σ/(2√T) - r·F·e^(-rT)·N(-d1) + r·K·e^(-rT)·N(-d2)`
+///
+/// The annual figure is divided by 365 to express decay per calendar day, then
+/// multiplied by `option.quantity`.
+///
+/// Theta does not flip with `Side`; the sign is governed by the formula itself.
+///
+/// # Errors
+///
+/// - `GreeksError::Pricing(UnsupportedOptionType)` for non-European options.
+/// - Propagates `GreeksError` from `calculate_d_values_black_76` when expiration
+///   or volatility are non-positive.
+#[instrument(skip(option), fields(strike = %option.strike_price))]
+pub fn theta_b76(option: &Options) -> Result<Decimal, GreeksError> {
+    ensure_european(option)?;
+    let t = option.expiration_date.get_years()?;
+    let (d1, d2) = calculate_d_values_black_76(option)?;
+
+    let df = discount_factor(option, t.to_dec());
+    let f = option.underlying_price.to_dec();
+    let k = option.strike_price.to_dec();
+    let r = option.risk_free_rate;
+    let sigma = option.implied_volatility.to_dec();
+    let sqrt_t = t.sqrt().to_dec();
+
+    // Common (volatility-decay) term, negative: -F·e^(-rT)·n(d1)·σ/(2·√T)
+    let two_sqrt_t = d_mul(Decimal::TWO, sqrt_t, "greeks::black_76::theta::two_sqrt_t")?;
+    let f_df = d_mul(f, df, "greeks::black_76::theta::f_df")?;
+    let f_df_n = d_mul(f_df, n(d1)?, "greeks::black_76::theta::f_df_n")?;
+    let f_df_n_sigma = d_mul(f_df_n, sigma, "greeks::black_76::theta::f_df_n_sigma")?;
+    let f_df_n_sigma_over_2sqrt_t =
+        d_div(f_df_n_sigma, two_sqrt_t, "greeks::black_76::theta::div")?;
+    let common = -f_df_n_sigma_over_2sqrt_t;
+
+    // r-dependent legs (annual, undiscounted view)
+    let r_f_df = d_mul(r, f_df, "greeks::black_76::theta::r_f_df")?;
+    let k_df = d_mul(k, df, "greeks::black_76::theta::k_df")?;
+    let r_k_df = d_mul(r, k_df, "greeks::black_76::theta::r_k_df")?;
+
+    let annual = match option.option_style {
+        OptionStyle::Call => {
+            // Θ_call = common + r·F·e^(-rT)·N(d1) − r·K·e^(-rT)·N(d2)
+            let plus = d_mul(r_f_df, big_n(d1)?, "greeks::black_76::theta::call::plus")?;
+            let minus = d_mul(r_k_df, big_n(d2)?, "greeks::black_76::theta::call::minus")?;
+            d_sub(common + plus, minus, "greeks::black_76::theta::call::sum")?
+        }
+        OptionStyle::Put => {
+            // Θ_put = common − r·F·e^(-rT)·N(−d1) + r·K·e^(-rT)·N(−d2)
+            let minus = d_mul(r_f_df, big_n(-d1)?, "greeks::black_76::theta::put::minus")?;
+            let plus = d_mul(r_k_df, big_n(-d2)?, "greeks::black_76::theta::put::plus")?;
+            d_sub(common + plus, minus, "greeks::black_76::theta::put::sum")?
+        }
+    };
+
+    let weighted = d_mul(
+        annual,
+        option.quantity.to_dec(),
+        "greeks::black_76::theta::quantity",
+    )?;
+    let result = d_div(
+        weighted,
+        Decimal::from(365),
+        "greeks::black_76::theta::per_day",
+    )?;
+    trace!(
+        "Black-76 Theta: F={}, K={}, d1={}, d2={}, annual={}, result={}",
+        option.underlying_price, option.strike_price, d1, d2, annual, result
+    );
+    Ok(result)
+}
+
+/// Computes the rho of an option under the Black-76 model, per 1% change in the
+/// risk-free rate.
+///
+/// # Formulas
+///
+/// In Black-76 the rate `r` only appears in the discount factor `e^(-rT)`, so
+/// the rho of the long option is simply `-T · price`. For a call:
+///
+/// `ρ_call = K · T · e^(-rT) · N(d2) - F · T · e^(-rT) · N(d1) = -T · C`
+///
+/// And symmetrically `ρ_put = -T · P`.
+///
+/// The annual figure is divided by 100 to express the sensitivity per 1
+/// percentage point of rate, then multiplied by `option.quantity`. Rho does not
+/// flip with `Side`.
+///
+/// # Errors
+///
+/// - `GreeksError::Pricing(UnsupportedOptionType)` for non-European options.
+/// - Propagates `GreeksError` from `calculate_d_values_black_76` when expiration
+///   or volatility are non-positive.
+#[instrument(skip(option), fields(strike = %option.strike_price))]
+pub fn rho_b76(option: &Options) -> Result<Decimal, GreeksError> {
+    ensure_european(option)?;
+    let t = option.expiration_date.get_years()?;
+    let (d1, d2) = calculate_d_values_black_76(option)?;
+
+    let df = discount_factor(option, t.to_dec());
+    let f = option.underlying_price.to_dec();
+    let k = option.strike_price.to_dec();
+    let t_dec = t.to_dec();
+
+    // Long-side, undiscounted rho:
+    //   call: -T · e^(-rT) · [F N(d1) - K N(d2)]
+    //   put : -T · e^(-rT) · [K N(-d2) - F N(-d1)]
+    let bracket = match option.option_style {
+        OptionStyle::Call => d_sub(
+            d_mul(f, big_n(d1)?, "greeks::black_76::rho::call::f_leg")?,
+            d_mul(k, big_n(d2)?, "greeks::black_76::rho::call::k_leg")?,
+            "greeks::black_76::rho::call::bracket",
+        )?,
+        OptionStyle::Put => d_sub(
+            d_mul(k, big_n(-d2)?, "greeks::black_76::rho::put::k_leg")?,
+            d_mul(f, big_n(-d1)?, "greeks::black_76::rho::put::f_leg")?,
+            "greeks::black_76::rho::put::bracket",
+        )?,
+    };
+
+    let neg_t_df = d_mul(-t_dec, df, "greeks::black_76::rho::neg_t_df")?;
+    let annual = d_mul(neg_t_df, bracket, "greeks::black_76::rho::annual")?;
+
+    let weighted = d_mul(
+        annual,
+        option.quantity.to_dec(),
+        "greeks::black_76::rho::quantity",
+    )?;
+    let result = d_div(
+        weighted,
+        Decimal::ONE_HUNDRED,
+        "greeks::black_76::rho::per_pct",
+    )?;
+    trace!(
+        "Black-76 Rho: F={}, K={}, d1={}, d2={}, annual={}, result={}",
+        option.underlying_price, option.strike_price, d1, d2, annual, result
+    );
+    Ok(result)
+}
+
+/// Trait that exposes Black-76 Greeks for any type that can produce an
+/// [`Options`] reference.
+///
+/// Mirrors the `Black76` pricing trait. Implementors only need to provide
+/// [`Black76Greeks::get_option`]; default implementations route to the
+/// free-function Greeks above.
+pub trait Black76Greeks {
+    /// Returns the option to price.
+    fn get_option(&self) -> Result<&Options, GreeksError>;
+
+    /// Black-76 delta — see [`delta_b76`].
+    fn delta_b76(&self) -> Result<Decimal, GreeksError> {
+        delta_b76(self.get_option()?)
+    }
+
+    /// Black-76 gamma — see [`gamma_b76`].
+    fn gamma_b76(&self) -> Result<Decimal, GreeksError> {
+        gamma_b76(self.get_option()?)
+    }
+
+    /// Black-76 vega — see [`vega_b76`].
+    fn vega_b76(&self) -> Result<Decimal, GreeksError> {
+        vega_b76(self.get_option()?)
+    }
+
+    /// Black-76 theta — see [`theta_b76`].
+    fn theta_b76(&self) -> Result<Decimal, GreeksError> {
+        theta_b76(self.get_option()?)
+    }
+
+    /// Black-76 rho — see [`rho_b76`].
+    fn rho_b76(&self) -> Result<Decimal, GreeksError> {
+        rho_b76(self.get_option()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ExpirationDate;
+    use crate::greeks::{delta, gamma, vega};
+    use crate::pricing::black_76;
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+
+    fn create_option(
+        f: f64,
+        k: f64,
+        r: Decimal,
+        t_days: f64,
+        sigma: f64,
+        style: OptionStyle,
+    ) -> Options {
+        Options::new(
+            OptionType::European,
+            Side::Long,
+            "FUT".to_string(),
+            pos_or_panic!(k),
+            ExpirationDate::Days(pos_or_panic!(t_days)),
+            pos_or_panic!(sigma),
+            Positive::ONE,
+            pos_or_panic!(f),
+            r,
+            style,
+            pos_or_panic!(0.0),
+            None,
+        )
+    }
+
+    fn close(a: Decimal, b: Decimal, tol: Decimal) -> bool {
+        (a - b).abs() < tol
+    }
+
+    // ---- delta ----------------------------------------------------------
+
+    #[test]
+    fn test_delta_call_in_unit_interval() {
+        for f in [80.0, 95.0, 100.0, 105.0, 120.0] {
+            let opt = create_option(f, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+            let d = delta_b76(&opt).expect("call delta");
+            assert!(d > Decimal::ZERO && d < Decimal::ONE, "F={} -> Δ={}", f, d);
+        }
+    }
+
+    #[test]
+    fn test_delta_put_in_negative_unit_interval() {
+        for f in [80.0, 95.0, 100.0, 105.0, 120.0] {
+            let opt = create_option(f, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Put);
+            let d = delta_b76(&opt).expect("put delta");
+            assert!(
+                d < Decimal::ZERO && d > Decimal::NEGATIVE_ONE,
+                "F={} -> Δ={}",
+                f,
+                d
+            );
+        }
+    }
+
+    /// Identity: `Δ_call - Δ_put = e^(-rT)` for long-side, qty=1.
+    #[test]
+    fn test_delta_call_minus_put_equals_discount_factor() {
+        let r = dec!(0.05);
+        let t_days = 180.0;
+        let call = create_option(100.0, 100.0, r, t_days, 0.2, OptionStyle::Call);
+        let put = create_option(100.0, 100.0, r, t_days, 0.2, OptionStyle::Put);
+
+        let dc = delta_b76(&call).unwrap();
+        let dp = delta_b76(&put).unwrap();
+
+        let years = call.expiration_date.get_years().unwrap().to_dec();
+        let expected = (-r * years).exp();
+        assert!(
+            close(dc - dp, expected, dec!(1e-9)),
+            "Δc - Δp = {} expected {}",
+            dc - dp,
+            expected
+        );
+    }
+
+    // ---- gamma / vega positivity ---------------------------------------
+
+    #[test]
+    fn test_gamma_positive_call_and_put() {
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            for f in [80.0, 100.0, 120.0] {
+                let opt = create_option(f, 100.0, dec!(0.05), 180.0, 0.2, style);
+                let g = gamma_b76(&opt).expect("gamma");
+                assert!(g > Decimal::ZERO, "style={:?} F={} Γ={}", style, f, g);
+            }
+        }
+    }
+
+    #[test]
+    fn test_vega_positive_call_and_put() {
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            for f in [80.0, 100.0, 120.0] {
+                let opt = create_option(f, 100.0, dec!(0.05), 180.0, 0.2, style);
+                let v = vega_b76(&opt).expect("vega");
+                assert!(v > Decimal::ZERO, "style={:?} F={} ν={}", style, f, v);
+            }
+        }
+    }
+
+    /// Calls and puts share the same gamma in Black-76.
+    #[test]
+    fn test_gamma_call_equals_put() {
+        let call = create_option(105.0, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        let put = create_option(105.0, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Put);
+        let gc = gamma_b76(&call).unwrap();
+        let gp = gamma_b76(&put).unwrap();
+        assert!(close(gc, gp, dec!(1e-15)), "Γc={} Γp={}", gc, gp);
+    }
+
+    /// Calls and puts share the same vega in Black-76.
+    #[test]
+    fn test_vega_call_equals_put() {
+        let call = create_option(105.0, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        let put = create_option(105.0, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Put);
+        let vc = vega_b76(&call).unwrap();
+        let vp = vega_b76(&put).unwrap();
+        assert!(close(vc, vp, dec!(1e-15)), "νc={} νp={}", vc, vp);
+    }
+
+    // ---- theta sanity ---------------------------------------------------
+
+    #[test]
+    fn test_theta_call_atm_long_negative() {
+        let opt = create_option(100.0, 100.0, dec!(0.05), 30.0, 0.2, OptionStyle::Call);
+        let th = theta_b76(&opt).expect("theta");
+        assert!(th < Decimal::ZERO, "ATM long call should decay: Θ={}", th);
+    }
+
+    #[test]
+    fn test_theta_put_atm_long_negative() {
+        let opt = create_option(100.0, 100.0, dec!(0.05), 30.0, 0.2, OptionStyle::Put);
+        let th = theta_b76(&opt).expect("theta");
+        assert!(th < Decimal::ZERO, "ATM long put should decay: Θ={}", th);
+    }
+
+    // ---- rho identity ---------------------------------------------------
+
+    /// In Black-76, `ρ_call = -T · price_call` (per pct of rate, before qty).
+    #[test]
+    fn test_rho_equals_minus_t_times_price_call() {
+        let opt = create_option(100.0, 95.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        let rho = rho_b76(&opt).unwrap();
+        let price = black_76(&opt).unwrap();
+        let years = opt.expiration_date.get_years().unwrap().to_dec();
+        let expected = -years * price / Decimal::ONE_HUNDRED;
+        assert!(
+            close(rho, expected, dec!(1e-15)),
+            "ρ={} expected={}",
+            rho,
+            expected
+        );
+    }
+
+    /// In Black-76, `ρ_put = -T · price_put` (per pct of rate, before qty).
+    #[test]
+    fn test_rho_equals_minus_t_times_price_put() {
+        let opt = create_option(100.0, 105.0, dec!(0.05), 180.0, 0.2, OptionStyle::Put);
+        let rho = rho_b76(&opt).unwrap();
+        let price = black_76(&opt).unwrap();
+        let years = opt.expiration_date.get_years().unwrap().to_dec();
+        let expected = -years * price / Decimal::ONE_HUNDRED;
+        assert!(
+            close(rho, expected, dec!(1e-15)),
+            "ρ={} expected={}",
+            rho,
+            expected
+        );
+    }
+
+    // ---- BSM cross-check (S = F·e^(-rT), q = 0) -------------------------
+
+    fn make_bsm_match(opt_b76: &Options) -> Options {
+        let years = opt_b76.expiration_date.get_years().unwrap().to_dec();
+        let df = (-opt_b76.risk_free_rate * years).exp();
+        let s = Positive::new_decimal(opt_b76.underlying_price.to_dec() * df).unwrap();
+        let mut bsm = opt_b76.clone();
+        bsm.underlying_price = s;
+        // dividend_yield already 0 from create_option
+        bsm
+    }
+
+    /// `Δ_b76 = e^(-rT) · Δ_bsm` under the discounted-spot transform, q=0.
+    #[test]
+    fn test_delta_matches_bsm_with_discounted_spot() {
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            for f in [90.0, 100.0, 110.0] {
+                let opt = create_option(f, 100.0, dec!(0.05), 180.0, 0.2, style);
+                let bsm = make_bsm_match(&opt);
+                let years = opt.expiration_date.get_years().unwrap().to_dec();
+                let df = (-opt.risk_free_rate * years).exp();
+                let lhs = delta_b76(&opt).unwrap();
+                let rhs = df * delta(&bsm).unwrap();
+                assert!(
+                    close(lhs, rhs, dec!(1e-9)),
+                    "style={:?} F={} Δ_b76={} vs e^(-rT)·Δ_bsm={}",
+                    style,
+                    f,
+                    lhs,
+                    rhs
+                );
+            }
+        }
+    }
+
+    /// `ν_b76 = ν_bsm` under the discounted-spot transform, q=0.
+    #[test]
+    fn test_vega_matches_bsm_with_discounted_spot() {
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            for f in [90.0, 100.0, 110.0] {
+                let opt = create_option(f, 100.0, dec!(0.05), 180.0, 0.2, style);
+                let bsm = make_bsm_match(&opt);
+                let lhs = vega_b76(&opt).unwrap();
+                let rhs = vega(&bsm).unwrap();
+                assert!(
+                    close(lhs, rhs, dec!(1e-9)),
+                    "style={:?} F={} ν_b76={} vs ν_bsm={}",
+                    style,
+                    f,
+                    lhs,
+                    rhs
+                );
+            }
+        }
+    }
+
+    /// `Γ_b76 = e^(-2rT) · Γ_bsm` under the discounted-spot transform, q=0.
+    #[test]
+    fn test_gamma_matches_bsm_with_discounted_spot() {
+        for f in [90.0, 100.0, 110.0] {
+            let opt = create_option(f, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+            let bsm = make_bsm_match(&opt);
+            let years = opt.expiration_date.get_years().unwrap().to_dec();
+            let df2 = (-Decimal::TWO * opt.risk_free_rate * years).exp();
+            let lhs = gamma_b76(&opt).unwrap();
+            let rhs = df2 * gamma(&bsm).unwrap();
+            assert!(
+                close(lhs, rhs, dec!(1e-9)),
+                "F={} Γ_b76={} vs e^(-2rT)·Γ_bsm={}",
+                f,
+                lhs,
+                rhs
+            );
+        }
+    }
+
+    // ---- error paths ----------------------------------------------------
+
+    #[test]
+    fn test_zero_volatility_returns_error() {
+        let opt = create_option(100.0, 100.0, dec!(0.05), 180.0, 0.0, OptionStyle::Call);
+        assert!(delta_b76(&opt).is_err());
+        assert!(gamma_b76(&opt).is_err());
+        assert!(vega_b76(&opt).is_err());
+        assert!(theta_b76(&opt).is_err());
+        assert!(rho_b76(&opt).is_err());
+    }
+
+    #[test]
+    fn test_unsupported_american_returns_error() {
+        let mut opt = create_option(100.0, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        opt.option_type = OptionType::American;
+        for r in [
+            delta_b76(&opt),
+            gamma_b76(&opt),
+            vega_b76(&opt),
+            theta_b76(&opt),
+            rho_b76(&opt),
+        ] {
+            match r {
+                Err(GreeksError::Pricing(boxed)) => match *boxed {
+                    PricingError::UnsupportedOptionType { .. } => {}
+                    other => panic!("wrong PricingError variant: {:?}", other),
+                },
+                Err(other) => panic!("wrong error: {:?}", other),
+                Ok(_) => panic!("expected error for American"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_unsupported_bermuda_returns_error() {
+        let mut opt = create_option(100.0, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        opt.option_type = OptionType::Bermuda {
+            exercise_dates: vec![],
+        };
+        assert!(matches!(delta_b76(&opt), Err(GreeksError::Pricing(_))));
+    }
+
+    // ---- side and quantity ---------------------------------------------
+
+    #[test]
+    fn test_side_short_negates_delta() {
+        let long = create_option(100.0, 95.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        let mut short = long.clone();
+        short.side = Side::Short;
+        let dl = delta_b76(&long).unwrap();
+        let ds = delta_b76(&short).unwrap();
+        assert_eq!(dl, -ds);
+    }
+
+    #[test]
+    fn test_quantity_scales_linearly() {
+        let mut opt = create_option(100.0, 95.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        let d1 = delta_b76(&opt).unwrap();
+        opt.quantity = pos_or_panic!(3.0);
+        let d3 = delta_b76(&opt).unwrap();
+        assert!(close(d3, d1 * Decimal::from(3), dec!(1e-15)));
+    }
+
+    // ---- trait ----------------------------------------------------------
+
+    #[test]
+    fn test_black76_greeks_trait() {
+        struct Wrap(Options);
+        impl Black76Greeks for Wrap {
+            fn get_option(&self) -> Result<&Options, GreeksError> {
+                Ok(&self.0)
+            }
+        }
+        let opt = create_option(100.0, 100.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        let w = Wrap(opt.clone());
+        assert_eq!(w.delta_b76().unwrap(), delta_b76(&opt).unwrap());
+        assert_eq!(w.gamma_b76().unwrap(), gamma_b76(&opt).unwrap());
+        assert_eq!(w.vega_b76().unwrap(), vega_b76(&opt).unwrap());
+        assert_eq!(w.theta_b76().unwrap(), theta_b76(&opt).unwrap());
+        assert_eq!(w.rho_b76().unwrap(), rho_b76(&opt).unwrap());
+    }
+
+    // ---- Hull reference -------------------------------------------------
+
+    /// Hull (10th ed., Ch. 18, ATM call on a futures contract):
+    /// F=20, K=20, T≈4/12, r=0.09, σ=0.25 → call delta ≈ e^(-rT) · N(d1).
+    /// d1 = σ√T / 2 ≈ 0.5·0.25·√(1/3) ≈ 0.0722, so N(d1) ≈ 0.5288 and
+    /// Δ ≈ e^(-0.03) · 0.5288 ≈ 0.5132. Tolerance 1e-3.
+    #[test]
+    fn test_hull_atm_call_delta() {
+        let opt = create_option(20.0, 20.0, dec!(0.09), 121.67, 0.25, OptionStyle::Call);
+        let d = delta_b76(&opt).unwrap();
+        let expected = dec!(0.5132);
+        assert!(
+            close(d, expected, dec!(1e-3)),
+            "Hull ATM call Δ = {} expected ≈ {}",
+            d,
+            expected
+        );
+    }
+}

--- a/src/greeks/mod.rs
+++ b/src/greeks/mod.rs
@@ -183,14 +183,16 @@ use positive::pos_or_panic;
 //! let color_surface = chain.color_time_surface(days)?;
 //! ```
 
+mod black_76;
 mod equations;
 pub mod numerical;
 mod utils;
 
+pub use black_76::{Black76Greeks, delta_b76, gamma_b76, rho_b76, theta_b76, vega_b76};
 pub use equations::{
     Greek, Greeks, GreeksSnapshot, charm, color, delta, gamma, rho, rho_d, theta, vanna, vega,
     veta, vomma,
 };
+pub(crate) use utils::calculate_d_values;
 pub use utils::calculate_delta_neutral_sizes;
-pub use utils::{big_n, d1, d2, n};
-pub(crate) use utils::{calculate_d_values, calculate_d_values_black_76};
+pub use utils::{big_n, calculate_d_values_black_76, d1, d2, n};

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -479,9 +479,7 @@ pub(crate) fn calculate_d_values(option: &Options) -> Result<(Decimal, Decimal),
 /// # Returns
 /// * `Ok((d1, d2))` - The Black-76 d1 and d2 parameters.
 /// * `Err(GreeksError)` - If validation or computation fails.
-pub(crate) fn calculate_d_values_black_76(
-    option: &Options,
-) -> Result<(Decimal, Decimal), GreeksError> {
+pub fn calculate_d_values_black_76(option: &Options) -> Result<(Decimal, Decimal), GreeksError> {
     // Black-76: cost of carry b = 0 (forward pricing, no carry term in d1/d2)
     let b = Decimal::ZERO;
     let years = option.expiration_date.get_years()?;


### PR DESCRIPTION
## Summary

Closed-form Greeks for the **Black-76** (Black 1976) pricing model, completing the futures/forwards story started in #398. Closes #400.

Black-76 prices options on futures, forwards, swaptions, caps/floors and commodity futures — anywhere the underlying is a forward price `F` with the cost of carry already baked in. The Greeks share a single `e^(-rT)` discount factor across both legs and ignore `dividend_yield` (because `F` is carry-adjusted).

## Public surface

New module `src/greeks/black_76.rs`:

- `pub fn delta_b76(option: &Options) -> Result<Decimal, GreeksError>`
- `pub fn gamma_b76(option: &Options) -> Result<Decimal, GreeksError>`
- `pub fn vega_b76(option: &Options)  -> Result<Decimal, GreeksError>` — per 1 % vol
- `pub fn theta_b76(option: &Options) -> Result<Decimal, GreeksError>` — per calendar day
- `pub fn rho_b76(option: &Options)   -> Result<Decimal, GreeksError>` — per 1 % rate
- `pub trait Black76Greeks` mirroring the existing `Black76` pricing trait

`calculate_d_values_black_76` was promoted from `pub(crate)` to `pub` so callers and the new module can share the helper.

Conventions match the BSM Greeks module:

- All math is `Decimal` end-to-end via `d_mul`/`d_sub`/`d_div`.
- Quantity scales linearly; `Side::Short` flips the delta sign only (gamma/vega/theta/rho stay sign-agnostic, same as `greeks::gamma`/`vega`/`theta`/`rho`).
- Vega ÷ 100 (per 1 percentage point of vol).
- Theta ÷ 365 (per calendar day).
- Rho ÷ 100 (per 1 percentage point of rate).
- `tracing::instrument` on every entry point.

## Formulas

The implementation follows **Hull, *Options, Futures and Other Derivatives* (10th ed., Ch. 18)** rigorously. The issue's formula for theta omitted the `+ r·F·e^(-rT)·N(d1)` term and the formula for rho was the BSM-style two-leg expression rather than the simpler Black-76 form. The complete Hull forms are:

```
Δ_call = e^(-rT) · N(d1)
Δ_put  = -e^(-rT) · N(-d1)

Γ      = e^(-rT) · n(d1) / (F · σ · √T)

ν      = F · e^(-rT) · n(d1) · √T

Θ_call = -F·e^(-rT)·n(d1)·σ/(2√T) + r·F·e^(-rT)·N(d1) - r·K·e^(-rT)·N(d2)
Θ_put  = -F·e^(-rT)·n(d1)·σ/(2√T) - r·F·e^(-rT)·N(-d1) + r·K·e^(-rT)·N(-d2)

ρ      = -T · price_b76     (the only place r appears in Black-76 is e^(-rT))
```

The `ρ = -T · price` identity is asserted analytically by tests for both call and put.

## Tests (21, all passing)

`#[cfg(test)] mod tests` in `src/greeks/black_76.rs`:

- Delta range and identity:
  - `Δ_call ∈ (0,1)`, `Δ_put ∈ (-1,0)` across moneyness
  - `Δ_call − Δ_put = e^(-rT)` to 1e-9
- Positivity / symmetry:
  - `Γ > 0`, `ν > 0` for both call and put across strikes
  - `Γ_call = Γ_put`, `ν_call = ν_put` (Black-76 invariant)
- Theta sanity:
  - long ATM call and put both decay (`Θ < 0`)
- Rho identity:
  - `ρ = -T · price / 100` for both call and put
- **BSM cross-check** under the `S = F·e^(-rT)`, `q = 0` transform (1e-9):
  - `Δ_b76 = e^(-rT) · Δ_bsm`
  - `ν_b76 = ν_bsm`
  - `Γ_b76 = e^(-2rT) · Γ_bsm`
- **Hull reference** (Ch. 18 ATM call, F=K=20, r=0.09, T≈1/3, σ=0.25): Δ ≈ 0.5132
- Error paths:
  - zero volatility on every Greek → `GreeksError`
  - American / Bermuda / exotic → `GreeksError::Pricing(UnsupportedOptionType)`
- Trait `Black76Greeks` round-trips against the free functions
- `Side::Short` negates delta
- Quantity scales linearly

## Example

`examples/examples_pricing/src/bin/black_76_greeks.rs` — 6-month crude-oil futures (σ=30 %, r=4.5 %), walks ATM / ITM / OTM calls and puts, prints all Greeks, demonstrates the `Δ_call − Δ_put = e^(-rT)` identity (zero residual) and trait usage on a wrapper type.

## Acceptance criteria (from #400)

- [x] Delta monotonicity: call ∈ [0,1], put ∈ [-1,0]; `Δ_call − Δ_put = e^(-rT)`
- [x] Gamma > 0
- [x] Vega > 0
- [x] Hull reference values to 1e-3
- [x] Cross-check vs BSM with `S = F·e^(-rT)`, `q = 0` to 1e-9 (post-transform relationships)
- [x] Zero volatility → error
- [x] American / Bermuda / exotic → `UnsupportedOptionType`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test` and `cargo test --features plotly` clean (lib: 3826 / 3822 passed). The `static_export` pass is pre-existing red on `origin/main` due to missing chromium for headless render — unrelated to this PR.
- [x] `cargo build --release` clean
- [x] All `pub` items documented

## Test plan

- [x] `cargo test --lib --all-features` — 3822 passed
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo build --release` — clean
- [x] `cargo run --bin black_76_greeks -p examples_pricing` — identity holds to zero
- [ ] CI green