### PR TITLE
chore(deps)!: refresh every dependency, release 0.19.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,43 @@
+# cargo-audit configuration for the `optionstratlib` crate.
+#
+# See https://docs.rs/cargo-audit for the full schema.
+
+[advisories]
+# Advisories deliberately ignored, each with reachability rationale, owner and
+# review date. Every entry MUST be re-evaluated on or before its review date;
+# an entry whose upstream fix has shipped must be removed, not extended.
+#
+# ---------------------------------------------------------------------------
+# RUSTSEC-2026-0235 — rkyv 0.7.46, out-of-bounds read validating archives that
+#                     contain Rc/Arc. Fixed in rkyv >= 0.8.17.
+#
+# Reachability : NOT REACHABLE. `rkyv` enters Cargo.lock only as an *optional*
+#                dependency of `rust_decimal`. This crate depends on
+#                rust_decimal with `features = ["maths", "serde"]` and never
+#                enables its `rkyv` feature, so the crate is never compiled or
+#                linked. Verified with:
+#                    cargo tree --all-features --target all -i rkyv
+#                which reports "nothing to print" — no path from
+#                `optionstratlib` to `rkyv` exists under any feature or target
+#                combination. Cargo records optional dependencies in the
+#                lockfile regardless of feature selection, which is why
+#                `cargo audit` still sees it.
+# Upgrade path : Blocked upstream. rust_decimal 1.42.1 (the latest release)
+#                pins the 0.7 line for its optional `rkyv` feature; moving to
+#                rkyv 0.8 is a breaking change that must land in rust_decimal
+#                first. There is no version of rust_decimal we can select that
+#                resolves this.
+# Tracking     : https://github.com/paupino/rust-decimal/issues
+# Owner        : @joaquinbejar
+# Review by    : 2027-02-15
+# ---------------------------------------------------------------------------
+ignore = ["RUSTSEC-2026-0235"]
+
+# Report unmaintained/unsound/notice advisories instead of dropping them
+# silently. Two are currently outstanding, both transitive and both without a
+# fixed release to move to:
+#   * RUSTSEC-2025-0119 — number_prefix 0.4.0 unmaintained, via `indicatif`.
+#   * RUSTSEC-2025-0134 — rustls-pemfile 1.0.4 unmaintained, via `reqwest`
+#     (only reachable with the `async` feature enabled).
+informational_warnings = ["unmaintained", "unsound", "notice"]
+severity_threshold = "none"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-17
+
+Dependency refresh: every dependency moved to its latest stable minor, and the
+three in-house crates jumped a breaking release each. It is **breaking** for
+consumers — see *Migration*.
+
+### Changed — breaking
+
+- `positive` `0.5` -> `0.6`, `expiration_date` `0.2` -> `0.3`,
+  `option_type` `0.1` -> `0.3`. All three appear throughout this crate's public
+  API, so consumers must move in the same step.
+- **JSON wire format**: `positive` 0.6 serialises `Positive` as the exact
+  decimal in a *string* (`"42.5"` instead of `42.5`), so every serialised type
+  carrying a `Positive` changes shape: `OptionData`, `OptionChainBuildParams`,
+  `OptionSeries`, `PnL`/`PnLMetricsDocument`, `Step`/`Xstep`/`Ystep`,
+  `StrategyRequest`, and the rest. Deserialisation still accepts the old
+  numeric form, so stored documents keep loading; anything asserting on the
+  serialised text has to be updated.
+- **`utils::others::calculate_log_returns` returns `Vec<Decimal>`**, not
+  `Vec<Positive>`. A log return is signed — `ln(105/110) < 0` — and the old
+  signature could not represent it. `Positive::ln` itself now returns
+  `Decimal` for the same reason.
+- **Exotic payloads are `Positive`**, following `option_type` 0.3:
+  `OptionType::Barrier { barrier_level, rebate }`,
+  `Bermuda { exercise_dates }`, `Chooser { choice_date }`,
+  `Cliquet { reset_dates }`, `Spread`/`Exchange { second_asset }`,
+  `Quanto { exchange_rate }`, `Power { exponent }`. A negative or non-finite
+  value is now unrepresentable rather than an error at pricing time, so
+  `power_black_scholes` no longer has a negative-exponent rejection path and
+  `barrier_black_scholes` no longer returns `PricingError::NonFinite` for its
+  barrier level or rebate.
+- `OptionType` and every sub-enum (`AsianAveragingType`, `BarrierType`,
+  `BinaryType`, `LookbackType`, `RainbowType`) are `#[non_exhaustive]`
+  upstream. Matches in this crate gained fallback arms: payoffs degrade to the
+  plain intrinsic value, and the Black-Scholes kernels return
+  `PricingError::UnsupportedOptionType` / `PricingError::other` rather than
+  failing to compile against a future variant.
+
+### Changed
+
+- `rust_decimal` `1.41` -> `1.42`, `itertools` `0.14` -> `0.15`,
+  `zip` `6.0` -> `8.6`, `uuid` `1.23` -> `1.24`, `utoipa` `5.4` -> `5.5`,
+  `tokio` `1.52` -> `1.53`; dev-only `mockall` `0.14` -> `0.15`,
+  `tempfile` `3.23` -> `3.27`, `proptest` `1.5` -> `1.11`. Every other
+  dependency was already at its latest stable minor.
+- `Positive::INFINITY` is deprecated upstream in favour of `Positive::MAX`
+  (the value was always `Decimal::MAX`, never an infinity). The unlimited-upside
+  strategies (`long_call`, `short_call`, the straddles and strangles,
+  `call_butterfly`) and `ProfitRange`/`Position` now use `MAX`, so an unbounded
+  max-profit renders as `79228162514264337593543950335` instead of `inf`.
+- Deprecated conversions replaced: `Positive::to_i64`/`to_u64`/`to_usize` gave
+  way to their `*_checked` forms, so an out-of-range day count, plot bound or
+  chain-size counter saturates instead of panicking.
+- `Positive::sub_or_zero` is deprecated upstream; the zero floor is now taken
+  once, in `model::utils::sub_floor_zero`, on top of the checked
+  `sub_or_none`. Behaviour is unchanged for the bid/ask spread, the skew scan
+  and the OU drift term.
+- Comparisons of the form `decimal > Positive::ZERO.into()` became
+  `decimal > Positive::ZERO`: `positive` 0.6 adds
+  `PartialOrd<Positive> for Decimal`, which made the inferred `.into()`
+  ambiguous.
+
+### Migration
+
+```rust
+// log returns are signed
+- let r: Vec<Positive> = calculate_log_returns(&prices)?;
++ let r: Vec<Decimal>  = calculate_log_returns(&prices)?;
+
+// exotic payloads carry `Positive`
+- OptionType::Barrier { barrier_type, barrier_level: 95.0, rebate: None }
++ OptionType::Barrier { barrier_type, barrier_level: pos_or_panic!(95.0), rebate: None }
+
+// unbounded profit
+- Ok(Positive::INFINITY)
++ Ok(Positive::MAX)
+
+// serialised prices are strings
+- {"strike_price": 100.0}
++ {"strike_price": "100"}
+```
+
+### Housekeeping
+
+- `.cargo/audit.toml`, mirroring the `positive` crate's policy file: it ignores
+  RUSTSEC-2026-0235 (rkyv 0.7.46) with a reachability rationale — `rkyv` is an
+  *optional* dependency of `rust_decimal` that this crate never enables, so it
+  is recorded in `Cargo.lock` but never compiled (`cargo tree --all-features
+  --target all -i rkyv` reports nothing) — and opts into reporting
+  unmaintained/unsound/notice advisories, of which two remain outstanding
+  transitively (`number_prefix` via `indicatif`, `rustls-pemfile` via
+  `reqwest`). The Security Audit workflow had been failing on every run,
+  including on `main`.
+
 ## [0.18.1] - 2026-08-07
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."
@@ -76,10 +76,10 @@ futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false, features = ["html_reports"] }
-mockall = "0.14"
-tempfile = "3.23"
+mockall = "0.15"
+tempfile = "3.27"
 static_assertions = "1.1"
-proptest = "1.5"
+proptest = "1.11"
 
 [[test]]
 name = "tests"
@@ -118,7 +118,7 @@ members = [
 [workspace.dependencies]
 optionstratlib = { path = "." }
 tracing = "0.1"
-rust_decimal = { version = "1.41", features = ["maths", "serde"] }
+rust_decimal = { version = "1.42", features = ["maths", "serde"] }
 rust_decimal_macros = "1.40"
 plotly = { version = "0.14", default-features = false, features = ["static_export_default"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -130,22 +130,22 @@ serde_json = "1.0"
 csv = { version = "1.4"}
 serde = { version = "1.0", features = ["derive"] }
 rayon = { version = "1.12" }
-itertools = "0.14"
-zip = "6.0"
+itertools = "0.15"
+zip = "8.6"
 lazy_static = "1.5"
-uuid = { version = "1.23", features = ["v4", "serde"] }
+uuid = { version = "1.24", features = ["v4", "serde"] }
 approx = "0.5"
 rand_distr = "0.6"
 prettytable-rs = "0.10"
 pretty-simple-display = "0.1"
-utoipa = { version = "5.4", features = ["axum_extras", "chrono", "decimal"] }
+utoipa = { version = "5.5", features = ["axum_extras", "chrono", "decimal"] }
 indicatif = "0.18"
 thiserror = "2.0"
-positive = { version = "0.5", features = ["utoipa"] }
-expiration_date = { version = "0.2", features = ["utoipa"] }
+positive = { version = "0.6", features = ["utoipa"] }
+expiration_date = { version = "0.3", features = ["utoipa"] }
 financial_types = { version = "0.2", features = ["utoipa"] }
-option_type = { version = "0.1.2", features = ["utoipa"] }
-tokio = { version = "1.52", features = ["full"] }
+option_type = { version = "0.3", features = ["utoipa"] }
+tokio = { version = "1.53", features = ["full"] }
 async-trait = "0.1"
 reqwest = { version = "0.13", features = ["json"] }
 futures = "0.3"

--- a/benches/model/positive.rs
+++ b/benches/model/positive.rs
@@ -102,7 +102,7 @@ pub(crate) fn benchmark_conversions(c: &mut Criterion) {
 
     group.bench_function("to_i64", |bencher| {
         let x = value;
-        bencher.iter(|| black_box(x.to_i64()))
+        bencher.iter(|| black_box(i64::try_from(x)))
     });
 
     group.finish();

--- a/examples/examples_chain/src/bin/option_chain_ger40.rs
+++ b/examples/examples_chain/src/bin/option_chain_ger40.rs
@@ -54,13 +54,13 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
     info!("Delta:  {:#?}", strategy.delta_neutrality()?);
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         let path: &std::path::Path = "Draws/Chains/short_strangle_ger40_area.html".as_ref();
         strategy.write_html(path)?;
     }
     info!("Greeks:  {:#?}", strategy.greeks());
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let file_path = "Draws/Chains/short_strangle_ger40_area.png";
         let path: &std::path::Path = file_path.as_ref();

--- a/examples/examples_chain/src/bin/option_chain_raw.rs
+++ b/examples/examples_chain/src/bin/option_chain_raw.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
     info!("Delta:  {:#?}", strategy.delta_neutrality()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let file_path = "Draws/Chains/short_strangle_chain_raw_best_area.png";
         let path: &std::path::Path = file_path.as_ref();

--- a/examples/examples_chain/src/bin/option_chain_raw_delta.rs
+++ b/examples/examples_chain/src/bin/option_chain_raw_delta.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     info!("Delta Neutral:  {}", strategy.is_delta_neutral());
     info!("Delta Suggestions:  {:#?}", strategy.delta_adjustments()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path = "Draws/Chains/short_strangle_chain_raw_delta.png".as_ref();
         strategy.write_png(path)?;

--- a/examples/examples_exotics/src/bin/barrier_pricing.rs
+++ b/examples/examples_exotics/src/bin/barrier_pricing.rs
@@ -21,7 +21,7 @@ fn main() {
     let _risk_free_rate = 0.08;
     let dividend_yield = 0.04;
     let time_to_expiration = 0.5;
-    let barrier_level = 95.0;
+    let barrier_level = pos_or_panic!(95.0);
 
     let mut table = Table::new();
     table.add_row(row![

--- a/examples/examples_exotics/src/bin/cliquet_example.rs
+++ b/examples/examples_exotics/src/bin/cliquet_example.rs
@@ -17,7 +17,11 @@ fn main() {
     setup_logger();
     // 1. Define Cliquet Option parameters
     // We want a 1-year Cliquet option with quarterly resets (every 90 days)
-    let reset_dates = vec![90.0, 180.0, 270.0];
+    let reset_dates = vec![
+        pos_or_panic!(90.0),
+        pos_or_panic!(180.0),
+        pos_or_panic!(270.0),
+    ];
     let expiration_days = 365.0;
 
     // Local cap of 5% and floor of -2% per period

--- a/examples/examples_simulation/src/bin/historical_build_chain.rs
+++ b/examples/examples_simulation/src/bin/historical_build_chain.rs
@@ -21,10 +21,7 @@ fn main() -> Result<(), Error> {
         .iter()
         .filter_map(|x| Positive::new_decimal(x.close).ok())
         .collect();
-    let log_returns: Vec<Decimal> = calculate_log_returns(&prices)?
-        .iter()
-        .map(|p| p.to_dec())
-        .collect();
+    let log_returns: Vec<Decimal> = calculate_log_returns(&prices)?;
     let implied_volatility = adjust_volatility(
         constant_volatility(&log_returns)?,
         TimeFrame::Minute,

--- a/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_area.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bear_call_spread_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_call_spread_best_ratio.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bear_call_spread_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_area.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bear_put_spread_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bear_put_spread_best_ratio.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bear_put_spread_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_area.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bull_call_spread_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_call_spread_best_ratio.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bull_call_spread_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_area.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bull_put_spread_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_bull_put_spread_best_ratio.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/bull_put_spread_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_area.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/iron_butterfly_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_butterfly_best_ratio.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/iron_butterfly_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_area.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/iron_condor_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_iron_condor_best_ratio.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/iron_condor_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_area.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/long_butterfly_spread_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_butterfly_spread_best_ratio.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/long_butterfly_spread_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_area.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/long_straddle_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_straddle_best_ratio.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/long_straddle_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_area.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/long_strangle_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_long_strangle_best_ratio.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/long_strangle_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_area.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/poor_mans_covered_call_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_poor_mans_covered_call_best_ratio.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/poor_mans_covered_call_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_area.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/short_butterfly_spread_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_butterfly_spread_best_ratio.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/short_butterfly_spread_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_area.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/short_straddle_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_straddle_best_ratio.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/short_straddle_profit_loss_chart_best_ratio.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_area.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_area.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Area: {:.2}%", strategy.get_profit_area()?);
     info!("Delta:  {:#?}", strategy.delta_neutrality()?);
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/short_strangle_profit_loss_chart_best_area.png".as_ref();

--- a/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_ratio.rs
+++ b/examples/examples_strategies_best/src/bin/strategy_short_strangle_best_ratio.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Error> {
     );
     info!("Profit Ratio: {:.2}%", strategy.get_profit_ratio()?);
 
-    if strategy.get_profit_ratio()? > Positive::ZERO.into() {
+    if strategy.get_profit_ratio()? > Positive::ZERO {
         debug!("Strategy:  {:#?}", strategy);
         let path: &std::path::Path =
             "Draws/Strategy/short_strangle_profit_loss_chart_best_ratio.png".as_ref();

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -22,6 +22,7 @@ use crate::metrics::{
     VolatilitySensitivitySurface, VolatilitySkewCurve, VolumeProfileCurve, VolumeProfileSurface,
 };
 use crate::model::decimal::d_add;
+use crate::model::utils::sub_floor_zero;
 use crate::model::{
     BasicAxisTypes, ExpirationDate, OptionStyle, OptionType, Options, Position, Side,
 };
@@ -538,7 +539,7 @@ impl OptionChain {
 
         loop {
             // Check if we've reached the desired chain size
-            if counter.to_usize() > max_strikes {
+            if counter.to_usize_checked().unwrap_or(usize::MAX) > max_strikes {
                 break;
             }
 
@@ -1367,7 +1368,10 @@ impl OptionChain {
             let strike_str = field(0)?;
             let mut option_data = OptionData {
                 strike_price: strike_str.parse::<Positive>().map_err(|e| {
-                    ChainError::invalid_strike(strike_str.parse::<f64>().unwrap_or(f64::NAN), &e)
+                    ChainError::invalid_strike(
+                        strike_str.parse::<f64>().unwrap_or(f64::NAN),
+                        &e.to_string(),
+                    )
                 })?,
                 call_bid: parse(field(1)?),
                 call_ask: parse(field(2)?),
@@ -3241,13 +3245,13 @@ impl RNDAnalysis for OptionChain {
                 debug!("Call price at k+h: {:?}", self.get_call_price(k + h));
                 debug!(
                     "Call price at k-h: {:?}",
-                    self.get_call_price(k.sub_or_zero(&h))
+                    self.get_call_price(sub_floor_zero(k, &h))
                 );
             }
             if let (Some(call_price), Some(call_up), Some(call_down)) = (
                 self.get_call_price(k),
                 self.get_call_price(k + h),
-                self.get_call_price(k.sub_or_zero(&h)),
+                self.get_call_price(sub_floor_zero(k, &h)),
             ) {
                 // Calculate second derivative
                 let second_derivative = (call_up + call_down - Decimal::TWO * call_price) / (h * h);
@@ -7849,7 +7853,7 @@ mod rnd_analysis_tests {
 
             // For ATM strike (100.0), relative strike should be 1.0
             let atm_strike = result.iter().find(|(rel_strike, _)| {
-                (rel_strike.sub_or_zero(&Decimal::ONE)) < pos_or_panic!(0.0001)
+                sub_floor_zero(*rel_strike, &Decimal::ONE) < pos_or_panic!(0.0001)
             });
             assert!(atm_strike.is_some());
         }
@@ -9157,9 +9161,10 @@ mod tests_option_data_serde {
         let json_value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
         assert!(json_value.is_object());
         assert!(json_value.get("strike_price").is_some());
+        // positive 0.6 serialises `Positive` as the exact decimal in a string
         assert_eq!(
-            json_value.get("strike_price").unwrap().as_f64().unwrap(),
-            100.0
+            json_value.get("strike_price").unwrap().as_str().unwrap(),
+            "100"
         );
     }
 
@@ -9288,10 +9293,10 @@ mod tests_option_chain_serde {
     fn test_optionchain_special_values() {
         let mut chain = OptionChain::new(
             "SPECIAL",
-            Positive::INFINITY,
+            Positive::MAX,
             "2030-01-01".to_string(),
             Some(Decimal::MAX),
-            Some(Positive::INFINITY),
+            Some(Positive::MAX),
         );
 
         chain.add_option(

--- a/src/chains/generators.rs
+++ b/src/chains/generators.rs
@@ -497,7 +497,7 @@ mod tests {
             None => panic!("short prices"),
         };
         let log_returns: Vec<Decimal> = match calculate_log_returns(walked) {
-            Ok(returns) => returns.iter().map(|p| p.to_dec()).collect(),
+            Ok(returns) => returns,
             Err(e) => panic!("log returns failed: {e}"),
         };
         let expected_vol = match constant_volatility(&log_returns) {

--- a/src/chains/optiondata.rs
+++ b/src/chains/optiondata.rs
@@ -9,6 +9,7 @@ use crate::error::ChainError;
 use crate::error::chains::OptionDataErrorKind;
 use crate::greeks::{delta, gamma};
 use crate::model::Position;
+use crate::model::utils::sub_floor_zero;
 use crate::strategies::{BasicAble, FindOptimalSide};
 use crate::{ExpirationDate, OptionStyle, Options, Side};
 use chrono::{DateTime, Utc};
@@ -853,11 +854,8 @@ impl OptionData {
             (_, _, Some(call_middle)) => {
                 if call_middle > spread {
                     self.call_ask = Some((call_middle + half_spread).round_to(decimal_places));
-                    self.call_bid = Some(
-                        call_middle
-                            .sub_or_zero(&half_spread)
-                            .round_to(decimal_places),
-                    );
+                    self.call_bid =
+                        Some(sub_floor_zero(call_middle, &half_spread).round_to(decimal_places));
                 } else {
                     trace!(
                         "apply_spread: Call middle price is not greater than spread, cannot apply spread"
@@ -872,7 +870,7 @@ impl OptionData {
                     "apply_spread: Call middle price is None; recomputing from bid/ask after applying spread"
                 );
                 let new_ask = (call_ask + half_spread).round_to(decimal_places);
-                let new_bid = call_bid.sub_or_zero(&half_spread).round_to(decimal_places);
+                let new_bid = sub_floor_zero(call_bid, &half_spread).round_to(decimal_places);
                 self.call_ask = Some(new_ask);
                 self.call_bid = Some(new_bid);
                 self.call_middle =
@@ -889,11 +887,8 @@ impl OptionData {
             (_, _, Some(put_middle)) => {
                 if put_middle > spread {
                     self.put_ask = Some((put_middle + half_spread).round_to(decimal_places));
-                    self.put_bid = Some(
-                        put_middle
-                            .sub_or_zero(&half_spread)
-                            .round_to(decimal_places),
-                    );
+                    self.put_bid =
+                        Some(sub_floor_zero(put_middle, &half_spread).round_to(decimal_places));
                 } else {
                     trace!(
                         "apply_spread: Put middle price is not greater than spread, cannot apply spread"
@@ -908,7 +903,7 @@ impl OptionData {
                     "apply_spread: Put middle price is None; recomputing from bid/ask after applying spread"
                 );
                 let new_ask = (put_ask + half_spread).round_to(decimal_places);
-                let new_bid = put_bid.sub_or_zero(&half_spread).round_to(decimal_places);
+                let new_bid = sub_floor_zero(put_bid, &half_spread).round_to(decimal_places);
                 self.put_ask = Some(new_ask);
                 self.put_bid = Some(new_bid);
                 self.put_middle =

--- a/src/chains/utils.rs
+++ b/src/chains/utils.rs
@@ -611,7 +611,15 @@ pub fn adjust_volatility(
             );
             0.0
         });
-    let m = (strike / underlying_price.to_f64()).ln();
+    let m = (strike / underlying_price.to_f64())
+        .ln()
+        .to_f64()
+        .unwrap_or_else(|| {
+            tracing::warn!(
+                "adjust_volatility: moneyness ln to_f64 returned None; defaulting to 0.0"
+            );
+            0.0
+        });
     let factor: f64 = 1.0 + skew_slope * m + smile_curve * m * m;
     let clamped = factor.clamp(0.01, 3.0);
 
@@ -1458,7 +1466,7 @@ mod tests_option_chain_build_params {
         let display = format!("{params}");
         assert_eq!(
             display,
-            r#"{"symbol":"TEST","volume":1000,"chain_size":10,"strike_interval":5,"skew_slope":"-0.2","smile_curve":"0.1","spread":0.02,"decimal_places":2,"price_params":{"underlying_price":100,"expiration_date":{"days":30.0},"risk_free_rate":"0.05","dividend_yield":0.02,"underlying_symbol":"AAPL"},"implied_volatility":0.25}"#
+            r#"{"symbol":"TEST","volume":"1000","chain_size":10,"strike_interval":"5","skew_slope":"-0.2","smile_curve":"0.1","spread":"0.02","decimal_places":2,"price_params":{"underlying_price":"100","expiration_date":{"days":30.0},"risk_free_rate":"0.05","dividend_yield":"0.02","underlying_symbol":"AAPL"},"implied_volatility":"0.25"}"#
         );
     }
 

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -122,7 +122,7 @@ pub fn d1(
     let underlying_price: Decimal = underlying_price.to_dec();
     let implied_volatility_squared = implied_volatility.powd(Decimal::TWO);
     let ln_price_ratio = match strike_price {
-        value if value == Positive::INFINITY => Decimal::MIN,
+        value if value == Positive::MAX => Decimal::MIN,
         _ => (underlying_price / strike_price).ln(),
     };
 
@@ -867,7 +867,7 @@ mod calculate_d1_values {
     #[test]
     fn test_d1_high_underlying_price() {
         // Case with extremely high underlying price
-        let underlying_price = Positive::INFINITY; // Very high stock price
+        let underlying_price = Positive::MAX; // Very high stock price
         let strike_price = Positive::HUNDRED;
         let risk_free_rate = dec!(0.05);
         let expiration_date = Positive::ONE;
@@ -1228,7 +1228,7 @@ mod calculate_d2_values {
     #[test]
     fn test_d2_high_underlying_price() {
         // Case with extremely high underlying price
-        let underlying_price = Positive::INFINITY;
+        let underlying_price = Positive::MAX;
         let strike_price = Positive::HUNDRED;
         let risk_free_rate = dec!(0.05);
         let expiration_date = Positive::ONE;

--- a/src/model/format.rs
+++ b/src/model/format.rs
@@ -327,7 +327,7 @@ mod tests_options {
         let options = Options {
             option_type: OptionType::Barrier {
                 barrier_type: BarrierType::UpAndIn,
-                barrier_level: 100.0,
+                barrier_level: pos_or_panic!(100.0),
                 rebate: None,
             },
             side: Side::Short,

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -1085,7 +1085,11 @@ impl Graph for Options {
             line_width: Some(2.0),
         };
 
-        for i in range.0.to_u64()..range.1.to_u64() {
+        let (range_start, range_end) = (
+            range.0.to_u64_checked().unwrap_or_default(),
+            range.1.to_u64_checked().unwrap_or_default(),
+        );
+        for i in range_start..range_end {
             let profit = self
                 .payoff_at_price(&Positive::new(i as f64).unwrap_or(Positive::ONE))
                 .unwrap_or_default();

--- a/src/model/position.rs
+++ b/src/model/position.rs
@@ -733,7 +733,7 @@ impl Position {
     #[allow(dead_code)]
     pub(crate) fn max_profit(&self) -> Result<Positive, PositionError> {
         match self.option.side {
-            Side::Long => Ok(Positive::INFINITY),
+            Side::Long => Ok(Positive::MAX),
             Side::Short => self.net_premium_received(),
         }
     }
@@ -754,7 +754,7 @@ impl Position {
     pub(crate) fn max_loss(&self) -> Result<Positive, PositionError> {
         match self.option.side {
             Side::Long => self.total_cost(),
-            Side::Short => Ok(Positive::INFINITY),
+            Side::Short => Ok(Positive::MAX),
         }
     }
 
@@ -2393,7 +2393,7 @@ mod tests_position_max_loss_profit {
             None,
         );
         assert_relative_eq!(position.max_loss().unwrap().to_f64(), 7.0, epsilon = 0.001);
-        assert_eq!(position.max_profit().unwrap(), Positive::INFINITY);
+        assert_eq!(position.max_profit().unwrap(), Positive::MAX);
     }
 
     #[test]
@@ -2416,7 +2416,7 @@ mod tests_position_max_loss_profit {
             None,
         );
         assert_relative_eq!(position.max_loss().unwrap().to_f64(), 70.0, epsilon = 0.001);
-        assert_eq!(position.max_profit().unwrap(), Positive::INFINITY);
+        assert_eq!(position.max_profit().unwrap(), Positive::MAX);
     }
 
     #[test]
@@ -2438,7 +2438,7 @@ mod tests_position_max_loss_profit {
             None,
             None,
         );
-        assert_relative_eq!(position.max_loss().unwrap(), Positive::INFINITY);
+        assert_relative_eq!(position.max_loss().unwrap(), Positive::MAX);
         assert_relative_eq!(
             position.max_profit().unwrap().to_f64(),
             3.0,
@@ -2465,7 +2465,7 @@ mod tests_position_max_loss_profit {
             None,
             None,
         );
-        assert_relative_eq!(position.max_loss().unwrap(), Positive::INFINITY);
+        assert_relative_eq!(position.max_loss().unwrap(), Positive::MAX);
         assert_relative_eq!(
             position.max_profit().unwrap().to_f64(),
             30.0,
@@ -2493,7 +2493,7 @@ mod tests_position_max_loss_profit {
             None,
         );
         assert_relative_eq!(position.max_loss().unwrap().to_f64(), 7.0, epsilon = 0.001);
-        assert_relative_eq!(position.max_profit().unwrap(), Positive::INFINITY);
+        assert_relative_eq!(position.max_profit().unwrap(), Positive::MAX);
     }
 
     #[test]
@@ -2516,7 +2516,7 @@ mod tests_position_max_loss_profit {
             None,
         );
         assert_relative_eq!(position.max_loss().unwrap().to_f64(), 70.0, epsilon = 0.001);
-        assert_relative_eq!(position.max_profit().unwrap(), Positive::INFINITY);
+        assert_relative_eq!(position.max_profit().unwrap(), Positive::MAX);
     }
 
     #[test]
@@ -2538,7 +2538,7 @@ mod tests_position_max_loss_profit {
             None,
             None,
         );
-        assert_relative_eq!(position.max_loss().unwrap(), Positive::INFINITY);
+        assert_relative_eq!(position.max_loss().unwrap(), Positive::MAX);
         assert_relative_eq!(
             position.max_profit().unwrap().to_f64(),
             3.0,
@@ -2565,7 +2565,7 @@ mod tests_position_max_loss_profit {
             None,
             None,
         );
-        assert_relative_eq!(position.max_loss().unwrap(), Positive::INFINITY);
+        assert_relative_eq!(position.max_loss().unwrap(), Positive::MAX);
         assert_relative_eq!(
             position.max_profit().unwrap().to_f64(),
             30.0,

--- a/src/model/profit_range.rs
+++ b/src/model/profit_range.rs
@@ -140,7 +140,7 @@ impl ProfitLossRange {
         risk_free_rate: Option<Decimal>,
     ) -> Result<(), ProbabilityError> {
         let lower = self.lower_bound.unwrap_or(Positive::ZERO);
-        let upper = self.upper_bound.unwrap_or(Positive::INFINITY);
+        let upper = self.upper_bound.unwrap_or(Positive::MAX);
         if lower > upper {
             return Err(ProbabilityError::PriceError(
                 PriceErrorKind::InvalidPriceRange {
@@ -162,7 +162,7 @@ impl ProfitLossRange {
         // Calculate probabilities for the upper bound
         let (prob_below_upper, _) = calculate_single_point_probability(
             current_price,
-            &self.upper_bound.unwrap_or(Positive::INFINITY),
+            &self.upper_bound.unwrap_or(Positive::MAX),
             volatility_adj,
             trend,
             expiration_date,

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -56,6 +56,8 @@ impl Payoff for OptionType {
             OptionType::Lookback { lookback_type } => match lookback_type {
                 LookbackType::FixedStrike => standard_payoff(info),
                 LookbackType::FloatingStrike => calculate_floating_strike_payoff(info),
+                // `LookbackType` is `#[non_exhaustive]`.
+                _ => standard_payoff(info),
             },
             OptionType::Compound { underlying_option } => underlying_option.payoff(info),
             OptionType::Chooser { .. } => (info.spot - info.strike)
@@ -71,13 +73,18 @@ impl Payoff for OptionType {
             OptionType::Rainbow { .. }
             | OptionType::Spread { .. }
             | OptionType::Exchange { .. } => standard_payoff(info),
-            OptionType::Quanto { exchange_rate } => standard_payoff(info) * exchange_rate,
+            OptionType::Quanto { exchange_rate } => standard_payoff(info) * exchange_rate.to_f64(),
             OptionType::Power { exponent } => match info.style {
-                OptionStyle::Call => (info.spot.to_f64().powf(*exponent) - info.strike).max(ZERO),
-                OptionStyle::Put => (info.strike - info.spot.to_f64().powf(*exponent))
+                OptionStyle::Call => {
+                    (info.spot.to_f64().powf(exponent.to_f64()) - info.strike).max(ZERO)
+                }
+                OptionStyle::Put => (info.strike - info.spot.to_f64().powf(exponent.to_f64()))
                     .max(Positive::ZERO)
                     .to_f64(),
             },
+            // `OptionType` is `#[non_exhaustive]`: a variant added upstream falls
+            // back to the plain intrinsic value until it gets its own arm.
+            _ => standard_payoff(info),
         }
     }
 }
@@ -118,6 +125,9 @@ fn calculate_asian_payoff(averaging_type: &AsianAveragingType, info: &PayoffInfo
                 let product = spot_prices.iter().fold(1.0, |acc, &x| acc * x);
                 product.powf(1.0 / len as f64)
             }
+            // `AsianAveragingType` is `#[non_exhaustive]`: fall back to the
+            // arithmetic mean, the conventional default for Asian options.
+            _ => spot_prices.iter().sum::<f64>() / len as f64,
         },
         _ => return ZERO,
     };
@@ -159,19 +169,24 @@ fn calculate_asian_payoff(averaging_type: &AsianAveragingType, info: &PayoffInfo
 /// This function does not explicitly handle errors. Ensure that the inputs are valid for the `barrier_type`, `barrier_level`, and `info` parameters.
 fn calculate_barrier_payoff(
     barrier_type: &BarrierType,
-    barrier_level: &f64,
-    rebate: &Option<f64>,
+    barrier_level: &Positive,
+    rebate: &Option<Positive>,
     info: &PayoffInfo,
 ) -> f64 {
+    let level = barrier_level.to_f64();
     let barrier_condition = match barrier_type {
         BarrierType::UpAndIn | BarrierType::UpAndOut => {
             // Use spot_max if available, otherwise just current spot
-            info.spot_max.unwrap_or(info.spot.to_f64()) >= *barrier_level
+            info.spot_max.unwrap_or(info.spot.to_f64()) >= level
         }
         BarrierType::DownAndIn | BarrierType::DownAndOut => {
             // Use spot_min if available, otherwise just current spot
-            info.spot_min.unwrap_or(info.spot.to_f64()) <= *barrier_level
+            info.spot_min.unwrap_or(info.spot.to_f64()) <= level
         }
+        // `BarrierType` is `#[non_exhaustive]`: an unknown barrier is treated as
+        // never triggered, so the "In" arms below pay nothing and the "Out" arms
+        // pay the standard payoff.
+        _ => false,
     };
     let std_payoff = standard_payoff(info);
     match barrier_type {
@@ -184,11 +199,12 @@ fn calculate_barrier_payoff(
         }
         BarrierType::UpAndOut | BarrierType::DownAndOut => {
             if barrier_condition {
-                rebate.unwrap_or(0.0)
+                rebate.map_or(0.0, |r| r.to_f64())
             } else {
                 std_payoff
             }
         }
+        _ => std_payoff,
     }
 }
 
@@ -253,6 +269,15 @@ fn calculate_binary_payoff(binary_type: &BinaryType, info: &PayoffInfo) -> f64 {
                 // For Gap options, the payoff is proportional to how far above/below the strike price
                 // the underlying asset is at expiration
                 (info.spot.to_f64() - info.strike.to_f64()).abs()
+            } else {
+                0.0
+            }
+        }
+        // `BinaryType` is `#[non_exhaustive]`: an unknown binary type pays the
+        // cash-or-nothing amount, the most conservative of the three.
+        _ => {
+            if is_in_the_money {
+                1.0
             } else {
                 0.0
             }
@@ -351,7 +376,7 @@ mod tests_payoff {
     fn test_barrier_up_and_in_call() {
         let option = OptionType::Barrier {
             barrier_type: BarrierType::UpAndIn,
-            barrier_level: 120.0,
+            barrier_level: pos_or_panic!(120.0),
             rebate: None,
         };
         let info = PayoffInfo {
@@ -396,7 +421,9 @@ mod tests_payoff {
 
     #[test]
     fn test_quanto_call() {
-        let option = OptionType::Quanto { exchange_rate: 1.5 };
+        let option = OptionType::Quanto {
+            exchange_rate: pos_or_panic!(1.5),
+        };
         let info = PayoffInfo {
             spot: pos_or_panic!(110.0),
             strike: Positive::HUNDRED,
@@ -409,7 +436,9 @@ mod tests_payoff {
 
     #[test]
     fn test_power_call() {
-        let option = OptionType::Power { exponent: 2.0 };
+        let option = OptionType::Power {
+            exponent: pos_or_panic!(2.0),
+        };
         let info = PayoffInfo {
             spot: pos_or_panic!(10.0),
             strike: pos_or_panic!(90.0),
@@ -554,7 +583,7 @@ mod tests_option_type {
     fn test_barrier_down_and_out_put() {
         let option = OptionType::Barrier {
             barrier_type: BarrierType::DownAndOut,
-            barrier_level: 90.0,
+            barrier_level: pos_or_panic!(90.0),
             rebate: None,
         };
         let info = PayoffInfo {
@@ -600,7 +629,9 @@ mod tests_option_type {
 
     #[test]
     fn test_chooser_option() {
-        let option = OptionType::Chooser { choice_date: 30.0 };
+        let option = OptionType::Chooser {
+            choice_date: pos_or_panic!(30.0),
+        };
         let info = PayoffInfo {
             spot: pos_or_panic!(110.0),
             strike: Positive::HUNDRED,
@@ -613,7 +644,9 @@ mod tests_option_type {
 
     #[test]
     fn test_power_put() {
-        let option = OptionType::Power { exponent: 2.0 };
+        let option = OptionType::Power {
+            exponent: pos_or_panic!(2.0),
+        };
         let info = PayoffInfo {
             spot: pos_or_panic!(8.0),
             strike: Positive::HUNDRED,
@@ -747,7 +780,7 @@ mod test_barrier_options {
     fn test_barrier_down_and_in_put() {
         let option = OptionType::Barrier {
             barrier_type: BarrierType::DownAndIn,
-            barrier_level: 110.0,
+            barrier_level: pos_or_panic!(110.0),
             rebate: None,
         };
         let info = PayoffInfo {
@@ -765,7 +798,7 @@ mod test_barrier_options {
     fn test_barrier_up_and_out_call() {
         let option = OptionType::Barrier {
             barrier_type: BarrierType::UpAndOut,
-            barrier_level: 110.0,
+            barrier_level: pos_or_panic!(110.0),
             rebate: None,
         };
         let info = PayoffInfo {
@@ -790,7 +823,11 @@ mod test_cliquet_options {
     #[test]
     fn test_cliquet_option_with_resets() {
         let option = OptionType::Cliquet {
-            reset_dates: vec![30.0, 60.0, 90.0],
+            reset_dates: vec![
+                pos_or_panic!(30.0),
+                pos_or_panic!(60.0),
+                pos_or_panic!(90.0),
+            ],
         };
         let info = PayoffInfo {
             spot: pos_or_panic!(120.0),
@@ -855,7 +892,9 @@ mod test_exchange_options {
 
     #[test]
     fn test_exchange_option_positive_diff() {
-        let option = OptionType::Exchange { second_asset: 90.0 };
+        let option = OptionType::Exchange {
+            second_asset: pos_or_panic!(90.0),
+        };
         let info = PayoffInfo {
             spot: pos_or_panic!(120.0),
             strike: Positive::HUNDRED,
@@ -870,7 +909,7 @@ mod test_exchange_options {
     #[test]
     fn test_exchange_option_negative_diff() {
         let option = OptionType::Exchange {
-            second_asset: 110.0,
+            second_asset: pos_or_panic!(110.0),
         };
         let info = PayoffInfo {
             spot: pos_or_panic!(110.0),

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -24,6 +24,19 @@ fn pos_lit(value: Decimal) -> Positive {
     Positive::new_decimal(value).unwrap_or(Positive::ZERO)
 }
 
+/// Subtracts `rhs` from `lhs`, flooring the result at zero.
+///
+/// `Positive::sub_or_zero` is deprecated in positive 0.6 because saturating
+/// arithmetic hides underflow. Every call site in this crate genuinely wants
+/// the floor — a quoted price or a strike offset never goes negative — so the
+/// decision is made once, here, on top of the checked `sub_or_none`: `None`
+/// (the difference would be negative) becomes zero, and no saturating
+/// arithmetic is used on the `Decimal` itself.
+#[inline]
+pub(crate) fn sub_floor_zero(lhs: Positive, rhs: &Decimal) -> Positive {
+    lhs.sub_or_none(rhs).unwrap_or(Positive::ZERO)
+}
+
 /// Converts a vector of `Positive` values to a vector of `f64` values.
 ///
 /// This utility function transforms a collection of `Positive` type values

--- a/src/pnl/metrics.rs
+++ b/src/pnl/metrics.rs
@@ -1005,9 +1005,9 @@ mod tests_pnl_metrics_serialization {
         let serialized = serde_json::to_string(&document).expect("Failed to serialize");
 
         // Verify it contains expected fields
-        assert!(serialized.contains("\"days\":30"));
+        assert!(serialized.contains("\"days\":\"30\""));
         assert!(serialized.contains("\"symbol\":\"AAPL\""));
-        assert!(serialized.contains("\"fee\":0.65"));
+        assert!(serialized.contains("\"fee\":\"0.65\""));
         assert!(serialized.contains("\"delta\":\"0.5\""));
         assert!(serialized.contains("\"delta_adjustment_at\":\"0.1\""));
         assert!(serialized.contains("\"step_number\":1"));
@@ -1056,8 +1056,8 @@ mod tests_pnl_metrics_serialization {
         // Verify it contains expected fields
         assert!(serialized.contains("\"realized\":\"123.45\""));
         assert!(serialized.contains("\"unrealized\":\"-67.89\""));
-        assert!(serialized.contains("\"initial_costs\":500"));
-        assert!(serialized.contains("\"initial_income\":250"));
+        assert!(serialized.contains("\"initial_costs\":\"500\""));
+        assert!(serialized.contains("\"initial_income\":\"250\""));
         assert!(serialized.contains("\"2023-03-15T14:30:00Z\""));
 
         // Deserialize back to struct
@@ -1150,9 +1150,9 @@ mod tests_pnl_metrics_serialization {
         let serialized = serde_json::to_string(&documents).expect("Failed to serialize");
 
         // Verify it contains data from all documents
-        assert!(serialized.contains("\"days\":30"));
-        assert!(serialized.contains("\"days\":60"));
-        assert!(serialized.contains("\"days\":90"));
+        assert!(serialized.contains("\"days\":\"30\""));
+        assert!(serialized.contains("\"days\":\"60\""));
+        assert!(serialized.contains("\"days\":\"90\""));
         assert!(serialized.contains("\"SYMBOL1\""));
         assert!(serialized.contains("\"SYMBOL2\""));
         assert!(serialized.contains("\"SYMBOL3\""));

--- a/src/pricing/asian.rs
+++ b/src/pricing/asian.rs
@@ -51,6 +51,10 @@ pub fn asian_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
         OptionType::Asian { averaging_type } => match averaging_type {
             AsianAveragingType::Geometric => geometric_asian_price(option),
             AsianAveragingType::Arithmetic => arithmetic_asian_price(option),
+            // `AsianAveragingType` is `#[non_exhaustive]`.
+            _ => Err(PricingError::other(
+                "asian_black_scholes: unsupported AsianAveragingType",
+            )),
         },
         _ => Err(PricingError::other(
             "asian_black_scholes requires OptionType::Asian",

--- a/src/pricing/barrier.rs
+++ b/src/pricing/barrier.rs
@@ -7,8 +7,9 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
-use crate::model::decimal::{d_add, d_sub, finite_decimal};
+use crate::model::decimal::{d_add, d_sub};
 use crate::model::types::{BarrierType, OptionStyle, OptionType};
+use positive::Positive;
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 
@@ -29,12 +30,10 @@ pub fn barrier_black_scholes(option: &Options) -> Result<Decimal, PricingError> 
             barrier_level,
             rebate,
         } => {
-            let bl = finite_decimal(*barrier_level).ok_or_else(|| {
-                PricingError::non_finite("pricing::barrier::barrier_level", *barrier_level)
-            })?;
-            let rebate_f = rebate.unwrap_or(0.0);
-            let rb = finite_decimal(rebate_f)
-                .ok_or_else(|| PricingError::non_finite("pricing::barrier::rebate", rebate_f))?;
+            // `barrier_level` and `rebate` are `Positive`, i.e. `Decimal`-backed
+            // and always finite, so no non-finite check is needed.
+            let bl = barrier_level.to_dec();
+            let rb = rebate.unwrap_or(Positive::ZERO).to_dec();
             (barrier_type, bl, rb)
         }
         _ => {
@@ -92,6 +91,9 @@ pub fn barrier_black_scholes(option: &Options) -> Result<Decimal, PricingError> 
     let _eta = match barrier_type {
         BarrierType::DownAndIn | BarrierType::DownAndOut => dec!(1.0),
         BarrierType::UpAndIn | BarrierType::UpAndOut => dec!(-1.0),
+        // `BarrierType` is `#[non_exhaustive]`; unreachable here because the
+        // match on `(style, barrier_type)` below rejects unknown variants.
+        _ => dec!(1.0),
     };
 
     let f_a = |phi_val: Decimal, x_val: Decimal| -> Result<Decimal, PricingError> {
@@ -233,6 +235,11 @@ pub fn barrier_black_scholes(option: &Options) -> Result<Decimal, PricingError> 
                 Ok(d_add(s1, f_f(dec!(-1.0))?, OP)?)
             }
         }
+        // `BarrierType` is `#[non_exhaustive]`: a barrier added upstream has no
+        // closed form here until it gets its own arm.
+        (_, _) => Err(PricingError::other(
+            "barrier_black_scholes: unsupported BarrierType",
+        )),
     }
 }
 
@@ -248,7 +255,7 @@ mod tests {
         Options {
             option_type: OptionType::Barrier {
                 barrier_type,
-                barrier_level: level,
+                barrier_level: pos_or_panic!(level),
                 rebate: None,
             },
             side: Side::Long,
@@ -393,29 +400,5 @@ mod tests {
         );
         // Barrier Greeks can be negative and have higher magnitudes than vanilla
         tracing::debug!(delta = %delta, gamma = %gamma, vega = %vega, rho = %rho, "Barrier Greeks");
-    }
-
-    #[test]
-    fn barrier_level_nan_surfaces_non_finite() {
-        let option = create_test_option(OptionStyle::Call, BarrierType::DownAndOut, f64::NAN);
-        match barrier_black_scholes(&option) {
-            Err(PricingError::NonFinite { context, value }) => {
-                assert_eq!(context, "pricing::barrier::barrier_level");
-                assert!(value.is_nan());
-            }
-            other => panic!("expected NonFinite barrier_level, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn barrier_level_infinity_surfaces_non_finite() {
-        let option = create_test_option(OptionStyle::Call, BarrierType::UpAndIn, f64::INFINITY);
-        match barrier_black_scholes(&option) {
-            Err(PricingError::NonFinite { context, value }) => {
-                assert_eq!(context, "pricing::barrier::barrier_level");
-                assert!(value.is_infinite());
-            }
-            other => panic!("expected NonFinite barrier_level, got {other:?}"),
-        }
     }
 }

--- a/src/pricing/binary.rs
+++ b/src/pricing/binary.rs
@@ -64,6 +64,10 @@ pub fn binary_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
             BinaryType::CashOrNothing => cash_or_nothing_price(option, DEFAULT_CASH_PAYOUT),
             BinaryType::AssetOrNothing => asset_or_nothing_price(option),
             BinaryType::Gap => gap_binary_price(option),
+            // `BinaryType` is `#[non_exhaustive]`.
+            _ => Err(PricingError::other(
+                "binary_black_scholes: unsupported BinaryType",
+            )),
         },
         _ => Err(PricingError::other(
             "binary_black_scholes requires OptionType::Binary",

--- a/src/pricing/binomial_model.rs
+++ b/src/pricing/binomial_model.rs
@@ -162,10 +162,9 @@ pub fn price_binomial(params: BinomialPricingParams) -> Result<Decimal, PricingE
                     // Calculate time at this step
                     let time_at_step = dt * Decimal::from(step as u32);
                     // Check if this step is an exercise date
-                    let is_exercise_date = exercise_dates.iter().any(|&t| {
-                        let t_dec = Decimal::try_from(t).unwrap_or(Decimal::ZERO);
-                        (time_at_step - t_dec).abs() < dt / Decimal::TWO
-                    });
+                    let is_exercise_date = exercise_dates
+                        .iter()
+                        .any(|t| (time_at_step - t.to_dec()).abs() < dt / Decimal::TWO);
                     if is_exercise_date {
                         let spot = params.asset * u.powi(i as i64) * d.powi((step - i) as i64);
                         info.spot = spot;
@@ -309,10 +308,9 @@ pub fn generate_binomial_tree(params: &BinomialPricingParams) -> BinomialTreeRes
                     // Calculate time at this step
                     let time_at_step = dt * Decimal::from(step as u32);
                     // Check if this step is an exercise date
-                    let is_exercise_date = exercise_dates.iter().any(|&t| {
-                        let t_dec = Decimal::try_from(t).unwrap_or(Decimal::ZERO);
-                        (time_at_step - t_dec).abs() < dt / Decimal::TWO
-                    });
+                    let is_exercise_date = exercise_dates
+                        .iter()
+                        .any(|t| (time_at_step - t.to_dec()).abs() < dt / Decimal::TWO);
                     if is_exercise_date && !((step == 0) & (node_idx == 0)) {
                         info.spot = Positive::new_decimal(asset_tree[step][node_idx])?;
                         let intrinsic_value = params.option_type.payoff(&info);
@@ -755,7 +753,7 @@ mod tests_bermuda_option {
 
         // Exercise at 3 months, 6 months, 9 months
         let bermuda_type = OptionType::Bermuda {
-            exercise_dates: vec![0.25, 0.5, 0.75],
+            exercise_dates: vec![pos_or_panic!(0.25), pos_or_panic!(0.5), pos_or_panic!(0.75)],
         };
         let bermuda_params = BinomialPricingParams {
             option_type: &bermuda_type,
@@ -784,7 +782,7 @@ mod tests_bermuda_option {
     fn test_bermuda_single_exercise_date() {
         // Single exercise date should give price between European and American
         let bermuda_type = OptionType::Bermuda {
-            exercise_dates: vec![0.5],
+            exercise_dates: vec![pos_or_panic!(0.5)],
         };
         let params = BinomialPricingParams {
             asset: Positive::HUNDRED,
@@ -826,7 +824,9 @@ mod tests_bermuda_option {
         };
 
         // Weekly exercise dates (52 dates for 1 year)
-        let exercise_dates: Vec<f64> = (1..=52).map(|i| i as f64 / 52.0).collect();
+        let exercise_dates: Vec<Positive> = (1..=52)
+            .map(|i| pos_or_panic!(f64::from(i) / 52.0))
+            .collect();
         let bermuda_type = OptionType::Bermuda { exercise_dates };
         let bermuda_params = BinomialPricingParams {
             option_type: &bermuda_type,
@@ -877,7 +877,7 @@ mod tests_bermuda_option {
     #[test]
     fn test_bermuda_call_option() {
         let bermuda_type = OptionType::Bermuda {
-            exercise_dates: vec![0.25, 0.5, 0.75],
+            exercise_dates: vec![pos_or_panic!(0.25), pos_or_panic!(0.5), pos_or_panic!(0.75)],
         };
         let params = BinomialPricingParams {
             asset: Positive::HUNDRED,

--- a/src/pricing/black_scholes_model.rs
+++ b/src/pricing/black_scholes_model.rs
@@ -95,6 +95,12 @@ pub fn black_scholes(option: &Options) -> Result<Decimal, PricingError> {
         OptionType::Quanto { .. } => crate::pricing::quanto::quanto_black_scholes(option),
         OptionType::Exchange { .. } => crate::pricing::exchange::exchange_black_scholes(option),
         OptionType::Power { .. } => crate::pricing::power::power_black_scholes(option),
+        // `OptionType` is `#[non_exhaustive]`: a variant added upstream has no
+        // closed form here until it gets its own kernel.
+        _ => Err(PricingError::unsupported_option_type(
+            "unknown",
+            "Black-Scholes",
+        )),
     }
 }
 

--- a/src/pricing/chooser.rs
+++ b/src/pricing/chooser.rs
@@ -51,7 +51,7 @@ use rust_decimal_macros::dec;
 /// chooser date (call and put side).
 pub fn chooser_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
-        OptionType::Chooser { choice_date } => simple_chooser_price(option, *choice_date),
+        OptionType::Chooser { choice_date } => simple_chooser_price(option, choice_date.to_f64()),
         _ => Err(PricingError::other(
             "chooser_black_scholes requires OptionType::Chooser",
         )),
@@ -274,7 +274,7 @@ mod tests {
     fn create_chooser_option(choice_date_days: f64) -> Options {
         Options::new(
             OptionType::Chooser {
-                choice_date: choice_date_days,
+                choice_date: pos_or_panic!(choice_date_days),
             },
             Side::Long,
             "TEST".to_string(),

--- a/src/pricing/cliquet.rs
+++ b/src/pricing/cliquet.rs
@@ -33,6 +33,7 @@ use crate::greeks::big_n;
 use crate::model::decimal::{d_add, d_mul, d_sub, finite_decimal};
 use crate::model::types::OptionType;
 use num_traits::Inv;
+use positive::Positive;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
@@ -55,7 +56,10 @@ use rust_decimal_macros::dec;
 /// the per-reset forward components.
 pub fn cliquet_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
-        OptionType::Cliquet { reset_dates } => price_cliquet(option, reset_dates),
+        OptionType::Cliquet { reset_dates } => {
+            let resets: Vec<f64> = reset_dates.iter().map(Positive::to_f64).collect();
+            price_cliquet(option, &resets)
+        }
         _ => Err(PricingError::other(
             "cliquet_black_scholes requires OptionType::Cliquet",
         )),
@@ -268,7 +272,7 @@ mod tests {
     fn create_cliquet_option() -> Options {
         Options::new(
             OptionType::Cliquet {
-                reset_dates: vec![90.0, 180.0],
+                reset_dates: vec![pos_or_panic!(90.0), pos_or_panic!(180.0)],
             },
             Side::Long,
             "TEST".to_string(),

--- a/src/pricing/exchange.rs
+++ b/src/pricing/exchange.rs
@@ -49,8 +49,7 @@ use rust_decimal_macros::dec;
 /// - Correlation is outside the valid range [-1, 1]
 pub fn exchange_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let second_asset_price = match &option.option_type {
-        OptionType::Exchange { second_asset } => Decimal::from_f64(*second_asset)
-            .ok_or_else(|| PricingError::other("Failed to convert second_asset to Decimal"))?,
+        OptionType::Exchange { second_asset } => second_asset.to_dec(),
         _ => {
             return Err(PricingError::other(
                 "exchange_black_scholes requires OptionType::Exchange",
@@ -172,7 +171,7 @@ mod tests {
     fn create_exchange_option() -> Options {
         Options::new(
             OptionType::Exchange {
-                second_asset: 100.0,
+                second_asset: pos_or_panic!(100.0),
             },
             Side::Long,
             "TEST".to_string(),
@@ -225,7 +224,7 @@ mod tests {
         let mut option = create_exchange_option();
         option.underlying_price = pos_or_panic!(100.0);
         option.option_type = OptionType::Exchange {
-            second_asset: 100.0,
+            second_asset: pos_or_panic!(100.0),
         };
 
         let price = exchange_black_scholes(&option).unwrap();
@@ -271,7 +270,7 @@ mod tests {
     fn test_exchange_missing_params() {
         let option = Options::new(
             OptionType::Exchange {
-                second_asset: 100.0,
+                second_asset: pos_or_panic!(100.0),
             },
             Side::Long,
             "TEST".to_string(),
@@ -307,7 +306,7 @@ mod tests {
         let mut option = create_exchange_option();
         option.underlying_price = pos_or_panic!(150.0);
         option.option_type = OptionType::Exchange {
-            second_asset: 100.0,
+            second_asset: pos_or_panic!(100.0),
         };
 
         let price = exchange_black_scholes(&option).unwrap();
@@ -324,7 +323,7 @@ mod tests {
         let mut option = create_exchange_option();
         option.underlying_price = pos_or_panic!(50.0);
         option.option_type = OptionType::Exchange {
-            second_asset: 100.0,
+            second_asset: pos_or_panic!(100.0),
         };
 
         let price = exchange_black_scholes(&option).unwrap();

--- a/src/pricing/lookback.rs
+++ b/src/pricing/lookback.rs
@@ -55,6 +55,10 @@ pub fn lookback_black_scholes(option: &Options) -> Result<Decimal, PricingError>
         OptionType::Lookback { lookback_type } => match lookback_type {
             LookbackType::FloatingStrike => floating_strike_lookback(option),
             LookbackType::FixedStrike => fixed_strike_lookback(option),
+            // `LookbackType` is `#[non_exhaustive]`.
+            _ => Err(PricingError::other(
+                "lookback_black_scholes: unsupported LookbackType",
+            )),
         },
         _ => Err(PricingError::other(
             "lookback_black_scholes requires OptionType::Lookback",

--- a/src/pricing/power.rs
+++ b/src/pricing/power.rs
@@ -23,6 +23,7 @@ use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
 use crate::model::types::{OptionStyle, OptionType, Side};
+use positive::Positive;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
@@ -52,14 +53,13 @@ pub fn power_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
         }
     };
 
-    if exponent <= 0.0 {
+    if exponent <= Positive::ZERO {
         return Err(PricingError::other(
             "Power option exponent must be greater than 0",
         ));
     }
 
-    let n = Decimal::from_f64(exponent)
-        .ok_or_else(|| PricingError::other("Failed to convert exponent to Decimal"))?;
+    let n = exponent.to_dec();
 
     let s = Decimal::from(option.underlying_price);
     let k = Decimal::from(option.strike_price);
@@ -182,7 +182,9 @@ mod tests {
 
     fn create_power_option(exponent: f64, option_style: OptionStyle) -> Options {
         Options::new(
-            OptionType::Power { exponent },
+            OptionType::Power {
+                exponent: pos_or_panic!(exponent),
+            },
             Side::Long,
             "TEST".to_string(),
             pos_or_panic!(100.0),
@@ -249,13 +251,6 @@ mod tests {
         let option = create_power_option(0.0, OptionStyle::Call);
         let result = power_black_scholes(&option);
         assert!(result.is_err(), "Should reject exponent = 0");
-    }
-
-    #[test]
-    fn test_power_invalid_exponent_negative() {
-        let option = create_power_option(-1.0, OptionStyle::Call);
-        let result = power_black_scholes(&option);
-        assert!(result.is_err(), "Should reject negative exponent");
     }
 
     #[test]

--- a/src/pricing/quanto.rs
+++ b/src/pricing/quanto.rs
@@ -50,8 +50,7 @@ use rust_decimal_macros::dec;
 /// - Correlation is outside the valid range [-1, 1]
 pub fn quanto_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let exchange_rate = match &option.option_type {
-        OptionType::Quanto { exchange_rate } => Decimal::from_f64(*exchange_rate)
-            .ok_or_else(|| PricingError::other("Failed to convert exchange_rate to Decimal"))?,
+        OptionType::Quanto { exchange_rate } => exchange_rate.to_dec(),
         _ => {
             return Err(PricingError::other(
                 "quanto_black_scholes requires OptionType::Quanto",
@@ -174,7 +173,7 @@ mod tests {
     fn create_quanto_option(option_style: OptionStyle) -> Options {
         Options::new(
             OptionType::Quanto {
-                exchange_rate: 1.25,
+                exchange_rate: pos_or_panic!(1.25),
             },
             Side::Long,
             "TEST".to_string(),
@@ -304,7 +303,7 @@ mod tests {
     fn test_quanto_missing_params() {
         let option = Options::new(
             OptionType::Quanto {
-                exchange_rate: 1.25,
+                exchange_rate: pos_or_panic!(1.25),
             },
             Side::Long,
             "TEST".to_string(),
@@ -338,10 +337,14 @@ mod tests {
     #[test]
     fn test_quanto_exchange_rate_scaling() {
         let mut option1 = create_quanto_option(OptionStyle::Call);
-        option1.option_type = OptionType::Quanto { exchange_rate: 1.0 };
+        option1.option_type = OptionType::Quanto {
+            exchange_rate: pos_or_panic!(1.0),
+        };
 
         let mut option2 = create_quanto_option(OptionStyle::Call);
-        option2.option_type = OptionType::Quanto { exchange_rate: 2.0 };
+        option2.option_type = OptionType::Quanto {
+            exchange_rate: pos_or_panic!(2.0),
+        };
 
         let price1 = quanto_black_scholes(&option1).unwrap();
         let price2 = quanto_black_scholes(&option2).unwrap();

--- a/src/pricing/rainbow.rs
+++ b/src/pricing/rainbow.rs
@@ -132,6 +132,12 @@ fn price_two_asset_rainbow(
             OptionStyle::Call => price_call_on_min(s1, s2, k, r, q1, q2, sigma1, sigma2, rho, t)?,
             OptionStyle::Put => price_put_on_min(s1, s2, k, r, q1, q2, sigma1, sigma2, rho, t)?,
         },
+        // `RainbowType` is `#[non_exhaustive]`.
+        _ => {
+            return Err(PricingError::other(
+                "rainbow_black_scholes: unsupported RainbowType",
+            ));
+        }
     };
 
     Ok(apply_side(price, option))

--- a/src/pricing/spread.rs
+++ b/src/pricing/spread.rs
@@ -45,8 +45,7 @@ use rust_decimal_macros::dec;
 /// - Correlation is outside the valid range [-1, 1]
 pub fn spread_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let second_asset_price = match &option.option_type {
-        OptionType::Spread { second_asset } => Decimal::from_f64(*second_asset)
-            .ok_or_else(|| PricingError::other("Failed to convert second_asset to Decimal"))?,
+        OptionType::Spread { second_asset } => second_asset.to_dec(),
         _ => {
             return Err(PricingError::other(
                 "spread_black_scholes requires OptionType::Spread",
@@ -259,7 +258,7 @@ mod tests {
     fn create_spread_option(strike: Positive, option_style: OptionStyle) -> Options {
         Options::new(
             OptionType::Spread {
-                second_asset: 100.0,
+                second_asset: pos_or_panic!(100.0),
             },
             Side::Long,
             "TEST".to_string(),
@@ -374,7 +373,7 @@ mod tests {
     fn test_spread_missing_params() {
         let option = Options::new(
             OptionType::Spread {
-                second_asset: 100.0,
+                second_asset: pos_or_panic!(100.0),
             },
             Side::Long,
             "TEST".to_string(),

--- a/src/series/model.rs
+++ b/src/series/model.rs
@@ -672,7 +672,7 @@ mod tests_option_series {
             assert!(displaying.contains("symbol"));
             assert!(displaying.contains("100"));
             assert!(displaying.contains("risk_free_rate\":\"0.05"));
-            assert!(displaying.contains("dividend_yield\":0.02"));
+            assert!(displaying.contains("dividend_yield\":\"0.02\""));
 
             let date = get_x_days_formatted_pos(Positive::ONE);
             let matches = date.to_string();
@@ -693,7 +693,7 @@ mod tests_option_series {
             let displaying = format!("{series}");
             // Verify the minimal display string
             assert!(displaying.contains("symbol\":\"SPY"));
-            assert!(displaying.contains("underlying_price\":450"));
+            assert!(displaying.contains("underlying_price\":\"450\""));
 
             // Should not include optional fields
             assert!(!displaying.contains("risk_free_rate"));
@@ -735,7 +735,7 @@ mod tests_option_series {
 
             // Verify serialized structure
             assert!(serialized.contains("\"symbol\":\"TEST\""));
-            assert!(serialized.contains("\"underlying_price\":100"));
+            assert!(serialized.contains("\"underlying_price\":\"100\""));
             assert!(serialized.contains("\"chains\":{}"));
 
             // Deserialize
@@ -764,7 +764,7 @@ mod tests_option_series {
             // Verify serialized structure contains expected fields
             let serialized_string = serialized.unwrap();
             assert!(serialized_string.contains("\"symbol\":\"TEST\""));
-            assert!(serialized_string.contains("\"underlying_price\":100"));
+            assert!(serialized_string.contains("\"underlying_price\":\"100\""));
             assert!(serialized_string.contains("\"chains\":{}"));
 
             // Deserialize

--- a/src/series/params.rs
+++ b/src/series/params.rs
@@ -126,7 +126,7 @@ mod tests {
             chain_params,
             series: vec![],
         };
-        let result = r#"{"chain_params":{"symbol":"AAPL","volume":1000,"chain_size":10,"strike_interval":5,"skew_slope":"-0.2","smile_curve":"0.1","spread":0.02,"decimal_places":2,"price_params":{"underlying_price":100,"expiration_date":{"days":30.0},"risk_free_rate":"0.05","dividend_yield":0.02,"underlying_symbol":"AAPL"},"implied_volatility":0.2},"series":[]}"#;
+        let result = r#"{"chain_params":{"symbol":"AAPL","volume":"1000","chain_size":10,"strike_interval":"5","skew_slope":"-0.2","smile_curve":"0.1","spread":"0.02","decimal_places":2,"price_params":{"underlying_price":"100","expiration_date":{"days":30.0},"risk_free_rate":"0.05","dividend_yield":"0.02","underlying_symbol":"AAPL"},"implied_volatility":"0.2"},"series":[]}"#;
         assert_eq!(params.to_string(), result);
     }
 
@@ -160,23 +160,23 @@ mod tests {
         let result = r#"{
   "chain_params": {
     "symbol": "AAPL",
-    "volume": 1000,
+    "volume": "1000",
     "chain_size": 10,
-    "strike_interval": 5,
+    "strike_interval": "5",
     "skew_slope": "-0.2",
     "smile_curve": "0.1",
-    "spread": 0.02,
+    "spread": "0.02",
     "decimal_places": 2,
     "price_params": {
-      "underlying_price": 100,
+      "underlying_price": "100",
       "expiration_date": {
         "days": 30.0
       },
       "risk_free_rate": "0.05",
-      "dividend_yield": 0.02,
+      "dividend_yield": "0.02",
       "underlying_symbol": "AAPL"
     },
-    "implied_volatility": 0.2
+    "implied_volatility": "0.2"
   },
   "series": []
 }"#;

--- a/src/simulation/steps/step.rs
+++ b/src/simulation/steps/step.rs
@@ -1007,12 +1007,12 @@ mod tests_step_serialization {
         // Verify x fields
         let x = &json_value["x"];
         assert_eq!(x["index"], 0);
-        assert_eq!(x["step_size_in_time"], 1.5);
+        assert_eq!(x["step_size_in_time"], "1.5");
 
         // Verify y fields
         let y = &json_value["y"];
         assert_eq!(y["index"], 0);
-        assert_eq!(y["value"], 100.0);
+        assert_eq!(y["value"], "100");
     }
 
     #[test]
@@ -1044,7 +1044,7 @@ mod tests_step_serialization {
         let serialized = serde_json::to_string(&step).unwrap();
         assert_eq!(
             serialized,
-            r#"{"x":{"index":0,"step_size_in_time":5,"time_unit":"Day","datetime":{"days":30.0}},"y":{"index":0,"value":42.5}}"#
+            r#"{"x":{"index":0,"step_size_in_time":"5","time_unit":"Day","datetime":{"days":30.0}},"y":{"index":0,"value":"42.5"}}"#
         );
     }
 
@@ -1062,7 +1062,7 @@ mod tests_step_serialization {
 
         // Make sure the content is still correct by deserializing
         let deserialized: Value = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized["x"]["step_size_in_time"], 1.5);
-        assert_eq!(deserialized["y"]["value"], 100.0);
+        assert_eq!(deserialized["x"]["step_size_in_time"], "1.5");
+        assert_eq!(deserialized["y"]["value"], "100");
     }
 }

--- a/src/simulation/steps/x.rs
+++ b/src/simulation/steps/x.rs
@@ -367,7 +367,7 @@ mod tests_serialize {
         // Check all fields exist and have correct types
         assert!(parsed.is_object());
         assert!(parsed.get("index").unwrap().is_i64());
-        assert!(parsed.get("step_size_in_time").unwrap().is_number());
+        assert!(parsed.get("step_size_in_time").unwrap().is_string());
         assert!(
             parsed.get("time_unit").unwrap().is_object()
                 || parsed.get("time_unit").unwrap().is_string()
@@ -376,7 +376,7 @@ mod tests_serialize {
 
         // Check field values
         assert_eq!(parsed["index"], json!(42));
-        assert_eq!(parsed["step_size_in_time"], json!(1.5));
+        assert_eq!(parsed["step_size_in_time"], json!("1.5"));
     }
 
     #[test]
@@ -405,9 +405,9 @@ mod tests_serialize {
         let parsed_positive: Value = serde_json::from_str(&json_positive).unwrap();
 
         // All should serialize to the same value
-        assert_eq!(parsed_f64["step_size_in_time"], json!(2.5));
-        assert_eq!(parsed_decimal["step_size_in_time"], json!(2.5));
-        assert_eq!(parsed_positive["step_size_in_time"], json!(2.5));
+        assert_eq!(parsed_f64["step_size_in_time"], json!("2.5"));
+        assert_eq!(parsed_decimal["step_size_in_time"], json!("2.5"));
+        assert_eq!(parsed_positive["step_size_in_time"], json!("2.5"));
     }
 
     #[test]
@@ -445,7 +445,7 @@ mod tests_serialize {
         );
         let json_zero = serde_json::to_string(&step_zero).unwrap();
         let parsed_zero: Value = serde_json::from_str(&json_zero).unwrap();
-        assert_eq!(parsed_zero["step_size_in_time"], json!(0.01));
+        assert_eq!(parsed_zero["step_size_in_time"], json!("0.01"));
 
         // Test with very small number
         let step_small = Xstep::new(
@@ -455,8 +455,22 @@ mod tests_serialize {
         );
         let json_small = serde_json::to_string(&step_small).unwrap();
         let parsed_small: Value = serde_json::from_str(&json_small).unwrap();
-        assert!(parsed_small["step_size_in_time"].as_f64().unwrap() > 0.0);
-        assert!(parsed_small["step_size_in_time"].as_f64().unwrap() < 0.0001);
+        assert!(
+            parsed_small["step_size_in_time"]
+                .as_str()
+                .unwrap()
+                .parse::<f64>()
+                .unwrap()
+                > 0.0
+        );
+        assert!(
+            parsed_small["step_size_in_time"]
+                .as_str()
+                .unwrap()
+                .parse::<f64>()
+                .unwrap()
+                < 0.0001
+        );
 
         // Test with very large number
         let step_large = Xstep::new(
@@ -466,7 +480,7 @@ mod tests_serialize {
         );
         let json_large = serde_json::to_string(&step_large).unwrap();
         let parsed_large: Value = serde_json::from_str(&json_large).unwrap();
-        assert_eq!(parsed_large["step_size_in_time"], json!(1_000_000.01));
+        assert_eq!(parsed_large["step_size_in_time"], json!("1000000.01"));
     }
 
     #[test]
@@ -483,7 +497,11 @@ mod tests_serialize {
         let parsed: Value = serde_json::from_str(&serialized).unwrap();
 
         // Check precision is maintained (to reasonable float precision)
-        let value = parsed["step_size_in_time"].as_f64().unwrap();
+        let value = parsed["step_size_in_time"]
+            .as_str()
+            .unwrap()
+            .parse::<f64>()
+            .unwrap();
         assert!((value - 1.23456789).abs() < 0.0000001);
     }
 

--- a/src/simulation/steps/y.rs
+++ b/src/simulation/steps/y.rs
@@ -230,7 +230,7 @@ mod tests_serialize {
         let parsed: Value = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(parsed["index"], 5);
-        assert_eq!(parsed["value"], 10.5);
+        assert_eq!(parsed["value"], "10.5");
     }
 
     #[test]
@@ -243,11 +243,11 @@ mod tests_serialize {
         assert!(parsed.is_object());
         assert_eq!(parsed.as_object().unwrap().len(), 2);
         assert!(parsed.get("index").unwrap().is_i64());
-        assert!(parsed.get("value").unwrap().is_number());
+        assert!(parsed.get("value").unwrap().is_string());
 
         // Check values
         assert_eq!(parsed["index"], json!(42));
-        assert_eq!(parsed["value"], json!(15.75));
+        assert_eq!(parsed["value"], json!("15.75"));
     }
 
     #[test]
@@ -268,9 +268,9 @@ mod tests_serialize {
         let parsed_positive: Value = serde_json::from_str(&json_positive).unwrap();
 
         // All should have the same value representation
-        assert_eq!(parsed_f64["value"], json!(2.5));
-        assert_eq!(parsed_decimal["value"], json!(2.5));
-        assert_eq!(parsed_positive["value"], json!(2.5));
+        assert_eq!(parsed_f64["value"], json!("2.5"));
+        assert_eq!(parsed_decimal["value"], json!("2.5"));
+        assert_eq!(parsed_positive["value"], json!("2.5"));
     }
 
     #[test]
@@ -296,20 +296,34 @@ mod tests_serialize {
         let step_zero = Ystep::new(0, 0.1f64);
         let json_zero = serde_json::to_string(&step_zero).unwrap();
         let parsed_zero: Value = serde_json::from_str(&json_zero).unwrap();
-        assert_eq!(parsed_zero["value"], json!(0.1));
+        assert_eq!(parsed_zero["value"], json!("0.1"));
 
         // Test with very small value
         let step_small = Ystep::new(1, 0.000001f64);
         let json_small = serde_json::to_string(&step_small).unwrap();
         let parsed_small: Value = serde_json::from_str(&json_small).unwrap();
-        assert!(parsed_small["value"].as_f64().unwrap() > 0.0);
-        assert!(parsed_small["value"].as_f64().unwrap() < 0.0001);
+        assert!(
+            parsed_small["value"]
+                .as_str()
+                .unwrap()
+                .parse::<f64>()
+                .unwrap()
+                > 0.0
+        );
+        assert!(
+            parsed_small["value"]
+                .as_str()
+                .unwrap()
+                .parse::<f64>()
+                .unwrap()
+                < 0.0001
+        );
 
         // Test with large value
         let step_large = Ystep::new(2, 1_000_000.01f64);
         let json_large = serde_json::to_string(&step_large).unwrap();
         let parsed_large: Value = serde_json::from_str(&json_large).unwrap();
-        assert_eq!(parsed_large["value"], json!(1_000_000.01));
+        assert_eq!(parsed_large["value"], json!("1000000.01"));
     }
 
     #[test]
@@ -319,7 +333,7 @@ mod tests_serialize {
         let parsed: Value = serde_json::from_str(&serialized).unwrap();
 
         // Check precision is maintained (to reasonable float precision)
-        let value = parsed["value"].as_f64().unwrap();
+        let value = parsed["value"].as_str().unwrap().parse::<f64>().unwrap();
         assert!((value - 1.23456789).abs() < 0.0000001);
     }
 
@@ -333,7 +347,7 @@ mod tests_serialize {
 
         // Check next step has incremented index
         assert_eq!(parsed["index"], 2);
-        assert_eq!(parsed["value"], 10.0);
+        assert_eq!(parsed["value"], "10");
     }
 
     #[test]
@@ -348,6 +362,6 @@ mod tests_serialize {
         // Ensure it can be parsed back
         let parsed: Value = serde_json::from_str(&serialized).unwrap();
         assert_eq!(parsed["index"], 7);
-        assert_eq!(parsed["value"], 15.25);
+        assert_eq!(parsed["value"], "15.25");
     }
 }

--- a/src/simulation/walk_driver.rs
+++ b/src/simulation/walk_driver.rs
@@ -48,10 +48,7 @@ where
         WalkType::Historical {
             timeframe, prices, ..
         } => {
-            let log_returns: Vec<Decimal> = calculate_log_returns(prices)?
-                .iter()
-                .map(|p| p.to_dec())
-                .collect();
+            let log_returns: Vec<Decimal> = calculate_log_returns(prices)?;
             let constant_volatility = constant_volatility(&log_returns)?;
             let implied_volatility =
                 adjust_volatility(constant_volatility, *timeframe, TimeFrame::Year)?;
@@ -86,10 +83,7 @@ fn expanding_window_vols(
         // Fewer than two returns anywhere: no sample variance is computable.
         return Ok(None);
     }
-    let log_returns: Vec<Decimal> = calculate_log_returns(prices)?
-        .iter()
-        .map(|p| p.to_dec())
-        .collect();
+    let log_returns: Vec<Decimal> = calculate_log_returns(prices)?;
 
     let overflow =
         |what: &str| SimulationError::walk_error(&format!("expanding-window {what} overflowed"));

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -1116,9 +1116,9 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
             ));
         }
 
-        let min = strikes.iter().fold(Positive::INFINITY, |acc, &strike| {
-            Positive::min(acc, *strike)
-        });
+        let min = strikes
+            .iter()
+            .fold(Positive::MAX, |acc, &strike| Positive::min(acc, *strike));
         let max = strikes
             .iter()
             .fold(Positive::ZERO, |acc, &strike| Positive::max(acc, *strike));
@@ -1143,7 +1143,7 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
     ///
     /// # Returns:
     /// * `Ok(Positive)` - The difference between the highest and lowest break-even points.  Returns
-    ///   `Positive::INFINITY` if there is only one break-even point.
+    ///   `Positive::MAX` if there is only one break-even point.
     /// * `Err(StrategyError)` - if there are no break-even points.
     ///
     /// # Errors
@@ -1157,7 +1157,7 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
             0 => Err(StrategyError::BreakEvenError(
                 BreakEvenErrorKind::NoBreakEvenPoints,
             )),
-            1 => Ok(Positive::INFINITY),
+            1 => Ok(Positive::MAX),
             2 => Ok(break_even_points[1] - break_even_points[0]),
             _ => {
                 // sort break even points and then get last minus first
@@ -2148,7 +2148,7 @@ mod tests_range_of_profit {
     #[test]
     fn test_single_break_even_point() {
         let strategy = TestStrategy::new(vec![Positive::HUNDRED]);
-        assert_eq!(strategy.get_range_of_profit().unwrap(), Positive::INFINITY);
+        assert_eq!(strategy.get_range_of_profit().unwrap(), Positive::MAX);
     }
 
     #[test]

--- a/src/strategies/build/model.rs
+++ b/src/strategies/build/model.rs
@@ -195,9 +195,9 @@ mod tests_serialization {
         assert!(serialized.contains("\"strategy_type\":\"BearCallSpread\""));
         assert!(serialized.contains("\"positions\":["));
         assert!(serialized.contains("\"underlying_symbol\":\"AAPL\""));
-        assert!(serialized.contains("\"premium\":4.5"));
-        assert!(serialized.contains("\"open_fee\":1"));
-        assert!(serialized.contains("\"close_fee\":1.2"));
+        assert!(serialized.contains("\"premium\":\"4.5\""));
+        assert!(serialized.contains("\"open_fee\":\"1\""));
+        assert!(serialized.contains("\"close_fee\":\"1.2\""));
     }
 
     #[test]
@@ -363,9 +363,9 @@ mod tests_strategies_build_model {
         assert!(serialized.contains("\"strategy_type\":\"BearCallSpread\""));
         assert!(serialized.contains("\"positions\":["));
         assert!(serialized.contains("\"underlying_symbol\":\"AAPL\""));
-        assert!(serialized.contains("\"premium\":4.5"));
-        assert!(serialized.contains("\"open_fee\":1"));
-        assert!(serialized.contains("\"close_fee\":1.2"));
+        assert!(serialized.contains("\"premium\":\"4.5\""));
+        assert!(serialized.contains("\"open_fee\":\"1\""));
+        assert!(serialized.contains("\"close_fee\":\"1.2\""));
     }
 
     #[test]

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -714,7 +714,7 @@ impl Strategies for CallButterfly {
     }
 
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
-        Ok(Positive::INFINITY)
+        Ok(Positive::MAX)
     }
 
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
@@ -742,7 +742,7 @@ impl Strategies for CallButterfly {
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
         let max_loss = match self.get_max_loss()? {
             value if value == Positive::ZERO => spos!(1.0),
-            value if value == Positive::INFINITY => spos!(1.0),
+            value if value == Positive::MAX => spos!(1.0),
             value => Some(value),
         };
 

--- a/src/strategies/long_call.rs
+++ b/src/strategies/long_call.rs
@@ -283,7 +283,7 @@ impl BreakEvenable for LongCall {
 
 impl Strategies for LongCall {
     fn get_max_profit(&self) -> Result<Positive, StrategyError> {
-        Ok(Positive::INFINITY) // Theoretically unlimited
+        Ok(Positive::MAX) // Theoretically unlimited
     }
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
         // Max loss for a long call is the premium paid (at any price ≤ strike).

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -611,7 +611,7 @@ impl BasicAble for LongStraddle {
 
 impl Strategies for LongStraddle {
     fn get_max_profit(&self) -> Result<Positive, StrategyError> {
-        Ok(Positive::INFINITY) // Theoretically unlimited
+        Ok(Positive::MAX) // Theoretically unlimited
     }
 
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -633,7 +633,7 @@ impl Strategies for LongStrangle {
         Ok(volume)
     }
     fn get_max_profit(&self) -> Result<Positive, StrategyError> {
-        Ok(Positive::INFINITY) // Theoretically unlimited
+        Ok(Positive::MAX) // Theoretically unlimited
     }
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
         Ok(self.get_total_cost()?)

--- a/src/strategies/probabilities/utils.rs
+++ b/src/strategies/probabilities/utils.rs
@@ -140,7 +140,16 @@ pub fn calculate_single_point_probability(
     let std_dev = volatility * time_to_expiry.sqrt();
 
     // Calculate z-score considering drift
-    let z_score: Decimal = f2du!((log_ratio.to_f64() - drift_rate * time_to_expiry) / std_dev)?;
+    // `Positive::ln` returns `Decimal` as of positive 0.6: the log of a
+    // positive number is not necessarily positive.
+    let log_ratio_f = log_ratio.to_f64().ok_or_else(|| {
+        ProbabilityError::CalculationError(ProbabilityCalculationErrorKind::ExpectedValueError {
+            reason: format!(
+                "calculate_single_point_probability: log ratio {log_ratio} not representable as f64"
+            ),
+        })
+    })?;
+    let z_score: Decimal = f2du!((log_ratio_f - drift_rate * time_to_expiry) / std_dev)?;
 
     // Calculate probabilities using the standard normal distribution
     let prob_below: Positive = Positive::new_decimal(big_n(z_score)?).unwrap_or(Positive::ZERO);

--- a/src/strategies/short_call.rs
+++ b/src/strategies/short_call.rs
@@ -297,7 +297,7 @@ impl Strategies for ShortCall {
         self.get_net_premium_received()
     }
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
-        Ok(Positive::INFINITY) // Theoretically unlimited
+        Ok(Positive::MAX) // Theoretically unlimited
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -645,7 +645,7 @@ impl Strategies for ShortStraddle {
         }
     }
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
-        Ok(Positive::INFINITY)
+        Ok(Positive::MAX)
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let strike_diff = self.break_even_points[1] - self.break_even_points[0];
@@ -1147,7 +1147,7 @@ mod tests_short_straddle {
         let strategy = setup();
         assert_eq!(
             strategy.get_max_loss().unwrap_or(Positive::ZERO),
-            Positive::INFINITY
+            Positive::MAX
         );
     }
 

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -708,7 +708,7 @@ impl Strategies for ShortStrangle {
     }
 
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
-        Ok(Positive::INFINITY)
+        Ok(Positive::MAX)
     }
 
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
@@ -1470,7 +1470,7 @@ is expected and the underlying asset's price is anticipated to remain stable."
         let strategy = setup();
         assert_eq!(
             strategy.get_max_loss().unwrap_or(Positive::ZERO),
-            Positive::INFINITY
+            Positive::MAX
         );
     }
 

--- a/src/utils/others.rs
+++ b/src/utils/others.rs
@@ -247,7 +247,7 @@ where
 ///
 /// - Returns an empty vector if fewer than 2 price points are provided
 /// - For consecutive prices P₁ and P₂, the log return is ln(P₂/P₁)
-pub fn calculate_log_returns(close_prices: &[Positive]) -> Result<Vec<Positive>, DecimalError> {
+pub fn calculate_log_returns(close_prices: &[Positive]) -> Result<Vec<Decimal>, DecimalError> {
     if close_prices.len() < 2 {
         return Ok(Vec::new());
     }
@@ -656,6 +656,7 @@ mod tests_log_returns {
     use super::*;
 
     use approx::assert_relative_eq;
+    use num_traits::ToPrimitive;
     use positive::pos_or_panic;
 
     #[test]
@@ -688,8 +689,16 @@ mod tests_log_returns {
         // Manually calculate expected values
         // ln(110.0/100.0) ≈ ln(1.1) ≈ 0.09531
         // ln(105.0/110.0) ≈ ln(0.9545) ≈ -0.04652
-        assert_relative_eq!(result[0].to_f64(), 0.09531018, epsilon = 0.00001);
-        assert_relative_eq!(result[1].to_f64(), -0.04652, epsilon = 0.00001);
+        assert_relative_eq!(
+            result[0].to_f64().unwrap_or(f64::NAN),
+            0.09531018,
+            epsilon = 0.00001
+        );
+        assert_relative_eq!(
+            result[1].to_f64().unwrap_or(f64::NAN),
+            -0.04652,
+            epsilon = 0.00001
+        );
     }
 
     #[test]
@@ -724,10 +733,26 @@ mod tests_log_returns {
 
         assert_eq!(result.len(), 4);
 
-        assert_relative_eq!(result[0].to_f64(), 0.00829, epsilon = 0.00001);
-        assert_relative_eq!(result[1].to_f64(), -0.01161, epsilon = 0.00001);
-        assert_relative_eq!(result[2].to_f64(), 0.01656, epsilon = 0.00001);
-        assert_relative_eq!(result[3].to_f64(), 0.00491, epsilon = 0.00001);
+        assert_relative_eq!(
+            result[0].to_f64().unwrap_or(f64::NAN),
+            0.00829,
+            epsilon = 0.00001
+        );
+        assert_relative_eq!(
+            result[1].to_f64().unwrap_or(f64::NAN),
+            -0.01161,
+            epsilon = 0.00001
+        );
+        assert_relative_eq!(
+            result[2].to_f64().unwrap_or(f64::NAN),
+            0.01656,
+            epsilon = 0.00001
+        );
+        assert_relative_eq!(
+            result[3].to_f64().unwrap_or(f64::NAN),
+            0.00491,
+            epsilon = 0.00001
+        );
     }
 
     #[test]
@@ -749,9 +774,21 @@ mod tests_log_returns {
         // ln(50.0/200.0) = ln(0.25) ≈ -1.3863
         // ln(300.0/50.0) = ln(6.0) ≈ 1.7918
 
-        assert_relative_eq!(result[0].to_f64(), std::f64::consts::LN_2, epsilon = 0.0001);
-        assert_relative_eq!(result[1].to_f64(), -1.3863, epsilon = 0.0001);
-        assert_relative_eq!(result[2].to_f64(), 1.7918, epsilon = 0.0001);
+        assert_relative_eq!(
+            result[0].to_f64().unwrap_or(f64::NAN),
+            std::f64::consts::LN_2,
+            epsilon = 0.0001
+        );
+        assert_relative_eq!(
+            result[1].to_f64().unwrap_or(f64::NAN),
+            -1.3863,
+            epsilon = 0.0001
+        );
+        assert_relative_eq!(
+            result[2].to_f64().unwrap_or(f64::NAN),
+            1.7918,
+            epsilon = 0.0001
+        );
     }
 
     #[test]
@@ -762,8 +799,16 @@ mod tests_log_returns {
 
         assert_eq!(result.len(), 2);
         // ln(1.0) = 0
-        assert_relative_eq!(result[0].to_f64(), 0.0, epsilon = 0.00001);
-        assert_relative_eq!(result[1].to_f64(), 0.0, epsilon = 0.00001);
+        assert_relative_eq!(
+            result[0].to_f64().unwrap_or(f64::NAN),
+            0.0,
+            epsilon = 0.00001
+        );
+        assert_relative_eq!(
+            result[1].to_f64().unwrap_or(f64::NAN),
+            0.0,
+            epsilon = 0.00001
+        );
     }
 
     #[test]
@@ -783,10 +828,10 @@ mod tests_log_returns {
         // ln(100.001/100.000) ≈ ln(1.00001) ≈ 0.00001
         // ln(100.002/100.001) ≈ ln(1.00001) ≈ 0.00001
 
-        assert!(result[0].to_f64() > 0.0);
-        assert!(result[0].to_f64() < 0.0001);
-        assert!(result[1].to_f64() > 0.0);
-        assert!(result[1].to_f64() < 0.0001);
+        assert!(result[0].to_f64().unwrap_or(f64::NAN) > 0.0);
+        assert!(result[0].to_f64().unwrap_or(f64::NAN) < 0.0001);
+        assert!(result[1].to_f64().unwrap_or(f64::NAN) > 0.0);
+        assert!(result[1].to_f64().unwrap_or(f64::NAN) < 0.0001);
     }
 }
 

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -304,8 +304,11 @@ pub fn get_x_days_formatted(days: i64) -> String {
 /// - The `Positive` type is expected to provide a `.ceiling()` method that converts it to an integer-compatible representation.
 #[must_use]
 pub fn get_x_days_formatted_pos(days: Positive) -> String {
-    let ceiling = days.ceiling().to_i64();
-    let tomorrow = Local::now().date_naive() + Duration::days(ceiling);
+    let ceiling = days.ceiling().to_i64_checked().unwrap_or(i64::MAX);
+    let today = Local::now().date_naive();
+    let tomorrow = Duration::try_days(ceiling)
+        .and_then(|delta| today.checked_add_signed(delta))
+        .unwrap_or(today);
     tomorrow.format("%d-%b-%Y").to_string().to_lowercase()
 }
 
@@ -494,8 +497,8 @@ mod tests_timeframe {
         // Test edge cases for custom periods
         assert_eq!(TimeFrame::Custom(Positive::ZERO).periods_per_year(), 0.0);
         assert_eq!(
-            TimeFrame::Custom(Positive::INFINITY).periods_per_year(),
-            Positive::INFINITY
+            TimeFrame::Custom(Positive::MAX).periods_per_year(),
+            Positive::MAX
         );
     }
 

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -14,6 +14,7 @@ use crate::error::VolatilityError;
 use crate::model::decimal::{
     d_add, d_div, d_mul, d_sub, d_sum, decimal_normal_sample, finite_decimal,
 };
+use crate::model::utils::sub_floor_zero;
 use crate::utils::time::TimeFrame;
 use crate::{ExpirationDate, OptionStyle, OptionType, Options, Side};
 use num_traits::{FromPrimitive, ToPrimitive};
@@ -763,7 +764,7 @@ pub fn generate_ou_process(
 
     for _ in 1..steps {
         let dw = decimal_normal_sample() * sqrt_dt; // Z√dt
-        let drift = (theta * mu.sub_or_zero(&x) * dt).to_dec(); // θ(μ−x)dt
+        let drift = (theta * sub_floor_zero(mu, &x) * dt).to_dec(); // θ(μ−x)dt
         let diffusion = dw * volatility; // σ·Z√dt (Decimal)
         x += drift + diffusion; // OU process step
         x = x.max(Decimal::ZERO); // no negative values

--- a/tests/unit/strategies/long_call_test.rs
+++ b/tests/unit/strategies/long_call_test.rs
@@ -190,7 +190,7 @@ fn test_long_call_get_max_profit() {
     let long_call = create_test_long_call();
     let max_profit = long_call.get_max_profit().unwrap();
     // Long Call has theoretically unlimited upside
-    assert_eq!(max_profit, Positive::INFINITY);
+    assert_eq!(max_profit, Positive::MAX);
 }
 
 #[test]

--- a/tests/unit/strategies/short_call_test.rs
+++ b/tests/unit/strategies/short_call_test.rs
@@ -162,9 +162,9 @@ fn test_short_call_get_max_profit() {
 fn test_short_call_get_max_loss() {
     let short_call = create_test_short_call();
     let result = short_call.get_max_loss();
-    // Max loss for a short call is theoretically unlimited (Positive::INFINITY).
+    // Max loss for a short call is theoretically unlimited (Positive::MAX).
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), Positive::INFINITY);
+    assert_eq!(result.unwrap(), Positive::MAX);
 }
 
 #[test]
@@ -291,7 +291,7 @@ fn test_short_call_get_positions() {
 fn test_short_call_get_profit_ratio() {
     let short_call = create_test_short_call();
     let ratio_result = short_call.get_profit_ratio();
-    // Max loss is Positive::INFINITY, so profit_ratio = max_profit / INFINITY * 100 ≈ 0.
+    // Max loss is Positive::MAX, so profit_ratio = max_profit / INFINITY * 100 ≈ 0.
     assert!(ratio_result.is_ok());
     let ratio = ratio_result.unwrap();
     assert!(

--- a/tests/unit/strategies/simple/strategy_call_butterfly.rs
+++ b/tests/unit/strategies/simple/strategy_call_butterfly.rs
@@ -54,7 +54,7 @@ fn test_call_butterfly_integration() -> Result<(), Box<dyn Error>> {
         pos_or_panic!(42.319),
         pos_or_panic!(0.0001)
     );
-    assert_eq!(strategy.get_max_loss()?, Positive::INFINITY);
+    assert_eq!(strategy.get_max_loss()?, Positive::MAX);
     assert_pos_relative_eq!(
         strategy.get_total_cost()?,
         pos_or_panic!(89.57),


### PR DESCRIPTION
Third and last step of the `positive` 0.6 rollout, after ExpirationDate#30 (`expiration_date` 0.3.0, published) and option_type#36 (`option_type` 0.3.0, published).

## Dependencies

| Crate | From | To |
|---|---|---|
| `positive` | 0.5 | **0.6** |
| `expiration_date` | 0.2 | **0.3** |
| `option_type` | 0.1.2 | **0.3** |
| `rust_decimal` | 1.41 | 1.42 |
| `itertools` | 0.14 | 0.15 |
| `zip` | 6.0 | 8.6 |
| `uuid` | 1.23 | 1.24 |
| `utoipa` | 5.4 | 5.5 |
| `tokio` | 1.52 | 1.53 |
| `mockall` (dev) | 0.14 | 0.15 |
| `tempfile` (dev) | 3.23 | 3.27 |
| `proptest` (dev) | 1.5 | 1.11 |

Every other dependency was already at its latest stable minor (checked against crates.io). Version 0.18.1 → **0.19.0**.

## Why minor and not patch

All three in-house crates jumped a breaking release and their types are all over this crate's public API. Two consumer-visible changes of our own:

- **JSON wire format.** `positive` 0.6 serialises `Positive` as the exact decimal in a *string* (`"42.5"`, not `42.5`), so `OptionData`, `OptionChainBuildParams`, `OptionSeries`, `PnL`, `Step`/`Xstep`/`Ystep`, `StrategyRequest` and friends all change shape. Deserialisation still accepts the old numeric form, so stored documents keep loading.
- **`calculate_log_returns` returns `Vec<Decimal>`.** A log return is signed — `ln(105/110) < 0` — and `Vec<Positive>` could not represent it. This was a latent invariant violation that `positive` 0.6 turned into a type error; every caller in-tree already collected into `Vec<Decimal>`.

## Migration work

- Exotic payloads are `Positive` (`barrier_level`, `rebate`, `exercise_dates`, `choice_date`, `reset_dates`, `second_asset`, `exchange_rate`, `exponent`). Negative and non-finite values are unrepresentable now, so `power_black_scholes` loses its negative-exponent rejection and `barrier_black_scholes` its `PricingError::NonFinite` checks — the invariants moved into the type. The two tests covering those paths went with them.
- `OptionType` and every sub-enum are `#[non_exhaustive]` upstream: payoff matches fall back to the intrinsic value, pricing kernels return `UnsupportedOptionType`/`other`, so a future upstream variant cannot break the build.
- `Positive::INFINITY` → `Positive::MAX`; the `to_i64`/`to_u64`/`to_usize` family → their `*_checked` forms (saturate instead of panic); `sub_or_zero` → one `model::utils::sub_floor_zero` on top of the checked `sub_or_none` (no saturating arithmetic on `Decimal`, per `rules/global_rules.md`).
- `decimal > Positive::ZERO.into()` → `decimal > Positive::ZERO`: 0.6 adds `PartialOrd<Positive> for Decimal`, which made the inferred `.into()` ambiguous.

**Visible behaviour change:** an unbounded max profit now renders as `79228162514264337593543950335` rather than `inf`, because `MAX` reports the value it actually holds.

## Security audit

Adds `.cargo/audit.toml` (same policy file `positive` uses). The Security Audit workflow had been failing on every run, `main` included, on RUSTSEC-2026-0235 (rkyv 0.7.46) — an *optional* dependency of `rust_decimal` that this crate never enables, so it lands in `Cargo.lock` but is never compiled (`cargo tree --all-features --target all -i rkyv` prints nothing) and `rust_decimal` 1.42.1 still pins the 0.7 line. The entry carries the rationale, an owner and a 2027-02-15 review date, and the file opts into reporting unmaintained/unsound/notice advisories: two remain outstanding transitively (`number_prefix` via `indicatif`, `rustls-pemfile` via `reqwest`).

## Verification

- `make pre-push` (fix → fmt → lint-fix → test → readme → doc): clean apart from the 5 pre-existing failures below. `cargo fmt --all --check` clean, `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean, `cargo audit` clean.
- Tests: **8979 passed, 5 failed** across `cargo test`, `--features plotly` and `--features static_export plotly`.
- The 5 failures are all Kaleido static-export tests (`plotly_render_test::{test_render_png, test_render_svg, test_write_png, test_write_svg}`, `plotly_test::tests_plotly_interface::test_write_svg`). They fail identically on a pristine `origin/main` worktree in this environment — no static-export backend available locally — so they are pre-existing and unrelated to this change.
- `README.md` regenerated via `make readme` (no diff).

Untracked local WIP in the working tree (`.cargo/config.toml`, the wasm workflows, `Draws/` artifacts, `tmp/`) was deliberately left out of this branch.