### PR TITLE
perf(greeks): compute the shared Black-Scholes kernels once per option

### DIFF
--- a/benches/chains/generators.rs
+++ b/benches/chains/generators.rs
@@ -112,6 +112,16 @@ pub fn benchmark_chain_generators(c: &mut Criterion) {
                 black_box(chain)
             })
         });
+
+        // Same build with the full twelve-greek snapshot per option style, the
+        // opt-in path used by consumers that read the snapshots.
+        let with_greeks = build_params.clone().with_greek_snapshots(true);
+        group.bench_function(format!("build_chain {strikes} strikes + greeks"), |b| {
+            b.iter(|| {
+                let chain = OptionChain::build_chain(black_box(&with_greeks));
+                black_box(chain)
+            })
+        });
     }
 
     let params_10 = chain_walk_params(10);

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -4792,3 +4792,284 @@ pub mod tests_color_equations {
         );
     }
 }
+
+#[cfg(test)]
+mod tests_shared_kernel_equivalence {
+    use super::*;
+    use crate::greeks::utils::d2 as fresh_d2_fn;
+    use crate::model::types::OptionType;
+    use crate::{ExpirationDate, Options};
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+
+    /// Every branch `kernels_for` distinguishes, so the fast path and the
+    /// per-greek fallbacks are both exercised.
+    fn branches() -> Vec<(&'static str, OptionType, Positive, Positive)> {
+        vec![
+            // name, type, time to expiry in days, implied volatility
+            (
+                "live european",
+                OptionType::European,
+                pos_or_panic!(30.0),
+                pos_or_panic!(0.2),
+            ),
+            (
+                "at expiry",
+                OptionType::European,
+                Positive::ZERO,
+                pos_or_panic!(0.2),
+            ),
+            (
+                "zero volatility",
+                OptionType::European,
+                pos_or_panic!(30.0),
+                Positive::ZERO,
+            ),
+            (
+                "non european",
+                OptionType::American,
+                pos_or_panic!(30.0),
+                pos_or_panic!(0.2),
+            ),
+        ]
+    }
+
+    fn option_for(
+        option_type: OptionType,
+        days: Positive,
+        implied_volatility: Positive,
+        style: OptionStyle,
+        side: Side,
+        quantity: Positive,
+    ) -> Options {
+        Options::new(
+            option_type,
+            side,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(days),
+            implied_volatility,
+            quantity,
+            pos_or_panic!(105.0),
+            dec!(0.05),
+            style,
+            pos_or_panic!(0.02),
+            None,
+        )
+    }
+
+    /// The aggregate shares one set of kernels across the twelve greeks and
+    /// reuses gamma and theta for alpha, while the public functions each build
+    /// their own. The two must agree exactly, in every branch, for both styles
+    /// and both sides — including on failure, so the fast path can neither
+    /// succeed where an individual greek errors nor error where they all
+    /// succeed.
+    ///
+    /// The zero-volatility branch is the one that fails today: seven of the
+    /// twelve have no guard for it, so `greeks()` errors there while `delta`
+    /// and `gamma` still return their discrete values.
+    #[test]
+    fn test_greeks_matches_the_individual_functions_exactly() {
+        for (name, option_type, days, iv) in branches() {
+            for style in [OptionStyle::Call, OptionStyle::Put] {
+                for side in [Side::Long, Side::Short] {
+                    let option = option_for(
+                        option_type.clone(),
+                        days,
+                        iv,
+                        style,
+                        side,
+                        pos_or_panic!(3.0),
+                    );
+                    let label = format!("{name} {style:?} {side:?}");
+
+                    let individual = [
+                        ("delta", delta(&option)),
+                        ("gamma", gamma(&option)),
+                        ("theta", theta(&option)),
+                        ("vega", vega(&option)),
+                        ("rho", rho(&option)),
+                        ("rho_d", rho_d(&option)),
+                        ("alpha", alpha(&option)),
+                        ("vanna", vanna(&option)),
+                        ("vomma", vomma(&option)),
+                        ("veta", veta(&option)),
+                        ("charm", charm(&option)),
+                        ("color", color(&option)),
+                    ];
+                    let all_ok = individual.iter().all(|(_, r)| r.is_ok());
+
+                    match (option.greeks(), all_ok) {
+                        (Ok(aggregate), true) => {
+                            let values = [
+                                aggregate.delta,
+                                aggregate.gamma,
+                                aggregate.theta,
+                                aggregate.vega,
+                                aggregate.rho,
+                                aggregate.rho_d,
+                                aggregate.alpha,
+                                aggregate.vanna,
+                                aggregate.vomma,
+                                aggregate.veta,
+                                aggregate.charm,
+                                aggregate.color,
+                            ];
+                            for ((greek, single), aggregated) in
+                                individual.iter().zip(values.iter())
+                            {
+                                assert_eq!(
+                                    aggregated,
+                                    &expect(single, &label),
+                                    "{greek} disagrees for {label}"
+                                );
+                            }
+                        }
+                        (Err(_), false) => {
+                            // Both paths reject these inputs, which is the
+                            // contract for the zero-volatility branch.
+                        }
+                        (Ok(_), false) => {
+                            panic!("greeks() succeeded for {label} where an individual greek fails")
+                        }
+                        (Err(e), true) => panic!(
+                            "greeks() failed for {label} where every individual greek succeeds: {e}"
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
+    fn expect(result: &Result<Decimal, GreeksError>, label: &str) -> Decimal {
+        match result {
+            Ok(value) => *value,
+            Err(e) => panic!("individual greek failed for {label}: {e}"),
+        }
+    }
+
+    /// The aggregate now sums option by option rather than greek by greek.
+    /// `Decimal` addition is exact, so a multi-leg position must match the sum
+    /// of the per-option aggregates term by term.
+    #[test]
+    fn test_greeks_aggregation_is_order_independent() {
+        struct Legs(Vec<Options>);
+        impl Greeks for Legs {
+            fn get_options(&self) -> Result<Vec<&Options>, GreeksError> {
+                Ok(self.0.iter().collect())
+            }
+        }
+
+        let legs = Legs(vec![
+            option_for(
+                OptionType::European,
+                pos_or_panic!(30.0),
+                pos_or_panic!(0.2),
+                OptionStyle::Call,
+                Side::Long,
+                pos_or_panic!(2.0),
+            ),
+            option_for(
+                OptionType::European,
+                pos_or_panic!(45.0),
+                pos_or_panic!(0.35),
+                OptionStyle::Put,
+                Side::Short,
+                pos_or_panic!(3.0),
+            ),
+            // A degenerate leg alongside live ones, so the mixed path is covered.
+            option_for(
+                OptionType::European,
+                Positive::ZERO,
+                pos_or_panic!(0.2),
+                OptionStyle::Call,
+                Side::Short,
+                Positive::ONE,
+            ),
+        ]);
+
+        let Ok(total) = legs.greeks() else {
+            panic!("aggregate greeks should succeed");
+        };
+
+        let mut delta_sum = Decimal::ZERO;
+        let mut charm_sum = Decimal::ZERO;
+        let mut alpha_sum = Decimal::ZERO;
+        for option in &legs.0 {
+            delta_sum += expect(&delta(option), "leg");
+            charm_sum += expect(&charm(option), "leg");
+            alpha_sum += expect(&alpha(option), "leg");
+        }
+        assert_eq!(total.delta, delta_sum);
+        assert_eq!(total.charm, charm_sum);
+        assert_eq!(total.alpha, alpha_sum);
+    }
+
+    /// Each cached kernel must equal the value the pre-refactor code derived
+    /// from scratch, which is what makes the sharing value-preserving rather
+    /// than an approximation.
+    #[test]
+    fn test_cached_kernels_match_freshly_derived_values() {
+        let option = option_for(
+            OptionType::European,
+            pos_or_panic!(30.0),
+            pos_or_panic!(0.2),
+            OptionStyle::Call,
+            Side::Long,
+            Positive::ONE,
+        );
+        let Ok(t) = option.expiration_date.get_years() else {
+            panic!("expiration should resolve");
+        };
+        let Ok(kernels) = BlackScholesKernels::new(&option, t) else {
+            panic!("kernels should build for a live european option");
+        };
+        let carry = option.risk_free_rate - option.dividend_yield.to_dec();
+
+        let Ok(fresh_d1) = d1(
+            option.underlying_price,
+            option.strike_price,
+            carry,
+            t,
+            option.implied_volatility,
+        ) else {
+            panic!("d1 should compute");
+        };
+        let Ok(fresh_d2) = fresh_d2_fn(
+            option.underlying_price,
+            option.strike_price,
+            carry,
+            t,
+            option.implied_volatility,
+        ) else {
+            panic!("d2 should compute");
+        };
+
+        assert_eq!(kernels.d1(), fresh_d1, "d1");
+        assert_eq!(kernels.d2(), fresh_d2, "d2 derived from d1");
+        assert_eq!(kernels.sqrt_t(), t.sqrt(), "sqrt(T)");
+        assert_eq!(kernels.n_d1().ok(), n(fresh_d1).ok(), "n(d1)");
+        assert_eq!(kernels.big_n_d1().ok(), big_n(fresh_d1).ok(), "big_n(d1)");
+        assert_eq!(
+            kernels.big_n_neg_d1().ok(),
+            big_n(-fresh_d1).ok(),
+            "big_n(-d1)"
+        );
+        assert_eq!(kernels.big_n_d2().ok(), big_n(fresh_d2).ok(), "big_n(d2)");
+        assert_eq!(
+            kernels.big_n_neg_d2().ok(),
+            big_n(-fresh_d2).ok(),
+            "big_n(-d2)"
+        );
+        assert_eq!(
+            kernels.exp_minus_qt(),
+            (-t.to_dec() * option.dividend_yield).exp(),
+            "exp(-qT)"
+        );
+        assert_eq!(
+            kernels.exp_minus_rt(),
+            (-option.risk_free_rate * t).exp(),
+            "exp(-rT)"
+        );
+    }
+}

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -5,7 +5,7 @@
 ******************************************************************************/
 use crate::constants::{TRADING_DAYS, ZERO};
 use crate::error::greeks::GreeksError;
-use crate::greeks::utils::{big_n, d1, d2, n};
+use crate::greeks::utils::{big_n, d1, n};
 use crate::model::decimal::{d_div, d_mul};
 use crate::model::types::{OptionStyle, OptionType};
 use crate::{Options, Side};
@@ -13,6 +13,7 @@ use positive::Positive;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
 use rust_decimal::{Decimal, MathematicalOps};
 use serde::{Deserialize, Serialize};
+use std::cell::OnceCell;
 use utoipa::ToSchema;
 
 /// Represents a complete set of option Greeks, which measure the sensitivity of an option's
@@ -201,18 +202,38 @@ pub trait Greeks {
     ///
     /// Returns a `GreeksError` if any individual Greek calculation fails.
     fn greeks(&self) -> Result<Greek, GreeksError> {
-        let delta = self.delta()?;
-        let gamma = self.gamma()?;
-        let theta = self.theta()?;
-        let vega = self.vega()?;
-        let rho = self.rho()?;
-        let rho_d = self.rho_d()?;
-        let alpha = self.alpha()?;
-        let vanna = self.vanna()?;
-        let vomma = self.vomma()?;
-        let veta = self.veta()?;
-        let charm = self.charm()?;
-        let color = self.color()?;
+        // Aggregate option by option rather than greek by greek, so the shared
+        // Black-Scholes kernels are computed once per option instead of once
+        // per greek. `Decimal` addition is exact, so the sums are identical to
+        // accumulating each greek across every option in turn.
+        let options = self.get_options()?;
+        let mut delta = Decimal::ZERO;
+        let mut gamma = Decimal::ZERO;
+        let mut theta = Decimal::ZERO;
+        let mut vega = Decimal::ZERO;
+        let mut rho = Decimal::ZERO;
+        let mut rho_d = Decimal::ZERO;
+        let mut alpha = Decimal::ZERO;
+        let mut vanna = Decimal::ZERO;
+        let mut vomma = Decimal::ZERO;
+        let mut veta = Decimal::ZERO;
+        let mut charm = Decimal::ZERO;
+        let mut color = Decimal::ZERO;
+        for option in options {
+            let single = greeks_for(option)?;
+            delta += single.delta;
+            gamma += single.gamma;
+            theta += single.theta;
+            vega += single.vega;
+            rho += single.rho;
+            rho_d += single.rho_d;
+            alpha += single.alpha;
+            vanna += single.vanna;
+            vomma += single.vomma;
+            veta += single.veta;
+            charm += single.charm;
+            color += single.color;
+        }
         Ok(Greek {
             delta,
             gamma,
@@ -434,6 +455,213 @@ pub trait Greeks {
     }
 }
 
+/// The Black-Scholes intermediates that every greek shares, computed at most
+/// once each.
+///
+/// Each of the twelve greek functions used to re-derive `d1`, `d2`, the normal
+/// pdf and cdf, and the two discount factors from scratch, so one call to
+/// [`Greeks::greeks`] evaluated the same handful of expensive `Decimal`
+/// transcendentals dozens of times. Measured on an M-series Mac, those kernels
+/// were about 93% of the aggregate's cost.
+///
+/// Every field is computed with the identical expression the individual greeks
+/// used, so sharing them is value-preserving rather than an approximation.
+/// `d2` in particular is derived exactly as [`crate::greeks::d2`] derives it,
+/// `d1 - sigma * sqrt(T)`, which also avoids a second `d1`.
+///
+/// Everything past `d1` is computed lazily, so a caller that needs one greek
+/// pays only for that greek's inputs while the aggregate path shares them all.
+///
+/// Only valid for a live European option: the caller must have established that
+/// the option type is European, that the time to expiry is non-zero and that the
+/// implied volatility is non-zero. Each greek keeps its own degenerate branch
+/// for the cases this cannot represent.
+#[derive(Debug, Clone)]
+pub(crate) struct BlackScholesKernels {
+    /// Time to expiry in years.
+    t: Positive,
+    /// `sqrt(T)`, shared by every greek that scales by time.
+    sqrt_t: Positive,
+    d1: Decimal,
+    sigma: Positive,
+    q: Decimal,
+    r: Decimal,
+    d2: OnceCell<Decimal>,
+    n_d1: OnceCell<Decimal>,
+    big_n_d1: OnceCell<Decimal>,
+    big_n_neg_d1: OnceCell<Decimal>,
+    big_n_d2: OnceCell<Decimal>,
+    big_n_neg_d2: OnceCell<Decimal>,
+    exp_minus_qt: OnceCell<Decimal>,
+    exp_minus_rt: OnceCell<Decimal>,
+}
+
+impl BlackScholesKernels {
+    /// Computes `d1` and `sqrt(T)` for `option` at a time to expiry of `t`.
+    ///
+    /// Everything else is derived on first use. `t` is passed in rather than
+    /// re-derived because every caller has already obtained it to test its own
+    /// degenerate branch.
+    fn new(option: &Options, t: Positive) -> Result<Self, GreeksError> {
+        let carry_rate = option.risk_free_rate - option.dividend_yield.to_dec();
+        let sqrt_t = t.sqrt();
+        let d1 = d1(
+            option.underlying_price,
+            option.strike_price,
+            carry_rate,
+            t,
+            option.implied_volatility,
+        )?;
+
+        Ok(Self {
+            t,
+            sqrt_t,
+            d1,
+            sigma: option.implied_volatility,
+            q: option.dividend_yield.to_dec(),
+            r: option.risk_free_rate,
+            d2: OnceCell::new(),
+            n_d1: OnceCell::new(),
+            big_n_d1: OnceCell::new(),
+            big_n_neg_d1: OnceCell::new(),
+            big_n_d2: OnceCell::new(),
+            big_n_neg_d2: OnceCell::new(),
+            exp_minus_qt: OnceCell::new(),
+            exp_minus_rt: OnceCell::new(),
+        })
+    }
+
+    /// Time to expiry in years.
+    fn t(&self) -> Positive {
+        self.t
+    }
+
+    /// `sqrt(T)`.
+    fn sqrt_t(&self) -> Positive {
+        self.sqrt_t
+    }
+
+    fn d1(&self) -> Decimal {
+        self.d1
+    }
+
+    /// `d2 = d1 - sigma * sqrt(T)`, exactly as [`crate::greeks::d2`] derives it.
+    fn d2(&self) -> Decimal {
+        *self.d2.get_or_init(|| self.d1 - self.sigma * self.sqrt_t)
+    }
+
+    /// Normal pdf at `d1`; the most expensive single kernel.
+    fn n_d1(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.n_d1, || n(self.d1))
+    }
+
+    fn big_n_d1(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.big_n_d1, || Ok(big_n(self.d1)?))
+    }
+
+    fn big_n_neg_d1(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.big_n_neg_d1, || Ok(big_n(-self.d1)?))
+    }
+
+    fn big_n_d2(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.big_n_d2, || Ok(big_n(self.d2())?))
+    }
+
+    fn big_n_neg_d2(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.big_n_neg_d2, || Ok(big_n(-self.d2())?))
+    }
+
+    /// `exp(-qT)`, the dividend discount factor.
+    fn exp_minus_qt(&self) -> Decimal {
+        *self
+            .exp_minus_qt
+            .get_or_init(|| (-self.t.to_dec() * self.q).exp())
+    }
+
+    /// `exp(-rT)`, the risk-free discount factor.
+    fn exp_minus_rt(&self) -> Decimal {
+        *self.exp_minus_rt.get_or_init(|| (-self.r * self.t).exp())
+    }
+}
+
+/// Memoises a fallible kernel in a [`OnceCell`].
+///
+/// [`OnceCell::get_or_init`] cannot carry a `Result`, and `get_or_try_init` is
+/// still unstable, so this does the same job by hand. A failed computation is
+/// not cached, which is harmless: the inputs are fixed, so a retry fails again.
+fn cached<F>(cell: &OnceCell<Decimal>, compute: F) -> Result<Decimal, GreeksError>
+where
+    F: FnOnce() -> Result<Decimal, GreeksError>,
+{
+    if let Some(value) = cell.get() {
+        return Ok(*value);
+    }
+    let value = compute()?;
+    let _ = cell.set(value);
+    Ok(value)
+}
+
+/// Builds the shared kernels when `option` is a live European contract.
+///
+/// Returns `None` for the degenerate cases — a non-European type, a zero time to
+/// expiry, or a zero implied volatility — where the individual greeks disagree
+/// on what to return and must each run their own branch.
+fn kernels_for(option: &Options) -> Result<Option<BlackScholesKernels>, GreeksError> {
+    if !matches!(option.option_type, OptionType::European) {
+        return Ok(None);
+    }
+    let t = option.expiration_date.get_years()?;
+    if t == Decimal::ZERO || option.implied_volatility == ZERO {
+        return Ok(None);
+    }
+    Ok(Some(BlackScholesKernels::new(option, t)?))
+}
+
+/// Computes all twelve greeks for a single option, sharing one set of
+/// Black-Scholes kernels across them.
+///
+/// This is the fast path behind [`Greeks::greeks`]. For a degenerate option —
+/// non-European, at expiry, or at zero volatility — the twelve disagree on what
+/// to return, so each individual function runs and owns its own branch.
+fn greeks_for(option: &Options) -> Result<Greek, GreeksError> {
+    let Some(kernels) = kernels_for(option)? else {
+        let gamma = gamma(option)?;
+        let theta = theta(option)?;
+        return Ok(Greek {
+            delta: delta(option)?,
+            gamma,
+            theta,
+            vega: vega(option)?,
+            rho: rho(option)?,
+            rho_d: rho_d(option)?,
+            alpha: alpha_from(gamma, theta),
+            vanna: vanna(option)?,
+            vomma: vomma(option)?,
+            veta: veta(option)?,
+            charm: charm(option)?,
+            color: color(option)?,
+        });
+    };
+
+    let gamma = gamma_with(option, &kernels)?;
+    let theta = theta_with(option, &kernels)?;
+    Ok(Greek {
+        delta: delta_with(option, &kernels)?,
+        gamma,
+        theta,
+        vega: vega_with(option, &kernels)?,
+        rho: rho_with(option, &kernels)?,
+        rho_d: rho_d_with(option, &kernels)?,
+        // Reuses the gamma and theta above instead of recomputing both.
+        alpha: alpha_from(gamma, theta),
+        vanna: vanna_with(option, &kernels)?,
+        vomma: vomma_with(option, &kernels)?,
+        veta: veta_with(option, &kernels)?,
+        charm: charm_with(option, &kernels)?,
+        color: color_with(option, &kernels)?,
+    })
+}
+
 /// Calculates the delta of an option.
 ///
 /// The delta measures the sensitivity of an option's price to changes in the price of the
@@ -563,8 +791,6 @@ pub fn delta(option: &Options) -> Result<Decimal, GreeksError> {
         };
     }
 
-    let dividend_yield: Positive = option.dividend_yield;
-
     let sign = if option.is_long() {
         Decimal::ONE
     } else {
@@ -589,18 +815,22 @@ pub fn delta(option: &Options) -> Result<Decimal, GreeksError> {
         };
     }
 
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, expiration_date)?;
+    delta_with(option, &kernels)
+}
 
-    let div_date = (-expiration_date.to_dec() * dividend_yield).exp();
+/// Delta from precomputed kernels. See [`delta`] for the degenerate branches,
+/// which carry the discrete values at expiry and at zero volatility.
+fn delta_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
+    let sign = if option.is_long() {
+        Decimal::ONE
+    } else {
+        Decimal::NEGATIVE_ONE
+    };
+    let div_date = k.exp_minus_qt();
     let delta = match option.option_style {
-        OptionStyle::Call => sign * big_n(d1)? * div_date,
-        OptionStyle::Put => sign * (big_n(d1)? - Decimal::ONE) * div_date,
+        OptionStyle::Call => sign * k.big_n_d1()? * div_date,
+        OptionStyle::Put => sign * (k.big_n_d1()? - Decimal::ONE) * div_date,
     };
     let delta: Decimal = delta.clamp(Decimal::NEGATIVE_ONE, Decimal::ONE);
     let quantity: Decimal = option.quantity.into();
@@ -712,20 +942,18 @@ pub fn gamma(option: &Options) -> Result<Decimal, GreeksError> {
         return Ok(Decimal::ZERO);
     }
 
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, expiration_date)?;
+    gamma_with(option, &kernels)
+}
 
-    let dividend_yield: Decimal = option.dividend_yield.into();
+/// Gamma from precomputed kernels. See [`gamma`] for the degenerate branches,
+/// which the caller must have ruled out before building the kernels.
+fn gamma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
     let underlying_price: Decimal = option.underlying_price.into();
     let implied_volatility: Positive = option.implied_volatility;
 
-    let gamma: Decimal = (expiration_date.to_dec() * -dividend_yield).exp() * n(d1)?
-        / (underlying_price * implied_volatility * expiration_date.sqrt().to_dec());
+    let gamma: Decimal = k.exp_minus_qt() * k.n_d1()?
+        / (underlying_price * implied_volatility * k.sqrt_t().to_dec());
 
     let quantity: Decimal = option.quantity.into();
     Ok(gamma * quantity)
@@ -846,42 +1074,35 @@ pub fn theta(option: &Options) -> Result<Decimal, GreeksError> {
         return Ok(Decimal::ZERO);
     }
 
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        t,
-        option.implied_volatility,
-    )?;
-    let d2 = d2(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        t,
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, t)?;
+    theta_with(option, &kernels)
+}
 
+/// Theta from precomputed kernels. See [`theta`] for the degenerate branch.
+fn theta_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
     let s = option.underlying_price.to_dec();
     let k = option.strike_price.to_dec();
     let r = option.risk_free_rate;
     let q = option.dividend_yield.to_dec();
     let sigma = option.implied_volatility.to_dec();
 
-    // Pre-calculate discount factors
-    let exp_minus_rt = (-r * t).exp();
-    let exp_minus_qt = (-q * t).exp();
+    let exp_minus_rt = kernels.exp_minus_rt();
+    let exp_minus_qt = kernels.exp_minus_qt();
 
     // Common term using n. The e^{-qT} factor discounts the S·n(d1) term to
     // present value (the underlying contributes S·e^{-qT} to the payoff);
     // omitting it made |theta| too large for dividend-paying underlyings.
-    let common_term = -(exp_minus_qt * s * n(d1)? * sigma) / (Decimal::TWO * t.sqrt());
+    let common_term =
+        -(exp_minus_qt * s * kernels.n_d1()? * sigma) / (Decimal::TWO * kernels.sqrt_t());
 
     let theta = match option.option_style {
         OptionStyle::Call => {
-            common_term - r * k * exp_minus_rt * big_n(d2)? + q * s * exp_minus_qt * big_n(d1)?
+            common_term - r * k * exp_minus_rt * kernels.big_n_d2()?
+                + q * s * exp_minus_qt * kernels.big_n_d1()?
         }
         OptionStyle::Put => {
-            common_term + r * k * exp_minus_rt * big_n(-d2)? - q * s * exp_minus_qt * big_n(-d1)?
+            common_term + r * k * exp_minus_rt * kernels.big_n_neg_d2()?
+                - q * s * exp_minus_qt * kernels.big_n_neg_d1()?
         }
     };
 
@@ -996,22 +1217,16 @@ pub fn vega(option: &Options) -> Result<Decimal, GreeksError> {
         // At expiration, volatility has no impact on option price
         return Ok(Decimal::ZERO);
     }
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, expiration_date)?;
+    vega_with(option, &kernels)
+}
 
-    let dividend_yield: Positive = option.dividend_yield;
+/// Vega from precomputed kernels. See [`vega`] for the degenerate branches.
+fn vega_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
     let underlying_price: Decimal = option.underlying_price.to_dec();
 
-    let vega: Decimal = underlying_price
-        * (-expiration_date.to_dec() * dividend_yield).exp()
-        * n(d1)?
-        * expiration_date.sqrt()
-        / Decimal::ONE_HUNDRED; // percentage of change in volatility
+    let vega: Decimal =
+        underlying_price * k.exp_minus_qt() * k.n_d1()? * k.sqrt_t() / Decimal::ONE_HUNDRED; // percentage of change in volatility
 
     let quantity: Decimal = option.quantity.into();
     Ok(vega * quantity)
@@ -1128,34 +1343,22 @@ pub fn rho(option: &Options) -> Result<Decimal, GreeksError> {
         return Ok(Decimal::ZERO);
     }
 
-    // Use existing d2 function
-    let d2 = d2(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        t,
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, t)?;
+    rho_with(option, &kernels)
+}
 
+/// Rho from precomputed kernels. See [`rho`] for the degenerate branch.
+fn rho_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
+    let t = kernels.t();
     let k = option.strike_price.to_dec();
-    let r = option.risk_free_rate;
 
-    // Calculate discount factor once
-    let e_rt = (-r * t).exp();
-
-    // Calculate base rho without sign
-    let base_rho = k * t * e_rt;
+    // Base rho without sign; the discount uses the risk-free rate, not the carry.
+    let base_rho = k * t * kernels.exp_minus_rt();
 
     // Calculate final rho based on option type
     let rho = match option.option_style {
-        OptionStyle::Call => {
-            let n_d2 = big_n(d2)?;
-            base_rho * n_d2
-        }
-        OptionStyle::Put => {
-            let n_minus_d2 = big_n(-d2)?;
-            -base_rho * n_minus_d2
-        }
+        OptionStyle::Call => base_rho * kernels.big_n_d2()?,
+        OptionStyle::Put => -base_rho * kernels.big_n_neg_d2()?,
     };
 
     // Adjust for quantity and convert to basis points (banker's rounding).
@@ -1278,28 +1481,21 @@ pub fn rho_d(option: &Options) -> Result<Decimal, GreeksError> {
         // At expiration the dividend yield can no longer move the value.
         return Ok(Decimal::ZERO);
     }
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
-    let dividend_yield: Positive = option.dividend_yield;
+    let kernels = BlackScholesKernels::new(option, expiration_date)?;
+    rho_d_with(option, &kernels)
+}
+
+/// Dividend rho from precomputed kernels. See [`rho_d`] for the degenerate branch.
+fn rho_d_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
+    let expiration_date = k.t();
     let underlying_price: Decimal = option.underlying_price.to_dec();
 
     let rhod = match option.option_style {
         OptionStyle::Call => {
-            -expiration_date.to_dec()
-                * underlying_price
-                * (-expiration_date.to_dec() * dividend_yield).exp()
-                * big_n(d1)?
+            -expiration_date.to_dec() * underlying_price * k.exp_minus_qt() * k.big_n_d1()?
         }
         OptionStyle::Put => {
-            expiration_date.to_dec()
-                * underlying_price
-                * (-expiration_date.to_dec() * dividend_yield).exp()
-                * big_n(-d1)?
+            expiration_date.to_dec() * underlying_price * k.exp_minus_qt() * k.big_n_neg_d1()?
         }
     };
 
@@ -1315,10 +1511,22 @@ pub fn rho_d(option: &Options) -> Result<Decimal, GreeksError> {
 pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
     let gamma = gamma(option)?;
     let theta = theta(option)?;
+    Ok(alpha_from(gamma, theta))
+}
+
+/// Alpha from a gamma and a theta that have already been computed.
+///
+/// Split out so the aggregate path does not recompute both from scratch, which
+/// was roughly 11% of the cost of a full twelve-greek evaluation.
+///
+/// Returns `Decimal::MAX` as a sentinel when theta vanishes but gamma does not.
+/// Callers that publish the value are responsible for mapping it to something
+/// meaningful; see `OptionData::calculate_greeks`.
+fn alpha_from(gamma: Decimal, theta: Decimal) -> Decimal {
     match (gamma, theta) {
-        (val, _) if val == Decimal::ZERO => Ok(Decimal::ZERO),
-        (_, val) if val == Decimal::ZERO => Ok(Decimal::MAX),
-        _ => Ok(gamma / theta),
+        (val, _) if val == Decimal::ZERO => Decimal::ZERO,
+        (_, val) if val == Decimal::ZERO => Decimal::MAX,
+        _ => gamma / theta,
     }
 }
 
@@ -1423,31 +1631,18 @@ pub fn vanna(option: &Options) -> Result<Decimal, GreeksError> {
         // volatility, so vanna is zero.
         return Ok(Decimal::ZERO);
     }
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, expiration_date)?;
+    vanna_with(option, &kernels)
+}
 
-    let d2 = d2(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
-    let dividend_yield: Decimal = option.dividend_yield.into();
+/// Vanna from precomputed kernels. See [`vanna`] for the degenerate branches.
+fn vanna_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
     let implied_volatility: Positive = option.implied_volatility;
-    let n_d1: Decimal = n(d1)?;
     // Discount factor e^{-qT} for the dividend-adjusted underlying term.
     // vanna = dDelta/dsigma = e^{-qT} * n(d1) * (dd1/dsigma), and the standard
     // result dd1/dsigma = -d2/sigma introduces an explicit minus sign, so the
     // closed form is -e^{-qT} * n(d1) * d2 / sigma (sign is opposite to d2).
-    let e_rt: Decimal = (-dividend_yield * expiration_date.to_dec()).exp();
-
-    let vanna: Decimal = -(e_rt * n_d1 * (d2 / implied_volatility));
+    let vanna: Decimal = -(k.exp_minus_qt() * k.n_d1()? * (k.d2() / implied_volatility));
 
     let quantity: Decimal = option.quantity.into();
     Ok(vanna * quantity)
@@ -1552,27 +1747,19 @@ pub fn vomma(option: &Options) -> Result<Decimal, GreeksError> {
         // At expiration, volatility has no impact on option price
         return Ok(Decimal::ZERO);
     }
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
-    let d2 = d2(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, expiration_date)?;
+    vomma_with(option, &kernels)
+}
+
+/// Vomma from precomputed kernels. See [`vomma`] for the degenerate branch.
+fn vomma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
     // `vega` already carries `option.quantity`. Vomma is a first derivative of
     // vega and is linear in position size, so the quantity must not be applied
     // a second time here.
-    let vega = vega(option)?;
+    let vega = vega_with(option, k)?;
     let implied_volatility: Positive = option.implied_volatility;
 
-    Ok(vega * (d1 * d2 / implied_volatility))
+    Ok(vega * (k.d1() * k.d2() / implied_volatility))
 }
 
 /// Computes the veta of an option.
@@ -1666,27 +1853,19 @@ pub fn veta(option: &Options) -> Result<Decimal, GreeksError> {
         // At expiration, volatility has no impact on option price
         return Ok(Decimal::ZERO);
     }
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
-    let d2 = d2(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        expiration_date,
-        option.implied_volatility,
-    )?;
-    let vega = vega(option)?;
+    let kernels = BlackScholesKernels::new(option, expiration_date)?;
+    veta_with(option, &kernels)
+}
+
+/// Veta from precomputed kernels. See [`veta`] for the degenerate branch.
+fn veta_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
+    let expiration_date = k.t();
+    let vega = vega_with(option, k)?;
     let implied_volatility: Positive = option.implied_volatility;
     let dividend_yield: Decimal = option.dividend_yield.into();
     let risk_free_rate: Decimal = option.risk_free_rate;
-    let add1 =
-        (risk_free_rate - dividend_yield) * d1 / (implied_volatility * expiration_date.sqrt());
-    let add2 = (Decimal::ONE + d1 * d2) / (Decimal::TWO * expiration_date);
+    let add1 = (risk_free_rate - dividend_yield) * k.d1() / (implied_volatility * k.sqrt_t());
+    let add2 = (Decimal::ONE + k.d1() * k.d2()) / (Decimal::TWO * expiration_date);
 
     let veta: Decimal = -vega * (dividend_yield + add1 - add2);
     // It is common practice to divide the mathematical result of veta by
@@ -1822,32 +2001,25 @@ pub fn charm(option: &Options) -> Result<Decimal, GreeksError> {
         return Ok(Decimal::ZERO);
     }
 
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        tau, // expiration date
-        option.implied_volatility,
-    )?;
-    let d2 = d2(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        tau, // expiration date
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, tau)?;
+    charm_with(option, &kernels)
+}
+
+/// Charm from precomputed kernels. See [`charm`] for the degenerate branch.
+fn charm_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
+    let tau = k.t();
     let r = option.risk_free_rate;
     let q = option.dividend_yield.to_dec();
     let sigma = option.implied_volatility;
-    let exp_minus_qt = (-q * tau).exp();
-    let common_term = (Decimal::TWO * (r - q) * tau - d2 * sigma * tau.sqrt())
-        / (Decimal::TWO * tau * sigma * tau.sqrt());
+    let exp_minus_qt = k.exp_minus_qt();
+    let common_term = (Decimal::TWO * (r - q) * tau - k.d2() * sigma * k.sqrt_t())
+        / (Decimal::TWO * tau * sigma * k.sqrt_t());
     let charm = match option.option_style {
         OptionStyle::Call => {
-            (q * exp_minus_qt * big_n(d1)?) - (exp_minus_qt * n(d1)? * common_term)
+            (q * exp_minus_qt * k.big_n_d1()?) - (exp_minus_qt * k.n_d1()? * common_term)
         }
         OptionStyle::Put => {
-            (-q * exp_minus_qt * big_n(-d1)?) - (exp_minus_qt * n(d1)? * common_term)
+            (-q * exp_minus_qt * k.big_n_neg_d1()?) - (exp_minus_qt * k.n_d1()? * common_term)
         }
     };
     // Adjust for quantity and convert to daily value.
@@ -1971,29 +2143,22 @@ pub fn color(option: &Options) -> Result<Decimal, GreeksError> {
         return Ok(Decimal::ZERO);
     }
 
-    let d1 = d1(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        tau, // expiration date
-        option.implied_volatility,
-    )?;
-    let d2 = d2(
-        option.underlying_price,
-        option.strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(),
-        tau, // expiration date
-        option.implied_volatility,
-    )?;
+    let kernels = BlackScholesKernels::new(option, tau)?;
+    color_with(option, &kernels)
+}
+
+/// Color from precomputed kernels. See [`color`] for the degenerate branch.
+fn color_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
+    let tau = k.t();
     let r = option.risk_free_rate;
     let s = option.underlying_price;
     let q = option.dividend_yield.to_dec();
     let sigma = option.implied_volatility;
-    let exp_minus_qt = (-q * tau).exp();
-    let factor1 = n(d1)? / (Decimal::TWO * s * tau * sigma * tau.sqrt());
-    let numerator = (Decimal::TWO * (r - q) * tau) - (d2 * sigma * tau.sqrt());
-    let denominator = sigma * tau.sqrt();
-    let factor2 = (Decimal::TWO * q * tau) + Decimal::ONE + ((numerator / denominator) * d1);
+    let exp_minus_qt = k.exp_minus_qt();
+    let factor1 = k.n_d1()? / (Decimal::TWO * s * tau * sigma * k.sqrt_t());
+    let numerator = (Decimal::TWO * (r - q) * tau) - (k.d2() * sigma * k.sqrt_t());
+    let denominator = sigma * k.sqrt_t();
+    let factor2 = (Decimal::TWO * q * tau) + Decimal::ONE + ((numerator / denominator) * k.d1());
     // Build the color numerator with checked multiplications so an
     // overflow on `-exp(-qt) * factor1 * factor2 * quantity` surfaces
     // a tagged `DecimalError::Overflow` instead of silently saturating


### PR DESCRIPTION
Closes #431. **Re-lands #432**, whose content never reached `main`.

## Why this PR exists

#432 was merged at 07:39:38Z into `issue-427-greeks-snapshot`. #430 had already
been squashed into `main` at 07:22:33Z, seventeen minutes earlier, so by then
that branch fed nothing. The kernel refactor landed on an orphan.

`main` has the snapshots from #430 but no `BlackScholesKernels`. This branch is
the same two commits cherry-picked onto current `main`; the diff against the
original branch is empty, so the content is identical to what was reviewed.

## What it does

Each of the twelve greek functions re-derived `d1`, `d2`, the normal pdf and
cdf, and the two discount factors from scratch, so one `Greeks::greeks()` call
evaluated the same expensive `Decimal` transcendentals dozens of times. Measured
per call, the pdf `n` at 11.68 us, `exp` at 6.61 us, `d1` at 4.85 us and the cdf
`big_n` at 2.41 us, against a whole `greeks()` of 473 us. Counting the calls
inside it, roughly 27 `d1`, 12 `n`, 20 `exp` and 15 `big_n` per style, accounts
for about 93% of that.

`BlackScholesKernels` holds those intermediates for one live European option,
computed lazily per field so a caller pays only for the kernels its own greek
touches. The twelve public signatures are unchanged and keep their degenerate
branches. `d2` comes from the cached `d1`, removing a second full `d1`, and
`alpha` no longer recomputes `gamma` and `theta`.

## Results

| case | before | after | speedup |
|------|--------|-------|---------|
| 11 strikes + greeks | 3.063 ms | 650 us | 4.7x |
| 21 strikes + greeks | 6.185 ms | 1.260 ms | 4.9x |
| 31 strikes + greeks | 9.266 ms | 1.954 ms | 4.7x |
| 31 strikes, no greeks | 1.321 ms | 1.262 ms | unchanged |

`Greeks::greeks()` itself goes from 473 us to 73.2 us, 6.5x. The cost of
enabling the snapshots drops from about 7x a chain build to about 1.5x.

## Coverage

Carries the tests added in review of #432. One walks every branch
`kernels_for` distinguishes, live European, at expiry, zero volatility and
non-European, across both styles and sides, asserting `greeks()` matches the
twelve public functions exactly and that the two paths agree on failure as well.
Another covers the reordered aggregation on a mixed multi-leg position. A third
pins every cached kernel against a freshly derived value.

No pinned 28-digit constants, deliberately: that is the bit-pattern lock removed
in #429, where a statrs ULP change could break a test without the mathematics
moving.

## Still open for you

With the overhead down to about 1.5x, #430's `greek_snapshots` opt-in flag could
be removed and the snapshots computed unconditionally, which is what #427
originally specified. Left in place here.

## Verification

- `cargo fmt --all --check` clean
- `cargo test --all-features --workspace`: 3882 lib + 12 property + 413
  integration + 207 doc, 0 failures