### PR TITLE
Bump statrs to 0.19, dropping unmaintained paste (RUSTSEC-2024-0436) (#420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-08-07
+
+### Changed
+
+- `statrs` bumped `0.18` -> `0.19` (pulling `nalgebra 0.35` / `simba 0.10.2`), which
+  drops the unmaintained `paste` crate (RUSTSEC-2024-0436) from the dependency graph
+  entirely — `cargo tree -i paste --all-features` now prints nothing. The `statrs`
+  surface this crate uses (`distribution::{Normal, ContinuousCDF}`) is unchanged
+  between the two lines, so no code changes. Requested by the Layer V fleet, where
+  this chain was the only path bringing `paste` into every downstream tree (#420,
+  Layer-V/common-rs#266). (#420)
+
 ## [0.18.0] - 2026-07-12
 
 Overhaul of the option-chain walk generators (issues #404-#411, PRs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."
@@ -123,7 +123,7 @@ rust_decimal_macros = "1.40"
 plotly = { version = "0.14", default-features = false, features = ["static_export_default"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = { version = "0.10" }
-statrs = "0.18"
+statrs = "0.19"
 tracing-subscriber = { version = "0.3"}
 num-traits = "0.2"
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

`statrs 0.19` pulls `nalgebra 0.35` / `simba 0.10.2`, and simba 0.10.2 removed its `paste` dependency — so this bump drops the unmaintained `paste` crate (RUSTSEC-2024-0436) from the graph entirely: `cargo tree -i paste --all-features` prints nothing after it. The statrs surface this crate uses (`distribution::{Normal, ContinuousCDF}`) is identical across the two lines, so there are no code changes. Version moves to `0.18.1` — dependency-only, public API untouched.

Requested by the Layer V fleet, where this chain was the only path bringing `paste` into every downstream tree (Layer-V/common-rs#266).

## Verification

- `cargo tree -i paste --all-features` → `warning: nothing to print.`
- Default-features tests: 383 passed, 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo doc` — all clean
- The four plotly static-export render tests fail identically on clean `main` in this environment (kaleido availability) and are unrelated to this change; CI is the arbiter there

Closes #420