### PR TITLE
fix(greeks): stop applying quantity twice in vomma and veta, and clean up after #426

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -42,4 +42,4 @@ jobs:
         run: sudo apt-get install make
 
       - name: Format check
-        run: make fmt
+        run: make fmt-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-08-28
+
+Correctness and housekeeping follow-up to the cost-of-carry fix in 0.19.0. No
+API changes.
+
+### Fixed
+
+- `vomma` and `veta` applied the position quantity twice, because `vega`
+  already carries it. Both are first derivatives of vega and are linear in
+  position size, so a 10-lot position reported 10x the true value and the error
+  propagated into `PortfolioGreeks`.
+- `d1`'s documentation still described its third argument as the risk-free rate
+  after it was renamed to `carry_rate`, stating two different meanings for the
+  same argument in one doc block. `d1` and `d2` are public and in the prelude,
+  so a caller following it disagreed with `option.delta()` by about 10%.
+- Four stale `charm` expectations meant two tests over the identical portfolio
+  asserted different numbers, both within 2% of their tolerance.
+- `test_dividend_high_q_carry_regression` pinned eleven greeks at `1e-28`, far
+  tighter than the f64 normal CDF behind them supports. Relaxed to `1e-12`.
+
+### Changed
+
+- The `format_check` CI job ran `make fmt`, which formats rather than checks and
+  exited 0 whatever the input, so no pull request was ever format-checked. It
+  now runs `make fmt-check`.
+
 ## [0.19.0] - 2026-08-17
 
 Dependency refresh: every dependency moved to its latest stable minor, and the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Wiki](https://img.shields.io/badge/wiki-latest-blue.svg)](https://deepwiki.com/joaquinbejar/OptionStratLib)
 
 
-## OptionStratLib v0.19.0: Financial Options Library
+## OptionStratLib v0.19.1: Financial Options Library
 
 ### Table of Contents
 1. [Introduction](#introduction)
@@ -805,7 +805,7 @@ Add OptionStratLib to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-optionstratlib = "0.19.0"
+optionstratlib = "0.19.1"
 ```
 
 Or use cargo to add it to your project:
@@ -820,7 +820,7 @@ The library includes optional features for enhanced functionality:
 
 ```toml
 [dependencies]
-optionstratlib = { version = "0.19.0", features = ["plotly"] }
+optionstratlib = { version = "0.19.1", features = ["plotly"] }
 ```
 
 - `plotly`: Enables interactive visualization using plotly.rs
@@ -1211,7 +1211,7 @@ cargo test --all-features
 
 ---
 
-**OptionStratLib v0.19.0** - Built with ❤️ in Rust for the financial community
+**OptionStratLib v0.19.1** - Built with ❤️ in Rust for the financial community
 
 
 

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -9909,7 +9909,11 @@ mod tests_vanna_calculations {
         assert!(result.is_ok());
         let vanna_exposure = result.unwrap();
         // Test against expected value from sample data
-        assert_decimal_eq!(vanna_exposure, dec!(-38.126585967162624451799179198), dec!(0.0001));
+        assert_decimal_eq!(
+            vanna_exposure,
+            dec!(-38.126585967162624451799179198),
+            dec!(0.0001)
+        );
     }
 
     #[test]

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -1514,13 +1514,13 @@ pub fn vomma(option: &Options) -> Result<Decimal, GreeksError> {
         expiration_date,
         option.implied_volatility,
     )?;
+    // `vega` already carries `option.quantity`. Vomma is a first derivative of
+    // vega and is linear in position size, so the quantity must not be applied
+    // a second time here.
     let vega = vega(option)?;
     let implied_volatility: Positive = option.implied_volatility;
 
-    let vomma: Decimal = vega * (d1 * d2 / implied_volatility);
-
-    let quantity: Decimal = option.quantity.into();
-    Ok(vomma * quantity)
+    Ok(vega * (d1 * d2 / implied_volatility))
 }
 
 /// Computes the veta of an option.
@@ -1640,10 +1640,10 @@ pub fn veta(option: &Options) -> Result<Decimal, GreeksError> {
     // It is common practice to divide the mathematical result of veta by
     // 100 times the number of days per year to reduce the value to the
     // percentage change in vega per one day
-    let veta_adj: Decimal = veta / (*TRADING_DAYS * Decimal::ONE_HUNDRED);
-
-    let quantity: Decimal = option.quantity.into();
-    Ok(veta_adj * quantity)
+    // `vega` already carries `option.quantity`. Veta is a first derivative of
+    // vega and is linear in position size, so the quantity must not be applied
+    // a second time here.
+    Ok(veta / (*TRADING_DAYS * Decimal::ONE_HUNDRED))
 }
 
 /// Computes the Charm of an option.
@@ -2139,7 +2139,11 @@ pub mod tests_delta_equations {
         );
         let delta_value = delta(&option).unwrap();
         info!("ATM Put Delta: {}", delta_value);
-        assert_decimal_eq!(delta_value, dec!(-0.4653476616529870686572684641), DELTA_THRESHOLD);
+        assert_decimal_eq!(
+            delta_value,
+            dec!(-0.4653476616529870686572684641),
+            DELTA_THRESHOLD
+        );
     }
 
     #[test]
@@ -2171,7 +2175,11 @@ pub mod tests_delta_equations {
         option.expiration_date = ExpirationDate::Days(DAYS_IN_A_YEAR);
         let delta_value = delta(&option).unwrap();
         info!("Long-term Low Vol Put Delta: {}", delta_value);
-        assert_decimal_eq!(delta_value, dec!(-0.3231079315892283130741442305), DELTA_THRESHOLD);
+        assert_decimal_eq!(
+            delta_value,
+            dec!(-0.3231079315892283130741442305),
+            DELTA_THRESHOLD
+        );
     }
 
     #[test]
@@ -2187,7 +2195,11 @@ pub mod tests_delta_equations {
         option.expiration_date = ExpirationDate::Days(Positive::ONE);
         let delta_value = delta(&option).unwrap();
         info!("Long-term Low Vol Put Delta: {}", delta_value);
-        assert_decimal_eq!(delta_value, dec!(-0.2298186207440564194124373536), DELTA_THRESHOLD);
+        assert_decimal_eq!(
+            delta_value,
+            dec!(-0.2298186207440564194124373536),
+            DELTA_THRESHOLD
+        );
     }
 }
 
@@ -2841,15 +2853,51 @@ mod tests_greeks_trait {
         let greeks = collection.greeks().unwrap();
 
         // Test each greek value
-        assert_decimal_eq!(greeks.delta, dec!(0.5338307582207135564475476937), dec!(0.000001));
-        assert_decimal_eq!(greeks.gamma, dec!(0.0692632117482215620683508231), dec!(0.000001));
-        assert_decimal_eq!(greeks.theta, dec!(-0.0434671314177636287945041349), dec!(0.000001));
-        assert_decimal_eq!(greeks.vega, dec!(0.1138573343806381728362131205), dec!(0.000001));
-        assert_decimal_eq!(greeks.rho, dec!(0.041863419880440417503050762), dec!(0.000001));
-        assert_decimal_eq!(greeks.rho_d, dec!(-0.0438765006756750824436552223), dec!(0.000001));
-        assert_decimal_eq!(greeks.vanna, dec!(-0.0569286671903190864181065602), dec!(0.000001));
-        assert_decimal_eq!(greeks.vomma, dec!(0.0014037205608571828124031742), dec!(0.000001));
-        assert_decimal_eq!(greeks.veta, dec!(0.000027236903336955576237203), dec!(0.000001));
+        assert_decimal_eq!(
+            greeks.delta,
+            dec!(0.5338307582207135564475476937),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.gamma,
+            dec!(0.0692632117482215620683508231),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.theta,
+            dec!(-0.0434671314177636287945041349),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.vega,
+            dec!(0.1138573343806381728362131205),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.rho,
+            dec!(0.041863419880440417503050762),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.rho_d,
+            dec!(-0.0438765006756750824436552223),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.vanna,
+            dec!(-0.0569286671903190864181065602),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.vomma,
+            dec!(0.0014037205608571828124031742),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.veta,
+            dec!(0.000027236903336955576237203),
+            dec!(0.000001)
+        );
     }
 
     #[test]
@@ -2926,7 +2974,11 @@ mod tests_greeks_trait {
         assert_decimal_eq!(greeks.vega, dec!(0.15350973), dec!(0.000001));
         assert_decimal_eq!(greeks.rho, dec!(0.03786580), dec!(0.000001));
         assert_decimal_eq!(greeks.rho_d, dec!(-0.03928351), dec!(0.000001));
-        assert_decimal_eq!(greeks.vanna, dec!(0.9439386484253192473553911946), dec!(0.000001));
+        assert_decimal_eq!(
+            greeks.vanna,
+            dec!(0.9439386484253192473553911946),
+            dec!(0.000001)
+        );
         assert_decimal_eq!(greeks.vomma, dec!(0.19140525), dec!(0.000001));
         assert_decimal_eq!(greeks.veta, dec!(0.00004880), dec!(0.000001));
     }
@@ -2952,7 +3004,6 @@ mod tests_greeks_trait {
         assert_eq!(greeks.veta, dec!(0.0));
     }
 
-
     #[test]
     fn test_dividend_high_q_carry_regression() {
         // Regression test for the dividend (carry) bug family.
@@ -2967,6 +3018,15 @@ mod tests_greeks_trait {
         // Reference computation (independent Python Black-Scholes Merton
         // implementation, cross-checked against finite differences of the
         // closed-form delta): b = -0.03, d1 = 0.05, d2 = -0.25.
+        //
+        // Tolerance is 1e-12, not tighter: `big_n` evaluates the normal CDF in
+        // f64 via statrs and widens the result with `Decimal::from_f64`, so
+        // genuine precision here is ~1e-16. The digits past the 16th are
+        // Decimal rounding noise, and asserting them would turn this into a
+        // bit-pattern lock that a statrs patch release could break without
+        // changing any of the mathematics. 1e-12 still separates these values
+        // from the pre-fix dividend-blind ones, which differ in the second
+        // significant digit (delta 0.5762569743 vs 0.4799640108).
         // Sanity checks implied by the values:
         //   * rho_d == -delta exactly, since S*T = 100 (both rho_d and delta
         //     are scaled by 1/100) and rho_d = -S*T*e^{-qT}*N(d1).
@@ -2987,17 +3047,17 @@ mod tests_greeks_trait {
             None,
         );
         let g = option.greeks().unwrap();
-        assert_decimal_eq!(g.delta, dec!(0.4799640107901480920925461492), dec!(1e-28));
-        assert_decimal_eq!(g.gamma, dec!(0.0122603363406382730603468554), dec!(1e-28));
-        assert_decimal_eq!(g.theta, dec!(-0.0098247973187618777368017226), dec!(1e-28));
-        assert_decimal_eq!(g.vega, dec!(0.3678100902191481918104056619), dec!(1e-28));
-        assert_decimal_eq!(g.rho, dec!(0.381722350876409446703382601), dec!(1e-28));
-        assert_decimal_eq!(g.rho_d, dec!(-0.4799640107901480920925461492), dec!(1e-28));
-        assert_decimal_eq!(g.vanna, dec!(0.3065084085159568265086713849), dec!(1e-28));
-        assert_decimal_eq!(g.vomma, dec!(-0.0153254204257978413254335693), dec!(1e-28));
-        assert_decimal_eq!(g.veta, dec!(0.0000061119236221931867190717), dec!(1e-28));
-        assert_decimal_eq!(g.charm, dec!(0.0000800051194732414864990234), dec!(1e-28));
-        assert_decimal_eq!(g.color, dec!(-0.000019524165747934236209114), dec!(1e-28));
+        assert_decimal_eq!(g.delta, dec!(0.4799640107901480920925461492), dec!(1e-12));
+        assert_decimal_eq!(g.gamma, dec!(0.0122603363406382730603468554), dec!(1e-12));
+        assert_decimal_eq!(g.theta, dec!(-0.0098247973187618777368017226), dec!(1e-12));
+        assert_decimal_eq!(g.vega, dec!(0.3678100902191481918104056619), dec!(1e-12));
+        assert_decimal_eq!(g.rho, dec!(0.381722350876409446703382601), dec!(1e-12));
+        assert_decimal_eq!(g.rho_d, dec!(-0.4799640107901480920925461492), dec!(1e-12));
+        assert_decimal_eq!(g.vanna, dec!(0.3065084085159568265086713849), dec!(1e-12));
+        assert_decimal_eq!(g.vomma, dec!(-0.0153254204257978413254335693), dec!(1e-12));
+        assert_decimal_eq!(g.veta, dec!(0.0000061119236221931867190717), dec!(1e-12));
+        assert_decimal_eq!(g.charm, dec!(0.0000800051194732414864990234), dec!(1e-12));
+        assert_decimal_eq!(g.color, dec!(-0.000019524165747934236209114), dec!(1e-12));
     }
 
     #[test]
@@ -3038,12 +3098,36 @@ mod tests_greeks_trait {
 
         // Opposing positions should mostly cancel out
         assert_decimal_eq!(greeks.delta, Decimal::ZERO, dec!(0.000001));
-        assert_decimal_eq!(greeks.gamma, dec!(0.0755185886581300512828146194), dec!(0.000001));
-        assert_decimal_eq!(greeks.vega, dec!(0.3775929432906502564140730968), dec!(0.000001));
-        assert_decimal_eq!(greeks.rho, dec!(0.5135001229824933847234299424), dec!(0.000001));
-        assert_decimal_eq!(greeks.vanna, dec!(-0.3775929432906502564140730968), dec!(0.000001));
-        assert_decimal_eq!(greeks.vomma, dec!(0.0566389414935975384621109646), dec!(0.000001));
-        assert_decimal_eq!(greeks.veta, dec!(0.0000066678118954102922263596), dec!(0.000001));
+        assert_decimal_eq!(
+            greeks.gamma,
+            dec!(0.0755185886581300512828146194),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.vega,
+            dec!(0.3775929432906502564140730968),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.rho,
+            dec!(0.5135001229824933847234299424),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.vanna,
+            dec!(-0.3775929432906502564140730968),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.vomma,
+            dec!(0.0566389414935975384621109646),
+            dec!(0.000001)
+        );
+        assert_decimal_eq!(
+            greeks.veta,
+            dec!(0.0000066678118954102922263596),
+            dec!(0.000001)
+        );
     }
 
     #[test]
@@ -3508,7 +3592,11 @@ pub mod tests_charm_equations {
         );
         let charm_value = charm(&option).unwrap();
         info!("Charm Call ITM Value: {}", charm_value);
-        assert_relative_eq!(charm_value.to_f64().unwrap(), 0.00274096463168, epsilon = 1e-8);
+        assert_relative_eq!(
+            charm_value.to_f64().unwrap(),
+            0.00274096463168,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -3524,7 +3612,11 @@ pub mod tests_charm_equations {
         );
         let charm_value = charm(&option).unwrap();
         info!("Charm Put ITM Value: {}", charm_value);
-        assert_relative_eq!(charm_value.to_f64().unwrap(), -0.0039614286773, epsilon = 1e-8);
+        assert_relative_eq!(
+            charm_value.to_f64().unwrap(),
+            -0.0039614286773,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -3540,7 +3632,11 @@ pub mod tests_charm_equations {
         );
         let charm_value = charm(&option).unwrap();
         info!("Charm Call ATM Value: {}", charm_value);
-        assert_relative_eq!(charm_value.to_f64().unwrap(), -0.000523300995754, epsilon = 1e-8);
+        assert_relative_eq!(
+            charm_value.to_f64().unwrap(),
+            -0.000523300995754,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -3556,7 +3652,11 @@ pub mod tests_charm_equations {
         );
         let charm_value = charm(&option).unwrap();
         info!("Charm Put ATM Value: {}", charm_value);
-        assert_relative_eq!(charm_value.to_f64().unwrap(), -0.000550675746984, epsilon = 1e-8);
+        assert_relative_eq!(
+            charm_value.to_f64().unwrap(),
+            -0.000550675746984,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -3572,7 +3672,11 @@ pub mod tests_charm_equations {
         );
         let charm_value = charm(&option).unwrap();
         info!("Charm Call OTM Value: {}", charm_value);
-        assert_relative_eq!(charm_value.to_f64().unwrap(), -0.00405183908388, epsilon = 1e-8);
+        assert_relative_eq!(
+            charm_value.to_f64().unwrap(),
+            -0.00405183908388,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -3588,7 +3692,11 @@ pub mod tests_charm_equations {
         );
         let charm_value = charm(&option).unwrap();
         info!("Charm Put OTM Value: {}", charm_value);
-        assert_relative_eq!(charm_value.to_f64().unwrap(), 0.00282022266253, epsilon = 1e-8);
+        assert_relative_eq!(
+            charm_value.to_f64().unwrap(),
+            0.00282022266253,
+            epsilon = 1e-8
+        );
     }
 }
 
@@ -4315,7 +4423,11 @@ pub mod tests_color_equations {
         );
         let color_value = color(&option).unwrap();
         info!("Color ITM Value: {}", color_value);
-        assert_relative_eq!(color_value.to_f64().unwrap(), -0.000400671355466, epsilon = 1e-8);
+        assert_relative_eq!(
+            color_value.to_f64().unwrap(),
+            -0.000400671355466,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -4331,7 +4443,11 @@ pub mod tests_color_equations {
         );
         let color_value = color(&option).unwrap();
         info!("Color ATM Value: {}", color_value);
-        assert_relative_eq!(color_value.to_f64().unwrap(), -0.000817099264221, epsilon = 1e-8);
+        assert_relative_eq!(
+            color_value.to_f64().unwrap(),
+            -0.000817099264221,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -4347,7 +4463,11 @@ pub mod tests_color_equations {
         );
         let color_value = color(&option).unwrap();
         info!("Color ATM Near Expiration Value: {}", color_value);
-        assert_relative_eq!(color_value.to_f64().unwrap(), -0.378230424889, epsilon = 1e-8);
+        assert_relative_eq!(
+            color_value.to_f64().unwrap(),
+            -0.378230424889,
+            epsilon = 1e-8
+        );
     }
 
     #[test]
@@ -4383,6 +4503,10 @@ pub mod tests_color_equations {
         );
         let color_value = color(&option).unwrap();
         info!("Color OTM Value: {}", color_value);
-        assert_relative_eq!(color_value.to_f64().unwrap(), -0.000452958052918, epsilon = 1e-8);
+        assert_relative_eq!(
+            color_value.to_f64().unwrap(),
+            -0.000452958052918,
+            epsilon = 1e-8
+        );
     }
 }

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -22,13 +22,13 @@ use statrs::distribution::{ContinuousCDF, Normal};
 /// It is computed using the formula:
 ///
 /// ```math
-/// d1 = (ln(S / K) + (r + σ² / 2) * T) / (σ * sqrt(T))
+/// d1 = (ln(S / K) + (b + σ² / 2) * T) / (σ * sqrt(T))
 /// ```
 ///
 /// Where:
 /// - `S`: Underlying price
 /// - `K`: Strike price
-/// - `r`: Risk-free rate
+/// - `b`: Cost of carry, `b = r - q` (risk-free rate minus dividend yield)
 /// - `T`: Time to expiration (in years)
 /// - `σ`: Implied volatility
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 // into, so the lint is silenced in `#[cfg(test)]` only.
 #![cfg_attr(test, allow(clippy::indexing_slicing))]
 
-//! # OptionStratLib v0.19.0: Financial Options Library
+//! # OptionStratLib v0.19.1: Financial Options Library
 //!
 //! ## Table of Contents
 //! 1. [Introduction](#introduction)
@@ -800,7 +800,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = "0.19.0"
+//! optionstratlib = "0.19.1"
 //! ```
 //!
 //! Or use cargo to add it to your project:
@@ -815,7 +815,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = { version = "0.19.0", features = ["plotly"] }
+//! optionstratlib = { version = "0.19.1", features = ["plotly"] }
 //! ```
 //!
 //! - `plotly`: Enables interactive visualization using plotly.rs
@@ -1206,7 +1206,7 @@
 //!
 //! ---
 //!
-//! **OptionStratLib v0.19.0** - Built with ❤️ in Rust for the financial community
+//! **OptionStratLib v0.19.1** - Built with ❤️ in Rust for the financial community
 //!
 
 /// # OptionsStratLib: Financial Options Trading Library

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -1911,98 +1911,158 @@ mod tests_greeks {
     fn test_delta_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.delta().unwrap(), dec!(1.0676615164414271128950953874), EPSILON);
+        assert_decimal_eq!(
+            option.delta().unwrap(),
+            dec!(1.0676615164414271128950953874),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_gamma() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.gamma().unwrap(), dec!(0.0692632117482215620683508231), EPSILON);
+        assert_decimal_eq!(
+            option.gamma().unwrap(),
+            dec!(0.0692632117482215620683508231),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_gamma_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.gamma().unwrap(), dec!(0.1385264234964431241367016462), EPSILON);
+        assert_decimal_eq!(
+            option.gamma().unwrap(),
+            dec!(0.1385264234964431241367016462),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_theta() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.theta().unwrap(), dec!(-0.0434671314177636287945041349), EPSILON);
+        assert_decimal_eq!(
+            option.theta().unwrap(),
+            dec!(-0.0434671314177636287945041349),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_theta_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.theta().unwrap(), dec!(-0.0869342628355272575890082697), EPSILON);
+        assert_decimal_eq!(
+            option.theta().unwrap(),
+            dec!(-0.0869342628355272575890082697),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_vega() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.vega().unwrap(), dec!(0.1138573343806381728362131205), EPSILON);
+        assert_decimal_eq!(
+            option.vega().unwrap(),
+            dec!(0.1138573343806381728362131205),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_vega_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.vega().unwrap(), dec!(0.2277146687612763456724262410), EPSILON);
+        assert_decimal_eq!(
+            option.vega().unwrap(),
+            dec!(0.2277146687612763456724262410),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_rho() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.rho().unwrap(), dec!(0.041863419880440417503050762), EPSILON);
+        assert_decimal_eq!(
+            option.rho().unwrap(),
+            dec!(0.041863419880440417503050762),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_rho_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.rho().unwrap(), dec!(0.0837268397608808350061015239), EPSILON);
+        assert_decimal_eq!(
+            option.rho().unwrap(),
+            dec!(0.0837268397608808350061015239),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_rho_d() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.rho_d().unwrap(), dec!(-0.0438765006756750824436552223), EPSILON);
+        assert_decimal_eq!(
+            option.rho_d().unwrap(),
+            dec!(-0.0438765006756750824436552223),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_rho_d_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.rho_d().unwrap(), dec!(-0.0877530013513501648873104446), EPSILON);
+        assert_decimal_eq!(
+            option.rho_d().unwrap(),
+            dec!(-0.0877530013513501648873104446),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_vanna() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.vanna().unwrap(), dec!(-0.0569286671903190864181065602), EPSILON);
+        assert_decimal_eq!(
+            option.vanna().unwrap(),
+            dec!(-0.0569286671903190864181065602),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_vanna_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.vanna().unwrap(), dec!(-0.1138573343806381728362131204), EPSILON);
+        assert_decimal_eq!(
+            option.vanna().unwrap(),
+            dec!(-0.1138573343806381728362131204),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_vomma() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.vomma().unwrap(), dec!(0.0014037205608571828124031742), EPSILON);
+        assert_decimal_eq!(
+            option.vomma().unwrap(),
+            dec!(0.0014037205608571828124031742),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_vomma_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.vomma().unwrap(), dec!(0.0056148822434287312496126966), EPSILON);
+        assert_decimal_eq!(
+            option.vomma().unwrap(),
+            dec!(0.0028074411217143656248063484),
+            EPSILON
+        );
     }
 
     #[test]
@@ -2015,33 +2075,67 @@ mod tests_greeks {
     fn test_veta_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.veta().unwrap(), dec!(0.000108824758), EPSILON);
+        assert_decimal_eq!(option.veta().unwrap(), dec!(0.000054412378), EPSILON);
+    }
+
+    #[test]
+    fn test_vomma_and_veta_scale_linearly_in_quantity() {
+        // `vega` already carries the position size, so `vomma` and `veta` must
+        // not apply it a second time. Both are first derivatives of vega and
+        // are therefore linear, not quadratic, in quantity.
+        let single = create_sample_option_simplest(OptionStyle::Call, Side::Long);
+        let vomma_per_lot = single.vomma().unwrap();
+        let veta_per_lot = single.veta().unwrap();
+
+        for lots in [2u64, 5, 10] {
+            let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
+            option.quantity = pos_or_panic!(lots as f64);
+            let scale = Decimal::from(lots);
+            assert_decimal_eq!(option.vomma().unwrap(), vomma_per_lot * scale, EPSILON);
+            assert_decimal_eq!(option.veta().unwrap(), veta_per_lot * scale, EPSILON);
+        }
     }
 
     #[test]
     fn test_charm() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.charm().unwrap(), dec!(-0.0005546611716779658921659644), EPSILON);
+        assert_decimal_eq!(
+            option.charm().unwrap(),
+            dec!(-0.0005546611716779658921659644),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_charm_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.charm().unwrap(), dec!(-0.0011093223433559317843319287), EPSILON);
+        assert_decimal_eq!(
+            option.charm().unwrap(),
+            dec!(-0.0011093223433559317843319287),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_color() {
         let option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
-        assert_decimal_eq!(option.color().unwrap(), dec!(-0.0011648237847885846501315451), EPSILON);
+        assert_decimal_eq!(
+            option.color().unwrap(),
+            dec!(-0.0011648237847885846501315451),
+            EPSILON
+        );
     }
 
     #[test]
     fn test_color_size() {
         let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
         option.quantity = Positive::TWO;
-        assert_decimal_eq!(option.color().unwrap(), dec!(-0.0023296475695771693002630901), EPSILON);
+        assert_decimal_eq!(
+            option.color().unwrap(),
+            dec!(-0.0023296475695771693002630901),
+            EPSILON
+        );
     }
 }
 

--- a/src/strategies/build/model.rs
+++ b/src/strategies/build/model.rs
@@ -414,16 +414,40 @@ mod tests_strategies_build_model {
         let greeks_result = strategy.greeks();
         assert!(greeks_result.is_ok());
         let greeks = greeks_result.unwrap();
-        assert_decimal_eq!(greeks.delta, dec!(0.1581527925803475549715372372), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.delta,
+            dec!(0.1581527925803475549715372372),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
-        assert_decimal_eq!(greeks.theta, dec!(-4.5538703856637124015693694077), dec!(1e-4));
-        assert_decimal_eq!(greeks.vega, dec!(0.2511686561527911084852785379), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.theta,
+            dec!(-4.5538703856637124015693694077),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vega,
+            dec!(0.2511686561527911084852785379),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.rho, dec!(0.0398), dec!(1e-4));
-        assert_decimal_eq!(greeks.vanna, dec!(-1.2129758899332920842988174278), dec!(1e-4));
-        assert_decimal_eq!(greeks.vomma, dec!(0.5466916419288404045805098926), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.vanna,
+            dec!(-1.2129758899332920842988174278),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vomma,
+            dec!(0.5466916419288404045805098926),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
-        assert_decimal_eq!(greeks.charm, dec!(0.209293), dec!(1e-4));
-        assert_decimal_eq!(greeks.color, dec!(-0.0038405632865186300729115151), dec!(1e-6));
+        assert_decimal_eq!(greeks.charm, dec!(0.2091949851158175385267637), dec!(1e-5));
+        assert_decimal_eq!(
+            greeks.color,
+            dec!(-0.0038405632865186300729115151),
+            dec!(1e-6)
+        );
     }
 
     #[test]
@@ -472,16 +496,40 @@ mod tests_strategies_build_model {
         let greeks = strategy
             .greeks()
             .unwrap_or_else(|e| panic!("greeks err: {e:?}"));
-        assert_decimal_eq!(greeks.delta, dec!(-0.1581527925803475549715372372), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.delta,
+            dec!(-0.1581527925803475549715372372),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
-        assert_decimal_eq!(greeks.theta, dec!(-4.5538703856637124015693694077), dec!(1e-4));
-        assert_decimal_eq!(greeks.vega, dec!(0.2511686561527911084852785379), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.theta,
+            dec!(-4.5538703856637124015693694077),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vega,
+            dec!(0.2511686561527911084852785379),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.rho, dec!(0.0398), dec!(1e-4));
-        assert_decimal_eq!(greeks.vanna, dec!(-1.2129758899332920842988174278), dec!(1e-4));
-        assert_decimal_eq!(greeks.vomma, dec!(0.5466916419288404045805098926), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.vanna,
+            dec!(-1.2129758899332920842988174278),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vomma,
+            dec!(0.5466916419288404045805098926),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
-        assert_decimal_eq!(greeks.charm, dec!(0.209293), dec!(1e-4));
-        assert_decimal_eq!(greeks.color, dec!(-0.0038405632865186300729115151), dec!(1e-6));
+        assert_decimal_eq!(greeks.charm, dec!(0.2091949851158175385267637), dec!(1e-5));
+        assert_decimal_eq!(
+            greeks.color,
+            dec!(-0.0038405632865186300729115151),
+            dec!(1e-6)
+        );
     }
 
     #[test]
@@ -530,16 +578,44 @@ mod tests_strategies_build_model {
         let greeks_result = strategy.greeks();
         assert!(greeks_result.is_ok());
         let greeks = greeks_result.unwrap();
-        assert_decimal_eq!(greeks.delta, dec!(0.1581527925803475549715372372), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.delta,
+            dec!(0.1581527925803475549715372372),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
-        assert_decimal_eq!(greeks.theta, dec!(-4.3563687207554982849013080107), dec!(1e-4));
-        assert_decimal_eq!(greeks.vega, dec!(0.2511686561527911084852785379), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.theta,
+            dec!(-4.3563687207554982849013080107),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vega,
+            dec!(0.2511686561527911084852785379),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.rho, dec!(-0.0097), dec!(1e-4));
-        assert_decimal_eq!(greeks.vanna, dec!(-1.2129758899332920842988174278), dec!(1e-4));
-        assert_decimal_eq!(greeks.vomma, dec!(0.5466916419288404045805098926), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.vanna,
+            dec!(-1.2129758899332920842988174278),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vomma,
+            dec!(0.5466916419288404045805098926),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
-        assert_decimal_eq!(greeks.charm, dec!(0.209239), dec!(1e-4));
-        assert_decimal_eq!(greeks.color, dec!(-0.0038405632865186300729115151), dec!(1e-6));
+        assert_decimal_eq!(
+            greeks.charm,
+            dec!(0.2091401920964686467636671300),
+            dec!(1e-5)
+        );
+        assert_decimal_eq!(
+            greeks.color,
+            dec!(-0.0038405632865186300729115151),
+            dec!(1e-6)
+        );
     }
 
     #[test]
@@ -588,16 +664,44 @@ mod tests_strategies_build_model {
         let greeks = strategy
             .greeks()
             .unwrap_or_else(|e| panic!("greeks err: {e:?}"));
-        assert_decimal_eq!(greeks.delta, dec!(-0.1581527925803475549715372372), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.delta,
+            dec!(-0.1581527925803475549715372372),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
-        assert_decimal_eq!(greeks.theta, dec!(-4.3563687207554982849013080107), dec!(1e-4));
-        assert_decimal_eq!(greeks.vega, dec!(0.2511686561527911084852785379), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.theta,
+            dec!(-4.3563687207554982849013080107),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vega,
+            dec!(0.2511686561527911084852785379),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.rho, dec!(-0.0097), dec!(1e-4));
-        assert_decimal_eq!(greeks.vanna, dec!(-1.2129758899332920842988174278), dec!(1e-4));
-        assert_decimal_eq!(greeks.vomma, dec!(0.5466916419288404045805098926), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.vanna,
+            dec!(-1.2129758899332920842988174278),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.vomma,
+            dec!(0.5466916419288404045805098926),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
-        assert_decimal_eq!(greeks.charm, dec!(0.2091401920964686467636671300), dec!(1e-5));
-        assert_decimal_eq!(greeks.color, dec!(-0.0038405632865186300729115151), dec!(1e-5));
+        assert_decimal_eq!(
+            greeks.charm,
+            dec!(0.2091401920964686467636671300),
+            dec!(1e-5)
+        );
+        assert_decimal_eq!(
+            greeks.color,
+            dec!(-0.0038405632865186300729115151),
+            dec!(1e-5)
+        );
     }
 
     #[test]

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -1199,8 +1199,16 @@ mod tests_implied_volatility {
         assert_decimal_eq!(vega, dec!(0.8735285922867751407644169906), dec!(0.002));
         assert_decimal_eq!(theta, dec!(-27.244276204109831381546317238), dec!(0.002));
         assert_decimal_eq!(rho, dec!(0.277), dec!(0.002));
-        assert_decimal_eq!(vanna, dec!(-0.4905170891818293972168486173), dec!(0.0000001));
-        assert_decimal_eq!(vomma, dec!(6.2569425433351718484053752895), dec!(0.00000001));
+        assert_decimal_eq!(
+            vanna,
+            dec!(-0.4905170891818293972168486173),
+            dec!(0.0000001)
+        );
+        assert_decimal_eq!(
+            vomma,
+            dec!(6.2569425433351718484053752895),
+            dec!(0.00000001)
+        );
         assert_decimal_eq!(veta, dec!(0.0434650505282011247018063025), dec!(0.0000001));
         assert_decimal_eq!(charm, dec!(0.1695474991264431915978503078), dec!(0.0000001));
         assert_decimal_eq!(color, dec!(0.0005864547013714062753140932), dec!(0.0000001));
@@ -1246,8 +1254,16 @@ mod tests_implied_volatility {
         assert_decimal_eq!(vega, dec!(0.8735285922867751407644169906), dec!(0.001));
         assert_decimal_eq!(theta, dec!(-30.127616013684725380529216795), dec!(0.001));
         assert_decimal_eq!(rho, dec!(-0.016), dec!(0.001));
-        assert_decimal_eq!(vanna, dec!(-0.4905170891818293972168486173), dec!(0.0000001));
-        assert_decimal_eq!(vomma, dec!(6.2569425433351718484053752895), dec!(0.00000001));
+        assert_decimal_eq!(
+            vanna,
+            dec!(-0.4905170891818293972168486173),
+            dec!(0.0000001)
+        );
+        assert_decimal_eq!(
+            vomma,
+            dec!(6.2569425433351718484053752895),
+            dec!(0.00000001)
+        );
         assert_decimal_eq!(veta, dec!(0.0434650505282011247018063025), dec!(0.0000001));
         assert_decimal_eq!(charm, dec!(0.1694105225826541109000514178), dec!(0.0000001));
         assert_decimal_eq!(color, dec!(0.0005864547013714062753140932), dec!(0.0000001));
@@ -1310,8 +1326,16 @@ mod tests_implied_volatility {
         assert_decimal_eq!(vega, dec!(0.8735285922867751407644169906), dec!(0.002));
         assert_decimal_eq!(theta, dec!(-27.244276204109831381546317238), dec!(0.002));
         assert_decimal_eq!(rho, dec!(0.277), dec!(0.002));
-        assert_decimal_eq!(vanna, dec!(-0.4905170891818293972168486173), dec!(0.0000001));
-        assert_decimal_eq!(vomma, dec!(6.2569425433351718484053752895), dec!(0.00000001));
+        assert_decimal_eq!(
+            vanna,
+            dec!(-0.4905170891818293972168486173),
+            dec!(0.0000001)
+        );
+        assert_decimal_eq!(
+            vomma,
+            dec!(6.2569425433351718484053752895),
+            dec!(0.00000001)
+        );
         assert_decimal_eq!(veta, dec!(0.0434650505282011247018063025), dec!(0.0000001));
         assert_decimal_eq!(charm, dec!(0.1695474991264431915978503078), dec!(0.0000001));
         assert_decimal_eq!(color, dec!(0.0005864547013714062753140932), dec!(0.0000001));
@@ -1357,8 +1381,16 @@ mod tests_implied_volatility {
         assert_decimal_eq!(vega, dec!(0.8735285922867751407644169906), dec!(0.001));
         assert_decimal_eq!(theta, dec!(-30.127616013684725380529216795), dec!(0.001));
         assert_decimal_eq!(rho, dec!(-0.016), dec!(0.001));
-        assert_decimal_eq!(vanna, dec!(-0.4905170891818293972168486173), dec!(0.0000001));
-        assert_decimal_eq!(vomma, dec!(6.2569425433351718484053752895), dec!(0.00000001));
+        assert_decimal_eq!(
+            vanna,
+            dec!(-0.4905170891818293972168486173),
+            dec!(0.0000001)
+        );
+        assert_decimal_eq!(
+            vomma,
+            dec!(6.2569425433351718484053752895),
+            dec!(0.00000001)
+        );
         assert_decimal_eq!(veta, dec!(0.0434650505282011247018063025), dec!(0.0000001));
         assert_decimal_eq!(charm, dec!(0.1694105225826541109000514178), dec!(0.0000001));
         assert_decimal_eq!(color, dec!(0.0005864547013714062753140932), dec!(0.0000001));
@@ -1421,7 +1453,11 @@ mod tests_implied_volatility {
         assert_decimal_eq!(vega, dec!(0.0105), dec!(0.002));
         assert_decimal_eq!(theta, dec!(-0.64997), dec!(0.002));
         assert_decimal_eq!(rho, dec!(-0.000083), dec!(0.002));
-        assert_decimal_eq!(vanna, dec!(-0.0144632755644302251546856722), dec!(0.0000001));
+        assert_decimal_eq!(
+            vanna,
+            dec!(-0.0144632755644302251546856722),
+            dec!(0.0000001)
+        );
         assert_decimal_eq!(vomma, dec!(0.3275301270), dec!(0.0000000001));
         assert_decimal_eq!(veta, dec!(0.0031824), dec!(0.0000001));
         assert_decimal_eq!(charm, dec!(0.0088981), dec!(0.0000001));
@@ -1481,7 +1517,11 @@ mod tests_implied_volatility {
         assert_decimal_eq!(vega, dec!(0.02255), dec!(0.002));
         assert_decimal_eq!(theta, dec!(-1.25733), dec!(0.002));
         assert_decimal_eq!(rho, dec!(0.204), dec!(0.002));
-        assert_decimal_eq!(vanna, dec!(-0.0274529936439301097044284653), dec!(0.0000001));
+        assert_decimal_eq!(
+            vanna,
+            dec!(-0.0274529936439301097044284653),
+            dec!(0.0000001)
+        );
         assert_decimal_eq!(vomma, dec!(0.6094669204), dec!(0.0000000001));
         assert_decimal_eq!(veta, dec!(0.0054321), dec!(0.0000001));
         assert_decimal_eq!(charm, dec!(0.0153063), dec!(0.0000001));

--- a/tests/unit/strategies/delta/strategy_bear_call_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bear_call_spread.rs
@@ -42,8 +42,8 @@ fn test_bear_call_spread_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(0.620955), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(-0.628208), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(0.182024), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(14.127513), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.053839), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(7.0637565), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0269195), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.022989), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.003705), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_bear_put_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bear_put_spread.rs
@@ -42,8 +42,8 @@ fn test_bear_put_spread_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(-0.645820), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(0.636651), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(0.0980755896), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(37.8187674591), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0593138779), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(18.90938372955), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.02965693895), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.015910), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.001047), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_bull_call_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bull_call_spread.rs
@@ -41,8 +41,8 @@ fn test_bull_call_spread_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(0.620955), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(-0.628208), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(0.1820241857), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(14.1275133271), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0538396250), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(7.06375666355), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0269198125), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.022989), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.003705), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_bull_put_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bull_put_spread.rs
@@ -42,8 +42,8 @@ fn test_bull_put_spread_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(-0.833461), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(0.816525), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(-0.0226839453), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(31.9307265715), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0486186188), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(15.96536328575), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0243093094), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.008209), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.000736), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_iron_butterfly.rs
+++ b/tests/unit/strategies/delta/strategy_iron_butterfly.rs
@@ -43,8 +43,8 @@ fn test_iron_butterfly_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(-1.796019), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(1.597057), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(5.7651822592), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(153.9868702894), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0139491695), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(76.9934351447), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.00697458475), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.021321), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.0000524805), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_iron_condor.rs
+++ b/tests/unit/strategies/delta/strategy_iron_condor.rs
@@ -44,8 +44,8 @@ fn test_iron_condor_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(0.558247), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(-0.633206), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(0.2487598459), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(170.9330480070), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0134886944), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(85.4665240035), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0067443472), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.00665184), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00003014), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_long_butterfly_spread.rs
+++ b/tests/unit/strategies/delta/strategy_long_butterfly_spread.rs
@@ -46,8 +46,8 @@ fn test_long_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(0.723546), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(-0.733649), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(-1.0392151544), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(11.7847657892), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0397196877), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(10.8363014211368996632778), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0271540829193105620224721), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(0.03338228), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00276925), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_poor_mans_covered_call.rs
+++ b/tests/unit/strategies/delta/strategy_poor_mans_covered_call.rs
@@ -42,8 +42,8 @@ fn test_poor_mans_covered_call_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(12.909435), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(-14.201310), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(0.5565729391), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(62.9867489281), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0051055965), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(31.49337446405), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.00255279825), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.00864689), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00005040), epsilon);
 

--- a/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
+++ b/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
@@ -44,8 +44,8 @@ fn test_short_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.rho, dec!(1.971329081), epsilon);
     assert_decimal_eq!(greeks.rho_d, dec!(-1.997983), epsilon);
     assert_decimal_eq!(greeks.vanna, dec!(-0.4538499018), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(100.0783474574), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.3561974334), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(33.2470297275943257605818), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0816909193673865686658299), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(-0.01945020), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00806599), epsilon);
 


### PR DESCRIPTION
Follow-up to #426, covering the five items recorded in #427.

## The real bug: `vomma` and `veta` scale as quantity squared

`vomma` (`src/greeks/equations.rs`) and `veta` call `vega(option)?`, which
already returns `vega * quantity`, and then multiply by `quantity` a second
time. Both are first derivatives of vega and are linear in position size, so a
10-lot position reported 10x the true vomma, and the error propagated into
`PortfolioGreeks`.

The defect pre-dates #426. What made it urgent is that #426 rewrote the two
tests that pin it into fresh 28-digit literals encoding exactly 4x the one-lot
value for a 2-lot position, so it was cemented by green assertions.

Fixed on both sides, plus `test_vomma_and_veta_scale_linearly_in_quantity`,
which asserts the scaling law directly at 2, 5 and 10 lots rather than pinning
a magic number.

Nine `tests/unit/strategies/delta/*` integration tests were pinning the same
quantity-squared aggregates. Their expectations are re-derived, not refitted:

- The seven uniform 2-lot strategies have a correct value of exactly half the
  old one, which is the algebra of removing one factor of `quantity` per leg.
- The two butterflies have mixed leg quantities (1/2/1 and 3/6/3), so no single
  scale factor applies. Both were recomputed leg by leg from the Merton closed
  forms with mpmath at 40 significant digits. They match the implementation to
  ~3e-17 (vomma) and ~4e-18 (veta), and the old literals reproduce exactly the
  quantity-weighted buggy sum.

## Stale `charm` expectations

`src/strategies/build/model.rs` had four `charm` values left at their pre-#426
numbers while a fifth was updated. `test_strategy_bear_put_spread` and
`test_strategy_bull_put_spread` build the identical two legs, so their aggregate
charm is the same number, yet they asserted different values. The three stale
literals survived only on a 10x looser tolerance, at 98.0% and 98.8% of their
1e-4 budget: any sub-1e-6 perturbation turned them red with the mathematics
unchanged.

Re-derived at 50 dps: call spreads 0.2091949851158175385267637, put spreads
0.2091401920964687698946958, both now at the 1e-5 tolerance already used by the
bull put spread.

## `1e-28` regression tolerance

`test_dividend_high_q_carry_regression` asserted all eleven Greeks at `1e-28`.
Those values pass through `big_n`, which evaluates the normal CDF in f64 via
statrs and widens the result with `Decimal::from_f64`, so genuine precision is
~1e-16; on values of magnitude 0.1 to 0.5, `1e-28` is roughly one unit in the
last Decimal place. Measured gap to an mpmath 50-dps reference: delta
-7.085e-16, vega -9.238e-16, vanna -7.698e-16. The statrs 0.18 to 0.19 bump in
`fe82222c`, one commit before that PR's base, would have broken this test
without changing any of the mathematics.

Relaxed to `1e-12`, which still separates these values from the pre-#426
dividend-blind ones: they differ in the second significant digit (delta
0.5762569743 vs 0.4799640108). The provenance comment is corrected too, since
no f64 reference can supply digits 17 through 28.

## `d1` rustdoc

The formula block and legend still documented the third argument as `r`, the
risk-free rate, while #426 renamed the parameter to `carry_rate` and documented
it correctly three lines below. The same doc block stated two meanings for one
argument and the more prominent one was wrong. `d1`/`d2` are `pub` and in the
prelude, so a caller following it for S=K=100, T=1, sigma=0.2, r=0.05, q=0.03
would pass `0.05`, get d1=0.35 and a delta of 0.6180 where `option.delta()`
returns 0.5622.

## Formatting, and why CI never noticed

Merging #426 left `main` with 47 unformatted hunks, so `make check` failed.
`cargo fmt --all` applied.

The reason this was invisible: `.github/workflows/format_check.yml` ran
`make fmt`, which `Makefile` defines as `cargo +stable fmt --all`, the
*formatter*. It rewrote files inside the runner and exited 0 whatever the input,
so no pull request has ever actually been format-checked. The checking target
`fmt-check` was invoked by no workflow. The job now runs `make fmt-check`.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- 3872 lib + 12 property + 383 integration + 207 doc tests, 0 failures

Refs #427