### PR TITLE
Eliminate redundant per-step work in walk generators (#404)

### DIFF
--- a/benches/chains/generators.rs
+++ b/benches/chains/generators.rs
@@ -1,0 +1,115 @@
+use criterion::Criterion;
+use optionstratlib::ExpirationDate;
+use optionstratlib::chains::utils::{OptionChainBuildParams, OptionDataPriceParams};
+use optionstratlib::chains::{OptionChain, generator_optionchain, generator_positive};
+use optionstratlib::simulation::steps::{Step, Xstep, Ystep};
+use optionstratlib::simulation::{WalkParams, WalkType, WalkTypeAble};
+use optionstratlib::utils::TimeFrame;
+use positive::{Positive, pos_or_panic, spos};
+use rust_decimal_macros::dec;
+use std::hint::black_box;
+
+#[derive(Clone)]
+struct BenchWalker {}
+
+impl WalkTypeAble<Positive, OptionChain> for BenchWalker {}
+impl WalkTypeAble<Positive, Positive> for BenchWalker {}
+
+fn build_initial_chain() -> OptionChain {
+    let price_params = OptionDataPriceParams::new(
+        Some(Box::new(Positive::HUNDRED)),
+        Some(ExpirationDate::Days(pos_or_panic!(30.0))),
+        Some(dec!(0.05)),
+        spos!(0.02),
+        Some("BENCH".to_string()),
+    );
+
+    let chain_params = OptionChainBuildParams::new(
+        "BENCH".to_string(),
+        None,
+        10,
+        spos!(5.0),
+        dec!(-0.2),
+        dec!(0.1),
+        pos_or_panic!(0.02),
+        2,
+        price_params,
+        pos_or_panic!(0.2),
+    );
+
+    match OptionChain::build_chain(&chain_params) {
+        Ok(chain) => chain,
+        Err(e) => panic!("bench fixture chain failed to build: {e}"),
+    }
+}
+
+fn chain_walk_params(size: usize) -> WalkParams<Positive, OptionChain> {
+    WalkParams {
+        size,
+        init_step: Step {
+            x: Xstep::new(
+                Positive::ONE,
+                TimeFrame::Day,
+                ExpirationDate::Days(pos_or_panic!(60.0)),
+            ),
+            y: Ystep::new(0, build_initial_chain()),
+        },
+        walk_type: WalkType::GeometricBrownian {
+            dt: pos_or_panic!(1.0 / 252.0),
+            drift: dec!(0.0),
+            volatility: pos_or_panic!(0.2),
+        },
+        walker: Box::new(BenchWalker {}),
+    }
+}
+
+fn positive_walk_params(size: usize) -> WalkParams<Positive, Positive> {
+    WalkParams {
+        size,
+        init_step: Step {
+            x: Xstep::new(
+                Positive::ONE,
+                TimeFrame::Day,
+                ExpirationDate::Days(pos_or_panic!(2000.0)),
+            ),
+            y: Ystep::new(0, Positive::HUNDRED),
+        },
+        walk_type: WalkType::GeometricBrownian {
+            dt: pos_or_panic!(1.0 / 252.0),
+            drift: dec!(0.0),
+            volatility: pos_or_panic!(0.2),
+        },
+        walker: Box::new(BenchWalker {}),
+    }
+}
+
+pub fn benchmark_chain_generators(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Chain Generators");
+    group.sample_size(20);
+
+    let params_10 = chain_walk_params(10);
+    group.bench_function("generator_optionchain 10 steps", |b| {
+        b.iter(|| {
+            let steps = generator_optionchain(black_box(&params_10));
+            black_box(steps)
+        })
+    });
+
+    let params_25 = chain_walk_params(25);
+    group.bench_function("generator_optionchain 25 steps", |b| {
+        b.iter(|| {
+            let steps = generator_optionchain(black_box(&params_25));
+            black_box(steps)
+        })
+    });
+
+    let positive_params = positive_walk_params(1_000);
+    group.bench_function("generator_positive 1000 steps", |b| {
+        b.iter(|| {
+            let steps = generator_positive(black_box(&positive_params));
+            black_box(steps)
+        })
+    });
+
+    group.finish();
+}

--- a/benches/chains/mod.rs
+++ b/benches/chains/mod.rs
@@ -1,1 +1,2 @@
+pub mod generators;
 pub mod optiondata;

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -3,6 +3,7 @@ use criterion::{criterion_group, criterion_main};
 mod chains;
 mod model;
 
+use chains::generators::benchmark_chain_generators;
 use chains::optiondata::benchmark_option_data;
 use model::positive::{
     benchmark_arithmetic, benchmark_comparisons, benchmark_conversions, benchmark_creation,
@@ -22,6 +23,7 @@ use model::position::{
 
 criterion_group!(
     benches,
+    benchmark_chain_generators,
     benchmark_option_data,
     benchmark_creation,
     benchmark_arithmetic,

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -500,6 +500,11 @@ impl OptionChain {
                         "Failed to calculate prices for strike: {} error: {}",
                         strike, e
                     );
+                    // Greeks do not depend on bid/ask prices, so compute them
+                    // even when pricing failed to keep the chain's greek
+                    // coverage identical to a post-build `update_greeks` pass.
+                    option_data.calculate_delta();
+                    option_data.calculate_gamma();
                 }
             }
             Ok(option_data)

--- a/src/chains/generators.rs
+++ b/src/chains/generators.rs
@@ -5,6 +5,7 @@
 ******************************************************************************/
 use crate::ExpirationDate;
 use crate::chains::OptionChain;
+use crate::chains::utils::OptionChainBuildParams;
 use crate::error::ChainError;
 use crate::simulation::steps::{Step, Ystep};
 use crate::simulation::{WalkParams, WalkType};
@@ -18,32 +19,37 @@ use positive::pos_or_panic;
 use rust_decimal::Decimal;
 use tracing::debug;
 
-/// Creates a new `OptionChain` from a previous `Ystep` and a new price.
+/// Creates a new `OptionChain` from pre-derived build parameters and a new price.
 ///
-/// This function takes a reference to the previous `Ystep` containing an `OptionChain`,
-/// a reference to the new underlying price, and an optional new volatility. It creates a new
-/// `OptionChain` with the updated price and volatility.
+/// This function clones the provided build parameters and overrides the underlying
+/// price, and optionally the implied volatility and expiration date, before building
+/// the new chain. Deriving the parameters once (outside the simulation loop) instead
+/// of from each freshly built chain keeps every step's chain shape anchored to the
+/// initial chain and avoids re-scanning the chain on every step.
+///
+/// Greeks (delta/gamma) are computed by `OptionChain::build_chain` itself for every
+/// strike, so no separate greek pass is needed here.
 ///
 /// # Arguments
 ///
-/// * `previous_y_step` - A reference to the previous `Ystep` containing the `OptionChain`.
+/// * `build_params` - Build parameters derived from the initial `OptionChain`.
 /// * `new_price` - A reference to the new underlying price.
 /// * `volatility` - An optional new implied volatility.
+/// * `expiration_date` - An optional new expiration date.
 ///
 /// # Returns
 ///
 /// * `Ok(OptionChain)` - A new `OptionChain` with the updated parameters.
-/// * `Err(optionstratlib::error::Error)` - If an error occurs during the creation of the new `OptionChain`.
+/// * `Err(ChainError)` - If an error occurs during the creation of the new `OptionChain`.
 ///
 fn create_chain_from_step(
-    previous_y_step: &Ystep<OptionChain>,
-    new_price: Option<Box<Positive>>,
+    build_params: &OptionChainBuildParams,
+    new_price: &Positive,
     volatility: Option<Positive>,
     expiration_date: Option<ExpirationDate>,
 ) -> Result<OptionChain, ChainError> {
-    let chain = previous_y_step.value();
-    let mut chain_params = chain.to_build_params()?;
-    chain_params.set_underlying_price(new_price);
+    let mut chain_params = build_params.clone();
+    chain_params.set_underlying_price(Some(Box::new(*new_price)));
     if let Some(volatility) = volatility {
         chain_params.set_implied_volatility(volatility);
     }
@@ -51,9 +57,7 @@ fn create_chain_from_step(
         chain_params.price_params.expiration_date = Some(exp_date);
     }
 
-    let mut new_chain = OptionChain::build_chain(&chain_params)?;
-    new_chain.update_greeks();
-    Ok(new_chain)
+    OptionChain::build_chain(&chain_params)
 }
 
 /// Generates a vector of `Step`s containing `Positive` x-values and `OptionChain` y-values.
@@ -82,7 +86,7 @@ pub fn generator_optionchain(
     walk_params: &WalkParams<Positive, OptionChain>,
 ) -> Result<Vec<Step<Positive, OptionChain>>, ChainError> {
     debug!("{}", walk_params);
-    let (mut y_steps, volatility) = match &walk_params.walk_type {
+    let (y_steps, volatility) = match &walk_params.walk_type {
         WalkType::Brownian { volatility, .. } => {
             (walk_params.walker.brownian(walk_params)?, Some(*volatility))
         }
@@ -135,35 +139,38 @@ pub fn generator_optionchain(
             }
         }
     };
-    if y_steps.is_empty() {
+    if y_steps.len() <= 1 {
         // Preserve the init-step invariant when the underlying walk produces
-        // no points (e.g., Historical with insufficient `prices`); downstream
-        // consumers expect at least the initial step to be present.
+        // no points beyond the initial one (e.g., Historical with
+        // insufficient `prices`, or a size-1 walk); downstream consumers
+        // expect at least the initial step to be present. Returning early
+        // also avoids deriving build params from a chain that will never be
+        // rebuilt.
         return Ok(vec![walk_params.init_step.clone()]);
     }
 
-    let _ = y_steps.remove(0); // remove initial step from y_steps to avoid early return
+    // Derive the build parameters once from the initial chain; every step's
+    // chain is anchored to the initial chain's shape instead of feeding back
+    // params re-derived from the previous rebuilt chain on each iteration.
+    let build_params = walk_params.ystep_ref().value().to_build_params()?;
     let mut steps: Vec<Step<Positive, OptionChain>> = vec![walk_params.init_step.clone()];
     let mut previous_x_step = walk_params.init_step.x;
-    let mut previous_y_step = walk_params.ystep();
+    let mut y_index = *walk_params.ystep_ref().index();
 
-    for y_step in y_steps.iter() {
+    // The first walker value duplicates the init step, so skip it.
+    for y_step in y_steps.iter().skip(1) {
         previous_x_step = match previous_x_step.next() {
             Ok(x_step) => x_step,
             Err(_) => break,
         };
         // convert y_step to OptionChain with updated expiration date
         let expiration_date = *previous_x_step.datetime();
-        let y_step_chain: OptionChain = create_chain_from_step(
-            &previous_y_step,
-            Some(Box::new(*y_step)),
-            volatility,
-            Some(expiration_date),
-        )?;
-        previous_y_step = previous_y_step.next(y_step_chain).clone();
+        let y_step_chain: OptionChain =
+            create_chain_from_step(&build_params, y_step, volatility, Some(expiration_date))?;
+        y_index += 1;
         let step = Step {
             x: previous_x_step,
-            y: previous_y_step.clone(),
+            y: Ystep::new(y_index, y_step_chain),
         };
 
         steps.push(step)
@@ -200,7 +207,7 @@ pub fn generator_positive(
     walk_params: &WalkParams<Positive, Positive>,
 ) -> Result<Vec<Step<Positive, Positive>>, ChainError> {
     debug!("{}", walk_params);
-    let mut y_steps = match &walk_params.walk_type {
+    let y_steps = match &walk_params.walk_type {
         WalkType::Brownian { .. } => walk_params.walker.brownian(walk_params)?,
         WalkType::GeometricBrownian { .. } => walk_params.walker.geometric_brownian(walk_params)?,
         WalkType::LogReturns { .. } => walk_params.walker.log_returns(walk_params)?,
@@ -213,13 +220,13 @@ pub fn generator_positive(
         WalkType::Historical { .. } => walk_params.walker.historical(walk_params)?,
     };
 
-    let _ = y_steps.remove(0);
     let mut steps: Vec<Step<Positive, Positive>> = vec![walk_params.init_step.clone()];
 
     let mut previous_x_step = walk_params.init_step.x;
     let mut previous_y_step = walk_params.init_step.y.clone();
 
-    for y_step in y_steps.iter() {
+    // The first walker value duplicates the init step, so skip it.
+    for y_step in y_steps.iter().skip(1) {
         previous_x_step = match previous_x_step.next() {
             Ok(x_step) => x_step,
             Err(_) => break,
@@ -269,7 +276,11 @@ mod tests {
             y: Ystep::new(0, initial_price),
         };
 
-        let result = create_chain_from_step(&step.y, Some(Box::new(new_price)), None, None);
+        let build_params = match step.y.value().to_build_params() {
+            Ok(params) => params,
+            Err(e) => panic!("to_build_params failed: {e}"),
+        };
+        let result = create_chain_from_step(&build_params, &new_price, None, None);
         assert!(result.is_ok());
 
         let new_chain = result.unwrap();

--- a/src/series/generators.rs
+++ b/src/series/generators.rs
@@ -1,5 +1,5 @@
 use crate::error::ChainError;
-use crate::series::OptionSeries;
+use crate::series::{OptionSeries, OptionSeriesBuildParams};
 use crate::simulation::steps::{Step, Ystep};
 use crate::simulation::{WalkParams, WalkType};
 use crate::utils::TimeFrame;
@@ -36,12 +36,11 @@ use positive::pos_or_panic;
 /// - Any other unexpected error occurs during the processing.
 ///
 fn create_series_from_step(
-    previous_y_step: &Ystep<OptionSeries>,
+    build_params: &OptionSeriesBuildParams,
     new_price: &Positive,
     volatility: Option<Positive>,
 ) -> Result<OptionSeries, ChainError> {
-    let series = previous_y_step.value();
-    let mut series_params = series.to_build_params()?;
+    let mut series_params = build_params.clone();
     series_params.set_underlying_price(new_price);
     if let Some(volatility) = volatility {
         series_params.set_implied_volatility(volatility);
@@ -108,7 +107,7 @@ pub fn generator_optionseries(
     walk_params: &WalkParams<Positive, OptionSeries>,
 ) -> Result<Vec<Step<Positive, OptionSeries>>, ChainError> {
     debug!("{}", walk_params);
-    let (mut y_steps, volatility) = match &walk_params.walk_type {
+    let (y_steps, volatility) = match &walk_params.walk_type {
         WalkType::Brownian { volatility, .. } => {
             (walk_params.walker.brownian(walk_params)?, Some(*volatility))
         }
@@ -161,33 +160,38 @@ pub fn generator_optionseries(
             }
         }
     };
-    if y_steps.is_empty() {
+    if y_steps.len() <= 1 {
         // Preserve the contains-init-step contract used by the other
         // generators; callers iterate over Step values and expect at
-        // least the initial state.
+        // least the initial state. Returning early also avoids deriving
+        // build params from a series that will never be rebuilt.
         return Ok(vec![walk_params.init_step.clone()]);
     }
 
-    let _ = y_steps.remove(0); // remove initial step from y_steps to avoid early return
+    // Derive the build parameters once from the initial series; every step's
+    // series is anchored to the initial series' shape instead of feeding back
+    // params re-derived from the previous rebuilt series on each iteration.
+    let build_params = walk_params.ystep_ref().value().to_build_params()?;
     let mut steps: Vec<Step<Positive, OptionSeries>> = vec![walk_params.init_step.clone()];
     let mut previous_x_step = walk_params.init_step.x;
-    let mut previous_y_step = walk_params.ystep();
+    let mut y_index = *walk_params.ystep_ref().index();
 
     let volatility =
         volatility.unwrap_or_else(|| Positive::new_decimal(dec!(0.20)).unwrap_or(Positive::ZERO));
 
-    for y_step in y_steps.iter() {
+    // The first walker value duplicates the init step, so skip it.
+    for y_step in y_steps.iter().skip(1) {
         previous_x_step = match previous_x_step.next() {
             Ok(x_step) => x_step,
             Err(_) => break,
         };
         // convert y_step to OptionSeries
         let y_step_series: OptionSeries =
-            create_series_from_step(&previous_y_step, y_step, Some(volatility))?;
-        previous_y_step = previous_y_step.next(y_step_series).clone();
+            create_series_from_step(&build_params, y_step, Some(volatility))?;
+        y_index += 1;
         let step = Step {
             x: previous_x_step,
-            y: previous_y_step.clone(),
+            y: Ystep::new(y_index, y_step_series),
         };
 
         steps.push(step)
@@ -565,12 +569,15 @@ mod tests_generator_optionseries {
     fn test_create_series_from_step() {
         // Test the create_series_from_step function directly
         let initial_series = create_test_option_series();
-        let y_step = Ystep::new(0, initial_series);
+        let build_params = match initial_series.to_build_params() {
+            Ok(params) => params,
+            Err(e) => panic!("to_build_params failed: {e}"),
+        };
         let new_price = pos_or_panic!(105.0);
         let volatility = spos!(0.22);
 
         // Execute
-        let result = create_series_from_step(&y_step, &new_price, volatility);
+        let result = create_series_from_step(&build_params, &new_price, volatility);
 
         // Verify
         assert!(result.is_ok(), "create_series_from_step should succeed");

--- a/src/simulation/exit.rs
+++ b/src/simulation/exit.rs
@@ -441,7 +441,8 @@ pub fn check_exit_policy(
         ExitPolicy::And(policies) => {
             let mut triggered = Vec::new();
             for p in policies {
-                if let Some(triggered_policy) = check_exit_policy(
+                // All must be true for AND; `?` propagates the None.
+                let triggered_policy = check_exit_policy(
                     p,
                     initial_premium,
                     current_premium,
@@ -449,11 +450,8 @@ pub fn check_exit_policy(
                     days_left,
                     underlying_price,
                     is_long,
-                ) {
-                    triggered.push(triggered_policy);
-                } else {
-                    return None; // All must be true for AND
-                }
+                )?;
+                triggered.push(triggered_policy);
             }
             Some(ExitPolicy::And(triggered))
         }

--- a/tests/unit/strategies/custom_test.rs
+++ b/tests/unit/strategies/custom_test.rs
@@ -271,7 +271,7 @@ mod tests {
         assert_eq!(iv_map.len(), 2);
 
         // All volatilities should be positive
-        for (_option_type, iv) in iv_map.iter() {
+        for iv in iv_map.values() {
             assert!(**iv > Positive::ZERO);
         }
     }
@@ -285,7 +285,7 @@ mod tests {
         assert_eq!(quantity_map.len(), 2);
 
         // All quantities should be positive
-        for (_option_type, quantity) in quantity_map.iter() {
+        for quantity in quantity_map.values() {
             assert!(**quantity > Positive::ZERO);
         }
     }


### PR DESCRIPTION
## Summary

Every simulation step in the walk generators paid for work that was either duplicated or immediately discarded: a full greek recomputation after `build_chain` had already computed greeks, per-step re-derivation of build parameters that were immediately overwritten, and several full-chain deep clones per iteration. This PR removes that overhead — Criterion shows **-27% / -29%** on `generator_optionchain` — with no behavioral change for chains whose strikes price successfully.

First PR of the `chains/generators.rs` improvement series (#404 → #411). Stacked: subsequent PRs branch off this one; all target `main`.

## Changes

- `create_chain_from_step` no longer calls `update_greeks()` after `build_chain` — `build_chain` computes delta/gamma per strike already. The price-failure arm of `create_chain_data` now computes greeks too, so greek coverage is identical to the removed post-build pass (greeks do not depend on bid/ask).
- Build parameters are derived **once** from the initial chain/series before the loop and cloned per step, instead of being re-derived from each freshly rebuilt chain (`to_build_params` does several O(S) scans plus an O(S log S) sort per call). Every step's chain shape is now anchored to the input chain instead of feeding back the previous rebuild's lossy parameters.
- Removed the spurious deep clone after `Ystep::next` (it returns an owned value) and replaced the O(n) `y_steps.remove(0)` front-shift with `iter().skip(1)` in all three generators (`generator_optionchain`, `generator_positive`, `generator_optionseries`).
- `create_chain_from_step` takes `new_price: &Positive` instead of `Option<Box<Positive>>` — `None` was an impossible state (guaranteed downstream "missing underlying price" error), and the sibling `create_series_from_step` already used `&Positive`.
- The size ≤ 1 early return now also covers walks whose walker produced only the initial value, avoiding a pointless `to_build_params` call on chains that will never be rebuilt (this also keeps empty synthetic chains working, as exercised by the existing coverage tests).
- Drive-by (separate commit): fixed two pre-existing clippy lints (`question_mark` in `simulation/exit.rs`, `for_kv_map` in `tests/unit/strategies/custom_test.rs`) that fail the `-D warnings` gate on current stable clippy; both pre-date this branch.

## Public API impact

None. `create_chain_from_step` / `create_series_from_step` are private; `generator_*` signatures unchanged.

## Performance

Criterion, group "Chain Generators" (new benchmark in `benches/chains/generators.rs`), Apple Silicon (darwin), default features, 20 samples:

| Benchmark | Before | After | Change |
|---|---|---|---|
| `generator_optionchain` 10 steps | 5.01 ms | 3.63 ms | **-27.2%** |
| `generator_optionchain` 25 steps | 12.46 ms | 8.90 ms | **-28.8%** |
| `generator_positive` 1000 steps | 1.256 ms | 1.246 ms | -0.6% (noise) |

## Testing

- [x] Unit tests updated (private-helper call sites in `chains::generators::tests` and `series::generators::tests_generator_optionseries`)
- [x] Criterion benchmark added/updated (for perf changes)
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --all-features --workspace` clean, except 6 pre-existing `visualization::plotly_*` PNG/SVG export tests that require a local WebDriver on port 4444 — they fail identically on unmodified `main` (environmental)
- [x] `cargo build --release` clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic only — no `saturating_*` / `wrapping_*` in financial math
- [x] `rust_decimal::Decimal` at public monetary boundaries — no `f64` on prices / premia / P&L
- [x] Module boundaries respected (`model/` has no deps on `strategies/`, `backtesting/`, `visualization/`)
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate

Closes #404
