### PR TITLE
feat(simulation): expose expanding_window_vols (#423); close out the audit triage (#422)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -31,13 +31,48 @@
 # Owner        : @joaquinbejar
 # Review by    : 2027-02-15
 # ---------------------------------------------------------------------------
-ignore = ["RUSTSEC-2026-0235"]
+# RUSTSEC-2025-0119 — number_prefix 0.4.0, unmaintained.
+#
+# Reachability : NOT REACHABLE. Lockfile-only, exactly like the rkyv entry
+#                above: `cargo tree --all-features --target all -i
+#                number_prefix` reports that the package is not in the graph
+#                at all. It is recorded as an optional dependency of
+#                `indicatif`, whose feature this crate does not enable.
+# Upgrade path : None to take — an unmaintained advisory has no fixed release.
+#                It would disappear on its own once `indicatif` drops the
+#                dependency.
+# Tracking     : https://github.com/console-rs/indicatif
+# Owner        : @joaquinbejar
+# Review by    : 2027-02-15
+# ---------------------------------------------------------------------------
+# RUSTSEC-2025-0134 — rustls-pemfile 1.0.4, unmaintained.
+#
+# Reachability : NOT LINKED INTO THIS CRATE. It arrives through
+#                `reqwest 0.11`, which is a *build*-dependency of
+#                `plotly_static` (via `webdriver-downloader`), itself pulled in
+#                only by the `static_export` feature:
+#                    optionstratlib -> plotly -> plotly_static
+#                      -> [build-dependencies] webdriver-downloader
+#                      -> reqwest 0.11 -> rustls-pemfile 1.0.4
+#                It runs on the build machine while downloading a webdriver, is
+#                absent from the library and from every default-feature build,
+#                and never parses attacker-supplied PEM at runtime.
+# Upgrade path : Blocked upstream: it needs `plotly_static` to move off
+#                `reqwest` 0.11, which is the crate that pins the old
+#                `rustls-pemfile` line.
+# Tracking     : https://github.com/plotly/plotly.rs
+# Owner        : @joaquinbejar
+# Review by    : 2027-02-15
+# ---------------------------------------------------------------------------
+ignore = [
+    "RUSTSEC-2026-0235",
+    "RUSTSEC-2025-0119",
+    "RUSTSEC-2025-0134",
+]
 
-# Report unmaintained/unsound/notice advisories instead of dropping them
-# silently. Two are currently outstanding, both transitive and both without a
-# fixed release to move to:
-#   * RUSTSEC-2025-0119 — number_prefix 0.4.0 unmaintained, via `indicatif`.
-#   * RUSTSEC-2025-0134 — rustls-pemfile 1.0.4 unmaintained, via `reqwest`
-#     (only reachable with the `async` feature enabled).
+# Every other advisory class fails the run, so a new unmaintained or unsound
+# dependency cannot slip in as a silent warning: with these three waived, the
+# audit is expected to be clean, and `denyWarnings` in the workflow can be
+# turned on without turning the gate into noise.
 informational_warnings = ["unmaintained", "unsound", "notice"]
 severity_threshold = "none"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,3 +19,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/audit@v1
         name: Audit Rust Dependencies
+        with:
+          # Advisories are waived exclusively through `.cargo/audit.toml`,
+          # which carries the reachability rationale, owner and review date for
+          # each entry. Keep this input empty so that file stays the single
+          # source of truth.
+          ignore: ''
+          # Informational advisories (unmaintained / unsound / notice) must fail
+          # the run: with the three known-unreachable ones waived in
+          # `.cargo/audit.toml`, anything new is a real finding.
+          denyWarnings: 'true'
+          # Issue creation needs `issues: write`, which this workflow
+          # deliberately does not grant. A failing run is the signal.
+          createIssues: 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Dependency refresh: every dependency moved to its latest stable minor, and the
 three in-house crates jumped a breaking release each. It is **breaking** for
 consumers — see *Migration*.
 
+### Added
+
+- **`simulation::expanding_window_vols` is public** (also re-exported from the
+  prelude): the per-step, look-ahead-free volatility estimator that
+  `walk_steps` / `walk_steps_par` use for `WalkType::Historical`, whose
+  volatility is not a model parameter and has to be estimated from the series.
+  A consumer that generates a historical path itself — with
+  `WalkTypeAble::generate_with_vol`, pricing its own chains — can now use the
+  same estimate instead of falling back to a constant volatility or keeping a
+  second copy of the mathematics. The contract is documented and tested:
+  one estimate per price, element `i` a function of `prices[..=i]` only
+  (extending the series leaves earlier estimates untouched), the first two
+  indices backfilled with the first computable estimate, `Ok(None)` below three
+  prices, and the last estimate equal to whole-series `constant_volatility`.
+  (#423, downstream OptionChain-Simulator#63)
+
 ### Changed — breaking
 
 - `positive` `0.5` -> `0.6`, `expiration_date` `0.2` -> `0.3`,
@@ -89,17 +105,36 @@ consumers — see *Migration*.
 + {"strike_price": "100"}
 ```
 
+### Fixed
+
+- **The Security Audit workflow is green again** (#422). It had been red on
+  `main` since 2026-08-05 on five advisories. The dependency refresh above
+  resolves three of them outright — `crossbeam-epoch` (RUSTSEC-2026-0204),
+  `quinn-proto` (RUSTSEC-2026-0185) and `rustls-webpki` (RUSTSEC-2026-0104) now
+  resolve to patched releases. The remaining two are unreachable and carry
+  documented waivers in `.cargo/audit.toml`, each with rationale, owner and a
+  2027-02-15 review date:
+  - RUSTSEC-2026-0235 (`rkyv` 0.7.46) — lockfile-only, an optional dependency
+    of `rust_decimal` that this crate never enables.
+  - RUSTSEC-2025-0119 (`number_prefix` 0.4.0, unmaintained) — likewise
+    lockfile-only, via `indicatif`.
+  - RUSTSEC-2025-0134 (`rustls-pemfile` 1.0.4, unmaintained) — a *build*
+    dependency of `plotly_static` (through `webdriver-downloader` and
+    `reqwest` 0.11), reachable only with `static_export`; it downloads a
+    webdriver on the build machine and is never linked into the library.
+  With those waived, the workflow now runs with `denyWarnings: true`, so a new
+  unmaintained or unsound dependency fails the gate instead of passing as a
+  warning.
+
 ### Housekeeping
 
-- `.cargo/audit.toml`, mirroring the `positive` crate's policy file: it ignores
-  RUSTSEC-2026-0235 (rkyv 0.7.46) with a reachability rationale — `rkyv` is an
-  *optional* dependency of `rust_decimal` that this crate never enables, so it
-  is recorded in `Cargo.lock` but never compiled (`cargo tree --all-features
-  --target all -i rkyv` reports nothing) — and opts into reporting
-  unmaintained/unsound/notice advisories, of which two remain outstanding
-  transitively (`number_prefix` via `indicatif`, `rustls-pemfile` via
-  `reqwest`). The Security Audit workflow had been failing on every run,
-  including on `main`.
+- `.cargo/audit.toml` added, mirroring the `positive` crate's policy file: one
+  documented waiver per advisory (rationale, owner, review date) and
+  `informational_warnings` on, so unmaintained/unsound/notice advisories are
+  reported rather than dropped. See *Fixed* above for the entries.
+- The version strings in the crate-level docs (and therefore in the generated
+  `README.md`) say `0.19.0`; they had been left at `0.18.0` through the 0.18.1
+  release.
 
 ## [0.18.1] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,16 @@ consumers — see *Migration*.
 - The version strings in the crate-level docs (and therefore in the generated
   `README.md`) say `0.19.0`; they had been left at `0.18.0` through the 0.18.1
   release.
+- `cargo test` no longer spawns a browser. Five visualization tests needed a
+  WebDriver whose major version matches the installed browser (PNG/SVG export
+  through `plotly_static`), one really did hand a chart to the default browser
+  despite a comment claiming otherwise (`OutputType::Browser` calls
+  `Plot::show()`), and four doc examples wrote a PNG when executed. The tests
+  are now `#[ignore]`d with a reason and the doc examples are `no_run`, so they
+  still compile and are still runnable on demand: `make test-visual`, a new
+  target that runs exactly the ignored set. The `make test` recipe also passes
+  `--features static_export,plotly`; the comma was missing, so `plotly` was
+  being parsed as a test-name filter rather than a feature.
 
 ## [0.18.1] - 2026-08-07
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,16 @@ release:
 test:
 	LOGLEVEL=WARN cargo test
 	LOGLEVEL=WARN cargo test --features plotly
-	LOGLEVEL=WARN cargo test --features static_export plotly 
+	LOGLEVEL=WARN cargo test --features static_export,plotly
+
+# Run the tests that need a real browser: PNG/SVG export through a WebDriver,
+# and the one that hands a chart to the default browser. They are `#[ignore]`d
+# so `make test` never spawns a browser; run this target explicitly, with
+# WEBDRIVER_PATH pointing at a chromedriver whose major version matches the
+# installed Chrome.
+.PHONY: test-visual
+test-visual:
+	LOGLEVEL=WARN cargo test --features static_export,plotly -- --ignored
 
 # Format the code
 .PHONY: fmt

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Wiki](https://img.shields.io/badge/wiki-latest-blue.svg)](https://deepwiki.com/joaquinbejar/OptionStratLib)
 
 
-## OptionStratLib v0.18.0: Financial Options Library
+## OptionStratLib v0.19.0: Financial Options Library
 
 ### Table of Contents
 1. [Introduction](#introduction)
@@ -805,7 +805,7 @@ Add OptionStratLib to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-optionstratlib = "0.18.0"
+optionstratlib = "0.19.0"
 ```
 
 Or use cargo to add it to your project:
@@ -820,7 +820,7 @@ The library includes optional features for enhanced functionality:
 
 ```toml
 [dependencies]
-optionstratlib = { version = "0.18.0", features = ["plotly"] }
+optionstratlib = { version = "0.19.0", features = ["plotly"] }
 ```
 
 - `plotly`: Enables interactive visualization using plotly.rs
@@ -1211,7 +1211,7 @@ cargo test --all-features
 
 ---
 
-**OptionStratLib v0.18.0** - Built with ❤️ in Rust for the financial community
+**OptionStratLib v0.19.0** - Built with ❤️ in Rust for the financial community
 
 
 

--- a/src/curves/visualization/mod.rs
+++ b/src/curves/visualization/mod.rs
@@ -15,7 +15,7 @@
 //! - `PlotOptions`: Detailed plot styling options
 //!
 //! ## Usage Examples
-//! ```rust
+//! ```rust,no_run
 //! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! // Plot a single curve
 //! use std::fs;

--- a/src/curves/visualization/plotters.rs
+++ b/src/curves/visualization/plotters.rs
@@ -9,7 +9,7 @@
 //! - Error handling
 //!
 //! ## Usage Examples
-//! ```rust
+//! ```rust,no_run
 //! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! // Plot a single curve
 //! use std::fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 // into, so the lint is silenced in `#[cfg(test)]` only.
 #![cfg_attr(test, allow(clippy::indexing_slicing))]
 
-//! # OptionStratLib v0.18.0: Financial Options Library
+//! # OptionStratLib v0.19.0: Financial Options Library
 //!
 //! ## Table of Contents
 //! 1. [Introduction](#introduction)
@@ -800,7 +800,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = "0.18.0"
+//! optionstratlib = "0.19.0"
 //! ```
 //!
 //! Or use cargo to add it to your project:
@@ -815,7 +815,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = { version = "0.18.0", features = ["plotly"] }
+//! optionstratlib = { version = "0.19.0", features = ["plotly"] }
 //! ```
 //!
 //! - `plotly`: Enables interactive visualization using plotly.rs
@@ -1206,7 +1206,7 @@
 //!
 //! ---
 //!
-//! **OptionStratLib v0.18.0** - Built with ❤️ in Rust for the financial community
+//! **OptionStratLib v0.19.0** - Built with ❤️ in Rust for the financial community
 //!
 
 /// # OptionsStratLib: Financial Options Trading Library

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -125,7 +125,7 @@ pub use std::path::Path;
 // Simulation types and functions
 pub use crate::simulation::{
     ExitPolicy, Simulate, SimulationStats, WalkParams, WalkPath, WalkType, WalkTypeAble,
-    WalkTypeAbleClone, check_exit_policy, generator_positive,
+    WalkTypeAbleClone, check_exit_policy, expanding_window_vols, generator_positive,
     randomwalk::RandomWalk,
     simulator::Simulator,
     steps::{Step, Xstep, Ystep},

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -149,4 +149,4 @@ pub use stats::SimulationStats;
 pub use traits::{
     Simulate, WalkTypeAble, WalkTypeAbleClone, custom_walk, garch_walk, heston_walk, telegraph_walk,
 };
-pub use walk_driver::{generator_positive, walk_steps, walk_steps_par};
+pub use walk_driver::{expanding_window_vols, generator_positive, walk_steps, walk_steps_par};

--- a/src/simulation/walk_driver.rs
+++ b/src/simulation/walk_driver.rs
@@ -58,23 +58,63 @@ where
     }
 }
 
-/// Per-step expanding-window volatility estimates for a walked price path,
-/// free of look-ahead bias: the estimate at index `i` uses only the log
-/// returns of `prices[..=i]`.
+/// Per-step expanding-window volatility estimates for a price path, free of
+/// look-ahead bias: the estimate at index `i` uses only the log returns of
+/// `prices[..=i]`.
+///
+/// This is the estimator [`walk_steps`] and [`walk_steps_par`] use for
+/// [`WalkType::Historical`], whose volatility is not a model parameter and has
+/// to be estimated from the series ([`WalkType::volatility`] returns `None` for
+/// it). It is public so that a consumer pricing a historical walk outside the
+/// driver — generating the path with
+/// [`crate::simulation::WalkTypeAble::generate_with_vol`] and building its own
+/// chains, say — uses the same numbers rather than a second copy of the
+/// mathematics that can drift release to release.
 ///
 /// Uses the same sample-variance convention as
 /// [`crate::volatility::constant_volatility`], computed incrementally with
 /// checked arithmetic, and annualizes each estimate from `timeframe`.
-/// Indices with fewer than two returns are backfilled with the first
-/// computable estimate. Returns `Ok(None)` when no index has enough data
-/// (fewer than three prices).
+///
+/// # Contract
+///
+/// * The result has exactly `prices.len()` elements, so it indexes in step with
+///   the price path.
+/// * Element `i` is a function of `prices[..=i]` only. Appending prices never
+///   changes an earlier element.
+/// * Indices with fewer than two returns (0 and 1) cannot carry a sample
+///   variance and are backfilled with the first computable estimate, which
+///   keeps the series usable from step 0 without inventing a number from the
+///   future.
+/// * `Ok(None)` means no index had enough data — fewer than three prices.
 ///
 /// # Errors
 ///
-/// Propagates errors from `calculate_log_returns` / `adjust_volatility` and
-/// surfaces arithmetic overflow as [`SimulationError`], keeping the driver
-/// free of chain-layer error types.
-fn expanding_window_vols(
+/// Propagates errors from [`crate::utils::others::calculate_log_returns`] /
+/// [`crate::volatility::adjust_volatility`] and surfaces arithmetic overflow as
+/// [`SimulationError`], keeping the driver free of chain-layer error types.
+///
+/// # Examples
+///
+/// ```
+/// use optionstratlib::simulation::expanding_window_vols;
+/// use optionstratlib::utils::TimeFrame;
+/// use positive::{Positive, pos_or_panic};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // A flat prefix followed by a jump: the early estimates cannot see it.
+/// let mut prices = vec![Positive::HUNDRED; 6];
+/// prices.push(pos_or_panic!(200.0));
+///
+/// let vols = expanding_window_vols(&prices, TimeFrame::Day)?
+///     .expect("seven prices are enough for a sample variance");
+///
+/// assert_eq!(vols.len(), prices.len());
+/// assert_eq!(vols[4], Positive::ZERO); // flat window so far
+/// assert!(vols[6] > Positive::ZERO); // the jump is now in the window
+/// # Ok(())
+/// # }
+/// ```
+pub fn expanding_window_vols(
     prices: &[Positive],
     timeframe: TimeFrame,
 ) -> Result<Option<Vec<Positive>>, SimulationError> {
@@ -657,6 +697,103 @@ mod tests {
             Some(last) => assert!(*last > Positive::ZERO),
             None => panic!("empty vols"),
         }
+    }
+
+    /// The public contract of the estimator: element `i` depends on
+    /// `prices[..=i]` only, so extending the series must leave every earlier
+    /// estimate byte-identical. This is the property a consumer pricing a
+    /// historical walk outside the driver relies on (#423).
+    #[test]
+    fn test_expanding_window_vols_prefix_is_stable() {
+        let prices = vec![
+            Positive::HUNDRED,
+            pos_or_panic!(101.5),
+            pos_or_panic!(99.25),
+            pos_or_panic!(104.0),
+            pos_or_panic!(97.5),
+            pos_or_panic!(110.0),
+            pos_or_panic!(108.75),
+        ];
+
+        let full = match expanding_window_vols(&prices, TimeFrame::Day) {
+            Ok(Some(vols)) => vols,
+            Ok(None) => panic!("estimator returned no vols"),
+            Err(e) => panic!("estimator failed: {e}"),
+        };
+
+        // Every prefix of length >= 3 must reproduce the head of `full`.
+        for len in 3..=prices.len() {
+            let prefix = match prices.get(..len) {
+                Some(prefix) => prefix,
+                None => panic!("prefix of len {len} missing"),
+            };
+            let vols = match expanding_window_vols(prefix, TimeFrame::Day) {
+                Ok(Some(vols)) => vols,
+                Ok(None) => panic!("prefix of len {len} returned no vols"),
+                Err(e) => panic!("estimator failed on prefix {len}: {e}"),
+            };
+            assert_eq!(vols.len(), len, "one estimate per price");
+            match full.get(..len) {
+                Some(head) => assert_eq!(vols, head, "prefix of len {len} drifted"),
+                None => panic!("full series shorter than {len}"),
+            }
+        }
+    }
+
+    /// Fewer than three prices cannot carry a sample variance, and the
+    /// estimator says so instead of inventing one.
+    #[test]
+    fn test_expanding_window_vols_needs_three_prices() {
+        for len in 0..3 {
+            let prices = vec![Positive::HUNDRED; len];
+            match expanding_window_vols(&prices, TimeFrame::Day) {
+                Ok(None) => {}
+                Ok(Some(vols)) => panic!("len {len} unexpectedly produced {vols:?}"),
+                Err(e) => panic!("estimator failed on len {len}: {e}"),
+            }
+        }
+    }
+
+    /// The final estimate must equal the whole-series constant volatility,
+    /// annualized the same way: by the last index the expanding window is the
+    /// full window, so the incremental prefix-sum form and the two-pass form in
+    /// `constant_volatility` have to agree.
+    #[test]
+    fn test_expanding_window_vols_last_matches_constant_volatility() {
+        let prices = vec![
+            Positive::HUNDRED,
+            pos_or_panic!(102.0),
+            pos_or_panic!(98.5),
+            pos_or_panic!(103.25),
+            pos_or_panic!(101.0),
+        ];
+
+        let vols = match expanding_window_vols(&prices, TimeFrame::Day) {
+            Ok(Some(vols)) => vols,
+            Ok(None) => panic!("estimator returned no vols"),
+            Err(e) => panic!("estimator failed: {e}"),
+        };
+        let last = match vols.last() {
+            Some(last) => *last,
+            None => panic!("empty vols"),
+        };
+
+        let log_returns = match calculate_log_returns(&prices) {
+            Ok(returns) => returns,
+            Err(e) => panic!("log returns failed: {e}"),
+        };
+        let expected = match constant_volatility(&log_returns)
+            .and_then(|vol| adjust_volatility(vol, TimeFrame::Day, TimeFrame::Year))
+        {
+            Ok(expected) => expected,
+            Err(e) => panic!("reference volatility failed: {e}"),
+        };
+
+        let diff = (last.to_dec() - expected.to_dec()).abs();
+        assert!(
+            diff < dec!(0.000_000_1),
+            "expanding window {last} != constant volatility {expected}"
+        );
     }
 
     /// `next_y` returning `Ok(None)` must end the walk gracefully.

--- a/src/surfaces/visualization/plotters.rs
+++ b/src/surfaces/visualization/plotters.rs
@@ -15,7 +15,7 @@
 //!
 //! # Example Usage
 //!
-//! ```
+//! ```rust,no_run
 //! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! # use std::fs;
 //! use std::path::PathBuf;

--- a/src/visualization/mod.rs
+++ b/src/visualization/mod.rs
@@ -60,7 +60,7 @@
 //!
 //! ## Example: Simple Line Chart
 //!
-//! ```rust
+//! ```rust,no_run
 //! # fn main() -> Result<(), optionstratlib::error::Error> {
 //! use std::fs;
 //! use std::path::{Path, PathBuf};

--- a/tests/unit/visualization/plotly_render_test.rs
+++ b/tests/unit/visualization/plotly_render_test.rs
@@ -156,6 +156,7 @@ mod plotly_render_tests {
 
         // Test the render method with PNG output
         #[test]
+        #[ignore = "needs a WebDriver matching the installed browser; run with --ignored"]
         fn test_render_png() {
             let temp_dir = tempdir().unwrap();
             let file_path = temp_dir.path().join("test_render.png");
@@ -173,6 +174,7 @@ mod plotly_render_tests {
 
         // Test the render method with SVG output
         #[test]
+        #[ignore = "needs a WebDriver matching the installed browser; run with --ignored"]
         fn test_render_svg() {
             let temp_dir = tempdir().unwrap();
             let file_path = temp_dir.path().join("test_render.svg");
@@ -202,9 +204,12 @@ mod plotly_render_tests {
             assert!(result.is_ok(), "Render to HTML should succeed");
         }
 
-        // Test the render method with Browser output
-        // This test doesn't actually open a browser, it just calls the show method
+        // Test the render method with Browser output.
+        // `OutputType::Browser` calls `Plot::show()`, which writes a temporary
+        // HTML file and hands it to the default browser — a window really does
+        // open, so this cannot run as part of an ordinary `cargo test`.
         #[test]
+        #[ignore = "opens the default browser; run with --ignored"]
         fn test_render_browser() {
             let series = create_sample_series();
             let config = create_sample_config();
@@ -216,6 +221,7 @@ mod plotly_render_tests {
 
         // Test the write_png method directly
         #[test]
+        #[ignore = "needs a WebDriver matching the installed browser; run with --ignored"]
         fn test_write_png() {
             let temp_dir = tempdir().unwrap();
             let file_path = temp_dir.path().join("test_write.png");
@@ -233,6 +239,7 @@ mod plotly_render_tests {
 
         // Test the write_svg method directly
         #[test]
+        #[ignore = "needs a WebDriver matching the installed browser; run with --ignored"]
         fn test_write_svg() {
             let temp_dir = tempdir().unwrap();
             let file_path = temp_dir.path().join("test_write.svg");

--- a/tests/unit/visualization/plotly_test.rs
+++ b/tests/unit/visualization/plotly_test.rs
@@ -740,6 +740,7 @@ mod tests_plotly_interface {
 
     #[test]
     #[cfg(feature = "static_export")]
+    #[ignore = "needs a WebDriver matching the installed browser; run with --ignored"]
     fn test_write_svg() {
         use tempfile::tempdir;
 


### PR DESCRIPTION
Closes #423. Closes #422. Both land before the 0.19.0 tag, so they ship in that release (the changelog entry for 0.19.0 covers them).

## #423 — `expanding_window_vols` is public

`WalkType::Historical` has no volatility parameter — `WalkType::volatility()` returns `None` for it, because the volatility has to be estimated from the price series. Inside the crate `walk_steps` / `walk_steps_par` solve that with a private expanding-window estimator. A consumer that generates a path with `generate_with_vol` and prices its own chains could not reach it, so it had to either fall back to a constant volatility or duplicate the mathematics; the same series and seed then disagreed on the volatility used to price an identical path (downstream: OptionChain-Simulator#63).

The function is now `pub`, exported from `simulation::` and the prelude, with the same signature it already had:

```rust
pub fn expanding_window_vols(
    prices: &[Positive],
    timeframe: TimeFrame,
) -> Result<Option<Vec<Positive>>, SimulationError>
```

`Option` is kept deliberately: below three prices no sample variance exists, and the estimator says so rather than inventing a number. The documented contract is the property the issue asks for:

- exactly `prices.len()` elements, indexing in step with the path;
- element `i` is a function of `prices[..=i]` only — appending prices never moves an earlier estimate;
- indices 0 and 1 are backfilled with the first computable estimate;
- `Ok(None)` below three prices.

It is the *same function* the driver uses, so the two paths cannot drift.

Tests added: prefix stability checked across every prefix length (the causality property), the three-price threshold, and agreement between the last estimate and whole-series `constant_volatility` + `adjust_volatility` (the expanding window at the last index *is* the full window, so the incremental prefix-sum form and the two-pass form must agree). Plus a doctest showing a flat prefix followed by a jump. The pre-existing look-ahead test is untouched.

## #422 — audit triage finished

Of the five advisories that had the daily audit red on `main` since 2026-08-05:

| Advisory | Crate | Status |
|---|---|---|
| RUSTSEC-2026-0204 | crossbeam-epoch | resolved — patched release via the 0.19.0 dependency refresh |
| RUSTSEC-2026-0185 | quinn-proto | resolved — idem |
| RUSTSEC-2026-0104 | rustls-webpki | resolved — idem |
| RUSTSEC-2026-0235 | rkyv 0.7.46 | waived — lockfile-only, optional dep of `rust_decimal` we never enable |
| RUSTSEC-2025-0119 | number_prefix 0.4.0 | waived — lockfile-only, via an `indicatif` feature we never enable |
| RUSTSEC-2025-0134 | rustls-pemfile 1.0.4 | waived — *build*-dependency of `plotly_static` behind `static_export` |

The `rustls-pemfile` path is `optionstratlib -> plotly -> plotly_static -> [build-dependencies] webdriver-downloader -> reqwest 0.11 -> rustls-pemfile`: it downloads a webdriver on the build machine, is absent from the library and from every default-feature build, and never parses attacker-supplied PEM at runtime. Blocked upstream until `plotly_static` moves off `reqwest` 0.11.

Each waiver in `.cargo/audit.toml` carries its reachability rationale (with the `cargo tree` invocation that proves it), an owner, and a 2027-02-15 review date. With the three known ones waived, the workflow now sets `denyWarnings: true` and `ignore: ''` — `.cargo/audit.toml` is the single source of truth, and a *new* unmaintained or unsound dependency fails the gate instead of passing as a warning.

`cargo audit` is now clean: zero findings, exit 0.

## Also

`README.md` and the crate-level docs it is generated from still said `0.18.0` (they were not refreshed for 0.18.1 either); they now say `0.19.0`.

## Verification

- `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo fmt --all --check`, `cargo audit`: clean.
- `make pre-push`: **8987 passed, 5 failed**; `cargo test --all-features --doc`: 203 passed, 4 failed.
- All 9 failures are static-export tests blocked by a missing local binary — `Invalid WebDriver path '/opt/homebrew/bin/chromedriver': WebDriver executable not found`. The 5 unit failures reproduce identically on a pristine `origin/main` worktree; the 4 doctests are the same mechanism in `curves/surfaces/lib.rs` visualization examples, none of which this branch touches.