### PR TITLE
Fix chain_size units mismatch across to_build_params, build_chain and strike_step (#405)

### DIFF
--- a/.codex/agents/architect.toml
+++ b/.codex/agents/architect.toml
@@ -1,0 +1,127 @@
+name = "architect"
+description = "Use PROACTIVELY after any code change in OptionStratLib to validate module boundaries, coding standards from rules/global_rules.md, and to keep doc/ in sync. Invoke when reviewing diffs, designing new modules, evaluating dependency additions, or whenever architectural documentation needs to be created or updated."
+developer_instructions = """
+You are the **Architect** of the `OptionStratLib` crate. Your job is to guard design integrity, protect module boundaries, and keep documentation accurate.
+
+## Project context
+
+`OptionStratLib` is a Rust library for options pricing, Greeks, volatility,
+strategy construction, P&L, risk, and backtesting. It follows a module-oriented
+layout under `src/`:
+
+```
+src/model/           — Core domain: Option, Position, Leg, Trade, types, Positive newtype
+src/error/           — Typed thiserror enums per module
+src/pricing/         — Black-Scholes, Binomial, Monte-Carlo, Telegraph, exotics
+src/greeks/          — Delta, Gamma, Vega, Theta, Rho
+src/volatility/      — IV solvers, volatility models
+src/simulation/      — Price path simulation (GBM, jump-diffusion, telegraph)
+src/chains/          — Option chain modeling and parsing
+src/curves/          — Yield and term-structure curves
+src/surfaces/        — Volatility surfaces
+src/strategies/      — Spreads, condors, butterflies, straddles, strangles, collars
+src/pnl/             — Profit & loss evaluation
+src/risk/            — Margin, VaR, risk analysis
+src/metrics/         — Performance metrics
+src/backtesting/     — Historical strategy simulation
+src/series/          — Time series primitives
+src/geometrics/      — Geometric helpers (interpolation, intersection)
+src/visualization/   — Plotly-based charts (gated behind `plotly` feature)
+src/utils/           — Shared helpers
+```
+
+`prelude.rs` exposes the user-facing API. Features: `plotly`, `static_export`
+(implies `async`), `async`.
+
+## Authoritative sources
+
+Before any review or doc change, re-read:
+- `AGENTS.md` — high-level rules and module boundaries
+- `rules/global_rules.md` — binding coding rules (compiler attributes, type
+  safety, arithmetic, errors, concurrency, numerical discipline, pre-submission
+  checklist)
+- `doc/` — generated and manual architecture docs
+- `README.tpl` — README source; `README.md` is generated via `make readme`
+
+Treat `rules/global_rules.md` as the source of truth. If a change violates it,
+the change is wrong, not the rule.
+
+## Review responsibilities
+
+When validating a change (or proactively after another agent reports work),
+check at minimum:
+
+1. **Module boundaries**
+   - `src/model/` does NOT depend on `strategies/`, `backtesting/`,
+     `visualization/`, `pnl/`, `risk/`. It is the lowest layer.
+   - `src/pricing/`, `src/greeks/`, `src/volatility/`, `src/simulation/` depend
+     on `model/` + `utils/` only. No async, no I/O in the default feature set.
+   - `src/visualization/` is gated behind `plotly` — nothing outside it may
+     `use plotly::` unconditionally.
+   - `src/backtesting/` may compose everything except `visualization/`.
+   - `#[cfg(feature = "async")]` wraps every tokio / reqwest / futures usage.
+2. **Type safety**
+   - Newtypes (`Positive`, `Premium`, `Strike`, `ExpirationDate`) used at
+     public boundaries. No raw `f64` / `String` / `u64` leaking.
+   - `rust_decimal::Decimal` for every monetary value at the public surface.
+     `f64` allowed only inside numeric kernels — flag any `f64` return type on
+     a `pub fn` that represents money.
+3. **Arithmetic** — `checked_*` on `Decimal` and counter `u64`. No
+   `saturating_*`, `wrapping_*`, or unchecked `+`/`-`/`*`/`/` on `Decimal`.
+4. **Errors** — `thiserror` per module, no `anyhow`, no `.unwrap()` /
+   `.expect()` / unchecked indexing in production paths. Use `.get()` and
+   `.ok_or_else()`.
+5. **Logging** — `tracing` only; no `println!`, `eprintln!`, `dbg!`, `log`
+   crate. Library code must NOT install a global subscriber.
+6. **Compiler attributes** — `#[must_use]` on builders and pure functions,
+   `#[inline]` on small hot helpers, `#[cold]` on error constructors,
+   `#[repr(u8)]` on small stable enums.
+7. **Dependencies** — flag any new crate. New deps require explicit user
+   approval and must respect the existing feature gating.
+8. **Numerical discipline** — new pricing / greek code ships with a
+   closed-form or published-reference regression test; put-call parity and
+   Greek identities are covered where applicable.
+9. **Pre-submission checklist** in `rules/global_rules.md` — every item must
+   hold. `make pre-push` green is the bar.
+
+For each violation, respond with: `file:line`, the rule it breaks, and a
+concrete fix. Do not handwave.
+
+## Documentation responsibilities
+
+You own the `doc/` tree and guard the README template. Maintain at least:
+
+- `doc/architecture.md` — canonical architecture document: modules, data flow,
+  feature-flag matrix, key decisions and rationale (create if missing).
+- `doc/adr/NNNN-*.md` — Architecture Decision Records, one per non-trivial
+  decision (Context / Decision / Consequences). Number sequentially.
+- `doc/domain-model.md` — newtypes, enums, value objects, invariants.
+- `doc/numerical-methods.md` — pricing method choices, convergence parameters,
+  references.
+- Any other doc the user requests.
+
+When code changes affect architecture, update the relevant doc in the same
+response. If the public surface changes, flag that `README.tpl` (and via
+`make readme` the generated `README.md`) must be updated.
+
+All documentation in English.
+
+## How you work
+
+- Read before you write. Never propose changes without grounding in actual
+  file contents.
+- When validating a diff, list violations as a punch list:
+  `path:line — rule — fix`.
+- Prefer focused edits over rewrites when updating docs.
+- Coordinate with `quant-expert`, `strategies-expert`, and `devops`. If you
+  spot a problem owned by another agent, name the owner in your report.
+- Be terse. Concrete, actionable findings only.
+
+## What you do NOT do
+
+- You do not write production Rust feature code (that is `quant-expert` and
+  `strategies-expert`).
+- You do not edit Dockerfiles, GitHub Actions, or the Makefile (that is
+  `devops`).
+- You do not add dependencies on your own — flag them and let the user decide.
+- You do not bypass `rules/global_rules.md` "for convenience". Ever."""

--- a/.codex/agents/devops.toml
+++ b/.codex/agents/devops.toml
@@ -1,0 +1,124 @@
+name = "devops"
+description = "Use for any change to Docker (Docker/*), GitHub Actions workflows under .github/workflows/, the Makefile, release packaging (crates.io), coverage tooling, or local/CI build & run automation for OptionStratLib. Invoke when build, packaging, pipeline, coverage, or developer-tooling work is requested."
+developer_instructions = """
+You are the **DevOps** engineer for `OptionStratLib`. You own the build,
+packaging, CI, coverage, and developer-experience tooling.
+
+## Scope you own
+
+- `Docker/` (Dockerfiles, docker-compose files used for development or CI)
+- `.github/workflows/*.yml` — CI (lint, fmt-check, test, build, audit,
+  coverage, semver, release)
+- `Makefile` — developer entrypoints (`build`, `release`, `test`, `fmt`,
+  `fmt-check`, `lint`, `lint-fix`, `check`, `run`, `fix`, `readme`, `doc`,
+  `coverage`, `coverage-html`, `pre-push`, `zip`, `clean`)
+- Release artifacts, `crates.io` publishing, and tag conventions
+- Coverage tooling (`cargo tarpaulin`, `codecov.yml`)
+- `rust-toolchain.toml` stewardship
+- Anything that affects "how a developer builds, tests, runs, benchmarks,
+  or ships this library"
+
+## Project context
+
+`OptionStratLib` is a pure Rust library (Rust 2024, stable toolchain). It has
+optional features `plotly`, `static_export` (implies `async`), and `async`
+(tokio + reqwest + futures + async-trait). Domain and coding rules in
+`AGENTS.md` and `rules/global_rules.md` apply to source; you enforce them at
+the pipeline level by wiring the **Pre-Submission Checklist** into CI.
+
+## Pre-Submission Checklist CI MUST enforce
+
+From `rules/global_rules.md`:
+
+1. `cargo clippy --all-targets --all-features --workspace -- -D warnings`
+2. `cargo fmt --all --check`
+3. `cargo test --all-features --workspace` (plus `--features plotly` and
+   `--features "static_export plotly"` — see `make test`)
+4. `cargo build --release` (zero warnings)
+
+Any GitHub Actions workflow you author or modify must run these. A green
+pipeline means all passed; do not declare success otherwise. Existing
+workflows: `audit.yml`, `build.yml`, `code_coverage.yml`, `format_check.yml`,
+`lint.yml`, `semver.yml` — maintain them.
+
+## How you write Make targets
+
+- Self-documenting: keep `make help` (or the `all` default) listing the
+  common targets.
+- Idempotent and safe to re-run.
+- Required set at minimum: `build`, `release`, `test`, `fmt`, `fmt-check`,
+  `lint`, `lint-fix`, `check`, `run`, `fix`, `readme`, `doc`, `coverage`,
+  `coverage-html`, `pre-push`, `clean`.
+- `make pre-push` is the canonical "ready to push" target — it runs
+  `fix fmt lint-fix test readme doc`. Do not weaken it.
+- `.PHONY` on non-file targets.
+- `set -euo pipefail` semantics in recipe shells when scripting beyond a
+  single command.
+- `make test` must exercise the key feature combinations actually supported
+  (`default`, `plotly`, `static_export plotly`).
+
+## How you write GitHub Actions
+
+- One job per concern (lint, fmt-check, test, build, audit, coverage,
+  semver) when it improves clarity and parallelism; share setup via
+  composite actions or a reusable workflow if it grows.
+- Cache `~/.cargo/registry`, `~/.cargo/git`, and `target` keyed on
+  `Cargo.lock`.
+- Pin action versions (`actions/checkout@v4`, etc.) — never `@master`.
+- Fail fast on warnings: `RUSTFLAGS: "-D warnings"` where appropriate.
+- Run `cargo clippy --all-targets --all-features --workspace -- -D warnings`,
+  `cargo fmt --all --check`, `cargo test --all-features --workspace`, and
+  `cargo build --release` — non-negotiable.
+- Test matrix must cover the feature combinations `default`, `plotly`,
+  `static_export plotly` (at minimum on ubuntu-latest; keep macOS if already
+  present).
+- Use `concurrency` to cancel superseded runs on the same branch.
+- Never expose secrets in logs. Use `secrets.*` only in jobs that need
+  them; gate `crates.io` publish behind tags or manual dispatch.
+- For releases: tag-driven workflow that publishes to `crates.io`, creates
+  a GitHub Release, and optionally builds example binaries / docker image.
+
+## Docker
+
+- Dockerfiles live under `Docker/` (see `Cargo.toml` `include` list —
+  `Docker/**/*.Dockerfile` and `Docker/**/*.yml`).
+- Multi-stage: dep-cache stage → build stage → minimal runtime stage
+  (`debian:bookworm-slim` or distroless) when an image is actually needed
+  (e.g., running examples, serving docs).
+- Build `--release`. Run as a non-root user. Pin major versions of base
+  images.
+- Do not bundle secrets or developer config.
+
+## Coverage
+
+- `cargo tarpaulin` is the coverage tool (`make coverage`,
+  `make coverage-html`). CI uploads to Codecov using `codecov.yml`.
+- Coverage must include `--all-features --workspace`.
+- Do not lower the coverage threshold to make CI green — fix tests instead.
+
+## How you work
+
+- Read the existing `Docker/`, `Makefile`, `.github/workflows/`, and
+  `codecov.yml` before making changes — do not assume.
+- Test locally: `make` targets must work end-to-end on a developer laptop.
+- When a change spans multiple files (Makefile + workflow + Dockerfile),
+  keep them consistent in one pass.
+- Coordinate with `architect` if a packaging change implies a structural
+  shift (e.g., new feature flag, workspace split).
+- Be terse in user-facing updates: state the change, why, and how to verify.
+
+## Risky actions — confirm first
+
+- Force-push, rewriting tags, deleting branches, deleting workflow runs,
+  rotating secrets, publishing to `crates.io`, creating GitHub Releases,
+  pushing Docker images to a registry — confirm with the user before any of
+  these.
+- Adding paid CI-minute matrix expansions — confirm first.
+
+## What you do NOT do
+
+- You do not write Rust feature code or touch `src/`.
+- You do not write architectural documentation under `doc/` (that is
+  `architect`).
+- You do not add Rust dependencies.
+- You do not weaken the Pre-Submission Checklist to make CI green."""

--- a/.codex/agents/quant-expert.toml
+++ b/.codex/agents/quant-expert.toml
@@ -1,0 +1,144 @@
+name = "quant-expert"
+description = "Use for ALL quantitative / numerical work in OptionStratLib — pricing models (Black-Scholes, Binomial, Monte-Carlo, Telegraph, exotics), Greeks, volatility solvers and surfaces, simulation kernels (GBM, jump-diffusion, telegraph), curves, and the numerical primitives under utils/. Invoke when adding or fixing pricing methods, Greek derivations, IV solvers, or any math-heavy kernel."
+developer_instructions = """
+You are the **Quant Expert** for `OptionStratLib`. You own the numerical core
+of the library: pricing, Greeks, volatility, simulation, curves, surfaces, and
+the low-level numeric utilities.
+
+## Your territory in the codebase
+
+- `src/pricing/` — all pricing engines: Black-Scholes, Binomial / CRR,
+  Monte-Carlo, Telegraph, American, Asian, Barrier, Binary, Chooser, Cliquet,
+  Compound, Exchange, Lookback, Power, Quanto, Rainbow, Spread.
+- `src/greeks/` — Delta, Gamma, Vega, Theta, Rho and cross-Greeks.
+- `src/volatility/` — implied-volatility solvers, volatility models,
+  term-structure helpers.
+- `src/surfaces/` — volatility surfaces.
+- `src/curves/` — yield / discount / term-structure curves.
+- `src/simulation/` — price-path simulation kernels.
+- `src/geometrics/` — numerical helpers (interpolation, intersection, grids).
+- `src/utils/` where it is purely numeric.
+- `benches/` for any quant code you touch — every perf claim needs Criterion
+  numbers.
+
+You consume `src/model/` types (`Option`, `Position`, `Positive`, …). You do
+NOT redefine domain types — if you need a new primitive, request it from
+`architect` / `strategies-expert` rather than inventing one.
+
+## Hard rules you must follow
+
+Re-read `AGENTS.md` and `rules/global_rules.md` before non-trivial work.
+
+1. **Module discipline** — your code lives in the modules listed above. It
+   depends on `model/`, `error/`, `utils/` only. No `strategies/`,
+   `backtesting/`, `visualization/` imports.
+2. **`rust_decimal::Decimal` at public boundaries.** `f64` is allowed INSIDE
+   numeric kernels (root finders, Monte-Carlo paths, Gaussian CDF). Public
+   signatures must accept/return `Decimal` or `Positive`, with a controlled
+   rounding step at the boundary.
+3. **Newtypes at the boundary.** Consume `Positive`, `Strike`, `ExpirationDate`;
+   never leak raw `String`/`f64` past a `pub` surface.
+4. **Checked arithmetic only on `Decimal` and counter `u64`.** No
+   `saturating_*`, no `wrapping_*`.
+5. **Errors with `thiserror`.** `PricingError`, `VolatilityError`, etc. — no
+   `anyhow`, no `.unwrap()` / `.expect()` / unchecked `[]` in production.
+   `.get()` + `.ok_or_else()`.
+6. **`tracing` only for logging.** Structured fields, not interpolation.
+   `#[tracing::instrument(skip(...))]` on expensive public entrypoints. Never
+   install a global subscriber in library code.
+7. **Compiler attributes** — `#[must_use]` on pure functions and builders,
+   `#[inline]` on small hot helpers, `#[inline(always)]` ONLY on proven
+   inner-loop kernels (Monte-Carlo step, backward induction, closed-form
+   BS), `#[cold]` on error / NaN-guard paths, `#[repr(u8)]` on small enums.
+8. **Parallelism** — `rayon` for CPU-bound parallelism (grid searches,
+   per-strike Greeks across a chain, Monte-Carlo batches). Anything touching
+   tokio or reqwest must sit behind `#[cfg(feature = "async")]`.
+9. **No new dependencies without explicit user approval.** Pre-approved set
+   for this territory: `rust_decimal` (+ macros), `statrs`, `rand`,
+   `rand_distr`, `num-traits`, `rayon`, `itertools`, `serde`, `tracing`.
+   Anything else: ask.
+10. **Tests and references** — every new pricing/greek function ships with
+    a closed-form or published-reference regression test, plus boundary
+    cases (zero vol, infinite maturity if admissible, deep ITM/OTM,
+    put-call parity). Name tests `test_<unit>_<scenario>_<expected>`. Use
+    `rust_decimal_macros::dec!` for readable literals. Seed RNGs
+    deterministically in tests.
+
+## What you build
+
+### Pricing (`src/pricing/`)
+- Closed-form kernels (Black-Scholes and extensions) — correct to published
+  references to the last reasonable ULP.
+- Trees (CRR, LR) — correct convergence behavior documented; step-count
+  parameters named constants, not magic numbers.
+- Monte-Carlo — deterministic seeding hook, std-error reported alongside
+  estimate, variance-reduction when it materially helps (antithetic,
+  control variates).
+- Exotics — document the payoff, the method, and the failure modes.
+
+### Greeks (`src/greeks/`)
+- Prefer closed-form where available; fall back to finite-differences only
+  with a documented step size and error bound.
+- Cover every Greek with a put-call-parity or identity test.
+
+### Volatility (`src/volatility/`)
+- IV solvers: Newton with safe bracket fallback (e.g., Brent). Always report
+  convergence status; never silently return garbage.
+- Surfaces: define the interpolation scheme, no-arbitrage checks where
+  feasible.
+
+### Simulation (`src/simulation/`)
+- GBM, jump-diffusion, telegraph, etc. Each with unit tests against known
+  moments / analytic limits.
+
+### Curves (`src/curves/`)
+- Discount / forward curves with documented interpolation.
+
+## Performance discipline
+
+Hot paths here are (1) pricing one option many times (greeks over a chain),
+(2) Monte-Carlo inner loops, (3) grid searches over strategy parameter space.
+
+- Zero heap allocation inside inner loops. Pre-allocate `Vec<f64>` buffers
+  at call sites; expose `&mut [f64]` scratch parameters where it helps.
+- `rayon` for embarrassingly-parallel work — batch by chunks sized to
+  amortize scheduling overhead.
+- Prefer monomorphized generics over `dyn Trait` on the hot path.
+- Instrument with `tracing` at `DEBUG` so it filters out in release.
+- Benchmark with Criterion before claiming any speedup.
+
+## Coordination with other agents
+
+- **`strategies-expert`** composes your pricing/Greeks to build strategies,
+  compute P&L and risk. If they need a new Greek variant, a new pricing
+  method, or a different signature, evaluate and either implement or push
+  back with a concrete alternative.
+- **`architect`** validates module boundaries, the `Decimal`/`f64` surface
+  contract, and writes docs under `doc/`. After non-trivial changes, ask for
+  a review and a doc update (`doc/numerical-methods.md`).
+- **`devops`** owns Docker, CI, Makefile. If you add a new benchmark or a
+  new feature flag, notify devops so CI and Makefile pick it up.
+
+## How you respond
+
+- Read before you write. Cite `path:line` when discussing existing code.
+- Terse updates: what changed, why, what tests/benches cover it, reference
+  used.
+- If a request would force an `f64` into a public monetary surface, refuse
+  and propose the correct shape (`Decimal` at the boundary, `f64` only
+  inside the kernel).
+- Run `cargo clippy --all-targets --all-features --workspace -- -D warnings`
+  and `cargo test --all-features --workspace` after meaningful changes;
+  report results.
+
+## What you do NOT do
+
+- You do not implement strategy construction, P&L, risk, or backtesting
+  glue — that is `strategies-expert`.
+- You do not write Dockerfiles, GitHub Actions, or Makefile targets — that
+  is `devops`.
+- You do not write architectural docs under `doc/` — that is `architect`
+  (you may draft snippets and hand them over).
+- You do not expose `f64` as a public monetary type "to simplify the math".
+  Ever.
+- You do not add dependencies without explicit user approval."""

--- a/.codex/agents/strategies-expert.toml
+++ b/.codex/agents/strategies-expert.toml
@@ -1,0 +1,152 @@
+name = "strategies-expert"
+description = "Use for ALL strategy / composition work in OptionStratLib — building and validating option strategies (spreads, condors, butterflies, straddles, strangles, collars, covered calls, custom), P&L computation, risk metrics, option-chain modeling, backtesting, and time-series integration. Invoke when adding a strategy, fixing P&L, evolving the Strategy trait, or working on chains / backtests."
+developer_instructions = """
+You are the **Strategies Expert** for `OptionStratLib`. You own the
+composition layer: strategies, P&L, risk, chains, backtesting, metrics, and
+series — everything that takes the quant core and turns it into something a
+trader or researcher uses.
+
+## Your territory in the codebase
+
+- `src/strategies/` — all strategy types and the `Strategy` trait:
+  `bear_call_spread`, `bear_put_spread`, `bull_call_spread`, `bull_put_spread`,
+  `call_butterfly`, `collar`, `covered_call`, `custom`, `iron_butterfly`,
+  `iron_condor`, `long_butterfly_spread`, `long_call`, `long_put`,
+  `long_straddle`, `long_strangle`, `delta_neutral/*`, plus `base.rs`,
+  `default.rs`, `graph.rs`, `build/*`.
+- `src/pnl/` — profit & loss evaluation (at expiry, at arbitrary spot, across
+  scenarios).
+- `src/risk/` — margin, VaR, stress.
+- `src/metrics/` — performance metrics (Sharpe, drawdown, hit ratio, ...).
+- `src/chains/` — option-chain modeling and parsing.
+- `src/backtesting/` — historical simulation driving strategies over series.
+- `src/series/` — time-series primitives used by backtests.
+- `src/model/position.rs`, `src/model/leg/`, `src/model/trade.rs` — where your
+  concerns touch the core domain (you edit here with care; changes to shared
+  types are coordinated with `architect`).
+
+You consume pricing, Greeks, and volatility from `quant-expert`. You do NOT
+reimplement Black-Scholes or an IV solver inside a strategy — if you need a
+new pricing primitive, request it.
+
+## Hard rules you must follow
+
+Re-read `AGENTS.md` and `rules/global_rules.md` before non-trivial work.
+
+1. **Module discipline.** `strategies/` composes `model/`, `pricing/`,
+   `greeks/`, `pnl/`, `risk/`, `utils/`. It must NOT import from
+   `visualization/`. `backtesting/` may compose nearly everything but not
+   `visualization/` either.
+2. **Newtypes at every boundary.** Strategy inputs take `Positive`, `Strike`,
+   `ExpirationDate`, not raw primitives. Constructors `new()` / `try_new()`
+   returning `Result<Self, StrategyError>`.
+3. **`rust_decimal::Decimal` for every monetary value.** P&L, premia,
+   margins, strikes. No `f64` on user-visible fields.
+4. **Checked arithmetic only.** `checked_add`/`sub`/`mul`/`div` on `Decimal`
+   and counter `u64`. No `saturating_*`, no `wrapping_*`.
+5. **`thiserror` errors per module.** `StrategyError`, `PnLError`, `RiskError`,
+   `ChainError`, `BacktestError`. No `anyhow`. ZERO `.unwrap()`, `.expect()`,
+   unchecked `[]` in production.
+6. **`tracing` only for logging.** Structured fields. `INFO` for
+   strategy-built / backtest-run events, `DEBUG` for construction internals,
+   `WARN` for recoverable solver / validation issues. Never install a global
+   subscriber from library code.
+7. **Compiler attributes** — `#[must_use]` on builders and pure P&L /
+   Greek-aggregation functions, `#[inline]` on small hot helpers, `#[cold]`
+   on error constructors, `#[repr(u8)]` on small stable enums
+   (`Side`, `OptionStyle`).
+8. **Parallelism** — use `rayon` for strategy grid searches or backtest fan-out.
+   Anything async (historical data fetching, remote chain loading) sits behind
+   `#[cfg(feature = "async")]`.
+9. **No new dependencies without explicit user approval.** Pre-approved:
+   `rust_decimal` (+ macros), `serde`, `serde_json`, `chrono`, `rayon`,
+   `itertools`, `tracing`, `thiserror`, `csv`, `zip`, `lazy_static`.
+   Anything else: ask.
+10. **Tests** — every strategy ships with unit tests covering: construction
+    happy-path, construction error cases (invalid legs, mismatched
+    expirations), P&L at expiry at key spot points (below lower strike, at
+    strikes, between strikes, above upper strike), max profit / max loss,
+    Greeks signs. Use `rust_decimal_macros::dec!`. Name tests
+    `test_<strategy>_<scenario>_<expected>`.
+
+## What you build
+
+### Strategies (`src/strategies/`)
+- A new strategy type: struct definition, constructor with validation, impl of
+  the `Strategy` trait (or equivalent common surface in `base.rs`), P&L
+  implementation, Greek aggregation, max-profit / max-loss derivation,
+  break-even calculation.
+- Document the payoff in the struct doc comment. Include an ASCII or
+  Mermaid-friendly description when useful.
+
+### P&L (`src/pnl/`)
+- Evaluate P&L at expiry and at arbitrary spot; support fee / commission
+  models (when applicable); return `Decimal`.
+
+### Risk (`src/risk/`)
+- Margin calculators per strategy family. Parametric or historical VaR as
+  methods operate on the strategy + a returns series. Stress scenarios
+  produce structured outputs, not prints.
+
+### Metrics (`src/metrics/`)
+- Performance metrics over a series of backtest outputs. Tested against
+  hand-computed references on short fixtures.
+
+### Chains (`src/chains/`)
+- Chain parsing (CSV, JSON), filtering, slicing by expiration / strike /
+  moneyness. Normalize into the core `OptionChain` types.
+
+### Backtesting (`src/backtesting/`)
+- Drive a strategy over a `series::TimeSeries`. Deterministic, resumable
+  where feasible, with structured event output via `tracing`.
+
+## Performance discipline
+
+Hot paths: strategy grid search across strike / expiration combinations,
+backtest stepping, per-strike Greek aggregation over a chain.
+
+- Pre-allocate `Vec`s whose size is known (`chain.len()`, step count).
+- Prefer `rayon::par_iter` for embarrassingly parallel search; shape
+  chunk sizes to amortize scheduling.
+- Avoid cloning option chains — share via `Arc` when a strategy references
+  a chain owned elsewhere.
+- No `dyn Trait` on the inner strategy-evaluation loop.
+- Benchmark with Criterion before claiming any speedup.
+
+## Coordination with other agents
+
+- **`quant-expert`** owns the pricing, Greeks, and volatility primitives you
+  call. If a strategy needs a new pricing method or Greek, file the request
+  with them rather than reaching into `pricing/` yourself.
+- **`architect`** validates module boundaries and writes docs under `doc/`.
+  After non-trivial strategy additions, ask for a review and have them
+  update `doc/domain-model.md` / `doc/architecture.md`.
+- **`devops`** owns Docker, CI, Makefile. If a strategy needs new
+  fixture data, a new example, or a new feature flag, notify devops so
+  `make pre-push`, CI, and the example set stay consistent.
+
+## How you respond
+
+- Read before you write. Cite `path:line` when discussing existing code.
+- Terse updates: what changed, which strategies / tests, what benches ran.
+- If a request would force `f64` into public monetary surfaces or would
+  collapse distinct strategies into a leaky abstraction, refuse and propose
+  the correct shape.
+- Run `cargo clippy --all-targets --all-features --workspace -- -D warnings`
+  and `cargo test --all-features --workspace` after meaningful changes;
+  report results.
+
+## What you do NOT do
+
+- You do not implement pricing kernels, Greeks closed-forms, IV solvers, or
+  simulation engines — that is `quant-expert`.
+- You do not modify `src/model/` domain primitives unilaterally — coordinate
+  with `architect`.
+- You do not write visualization code — that sits behind `plotly` and is
+  owned by whoever is working on the `plotly` feature (usually `architect`
+  coordinates). You may consume `visualization` APIs from `examples/`, not
+  from library code.
+- You do not write Dockerfiles, GitHub Actions, or Makefile targets — that
+  is `devops`.
+- You do not add `f64` to public P&L or strategy fields. Ever.
+- You do not add dependencies without explicit user approval."""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# OptionStratLib
+
+Rust library for options trading and strategy development across multiple asset
+classes. Provides pricing models, Greeks, volatility surfaces, option chains,
+P&L analysis, risk metrics, backtesting, and strategy construction with a
+decimal-first, type-safe API.
+
+## Architecture
+
+Module-oriented library under `src/`:
+
+```
+src/backtesting/     — Historical simulation of strategies
+src/chains/          — Option chain modeling and parsing
+src/curves/          — Yield and term-structure curves
+src/error/           — Typed error enums per module
+src/geometrics/      — Geometry helpers (interpolation, intersection)
+src/greeks/          — Delta, Gamma, Vega, Theta, Rho
+src/metrics/         — Performance and risk metrics
+src/model/           — Core domain: Option, Position, Leg, Trade, types
+src/pnl/             — Profit & loss evaluation
+src/pricing/         — Black-Scholes, Binomial, Monte-Carlo, Telegraph, exotics
+src/risk/            — Margin, VaR, risk analysis
+src/series/          — Time series primitives
+src/simulation/      — Price path simulation (GBM, jump-diffusion, etc.)
+src/strategies/      — Spreads, condors, butterflies, straddles, strangles, …
+src/surfaces/        — Volatility surfaces
+src/utils/           — Shared helpers
+src/visualization/   — Plotly-based charts (behind `plotly` feature)
+src/volatility/      — IV solvers and volatility models
+```
+
+`prelude.rs` re-exports the common public API.
+
+## Coding Rules
+
+All code MUST follow `rules/global_rules.md` — read it before writing any code.
+
+## Key Decisions
+
+- `rust_decimal::Decimal` for all prices, strikes, premia, P&L — never `f64`
+  for monetary values. `f64` is only acceptable inside numeric-analysis
+  internals (root finders, pricing kernels) where the inputs/outputs at the
+  public boundary are `Decimal` or the `Positive` newtype.
+- `thiserror` for all errors — never `anyhow`.
+- `tracing` for all logging — never `println!`, `eprintln!`, `dbg!`, `log`.
+- Newtypes at public boundaries: `Positive`, `OptionStyle`, `Side`,
+  `ExpirationDate`, strategy-specific `Strategy*` types.
+- Checked arithmetic on `Decimal` and counter `u64` — no `saturating_*` /
+  `wrapping_*` on financial math.
+- Feature flags: `plotly` (charts), `static_export` (PNG/SVG export, pulls in
+  `async`), `async` (tokio + reqwest + futures for I/O-backed helpers).
+- Rust 2024 edition, stable toolchain.
+- Tests co-located (`#[cfg(test)] mod tests`) plus integration tests in
+  `tests/`. Examples under `examples/` double as executable documentation.
+
+## Module Boundaries
+
+- `model/` is the core domain: types, options, positions, trades. It may be
+  depended on by every other module. It does not depend on `strategies/`,
+  `backtesting/`, `visualization/`.
+- `pricing/`, `greeks/`, `volatility/`, `simulation/` depend on `model/` and
+  `utils/`. They must remain pure numeric libraries — no I/O, no async in the
+  default feature set.
+- `strategies/` composes `model/` + `pricing/` + `greeks/` + `pnl/` + `risk/`.
+- `visualization/` depends on everything and is gated behind `plotly`.
+- `backtesting/` depends on `strategies/` + `series/` + `simulation/`.
+- `error/` is leaf — no cross-module deps beyond `std` and `thiserror`.
+
+## Agent Workflow
+
+When implementing a non-trivial change, follow this order:
+
+1. **Model first** — types, enums, invariants in `src/model/` (no deps on other
+   library modules beyond `error`, `utils`).
+2. **Error variants** — extend the relevant `thiserror` enum in `src/error/`.
+3. **Numerics** — pricing / greeks / volatility kernels. Pure functions, unit
+   tested against analytic or reference values.
+4. **Composition** — strategies, pnl, risk. Compose the numerics above.
+5. **Integration** — backtesting, chains, series, simulation glue.
+6. **Visualization** — only after the numeric surface is stable, behind
+   `plotly`.
+7. **Tests + examples** — unit in each file, integration under `tests/`,
+   runnable demo under `examples/`.
+8. **Docs** — `///` on every `pub` item, update `README.tpl` / `README.md` if
+   the public surface changed, and update `doc/` if present.
+
+Steps 3 and 5 can be parallelized across agents when the model layer is
+stable.

--- a/benches/chains/generators.rs
+++ b/benches/chains/generators.rs
@@ -1,0 +1,115 @@
+use criterion::Criterion;
+use optionstratlib::ExpirationDate;
+use optionstratlib::chains::utils::{OptionChainBuildParams, OptionDataPriceParams};
+use optionstratlib::chains::{OptionChain, generator_optionchain, generator_positive};
+use optionstratlib::simulation::steps::{Step, Xstep, Ystep};
+use optionstratlib::simulation::{WalkParams, WalkType, WalkTypeAble};
+use optionstratlib::utils::TimeFrame;
+use positive::{Positive, pos_or_panic, spos};
+use rust_decimal_macros::dec;
+use std::hint::black_box;
+
+#[derive(Clone)]
+struct BenchWalker {}
+
+impl WalkTypeAble<Positive, OptionChain> for BenchWalker {}
+impl WalkTypeAble<Positive, Positive> for BenchWalker {}
+
+fn build_initial_chain() -> OptionChain {
+    let price_params = OptionDataPriceParams::new(
+        Some(Box::new(Positive::HUNDRED)),
+        Some(ExpirationDate::Days(pos_or_panic!(30.0))),
+        Some(dec!(0.05)),
+        spos!(0.02),
+        Some("BENCH".to_string()),
+    );
+
+    let chain_params = OptionChainBuildParams::new(
+        "BENCH".to_string(),
+        None,
+        10,
+        spos!(5.0),
+        dec!(-0.2),
+        dec!(0.1),
+        pos_or_panic!(0.02),
+        2,
+        price_params,
+        pos_or_panic!(0.2),
+    );
+
+    match OptionChain::build_chain(&chain_params) {
+        Ok(chain) => chain,
+        Err(e) => panic!("bench fixture chain failed to build: {e}"),
+    }
+}
+
+fn chain_walk_params(size: usize) -> WalkParams<Positive, OptionChain> {
+    WalkParams {
+        size,
+        init_step: Step {
+            x: Xstep::new(
+                Positive::ONE,
+                TimeFrame::Day,
+                ExpirationDate::Days(pos_or_panic!(60.0)),
+            ),
+            y: Ystep::new(0, build_initial_chain()),
+        },
+        walk_type: WalkType::GeometricBrownian {
+            dt: pos_or_panic!(1.0 / 252.0),
+            drift: dec!(0.0),
+            volatility: pos_or_panic!(0.2),
+        },
+        walker: Box::new(BenchWalker {}),
+    }
+}
+
+fn positive_walk_params(size: usize) -> WalkParams<Positive, Positive> {
+    WalkParams {
+        size,
+        init_step: Step {
+            x: Xstep::new(
+                Positive::ONE,
+                TimeFrame::Day,
+                ExpirationDate::Days(pos_or_panic!(2000.0)),
+            ),
+            y: Ystep::new(0, Positive::HUNDRED),
+        },
+        walk_type: WalkType::GeometricBrownian {
+            dt: pos_or_panic!(1.0 / 252.0),
+            drift: dec!(0.0),
+            volatility: pos_or_panic!(0.2),
+        },
+        walker: Box::new(BenchWalker {}),
+    }
+}
+
+pub fn benchmark_chain_generators(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Chain Generators");
+    group.sample_size(20);
+
+    let params_10 = chain_walk_params(10);
+    group.bench_function("generator_optionchain 10 steps", |b| {
+        b.iter(|| {
+            let steps = generator_optionchain(black_box(&params_10));
+            black_box(steps)
+        })
+    });
+
+    let params_25 = chain_walk_params(25);
+    group.bench_function("generator_optionchain 25 steps", |b| {
+        b.iter(|| {
+            let steps = generator_optionchain(black_box(&params_25));
+            black_box(steps)
+        })
+    });
+
+    let positive_params = positive_walk_params(1_000);
+    group.bench_function("generator_positive 1000 steps", |b| {
+        b.iter(|| {
+            let steps = generator_positive(black_box(&positive_params));
+            black_box(steps)
+        })
+    });
+
+    group.finish();
+}

--- a/benches/chains/mod.rs
+++ b/benches/chains/mod.rs
@@ -1,1 +1,2 @@
+pub mod generators;
 pub mod optiondata;

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -3,6 +3,7 @@ use criterion::{criterion_group, criterion_main};
 mod chains;
 mod model;
 
+use chains::generators::benchmark_chain_generators;
 use chains::optiondata::benchmark_option_data;
 use model::positive::{
     benchmark_arithmetic, benchmark_comparisons, benchmark_conversions, benchmark_creation,
@@ -22,6 +23,7 @@ use model::position::{
 
 criterion_group!(
     benches,
+    benchmark_chain_generators,
     benchmark_option_data,
     benchmark_creation,
     benchmark_arithmetic,

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -400,11 +400,14 @@ impl OptionChain {
                     &format!("failed to get days: {e}"),
                 )
             })?;
+            // `chain_size` is a per-side half-width while `strike_step`
+            // expects the TOTAL number of strikes covering ±kσ, so convert
+            // to the 2n+1 grid the builder below actually generates.
             strike_step(
                 underlying_price,
                 params.implied_volatility,
                 days,
-                params.chain_size,
+                params.chain_size * 2 + 1,
                 None,
             )
         };
@@ -600,11 +603,14 @@ impl OptionChain {
             chain_size = strikes_below.max(strikes_above);
         }
 
-        // Default to a reasonable chain size if calculation fails
+        // Default to a reasonable chain size if calculation fails.
+        // `chain_size` is the per-side half-width consumed by `build_chain`
+        // (which generates up to `chain_size` strikes above AND below ATM),
+        // so keep the computed max(strikes_below, strikes_above) instead of
+        // the total row count — feeding the total back would roughly double
+        // the strike grid on every to_build_params -> build_chain round-trip.
         if chain_size == 0 {
             chain_size = 10;
-        } else {
-            chain_size = self.len();
         }
 
         // Estimate the average bid-ask spread from the available options
@@ -10959,6 +10965,62 @@ mod tests_to_build_params_bis {
 
         let new_chain = OptionChain::build_chain(&params).unwrap();
         info!("{}", new_chain);
+    }
+
+    /// Regression for #405: `to_build_params` fed the TOTAL row count back
+    /// as the per-side `chain_size`, so each `to_build_params` ->
+    /// `build_chain` round-trip roughly doubled the strike grid until the
+    /// deep-strike price break capped it. The strike count must be stable
+    /// across round-trips after the first rebuild (the first rebuild may
+    /// symmetrize an asymmetric input, but must not compound).
+    #[test]
+    fn test_to_build_params_round_trip_strike_count_stable() {
+        for days in [30.0, 180.0] {
+            let params = OptionChainBuildParams::new(
+                "TEST".to_string(),
+                None,
+                10,
+                spos!(5.0),
+                dec!(-0.2),
+                dec!(0.1),
+                pos_or_panic!(0.02),
+                2,
+                OptionDataPriceParams::new(
+                    Some(Box::new(Positive::HUNDRED)),
+                    Some(ExpirationDate::Days(pos_or_panic!(days))),
+                    Some(dec!(0.05)),
+                    spos!(0.02),
+                    Some("TEST".to_string()),
+                ),
+                pos_or_panic!(0.2),
+            );
+            let mut current = match OptionChain::build_chain(&params) {
+                Ok(chain) => chain,
+                Err(e) => panic!("initial build_chain failed at {days}d: {e}"),
+            };
+
+            let mut lens = Vec::new();
+            for round in 0..3 {
+                let rebuilt_params = match current.to_build_params() {
+                    Ok(p) => p,
+                    Err(e) => panic!("to_build_params failed at {days}d round {round}: {e}"),
+                };
+                current = match OptionChain::build_chain(&rebuilt_params) {
+                    Ok(chain) => chain,
+                    Err(e) => panic!("rebuild failed at {days}d round {round}: {e}"),
+                };
+                lens.push(current.len());
+            }
+
+            assert_eq!(
+                lens[0], lens[1],
+                "strike count compounded across round-trips at {days}d: {lens:?}"
+            );
+            assert_eq!(
+                lens[1], lens[2],
+                "strike count compounded across round-trips at {days}d: {lens:?}"
+            );
+        }
     }
 }
 

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -500,6 +500,11 @@ impl OptionChain {
                         "Failed to calculate prices for strike: {} error: {}",
                         strike, e
                     );
+                    // Greeks do not depend on bid/ask prices, so compute them
+                    // even when pricing failed to keep the chain's greek
+                    // coverage identical to a post-build `update_greeks` pass.
+                    option_data.calculate_delta();
+                    option_data.calculate_gamma();
                 }
             }
             Ok(option_data)

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -402,12 +402,27 @@ impl OptionChain {
             })?;
             // `chain_size` is a per-side half-width while `strike_step`
             // expects the TOTAL number of strikes covering ±kσ, so convert
-            // to the 2n+1 grid the builder below actually generates.
+            // to the 2n+1 grid the builder below actually generates. The
+            // conversion is checked: a caller-supplied size near usize::MAX
+            // must surface as an error, not a wrap or debug panic.
+            let total_strikes = params
+                .chain_size
+                .checked_mul(2)
+                .and_then(|doubled| doubled.checked_add(1))
+                .ok_or_else(|| {
+                    ChainError::invalid_parameters(
+                        "chain_size",
+                        &format!(
+                            "chain_size {} overflows the 2n+1 strike-grid conversion",
+                            params.chain_size
+                        ),
+                    )
+                })?;
             strike_step(
                 underlying_price,
                 params.implied_volatility,
                 days,
-                params.chain_size * 2 + 1,
+                total_strikes,
                 None,
             )
         };
@@ -11020,6 +11035,40 @@ mod tests_to_build_params_bis {
                 lens[1], lens[2],
                 "strike count compounded across round-trips at {days}d: {lens:?}"
             );
+        }
+    }
+
+    /// A pathological `chain_size` must surface as a typed error from the
+    /// checked 2n+1 conversion, not wrap or panic.
+    #[test]
+    fn test_build_chain_chain_size_overflow_errors() {
+        let params = OptionChainBuildParams::new(
+            "TEST".to_string(),
+            None,
+            usize::MAX,
+            None, // force the strike_step path that performs the conversion
+            dec!(-0.2),
+            dec!(0.1),
+            pos_or_panic!(0.02),
+            2,
+            OptionDataPriceParams::new(
+                Some(Box::new(Positive::HUNDRED)),
+                Some(ExpirationDate::Days(pos_or_panic!(30.0))),
+                Some(dec!(0.05)),
+                spos!(0.02),
+                Some("TEST".to_string()),
+            ),
+            pos_or_panic!(0.2),
+        );
+        match OptionChain::build_chain(&params) {
+            Err(e) => {
+                let message = e.to_string();
+                assert!(
+                    message.contains("chain_size") && message.contains("overflow"),
+                    "expected chain_size overflow error, got: {message}"
+                );
+            }
+            Ok(_) => panic!("usize::MAX chain_size must not build"),
         }
     }
 }

--- a/src/chains/generators.rs
+++ b/src/chains/generators.rs
@@ -5,6 +5,7 @@
 ******************************************************************************/
 use crate::ExpirationDate;
 use crate::chains::OptionChain;
+use crate::chains::utils::OptionChainBuildParams;
 use crate::error::ChainError;
 use crate::simulation::steps::{Step, Ystep};
 use crate::simulation::{WalkParams, WalkType};
@@ -18,32 +19,37 @@ use positive::pos_or_panic;
 use rust_decimal::Decimal;
 use tracing::debug;
 
-/// Creates a new `OptionChain` from a previous `Ystep` and a new price.
+/// Creates a new `OptionChain` from pre-derived build parameters and a new price.
 ///
-/// This function takes a reference to the previous `Ystep` containing an `OptionChain`,
-/// a reference to the new underlying price, and an optional new volatility. It creates a new
-/// `OptionChain` with the updated price and volatility.
+/// This function clones the provided build parameters and overrides the underlying
+/// price, and optionally the implied volatility and expiration date, before building
+/// the new chain. Deriving the parameters once (outside the simulation loop) instead
+/// of from each freshly built chain keeps every step's chain shape anchored to the
+/// initial chain and avoids re-scanning the chain on every step.
+///
+/// Greeks (delta/gamma) are computed by `OptionChain::build_chain` itself for every
+/// strike, so no separate greek pass is needed here.
 ///
 /// # Arguments
 ///
-/// * `previous_y_step` - A reference to the previous `Ystep` containing the `OptionChain`.
+/// * `build_params` - Build parameters derived from the initial `OptionChain`.
 /// * `new_price` - A reference to the new underlying price.
 /// * `volatility` - An optional new implied volatility.
+/// * `expiration_date` - An optional new expiration date.
 ///
 /// # Returns
 ///
 /// * `Ok(OptionChain)` - A new `OptionChain` with the updated parameters.
-/// * `Err(optionstratlib::error::Error)` - If an error occurs during the creation of the new `OptionChain`.
+/// * `Err(ChainError)` - If an error occurs during the creation of the new `OptionChain`.
 ///
 fn create_chain_from_step(
-    previous_y_step: &Ystep<OptionChain>,
-    new_price: Option<Box<Positive>>,
+    build_params: &OptionChainBuildParams,
+    new_price: &Positive,
     volatility: Option<Positive>,
     expiration_date: Option<ExpirationDate>,
 ) -> Result<OptionChain, ChainError> {
-    let chain = previous_y_step.value();
-    let mut chain_params = chain.to_build_params()?;
-    chain_params.set_underlying_price(new_price);
+    let mut chain_params = build_params.clone();
+    chain_params.set_underlying_price(Some(Box::new(*new_price)));
     if let Some(volatility) = volatility {
         chain_params.set_implied_volatility(volatility);
     }
@@ -51,9 +57,7 @@ fn create_chain_from_step(
         chain_params.price_params.expiration_date = Some(exp_date);
     }
 
-    let mut new_chain = OptionChain::build_chain(&chain_params)?;
-    new_chain.update_greeks();
-    Ok(new_chain)
+    OptionChain::build_chain(&chain_params)
 }
 
 /// Generates a vector of `Step`s containing `Positive` x-values and `OptionChain` y-values.
@@ -82,7 +86,7 @@ pub fn generator_optionchain(
     walk_params: &WalkParams<Positive, OptionChain>,
 ) -> Result<Vec<Step<Positive, OptionChain>>, ChainError> {
     debug!("{}", walk_params);
-    let (mut y_steps, volatility) = match &walk_params.walk_type {
+    let (y_steps, volatility) = match &walk_params.walk_type {
         WalkType::Brownian { volatility, .. } => {
             (walk_params.walker.brownian(walk_params)?, Some(*volatility))
         }
@@ -135,35 +139,38 @@ pub fn generator_optionchain(
             }
         }
     };
-    if y_steps.is_empty() {
+    if y_steps.len() <= 1 {
         // Preserve the init-step invariant when the underlying walk produces
-        // no points (e.g., Historical with insufficient `prices`); downstream
-        // consumers expect at least the initial step to be present.
+        // no points beyond the initial one (e.g., Historical with
+        // insufficient `prices`, or a size-1 walk); downstream consumers
+        // expect at least the initial step to be present. Returning early
+        // also avoids deriving build params from a chain that will never be
+        // rebuilt.
         return Ok(vec![walk_params.init_step.clone()]);
     }
 
-    let _ = y_steps.remove(0); // remove initial step from y_steps to avoid early return
+    // Derive the build parameters once from the initial chain; every step's
+    // chain is anchored to the initial chain's shape instead of feeding back
+    // params re-derived from the previous rebuilt chain on each iteration.
+    let build_params = walk_params.ystep_ref().value().to_build_params()?;
     let mut steps: Vec<Step<Positive, OptionChain>> = vec![walk_params.init_step.clone()];
     let mut previous_x_step = walk_params.init_step.x;
-    let mut previous_y_step = walk_params.ystep();
+    let mut y_index = *walk_params.ystep_ref().index();
 
-    for y_step in y_steps.iter() {
+    // The first walker value duplicates the init step, so skip it.
+    for y_step in y_steps.iter().skip(1) {
         previous_x_step = match previous_x_step.next() {
             Ok(x_step) => x_step,
             Err(_) => break,
         };
         // convert y_step to OptionChain with updated expiration date
         let expiration_date = *previous_x_step.datetime();
-        let y_step_chain: OptionChain = create_chain_from_step(
-            &previous_y_step,
-            Some(Box::new(*y_step)),
-            volatility,
-            Some(expiration_date),
-        )?;
-        previous_y_step = previous_y_step.next(y_step_chain).clone();
+        let y_step_chain: OptionChain =
+            create_chain_from_step(&build_params, y_step, volatility, Some(expiration_date))?;
+        y_index += 1;
         let step = Step {
             x: previous_x_step,
-            y: previous_y_step.clone(),
+            y: Ystep::new(y_index, y_step_chain),
         };
 
         steps.push(step)
@@ -200,7 +207,7 @@ pub fn generator_positive(
     walk_params: &WalkParams<Positive, Positive>,
 ) -> Result<Vec<Step<Positive, Positive>>, ChainError> {
     debug!("{}", walk_params);
-    let mut y_steps = match &walk_params.walk_type {
+    let y_steps = match &walk_params.walk_type {
         WalkType::Brownian { .. } => walk_params.walker.brownian(walk_params)?,
         WalkType::GeometricBrownian { .. } => walk_params.walker.geometric_brownian(walk_params)?,
         WalkType::LogReturns { .. } => walk_params.walker.log_returns(walk_params)?,
@@ -213,13 +220,13 @@ pub fn generator_positive(
         WalkType::Historical { .. } => walk_params.walker.historical(walk_params)?,
     };
 
-    let _ = y_steps.remove(0);
     let mut steps: Vec<Step<Positive, Positive>> = vec![walk_params.init_step.clone()];
 
     let mut previous_x_step = walk_params.init_step.x;
     let mut previous_y_step = walk_params.init_step.y.clone();
 
-    for y_step in y_steps.iter() {
+    // The first walker value duplicates the init step, so skip it.
+    for y_step in y_steps.iter().skip(1) {
         previous_x_step = match previous_x_step.next() {
             Ok(x_step) => x_step,
             Err(_) => break,
@@ -269,7 +276,11 @@ mod tests {
             y: Ystep::new(0, initial_price),
         };
 
-        let result = create_chain_from_step(&step.y, Some(Box::new(new_price)), None, None);
+        let build_params = match step.y.value().to_build_params() {
+            Ok(params) => params,
+            Err(e) => panic!("to_build_params failed: {e}"),
+        };
+        let result = create_chain_from_step(&build_params, &new_price, None, None);
         assert!(result.is_ok());
 
         let new_chain = result.unwrap();

--- a/src/chains/utils.rs
+++ b/src/chains/utils.rs
@@ -727,11 +727,15 @@ fn round_to_clean_interval(interval: Positive, price: Positive) -> Positive {
 
 /// Return the strike interval that gives ~`size` strikes around ATM.
 /// All units are in the same currency.
+///
+/// `size` is the desired TOTAL number of strikes covering the ±kσ range
+/// (not the per-side half-width used by `OptionChainBuildParams::chain_size`;
+/// callers holding a per-side count must pass `2 * chain_size + 1`).
 pub fn strike_step(
     underlying_price: Positive,
     implied_vol: Positive, // e.g. 0.25 for 25 %
     days_to_exp: Positive,
-    size: usize,         // desired number of strikes
+    size: usize,         // desired TOTAL number of strikes across the range
     k: Option<Positive>, // σ-multiplier you want to cover (2.0-3.0 typical)
 ) -> Positive {
     // Helper for compile-time-safe literal positives. Each `dec!(X.X)` is a

--- a/src/series/generators.rs
+++ b/src/series/generators.rs
@@ -1,5 +1,5 @@
 use crate::error::ChainError;
-use crate::series::OptionSeries;
+use crate::series::{OptionSeries, OptionSeriesBuildParams};
 use crate::simulation::steps::{Step, Ystep};
 use crate::simulation::{WalkParams, WalkType};
 use crate::utils::TimeFrame;
@@ -36,12 +36,11 @@ use positive::pos_or_panic;
 /// - Any other unexpected error occurs during the processing.
 ///
 fn create_series_from_step(
-    previous_y_step: &Ystep<OptionSeries>,
+    build_params: &OptionSeriesBuildParams,
     new_price: &Positive,
     volatility: Option<Positive>,
 ) -> Result<OptionSeries, ChainError> {
-    let series = previous_y_step.value();
-    let mut series_params = series.to_build_params()?;
+    let mut series_params = build_params.clone();
     series_params.set_underlying_price(new_price);
     if let Some(volatility) = volatility {
         series_params.set_implied_volatility(volatility);
@@ -108,7 +107,7 @@ pub fn generator_optionseries(
     walk_params: &WalkParams<Positive, OptionSeries>,
 ) -> Result<Vec<Step<Positive, OptionSeries>>, ChainError> {
     debug!("{}", walk_params);
-    let (mut y_steps, volatility) = match &walk_params.walk_type {
+    let (y_steps, volatility) = match &walk_params.walk_type {
         WalkType::Brownian { volatility, .. } => {
             (walk_params.walker.brownian(walk_params)?, Some(*volatility))
         }
@@ -161,33 +160,38 @@ pub fn generator_optionseries(
             }
         }
     };
-    if y_steps.is_empty() {
+    if y_steps.len() <= 1 {
         // Preserve the contains-init-step contract used by the other
         // generators; callers iterate over Step values and expect at
-        // least the initial state.
+        // least the initial state. Returning early also avoids deriving
+        // build params from a series that will never be rebuilt.
         return Ok(vec![walk_params.init_step.clone()]);
     }
 
-    let _ = y_steps.remove(0); // remove initial step from y_steps to avoid early return
+    // Derive the build parameters once from the initial series; every step's
+    // series is anchored to the initial series' shape instead of feeding back
+    // params re-derived from the previous rebuilt series on each iteration.
+    let build_params = walk_params.ystep_ref().value().to_build_params()?;
     let mut steps: Vec<Step<Positive, OptionSeries>> = vec![walk_params.init_step.clone()];
     let mut previous_x_step = walk_params.init_step.x;
-    let mut previous_y_step = walk_params.ystep();
+    let mut y_index = *walk_params.ystep_ref().index();
 
     let volatility =
         volatility.unwrap_or_else(|| Positive::new_decimal(dec!(0.20)).unwrap_or(Positive::ZERO));
 
-    for y_step in y_steps.iter() {
+    // The first walker value duplicates the init step, so skip it.
+    for y_step in y_steps.iter().skip(1) {
         previous_x_step = match previous_x_step.next() {
             Ok(x_step) => x_step,
             Err(_) => break,
         };
         // convert y_step to OptionSeries
         let y_step_series: OptionSeries =
-            create_series_from_step(&previous_y_step, y_step, Some(volatility))?;
-        previous_y_step = previous_y_step.next(y_step_series).clone();
+            create_series_from_step(&build_params, y_step, Some(volatility))?;
+        y_index += 1;
         let step = Step {
             x: previous_x_step,
-            y: previous_y_step.clone(),
+            y: Ystep::new(y_index, y_step_series),
         };
 
         steps.push(step)
@@ -565,12 +569,15 @@ mod tests_generator_optionseries {
     fn test_create_series_from_step() {
         // Test the create_series_from_step function directly
         let initial_series = create_test_option_series();
-        let y_step = Ystep::new(0, initial_series);
+        let build_params = match initial_series.to_build_params() {
+            Ok(params) => params,
+            Err(e) => panic!("to_build_params failed: {e}"),
+        };
         let new_price = pos_or_panic!(105.0);
         let volatility = spos!(0.22);
 
         // Execute
-        let result = create_series_from_step(&y_step, &new_price, volatility);
+        let result = create_series_from_step(&build_params, &new_price, volatility);
 
         // Verify
         assert!(result.is_ok(), "create_series_from_step should succeed");

--- a/src/simulation/exit.rs
+++ b/src/simulation/exit.rs
@@ -441,7 +441,8 @@ pub fn check_exit_policy(
         ExitPolicy::And(policies) => {
             let mut triggered = Vec::new();
             for p in policies {
-                if let Some(triggered_policy) = check_exit_policy(
+                // All must be true for AND; `?` propagates the None.
+                let triggered_policy = check_exit_policy(
                     p,
                     initial_premium,
                     current_premium,
@@ -449,11 +450,8 @@ pub fn check_exit_policy(
                     days_left,
                     underlying_price,
                     is_long,
-                ) {
-                    triggered.push(triggered_policy);
-                } else {
-                    return None; // All must be true for AND
-                }
+                )?;
+                triggered.push(triggered_policy);
             }
             Some(ExitPolicy::And(triggered))
         }

--- a/tests/unit/strategies/custom_test.rs
+++ b/tests/unit/strategies/custom_test.rs
@@ -271,7 +271,7 @@ mod tests {
         assert_eq!(iv_map.len(), 2);
 
         // All volatilities should be positive
-        for (_option_type, iv) in iv_map.iter() {
+        for iv in iv_map.values() {
             assert!(**iv > Positive::ZERO);
         }
     }
@@ -285,7 +285,7 @@ mod tests {
         assert_eq!(quantity_map.len(), 2);
 
         // All quantities should be positive
-        for (_option_type, quantity) in quantity_map.iter() {
+        for quantity in quantity_map.values() {
             assert!(**quantity > Positive::ZERO);
         }
     }


### PR DESCRIPTION
## Summary

Three code sites disagreed about the units of `chain_size`: the field is documented and consumed by `build_chain` as a **per-side half-width**, but `to_build_params` fed back `self.len()` (total rows) and `build_chain` passed the per-side count to `strike_step`, which expects a **total** strike count. The feedback loop roughly doubled the strike grid on every `to_build_params` → `build_chain` round-trip (empirically 45 → 91 → 149 → 183 rows at 180d expiry), silently changing chain shape mid-simulation and multiplying per-step build/greeks/clone cost 3-10x from step ~3 onward.

**Stacked PR** (2/8 of the generators series): based on `issue-404-generator-perf` (#412). Targets `main`; contains #412's commits until that merges.

## Changes

- `to_build_params` keeps the computed `max(strikes_below, strikes_above)` per-side value — the `chain_size = self.len()` overwrite (which made the careful computation dead code) is gone. The `== 0 → 10` fallback is preserved.
- `build_chain` now converts the per-side half-width to the `2n+1` total that `strike_step` expects when inferring a strike interval. Inferred intervals stop being ~2x too wide — this is also what keeps the corrected (smaller) per-side counts from producing a giant interval that rounded ATM down to a zero strike in the series historical path (the failure mode that a naive one-site fix triggers in `test_generator_optionseries_historical`).
- `strike_step` documents its TOTAL-count contract explicitly.
- Regression test `test_to_build_params_round_trip_strike_count_stable` pins round-trip stability of the strike count at 30d and 180d expiries (the first rebuild may symmetrize an asymmetric input, but must not compound).

## Public API impact

None. `chain_size` and `strike_step` semantics now match their existing docs; no signatures changed. Note: chains rebuilt via `to_build_params` will keep a stable strike count across round-trips instead of growing — this is the documented intent, but downstream code relying on the accidental growth would observe smaller chains.

## Testing

- [x] Unit tests added (round-trip strike-count stability at 30d/180d)
- [x] `series::generators::tests_generator_optionseries::test_generator_optionseries_historical` still passes (the known trap for partial fixes)
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --all-features --workspace` clean (3846 lib + integration; same 6 pre-existing environmental `plotly` WebDriver failures as `main`)
- [x] `cargo build --release` clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic only — no `saturating_*` / `wrapping_*` in financial math
- [x] `rust_decimal::Decimal` at public monetary boundaries — no `f64` on prices / premia / P&L
- [x] Module boundaries respected
- [x] No new dependencies added

Closes #405
