### PR TITLE
fix(greeks): respect Side in every greek, not just delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Breaking behaviour change.** Every greek now respects `Side`. Only `delta`
+  did before, so any strategy holding a short leg reported gamma, theta, vega,
+  rho and the higher-order greeks with the sign of the equivalent long position,
+  next to a delta that was signed correctly. A short-premium position looked as
+  though it was losing to time decay when it was collecting it. `Options::
+  quantity` is `Positive` and can never carry direction, so `Side` is the only
+  carrier of it (#428).
+
+  Migration: any consumer that was compensating for the old behaviour, by
+  negating the eleven unsigned greeks itself, must stop. A long and a short of
+  the same contract now net to exactly zero across all twelve. `alpha` is the
+  one exception and is unchanged, being the ratio `gamma / theta`, which a short
+  negates in both terms.
+
+  `OptionData::greeks_call` and `greeks_put` are unaffected: they are built
+  through `get_option(Side::Long, style)` and remain per-long-contract values.
+
+### Changed
+
+- `Greeks::greeks()` computes the shared Black-Scholes intermediates once per
+  option rather than once per greek, which makes it about 6.5x faster and cuts
+  the cost of a chain build with greek snapshots by about 4.7x. Every value is
+  unchanged (#431).
+- `alpha` is now re-exported from `crate::greeks`, alongside the other eleven.
+
+
 ## [0.20.0] - 2026-08-28
 
 Adds the full twelve-greek set to the option chain data. **Breaking** for

--- a/README.md
+++ b/README.md
@@ -886,7 +886,11 @@ fn main() -> Result<(), optionstratlib::error::Error> {
     let price = option.calculate_price_black_scholes()?;
     tracing::info!("Option price: ${:.2}", price);
 
-    // Calculate Greeks for risk management
+    // Calculate Greeks for risk management. Every greek is the sensitivity
+    // of the *position*: signed by its `Side` and scaled by its `quantity`,
+    // so a short reports the negative of the equivalent long. `alpha` is the
+    // one exception, being the ratio `gamma / theta`, which a short negates
+    // in both terms.
     let delta = option.delta()?;
     let gamma = option.gamma()?;
     let theta = option.theta()?;

--- a/src/chains/optiondata.rs
+++ b/src/chains/optiondata.rs
@@ -181,10 +181,10 @@ pub struct OptionData {
     /// flips sign with it. Scaling by position size is likewise the consumer's
     /// job.
     ///
-    /// Note this is deliberately *not* what [`crate::greeks::Greeks`] does when
-    /// aggregating a position today: it applies the long/short sign in `delta`
-    /// and nowhere else, which is the bug tracked in issue #428. These fields
-    /// are per-long-contract values and do not inherit that asymmetry.
+    /// [`crate::greeks::Greeks`] signs an aggregate position by each leg's
+    /// [`Side`] for you. These fields do not, by construction: they are built
+    /// through `get_option(Side::Long, style)`, so they stay per-long-contract
+    /// and the caller owns both the sign and the size.
     ///
     /// # When this is `None`
     ///

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -620,6 +620,7 @@ where
 ///
 /// Negating a `Decimal` is exact, so this needs no checked multiplication.
 #[inline]
+#[must_use]
 fn signed_quantity(option: &Options) -> Decimal {
     let quantity = option.quantity.to_dec();
     if option.is_long() {
@@ -779,7 +780,14 @@ fn greeks_for(option: &Options) -> Result<Greek, GreeksError> {
 /// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn delta(option: &Options) -> Result<Decimal, GreeksError> {
     if !matches!(option.option_type, OptionType::European) {
-        return crate::greeks::numerical::numerical_delta(option);
+        // The numerical fallback prices through `price_option`, which takes the
+        // absolute value, so it returns a per-contract long sensitivity. Sign
+        // and scale it here to keep the documented convention.
+        return Ok(d_mul(
+            crate::greeks::numerical::numerical_delta(option)?,
+            signed_quantity(option),
+            "greeks::delta::numerical_position_weighted",
+        )?);
     }
     let expiration_date = option.expiration_date.get_years()?;
 
@@ -804,24 +812,27 @@ pub fn delta(option: &Options) -> Result<Decimal, GreeksError> {
     // This happens because at expiration, the option effectively becomes a direct position in the
     // underlying asset (**delta = 1 or -1**) if it is ITM, or has no value (**delta = 0**) if it is OTM.
     if expiration_date == Decimal::ZERO {
-        return match (
+        // These arms already carry the side, so they scale by the bare quantity
+        // rather than by `signed_quantity`, which would apply it twice.
+        let per_contract = match (
             &option.option_style,
             &option.side,
             &option.strike_price,
             &option.underlying_price,
         ) {
             // Call Options
-            (OptionStyle::Call, Side::Long, strike, price) if price > strike => Ok(Decimal::ONE),
-            (OptionStyle::Call, Side::Long, _, _) => Ok(Decimal::ZERO),
-            (OptionStyle::Call, Side::Short, strike, price) if price > strike => Ok(-Decimal::ONE),
-            (OptionStyle::Call, Side::Short, _, _) => Ok(Decimal::ZERO),
+            (OptionStyle::Call, Side::Long, strike, price) if price > strike => Decimal::ONE,
+            (OptionStyle::Call, Side::Long, _, _) => Decimal::ZERO,
+            (OptionStyle::Call, Side::Short, strike, price) if price > strike => -Decimal::ONE,
+            (OptionStyle::Call, Side::Short, _, _) => Decimal::ZERO,
 
             // Put Options
-            (OptionStyle::Put, Side::Long, strike, price) if price < strike => Ok(-Decimal::ONE),
-            (OptionStyle::Put, Side::Long, _, _) => Ok(Decimal::ZERO),
-            (OptionStyle::Put, Side::Short, strike, price) if price < strike => Ok(Decimal::ONE),
-            (OptionStyle::Put, Side::Short, _, _) => Ok(Decimal::ZERO),
+            (OptionStyle::Put, Side::Long, strike, price) if price < strike => -Decimal::ONE,
+            (OptionStyle::Put, Side::Long, _, _) => Decimal::ZERO,
+            (OptionStyle::Put, Side::Short, strike, price) if price < strike => Decimal::ONE,
+            (OptionStyle::Put, Side::Short, _, _) => Decimal::ZERO,
         };
+        return Ok(per_contract * option.quantity.to_dec());
     }
 
     let sign = if option.is_long() {
@@ -830,22 +841,24 @@ pub fn delta(option: &Options) -> Result<Decimal, GreeksError> {
         Decimal::NEGATIVE_ONE
     };
     if option.implied_volatility == ZERO {
-        return match option.option_style {
+        // `sign` is already applied here, so scale by the bare quantity.
+        let per_contract = match option.option_style {
             OptionStyle::Call => {
                 if option.underlying_price >= option.strike_price {
-                    Ok(sign) // Delta is 1 for Call in-the-money
+                    sign // Delta is 1 for Call in-the-money
                 } else {
-                    Ok(Decimal::ZERO) // Delta is 0 for Call out-of-the-money
+                    Decimal::ZERO // Delta is 0 for Call out-of-the-money
                 }
             }
             OptionStyle::Put => {
                 if option.underlying_price <= option.strike_price {
-                    Ok(sign * Decimal::NEGATIVE_ONE) // Delta is -1 for Put in-the-money
+                    sign * Decimal::NEGATIVE_ONE // Delta is -1 for Put in-the-money
                 } else {
-                    Ok(Decimal::ZERO) // Delta is 0 for Put out-of-the-money
+                    Decimal::ZERO // Delta is 0 for Put out-of-the-money
                 }
             }
         };
+        return Ok(per_contract * option.quantity.to_dec());
     }
 
     let kernels = BlackScholesKernels::new(option, expiration_date)?;
@@ -969,7 +982,12 @@ fn delta_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
 /// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn gamma(option: &Options) -> Result<Decimal, GreeksError> {
     if !matches!(option.option_type, OptionType::European) {
-        return crate::greeks::numerical::numerical_gamma(option);
+        // Same per-contract long value as the delta fallback; see there.
+        return Ok(d_mul(
+            crate::greeks::numerical::numerical_gamma(option)?,
+            signed_quantity(option),
+            "greeks::gamma::numerical_position_weighted",
+        )?);
     }
     if option.implied_volatility == ZERO {
         return Ok(Decimal::ZERO);
@@ -993,7 +1011,11 @@ fn gamma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let gamma: Decimal = k.exp_minus_qt() * k.n_d1()?
         / (underlying_price * implied_volatility * k.sqrt_t().to_dec());
 
-    Ok(gamma * signed_quantity(option))
+    Ok(d_mul(
+        gamma,
+        signed_quantity(option),
+        "greeks::gamma::position_weighted",
+    )?)
 }
 
 /// Computes the Theta of an option.
@@ -1276,7 +1298,11 @@ fn vega_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Greek
     let vega: Decimal =
         underlying_price * k.exp_minus_qt() * k.n_d1()? * k.sqrt_t() / Decimal::ONE_HUNDRED; // percentage of change in volatility
 
-    Ok(vega * signed_quantity(option))
+    Ok(d_mul(
+        vega,
+        signed_quantity(option),
+        "greeks::vega::position_weighted",
+    )?)
 }
 
 /// Computes the rho of an options contract.
@@ -1730,7 +1756,11 @@ fn vanna_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     // closed form is -e^{-qT} * n(d1) * d2 / sigma (sign is opposite to d2).
     let vanna: Decimal = -(k.exp_minus_qt() * k.n_d1()? * (k.d2() / implied_volatility));
 
-    Ok(vanna * signed_quantity(option))
+    Ok(d_mul(
+        vanna,
+        signed_quantity(option),
+        "greeks::vanna::position_weighted",
+    )?)
 }
 
 /// Computes the vomma of an option.

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -178,6 +178,17 @@ impl From<Greek> for GreeksSnapshot {
 /// references to option contracts. The trait will handle aggregating the Greek values across
 /// all options in the collection.
 ///
+/// # Sign convention
+///
+/// Every method here returns the sensitivity of the **aggregate position**: each
+/// leg is signed by its [`Side`] and scaled by its `quantity`, then summed. A
+/// short leg contributes the negative of the equivalent long one, so a
+/// short-premium strategy reports a positive theta when it collects decay.
+///
+/// The single exception is [`Greeks::alpha`], which sums per-leg `gamma / theta`
+/// ratios. A short negates both terms, so each ratio is invariant under `Side`
+/// by construction.
+///
 /// # Errors
 ///
 /// Methods return `Result<T, GreeksError>` to handle various calculation errors that may
@@ -601,6 +612,23 @@ where
     Ok(value)
 }
 
+/// The position's signed size, `+quantity` when long and `-quantity` when short.
+///
+/// [`Options::quantity`] is [`Positive`] and can never carry direction, so
+/// [`Side`] is the only carrier of it. Every greek is the sensitivity of the
+/// *position*, so the sign belongs wherever the size is applied.
+///
+/// Negating a `Decimal` is exact, so this needs no checked multiplication.
+#[inline]
+fn signed_quantity(option: &Options) -> Decimal {
+    let quantity = option.quantity.to_dec();
+    if option.is_long() {
+        quantity
+    } else {
+        -quantity
+    }
+}
+
 /// Builds the shared kernels when `option` is a live European contract.
 ///
 /// Returns `None` for the degenerate cases — a non-European type, a zero time to
@@ -744,6 +772,11 @@ fn greeks_for(option: &Options) -> Result<Greek, GreeksError> {
 ///     Err(e) => error!("Error calculating delta: {:?}", e),
 /// }
 /// ```
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn delta(option: &Options) -> Result<Decimal, GreeksError> {
     if !matches!(option.option_type, OptionType::European) {
         return crate::greeks::numerical::numerical_delta(option);
@@ -929,6 +962,11 @@ fn delta_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
 /// [`GreeksError`] surfaced by `numerical_gamma` for non-European
 /// options (typically [`GreeksError::Pricing`] when the perturbation
 /// evaluation fails).
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn gamma(option: &Options) -> Result<Decimal, GreeksError> {
     if !matches!(option.option_type, OptionType::European) {
         return crate::greeks::numerical::numerical_gamma(option);
@@ -955,8 +993,7 @@ fn gamma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let gamma: Decimal = k.exp_minus_qt() * k.n_d1()?
         / (underlying_price * implied_volatility * k.sqrt_t().to_dec());
 
-    let quantity: Decimal = option.quantity.into();
-    Ok(gamma * quantity)
+    Ok(gamma * signed_quantity(option))
 }
 
 /// Computes the Theta of an option.
@@ -1068,6 +1105,12 @@ fn gamma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by `numerical_theta` for non-European
 /// options.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position therefore reports a positive theta when it
+/// collects decay.
 pub fn theta(option: &Options) -> Result<Decimal, GreeksError> {
     let t = option.expiration_date.get_years()?;
     if t == Decimal::ZERO {
@@ -1109,7 +1152,7 @@ fn theta_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal
     // Adjust for quantity and convert to daily value (banker's-rounded annualisation).
     let weighted = d_mul(
         theta,
-        option.quantity.to_dec(),
+        signed_quantity(option),
         "greeks::theta::position_weighted",
     )?;
     Ok(d_div(
@@ -1211,6 +1254,11 @@ fn theta_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by `numerical_vega` for non-European
 /// options.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn vega(option: &Options) -> Result<Decimal, GreeksError> {
     let expiration_date: Positive = option.expiration_date.get_years()?;
     if expiration_date == Decimal::ZERO {
@@ -1228,8 +1276,7 @@ fn vega_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Greek
     let vega: Decimal =
         underlying_price * k.exp_minus_qt() * k.n_d1()? * k.sqrt_t() / Decimal::ONE_HUNDRED; // percentage of change in volatility
 
-    let quantity: Decimal = option.quantity.into();
-    Ok(vega * quantity)
+    Ok(vega * signed_quantity(option))
 }
 
 /// Computes the rho of an options contract.
@@ -1336,6 +1383,11 @@ fn vega_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Greek
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by `numerical_rho` for non-European
 /// options.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn rho(option: &Options) -> Result<Decimal, GreeksError> {
     // Get time to expiration first and validate
     let t = option.expiration_date.get_years()?;
@@ -1364,7 +1416,7 @@ fn rho_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal, 
     // Adjust for quantity and convert to basis points (banker's rounding).
     let weighted = d_mul(
         rho,
-        option.quantity.to_dec(),
+        signed_quantity(option),
         "greeks::rho::position_weighted",
     )?;
     Ok(d_div(
@@ -1475,6 +1527,11 @@ fn rho_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal, 
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by intermediate Black–Scholes kernels
 /// (typically [`GreeksError::Pricing`] on numerical failure).
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn rho_d(option: &Options) -> Result<Decimal, GreeksError> {
     let expiration_date: Positive = option.expiration_date.get_years()?;
     if expiration_date == Decimal::ZERO {
@@ -1499,8 +1556,11 @@ fn rho_d_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
         }
     };
 
-    let quantity: Decimal = option.quantity.into();
-    let weighted = d_mul(rhod, quantity, "greeks::rho_d::position_weighted")?;
+    let weighted = d_mul(
+        rhod,
+        signed_quantity(option),
+        "greeks::rho_d::position_weighted",
+    )?;
     Ok(d_div(
         weighted,
         Decimal::from(100),
@@ -1508,6 +1568,27 @@ fn rho_d_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     )?)
 }
 
+/// Computes the alpha of an option, the ratio of gamma to theta.
+///
+/// Alpha expresses how much convexity a position buys per unit of time decay,
+/// so it is the natural way to compare two positions that trade one against the
+/// other.
+///
+/// # Sign convention
+///
+/// Unlike the other eleven, this one is **invariant** under [`Side`]. It is the
+/// ratio `gamma / theta`, and a short position negates both, so the ratio is
+/// unchanged. That is the correct result, not a missing case.
+///
+/// # Returns
+///
+/// `Decimal::ZERO` when gamma vanishes, and the `Decimal::MAX` sentinel when
+/// theta vanishes but gamma does not. Callers that publish the value are
+/// responsible for mapping that sentinel to something meaningful.
+///
+/// # Errors
+///
+/// Propagates any [`GreeksError`] surfaced by [`gamma`] or [`theta`].
 pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
     let gamma = gamma(option)?;
     let theta = theta(option)?;
@@ -1620,6 +1701,11 @@ fn alpha_from(gamma: Decimal, theta: Decimal) -> Decimal {
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by the underlying Black–Scholes
 /// evaluation (typically [`GreeksError::Pricing`]).
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn vanna(option: &Options) -> Result<Decimal, GreeksError> {
     if option.implied_volatility == ZERO {
         return Ok(Decimal::ZERO);
@@ -1644,8 +1730,7 @@ fn vanna_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     // closed form is -e^{-qT} * n(d1) * d2 / sigma (sign is opposite to d2).
     let vanna: Decimal = -(k.exp_minus_qt() * k.n_d1()? * (k.d2() / implied_volatility));
 
-    let quantity: Decimal = option.quantity.into();
-    Ok(vanna * quantity)
+    Ok(vanna * signed_quantity(option))
 }
 
 /// Computes the vomma of an option.
@@ -1741,6 +1826,12 @@ fn vanna_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by the underlying Black–Scholes
 /// evaluation.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**. The sign and the size are
+/// inherited from [`vega`], which this is a derivative of, so neither is
+/// applied a second time here.
 pub fn vomma(option: &Options) -> Result<Decimal, GreeksError> {
     let expiration_date: Positive = option.expiration_date.get_years()?;
     if expiration_date == Decimal::ZERO {
@@ -1847,6 +1938,12 @@ fn vomma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by the underlying Black–Scholes
 /// evaluation.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**. The sign and the size are
+/// inherited from [`vega`], which this is a derivative of, so neither is
+/// applied a second time here.
 pub fn veta(option: &Options) -> Result<Decimal, GreeksError> {
     let expiration_date: Positive = option.expiration_date.get_years()?;
     if expiration_date == Decimal::ZERO {
@@ -1994,6 +2091,11 @@ fn veta_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Greek
 /// Returns [`GreeksError::ExpirationDate`] when the option's expiration
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by intermediate Black–Scholes kernels.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn charm(option: &Options) -> Result<Decimal, GreeksError> {
     let tau = option.expiration_date.get_years()?;
     // if DTE is zero we can assume Charm is also zero
@@ -2025,7 +2127,7 @@ fn charm_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     // Adjust for quantity and convert to daily value.
     let weighted = d_mul(
         charm,
-        option.quantity.to_dec(),
+        signed_quantity(option),
         "greeks::charm::position_weighted",
     )?;
     Ok(d_div(
@@ -2136,6 +2238,11 @@ fn charm_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
 /// Returns [`GreeksError::ExpirationDate`] when the option's expiration
 /// cannot be converted to a positive year fraction, and propagates any
 /// [`GreeksError`] surfaced by intermediate Black–Scholes kernels.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `quantity`. A short position reports the negative of the equivalent long.
 pub fn color(option: &Options) -> Result<Decimal, GreeksError> {
     let tau = option.expiration_date.get_years()?;
     // if DTE is zero we can assume Color is also zero
@@ -2171,7 +2278,7 @@ fn color_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let numerator = d_mul(numerator, factor2, "greeks::color::numerator_factor2")?;
     let numerator = d_mul(
         numerator,
-        option.quantity.to_dec(),
+        signed_quantity(option),
         "greeks::color::numerator_quantity",
     )?;
     let color = d_div(numerator, Decimal::from(365), "greeks::color::per_day")?;
@@ -2537,7 +2644,8 @@ pub mod tests_gamma_equations {
         );
         let gamma_value = gamma(&option).unwrap().to_f64().unwrap();
         info!("Extreme High Volatility Put Gamma: {}", gamma_value);
-        assert_relative_eq!(gamma_value, 0.002147363766511278, epsilon = 1e-8);
+        // Short position, so gamma carries the negative sign; see #428.
+        assert_relative_eq!(gamma_value, -0.002147363766511278, epsilon = 1e-8);
     }
 }
 
@@ -2944,8 +3052,8 @@ pub mod tests_theta_short_equations {
             pos_or_panic!(0.20),  // implied volatility
         );
 
-        // Expected theta value for a short call option (precomputed or from known source)
-        let expected_theta = -0.05569703183000544;
+        // A short call collects decay, so its theta is positive; see #428.
+        let expected_theta = 0.05569703183000544;
 
         // Compute the theta value using the function
         let calculated_theta = theta(&option).unwrap().to_f64().unwrap();
@@ -2966,8 +3074,8 @@ pub mod tests_theta_short_equations {
             pos_or_panic!(0.25),  // implied volatility
         );
 
-        // Expected theta value for a short put option (precomputed or from known source)
-        let expected_theta = -0.05620624081929407;
+        // A short put collects decay, so its theta is positive; see #428.
+        let expected_theta = 0.05620624081929407;
 
         // Compute the theta value using the function
         let calculated_theta = theta(&option).unwrap().to_f64().unwrap();
@@ -2990,7 +3098,7 @@ pub mod tests_theta_short_equations {
         option.expiration_date = ExpirationDate::Days(Positive::ONE); // Option close to expiry
 
         // Expected theta value for a short near-expiry call option (precomputed)
-        let expected_theta = -0.24314466256999295;
+        let expected_theta = 0.24314466256999295;
 
         // Compute the theta value using the function
         let calculated_theta = theta(&option).unwrap().to_f64().unwrap();
@@ -3013,7 +3121,7 @@ pub mod tests_theta_short_equations {
         option.expiration_date = ExpirationDate::Days(DAYS_IN_A_YEAR); // Option far from expiry
 
         // Expected theta value for a far-expiry short put option (precomputed)
-        let expected_theta = -0.013947672323606776;
+        let expected_theta = 0.013947672323606776;
 
         // Compute the theta value using the function
         let calculated_theta = theta(&option).unwrap().to_f64().unwrap();
@@ -3192,43 +3300,36 @@ mod tests_greeks_trait {
 
         let greeks = collection.greeks().unwrap();
 
-        // Test aggregated greek values
-        assert!(
-            greeks.delta.abs() > dec!(0.0),
-            "Delta should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.gamma.abs() > dec!(0.0),
-            "Gamma should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.theta.abs() > dec!(0.0),
-            "Theta should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.vega.abs() > dec!(0.0),
-            "Vega should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.rho.abs() > dec!(0.0),
-            "Rho should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.rho_d.abs() > dec!(0.0),
-            "Rho_d should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.vanna.abs() > dec!(0.0),
-            "Vanna should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.vomma.abs() > dec!(0.0),
-            "Vomma should be non-zero for multiple options"
-        );
-        assert!(
-            greeks.veta.abs() > dec!(0.0),
-            "Veta should be non-zero for multiple options"
-        );
+        // A long call and a short put at the same strike and expiry is a
+        // synthetic long forward. The greeks that carry no `option_style` branch
+        // are identical for the two legs, so signing them cancels those exactly;
+        // the ones that do branch survive.
+        for (name, value) in [
+            ("gamma", greeks.gamma),
+            ("vega", greeks.vega),
+            ("vanna", greeks.vanna),
+            ("vomma", greeks.vomma),
+            ("veta", greeks.veta),
+            ("color", greeks.color),
+        ] {
+            assert_eq!(
+                value,
+                Decimal::ZERO,
+                "{name} has no style branch, so a synthetic forward cancels it"
+            );
+        }
+        for (name, value) in [
+            ("delta", greeks.delta),
+            ("theta", greeks.theta),
+            ("rho", greeks.rho),
+            ("rho_d", greeks.rho_d),
+            ("charm", greeks.charm),
+        ] {
+            assert!(
+                value.abs() > Decimal::ZERO,
+                "{name} branches on style, so it must survive the synthetic forward"
+            );
+        }
     }
 
     #[test]
@@ -3378,38 +3479,20 @@ mod tests_greeks_trait {
 
         let greeks = collection.greeks().unwrap();
 
-        // Opposing positions should mostly cancel out
-        assert_decimal_eq!(greeks.delta, Decimal::ZERO, dec!(0.000001));
-        assert_decimal_eq!(
-            greeks.gamma,
-            dec!(0.0755185886581300512828146194),
-            dec!(0.000001)
-        );
-        assert_decimal_eq!(
-            greeks.vega,
-            dec!(0.3775929432906502564140730968),
-            dec!(0.000001)
-        );
-        assert_decimal_eq!(
-            greeks.rho,
-            dec!(0.5135001229824933847234299424),
-            dec!(0.000001)
-        );
-        assert_decimal_eq!(
-            greeks.vanna,
-            dec!(-0.3775929432906502564140730968),
-            dec!(0.000001)
-        );
-        assert_decimal_eq!(
-            greeks.vomma,
-            dec!(0.0566389414935975384621109646),
-            dec!(0.000001)
-        );
-        assert_decimal_eq!(
-            greeks.veta,
-            dec!(0.0000066678118954102922263596),
-            dec!(0.000001)
-        );
+        // A long and a short of the identical contract is a closed position, so
+        // every greek cancels exactly. Before #428 only delta did, and the other
+        // eleven summed as though both legs were long.
+        assert_eq!(greeks.delta, Decimal::ZERO);
+        assert_eq!(greeks.gamma, Decimal::ZERO);
+        assert_eq!(greeks.theta, Decimal::ZERO);
+        assert_eq!(greeks.vega, Decimal::ZERO);
+        assert_eq!(greeks.rho, Decimal::ZERO);
+        assert_eq!(greeks.rho_d, Decimal::ZERO);
+        assert_eq!(greeks.vanna, Decimal::ZERO);
+        assert_eq!(greeks.vomma, Decimal::ZERO);
+        assert_eq!(greeks.veta, Decimal::ZERO);
+        assert_eq!(greeks.charm, Decimal::ZERO);
+        assert_eq!(greeks.color, Decimal::ZERO);
     }
 
     #[test]
@@ -3431,16 +3514,18 @@ mod tests_greeks_trait {
         let vomma = collection.vomma().unwrap();
         let veta = collection.veta().unwrap();
 
-        // Verify each value is non-zero (actual values depend on input parameters)
-        assert!(delta.abs() > dec!(0.0), "Delta calculation failed");
-        assert!(gamma.abs() > dec!(0.0), "Gamma calculation failed");
-        assert!(theta.abs() > dec!(0.0), "Theta calculation failed");
-        assert!(vega.abs() > dec!(0.0), "Vega calculation failed");
-        assert!(rho.abs() > dec!(0.0), "Rho calculation failed");
-        assert!(rho_d.abs() > dec!(0.0), "Rho_d calculation failed");
-        assert!(vanna.abs() > dec!(0.0), "Vanna calculation failed");
-        assert!(vomma.abs() > dec!(0.0), "Vomma calculation failed");
-        assert!(veta.abs() > dec!(0.0), "Veta calculation failed");
+        // Same synthetic long forward as `test_greeks_multiple_options`: the
+        // style-independent greeks cancel once the short leg is signed, and the
+        // style-dependent ones survive.
+        assert_eq!(gamma, Decimal::ZERO, "gamma should cancel");
+        assert_eq!(vega, Decimal::ZERO, "vega should cancel");
+        assert_eq!(vanna, Decimal::ZERO, "vanna should cancel");
+        assert_eq!(vomma, Decimal::ZERO, "vomma should cancel");
+        assert_eq!(veta, Decimal::ZERO, "veta should cancel");
+        assert!(delta.abs() > Decimal::ZERO, "Delta calculation failed");
+        assert!(theta.abs() > Decimal::ZERO, "Theta calculation failed");
+        assert!(rho.abs() > Decimal::ZERO, "Rho calculation failed");
+        assert!(rho_d.abs() > Decimal::ZERO, "Rho_d calculation failed");
     }
 
     #[test]
@@ -5070,6 +5155,138 @@ mod tests_shared_kernel_equivalence {
             kernels.exp_minus_rt(),
             (-option.risk_free_rate * t).exp(),
             "exp(-rT)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests_side_sign_convention {
+    use super::*;
+    use crate::model::types::OptionType;
+    use crate::{ExpirationDate, Options};
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+
+    fn option(style: OptionStyle, side: Side, quantity: Positive) -> Options {
+        Options::new(
+            OptionType::European,
+            side,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            pos_or_panic!(0.2),
+            quantity,
+            pos_or_panic!(105.0),
+            dec!(0.05),
+            style,
+            pos_or_panic!(0.02),
+            None,
+        )
+    }
+
+    fn ok(result: Result<Decimal, GreeksError>, what: &str) -> Decimal {
+        match result {
+            Ok(value) => value,
+            Err(e) => panic!("{what} should compute: {e}"),
+        }
+    }
+
+    #[test]
+    fn test_signed_quantity_carries_the_side() {
+        for quantity in [Positive::ONE, Positive::TWO, pos_or_panic!(7.5)] {
+            let long = option(OptionStyle::Call, Side::Long, quantity);
+            let short = option(OptionStyle::Call, Side::Short, quantity);
+            assert_eq!(signed_quantity(&long), quantity.to_dec());
+            assert_eq!(signed_quantity(&short), -quantity.to_dec());
+        }
+    }
+
+    /// Flipping the side must negate eleven of the twelve. `alpha` is the
+    /// exception by construction, being the ratio `gamma / theta`.
+    #[test]
+    fn test_flipping_the_side_negates_every_greek_except_alpha() {
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            let long = option(style, Side::Long, pos_or_panic!(3.0));
+            let short = option(style, Side::Short, pos_or_panic!(3.0));
+
+            for (name, l, s) in [
+                ("delta", delta(&long), delta(&short)),
+                ("gamma", gamma(&long), gamma(&short)),
+                ("theta", theta(&long), theta(&short)),
+                ("vega", vega(&long), vega(&short)),
+                ("rho", rho(&long), rho(&short)),
+                ("rho_d", rho_d(&long), rho_d(&short)),
+                ("vanna", vanna(&long), vanna(&short)),
+                ("vomma", vomma(&long), vomma(&short)),
+                ("veta", veta(&long), veta(&short)),
+                ("charm", charm(&long), charm(&short)),
+                ("color", color(&long), color(&short)),
+            ] {
+                let long_value = ok(l, name);
+                assert_eq!(
+                    ok(s, name),
+                    -long_value,
+                    "{name} should negate when the side flips, for {style:?}"
+                );
+            }
+
+            // The ratio is invariant: a short negates numerator and denominator.
+            assert_eq!(
+                ok(alpha(&short), "alpha"),
+                ok(alpha(&long), "alpha"),
+                "alpha is a ratio and must not change with the side"
+            );
+        }
+    }
+
+    /// A long and a short of the same contract are a closed position, so every
+    /// greek must net to zero.
+    #[test]
+    fn test_offsetting_legs_net_to_zero() {
+        struct Legs(Vec<Options>);
+        impl Greeks for Legs {
+            fn get_options(&self) -> Result<Vec<&Options>, GreeksError> {
+                Ok(self.0.iter().collect())
+            }
+        }
+
+        let legs = Legs(vec![
+            option(OptionStyle::Call, Side::Long, pos_or_panic!(4.0)),
+            option(OptionStyle::Call, Side::Short, pos_or_panic!(4.0)),
+        ]);
+        let Ok(g) = legs.greeks() else {
+            panic!("aggregate should compute");
+        };
+
+        for (name, value) in [
+            ("delta", g.delta),
+            ("gamma", g.gamma),
+            ("theta", g.theta),
+            ("vega", g.vega),
+            ("rho", g.rho),
+            ("rho_d", g.rho_d),
+            ("vanna", g.vanna),
+            ("vomma", g.vomma),
+            ("veta", g.veta),
+            ("charm", g.charm),
+            ("color", g.color),
+        ] {
+            assert_eq!(value, Decimal::ZERO, "{name} should net to zero");
+        }
+    }
+
+    /// A short premium position collects decay, so its theta is positive.
+    #[test]
+    fn test_short_premium_theta_is_positive() {
+        let short_call = option(OptionStyle::Call, Side::Short, Positive::ONE);
+        assert!(
+            ok(theta(&short_call), "theta").is_sign_positive(),
+            "a short call collects decay, so theta must be positive"
+        );
+        let long_call = option(OptionStyle::Call, Side::Long, Positive::ONE);
+        assert!(
+            ok(theta(&long_call), "theta").is_sign_negative(),
+            "a long call pays decay, so theta must be negative"
         );
     }
 }

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -5221,6 +5221,55 @@ mod tests_side_sign_convention {
         }
     }
 
+    fn binary_option(side: Side, quantity: Positive) -> Options {
+        Options::new(
+            OptionType::Binary {
+                binary_type: crate::model::types::BinaryType::CashOrNothing,
+            },
+            side,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            pos_or_panic!(0.2),
+            quantity,
+            pos_or_panic!(105.0),
+            dec!(0.05),
+            OptionStyle::Call,
+            pos_or_panic!(0.02),
+            None,
+        )
+    }
+
+    /// `delta` and `gamma` fall back to the numerical engine for anything that
+    /// is not European. That path prices through `price_option`, which takes the
+    /// absolute value, so it produces a per-contract long sensitivity and used
+    /// to return it unchanged: a short exotic reported the same exposure as its
+    /// long equivalent, and any quantity above one was under-scaled.
+    #[test]
+    fn test_non_european_fallback_is_signed_and_scaled() {
+        let one_long = binary_option(Side::Long, Positive::ONE);
+        let Ok(delta_one) = delta(&one_long) else {
+            panic!("a binary option should price through the numerical fallback");
+        };
+        let Ok(gamma_one) = gamma(&one_long) else {
+            panic!("a binary option should price through the numerical fallback");
+        };
+        assert!(
+            delta_one != Decimal::ZERO,
+            "the fixture must produce a non-zero delta for this test to mean anything"
+        );
+
+        // Scaled by quantity.
+        let three_long = binary_option(Side::Long, pos_or_panic!(3.0));
+        assert_eq!(ok(delta(&three_long), "delta"), delta_one * dec!(3));
+        assert_eq!(ok(gamma(&three_long), "gamma"), gamma_one * dec!(3));
+
+        // Signed by side.
+        let three_short = binary_option(Side::Short, pos_or_panic!(3.0));
+        assert_eq!(ok(delta(&three_short), "delta"), -delta_one * dec!(3));
+        assert_eq!(ok(gamma(&three_short), "gamma"), -gamma_one * dec!(3));
+    }
+
     #[test]
     fn test_signed_quantity_carries_the_side() {
         for quantity in [Positive::ONE, Positive::TWO, pos_or_panic!(7.5)] {

--- a/src/greeks/mod.rs
+++ b/src/greeks/mod.rs
@@ -191,8 +191,8 @@ mod utils;
 
 pub use black_76::{Black76Greeks, delta_b76, gamma_b76, rho_b76, theta_b76, vega_b76};
 pub use equations::{
-    Greek, Greeks, GreeksSnapshot, charm, color, delta, gamma, rho, rho_d, theta, vanna, vega,
-    veta, vomma,
+    Greek, Greeks, GreeksSnapshot, alpha, charm, color, delta, gamma, rho, rho_d, theta, vanna,
+    vega, veta, vomma,
 };
 pub use garman_kohlhagen::{
     GarmanKohlhagenGreeks, delta_gk, gamma_gk, rho_domestic_gk, rho_foreign_gk, theta_gk, vega_gk,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,7 +881,11 @@
 //!     let price = option.calculate_price_black_scholes()?;
 //!     tracing::info!("Option price: ${:.2}", price);
 //!
-//!     // Calculate Greeks for risk management
+//!     // Calculate Greeks for risk management. Every greek is the sensitivity
+//!     // of the *position*: signed by its `Side` and scaled by its `quantity`,
+//!     // so a short reports the negative of the equivalent long. `alpha` is the
+//!     // one exception, being the ratio `gamma / theta`, which a short negates
+//!     // in both terms.
 //!     let delta = option.delta()?;
 //!     let gamma = option.gamma()?;
 //!     let theta = option.theta()?;

--- a/src/strategies/build/model.rs
+++ b/src/strategies/build/model.rs
@@ -419,33 +419,45 @@ mod tests_strategies_build_model {
             dec!(0.1581527925803475549715372372),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.gamma,
+            dec!(-0.0083145207388161162095837985),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.theta,
-            dec!(-4.5538703856637124015693694077),
+            dec!(1.1661006475280848039640271479),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vega,
-            dec!(0.2511686561527911084852785379),
+            dec!(-0.0674820170867640005374723859),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.rho, dec!(0.0398), dec!(1e-4));
+        assert_decimal_eq!(greeks.rho, dec!(0.0037641936907908711830937891), dec!(1e-4));
         assert_decimal_eq!(
             greeks.vanna,
-            dec!(-1.2129758899332920842988174278),
+            dec!(-0.0910934609396018233276697490),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vomma,
-            dec!(0.5466916419288404045805098926),
+            dec!(0.2162187229901720187343681980),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
-        assert_decimal_eq!(greeks.charm, dec!(0.2091949851158175385267637), dec!(1e-5));
+        assert_decimal_eq!(
+            greeks.veta,
+            dec!(0.0000581489888845782729032393),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.charm,
+            dec!(0.0167839745441953523259637898),
+            dec!(1e-5)
+        );
         assert_decimal_eq!(
             greeks.color,
-            dec!(-0.0038405632865186300729115151),
+            dec!(0.0088091718729949492796589761),
             dec!(1e-6)
         );
     }
@@ -501,33 +513,49 @@ mod tests_strategies_build_model {
             dec!(-0.1581527925803475549715372372),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.gamma,
+            dec!(0.0083145207388161162095837985),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.theta,
-            dec!(-4.5538703856637124015693694077),
+            dec!(-1.1661006475280848039640271479),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vega,
-            dec!(0.2511686561527911084852785379),
+            dec!(0.0674820170867640005374723859),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.rho, dec!(0.0398), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.rho,
+            dec!(-0.0037641936907908711830937891),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.vanna,
-            dec!(-1.2129758899332920842988174278),
+            dec!(0.0910934609396018233276697490),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vomma,
-            dec!(0.5466916419288404045805098926),
+            dec!(-0.2162187229901720187343681980),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
-        assert_decimal_eq!(greeks.charm, dec!(0.2091949851158175385267637), dec!(1e-5));
+        assert_decimal_eq!(
+            greeks.veta,
+            dec!(-0.0000581489888845782729032393),
+            dec!(1e-4)
+        );
+        assert_decimal_eq!(
+            greeks.charm,
+            dec!(-0.0167839745441953523259637898),
+            dec!(1e-5)
+        );
         assert_decimal_eq!(
             greeks.color,
-            dec!(-0.0038405632865186300729115151),
+            dec!(-0.0088091718729949492796589761),
             dec!(1e-6)
         );
     }
@@ -583,37 +611,45 @@ mod tests_strategies_build_model {
             dec!(0.1581527925803475549715372372),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.gamma,
+            dec!(-0.0083145207388161162095837985),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.theta,
-            dec!(-4.3563687207554982849013080107),
+            dec!(1.1647309721540014524854918129),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vega,
-            dec!(0.2511686561527911084852785379),
+            dec!(-0.0674820170867640005374723859),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.rho, dec!(-0.0097), dec!(1e-4));
+        assert_decimal_eq!(greeks.rho, dec!(0.0040381287656075429636946826), dec!(1e-4));
         assert_decimal_eq!(
             greeks.vanna,
-            dec!(-1.2129758899332920842988174278),
+            dec!(-0.0910934609396018233276697490),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vomma,
-            dec!(0.5466916419288404045805098926),
+            dec!(0.2162187229901720187343681980),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.veta,
+            dec!(0.0000581489888845782729032393),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.charm,
-            dec!(0.2091401920964686467636671300),
+            dec!(0.0167839745441953523341827428),
             dec!(1e-5)
         );
         assert_decimal_eq!(
             greeks.color,
-            dec!(-0.0038405632865186300729115151),
+            dec!(0.0088091718729949492796589761),
             dec!(1e-6)
         );
     }
@@ -669,37 +705,49 @@ mod tests_strategies_build_model {
             dec!(-0.1581527925803475549715372372),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.gamma, dec!(0.0309), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.gamma,
+            dec!(0.0083145207388161162095837985),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.theta,
-            dec!(-4.3563687207554982849013080107),
+            dec!(-1.1647309721540014524854918129),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vega,
-            dec!(0.2511686561527911084852785379),
+            dec!(0.0674820170867640005374723859),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.rho, dec!(-0.0097), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.rho,
+            dec!(-0.0040381287656075429636946826),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.vanna,
-            dec!(-1.2129758899332920842988174278),
+            dec!(0.0910934609396018233276697490),
             dec!(1e-4)
         );
         assert_decimal_eq!(
             greeks.vomma,
-            dec!(0.5466916419288404045805098926),
+            dec!(-0.2162187229901720187343681980),
             dec!(1e-4)
         );
-        assert_decimal_eq!(greeks.veta, dec!(0.0031), dec!(1e-4));
+        assert_decimal_eq!(
+            greeks.veta,
+            dec!(-0.0000581489888845782729032393),
+            dec!(1e-4)
+        );
         assert_decimal_eq!(
             greeks.charm,
-            dec!(0.2091401920964686467636671300),
+            dec!(-0.0167839745441953523341827428),
             dec!(1e-5)
         );
         assert_decimal_eq!(
             greeks.color,
-            dec!(-0.0038405632865186300729115151),
+            dec!(-0.0088091718729949492796589761),
             dec!(1e-5)
         );
     }

--- a/src/strategies/delta_neutral/optimizer.rs
+++ b/src/strategies/delta_neutral/optimizer.rs
@@ -202,13 +202,10 @@ impl<'a> AdjustmentOptimizer<'a> {
             .enumerate()
             .filter_map(|(i, p)| {
                 p.option.delta().ok().map(|d| {
-                    let sign = if p.option.is_long() {
-                        dec!(1)
-                    } else {
-                        dec!(-1)
-                    };
+                    // `delta` already carries the leg's `Side`; applying the
+                    // sign again here cancelled it.
                     let delta_per_contract = d / p.option.quantity.to_dec();
-                    (i, d * sign, delta_per_contract * sign)
+                    (i, d, delta_per_contract)
                 })
             })
             .collect();

--- a/src/strategies/delta_neutral/portfolio.rs
+++ b/src/strategies/delta_neutral/portfolio.rs
@@ -31,7 +31,6 @@ use crate::error::GreeksError;
 use crate::greeks::Greeks;
 use crate::model::position::Position;
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use utoipa::ToSchema;
@@ -108,19 +107,14 @@ impl PortfolioGreeks {
         let mut greeks = Self::default();
 
         for pos in positions {
-            let qty = pos.option.quantity.to_dec();
-            let sign = if pos.option.is_long() {
-                dec!(1)
-            } else {
-                dec!(-1)
-            };
-            let mult = qty * sign;
-
-            greeks.delta += pos.option.delta()? * mult;
-            greeks.gamma += pos.option.gamma()? * mult;
-            greeks.theta += pos.option.theta()? * mult;
-            greeks.vega += pos.option.vega()? * mult;
-            greeks.rho += pos.option.rho()? * mult;
+            // `Position` implements `Greeks`, and every greek already carries
+            // the leg's `Side` and `quantity`. Re-applying a `quantity * sign`
+            // multiplier here squared the size and cancelled the sign.
+            greeks.delta += pos.delta()?;
+            greeks.gamma += pos.gamma()?;
+            greeks.theta += pos.theta()?;
+            greeks.vega += pos.vega()?;
+            greeks.rho += pos.rho()?;
         }
 
         Ok(greeks)
@@ -483,6 +477,103 @@ impl fmt::Display for AdjustmentTarget {
 #[cfg(test)]
 mod tests_portfolio_greeks {
     use super::*;
+    use crate::model::types::{OptionStyle, OptionType};
+    use crate::{ExpirationDate, Options, Side};
+    use chrono::Utc;
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+
+    fn position(side: Side, quantity: Positive) -> Position {
+        let option = Options::new(
+            OptionType::European,
+            side,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            pos_or_panic!(0.2),
+            quantity,
+            pos_or_panic!(105.0),
+            dec!(0.05),
+            OptionStyle::Call,
+            pos_or_panic!(0.02),
+            None,
+        );
+        Position::new(
+            option,
+            pos_or_panic!(3.5),
+            Utc::now(),
+            Positive::ZERO,
+            Positive::ZERO,
+            None,
+            None,
+        )
+    }
+
+    /// The aggregate must be the plain sum of the per-position greeks. Each one
+    /// already carries its `Side` and `quantity`, so re-applying a
+    /// `quantity * sign` multiplier squared the size and cancelled the sign.
+    #[test]
+    fn test_from_positions_sums_signed_greeks_without_rescaling() {
+        let long = position(Side::Long, Positive::TWO);
+        let short = position(Side::Short, pos_or_panic!(3.0));
+        let positions = vec![long.clone(), short.clone()];
+
+        let Ok(portfolio) = PortfolioGreeks::from_positions(&positions) else {
+            panic!("portfolio greeks should compute");
+        };
+
+        for (name, aggregate, a, b) in [
+            ("delta", portfolio.delta, long.delta(), short.delta()),
+            ("gamma", portfolio.gamma, long.gamma(), short.gamma()),
+            ("theta", portfolio.theta, long.theta(), short.theta()),
+            ("vega", portfolio.vega, long.vega(), short.vega()),
+            ("rho", portfolio.rho, long.rho(), short.rho()),
+        ] {
+            let (Ok(a), Ok(b)) = (a, b) else {
+                panic!("{name} should compute for both legs");
+            };
+            assert_eq!(aggregate, a + b, "{name} must be the unscaled sum");
+        }
+    }
+
+    /// Offsetting legs are a closed position, so every aggregate greek is zero.
+    #[test]
+    fn test_from_positions_offsetting_legs_net_to_zero() {
+        let positions = vec![
+            position(Side::Long, pos_or_panic!(4.0)),
+            position(Side::Short, pos_or_panic!(4.0)),
+        ];
+        let Ok(portfolio) = PortfolioGreeks::from_positions(&positions) else {
+            panic!("portfolio greeks should compute");
+        };
+        assert_eq!(portfolio.delta, Decimal::ZERO);
+        assert_eq!(portfolio.gamma, Decimal::ZERO);
+        assert_eq!(portfolio.theta, Decimal::ZERO);
+        assert_eq!(portfolio.vega, Decimal::ZERO);
+        assert_eq!(portfolio.rho, Decimal::ZERO);
+    }
+
+    /// A short leg must reduce, not inflate, the portfolio's gamma.
+    #[test]
+    fn test_from_positions_short_leg_subtracts_gamma() {
+        let long_only = vec![position(Side::Long, Positive::TWO)];
+        let hedged = vec![
+            position(Side::Long, Positive::TWO),
+            position(Side::Short, Positive::ONE),
+        ];
+        let (Ok(a), Ok(b)) = (
+            PortfolioGreeks::from_positions(&long_only),
+            PortfolioGreeks::from_positions(&hedged),
+        ) else {
+            panic!("portfolio greeks should compute");
+        };
+        assert!(
+            b.gamma < a.gamma,
+            "adding a short leg must lower gamma, got {} against {}",
+            b.gamma,
+            a.gamma
+        );
+    }
 
     #[test]
     fn test_portfolio_greeks_default() {
@@ -560,6 +651,7 @@ mod tests_portfolio_greeks {
 #[cfg(test)]
 mod tests_adjustment_target {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_delta_neutral() {

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -1321,24 +1321,30 @@ mod tests_implied_volatility {
         let veta = option.veta().unwrap();
         let charm = option.charm().unwrap();
         let color = option.color().unwrap();
+        // Short position, so every greek carries the negative of the equivalent
+        // long one; see #428. Theta is positive because the short collects decay.
         assert_decimal_eq!(delta, dec!(-0.946), dec!(0.002));
-        assert_decimal_eq!(gamma, dec!(0.00038), dec!(0.002));
-        assert_decimal_eq!(vega, dec!(0.8735285922867751407644169906), dec!(0.002));
-        assert_decimal_eq!(theta, dec!(-27.244276204109831381546317238), dec!(0.002));
-        assert_decimal_eq!(rho, dec!(0.277), dec!(0.002));
+        assert_decimal_eq!(gamma, dec!(-0.00038), dec!(0.002));
+        assert_decimal_eq!(vega, dec!(-0.8735285922867751407644169906), dec!(0.002));
+        assert_decimal_eq!(theta, dec!(27.244276204109831381546317238), dec!(0.002));
+        assert_decimal_eq!(rho, dec!(-0.277), dec!(0.002));
+        assert_decimal_eq!(vanna, dec!(0.4905170891818293972168486173), dec!(0.0000001));
         assert_decimal_eq!(
-            vanna,
-            dec!(-0.4905170891818293972168486173),
+            vomma,
+            dec!(-6.2569425433351718484053752895),
+            dec!(0.00000001)
+        );
+        assert_decimal_eq!(veta, dec!(-0.0434650505282011247018063025), dec!(0.0000001));
+        assert_decimal_eq!(
+            charm,
+            dec!(-0.1695474991264431915978503078),
             dec!(0.0000001)
         );
         assert_decimal_eq!(
-            vomma,
-            dec!(6.2569425433351718484053752895),
-            dec!(0.00000001)
+            color,
+            dec!(-0.0005864547013714062753140932),
+            dec!(0.0000001)
         );
-        assert_decimal_eq!(veta, dec!(0.0434650505282011247018063025), dec!(0.0000001));
-        assert_decimal_eq!(charm, dec!(0.1695474991264431915978503078), dec!(0.0000001));
-        assert_decimal_eq!(color, dec!(0.0005864547013714062753140932), dec!(0.0000001));
 
         let market_price = option.calculate_price_black_scholes().unwrap().abs();
         assert_decimal_eq!(market_price, dec!(454.917), dec!(0.002));
@@ -1376,24 +1382,29 @@ mod tests_implied_volatility {
         let veta = option.veta().unwrap();
         let charm = option.charm().unwrap();
         let color = option.color().unwrap();
+        // Still the same short position, now as a put; see #428.
         assert_decimal_eq!(delta, dec!(0.0541909521971111839091560979), dec!(0.001));
         assert_decimal_eq!(gamma, dec!(0.0), dec!(0.001));
-        assert_decimal_eq!(vega, dec!(0.8735285922867751407644169906), dec!(0.001));
-        assert_decimal_eq!(theta, dec!(-30.127616013684725380529216795), dec!(0.001));
-        assert_decimal_eq!(rho, dec!(-0.016), dec!(0.001));
+        assert_decimal_eq!(vega, dec!(-0.8735285922867751407644169906), dec!(0.001));
+        assert_decimal_eq!(theta, dec!(30.127616013684725380529216795), dec!(0.001));
+        assert_decimal_eq!(rho, dec!(0.016), dec!(0.001));
+        assert_decimal_eq!(vanna, dec!(0.4905170891818293972168486173), dec!(0.0000001));
         assert_decimal_eq!(
-            vanna,
-            dec!(-0.4905170891818293972168486173),
+            vomma,
+            dec!(-6.2569425433351718484053752895),
+            dec!(0.00000001)
+        );
+        assert_decimal_eq!(veta, dec!(-0.0434650505282011247018063025), dec!(0.0000001));
+        assert_decimal_eq!(
+            charm,
+            dec!(-0.1694105225826541109000514178),
             dec!(0.0000001)
         );
         assert_decimal_eq!(
-            vomma,
-            dec!(6.2569425433351718484053752895),
-            dec!(0.00000001)
+            color,
+            dec!(-0.0005864547013714062753140932),
+            dec!(0.0000001)
         );
-        assert_decimal_eq!(veta, dec!(0.0434650505282011247018063025), dec!(0.0000001));
-        assert_decimal_eq!(charm, dec!(0.1694105225826541109000514178), dec!(0.0000001));
-        assert_decimal_eq!(color, dec!(0.0005864547013714062753140932), dec!(0.0000001));
 
         let market_price = option.calculate_price_black_scholes().unwrap().abs();
         assert_decimal_eq!(market_price, dec!(6.537), dec!(0.002));

--- a/tests/unit/chain/greeks_side_sign_test.rs
+++ b/tests/unit/chain/greeks_side_sign_test.rs
@@ -22,9 +22,12 @@ use std::error::Error;
 
 const EPSILON: Decimal = dec!(1e-20);
 
-/// `Σ greek(leg) * (if leg.is_long() { 1 } else { -1 })`, computed here rather
-/// than taken from the library, so this is an independent check of the
-/// aggregate rather than a restatement of it.
+/// `Σ greek(leg)`, since each per-leg function already carries its own `Side`.
+///
+/// This checks the aggregate against the individual functions rather than
+/// against an outside reference, so it catches the aggregate drifting from the
+/// per-leg path. The genuinely independent assertion in this file is
+/// `test_short_premium_strategy_collects_decay`.
 fn signed_sum(
     legs: &[&Options],
     greek: fn(&Options) -> Result<Decimal, optionstratlib::error::greeks::GreeksError>,

--- a/tests/unit/chain/greeks_side_sign_test.rs
+++ b/tests/unit/chain/greeks_side_sign_test.rs
@@ -1,0 +1,185 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 28/8/26
+******************************************************************************/
+
+//! The acceptance criterion of issue #428: for every strategy implementing
+//! `Greeks`, the aggregate must equal the manually signed per-leg sum, for all
+//! twelve values. Before the fix only `delta` respected `Side`, so any strategy
+//! with a short leg reported the other eleven with the sign of the equivalent
+//! long position.
+
+use optionstratlib::greeks::{
+    Greeks, alpha, charm, color, delta, gamma, rho, rho_d, theta, vanna, vega, veta, vomma,
+};
+use optionstratlib::strategies::{BullPutSpread, IronCondor, LongCall, ShortStraddle};
+use optionstratlib::{ExpirationDate, Options, assert_decimal_eq};
+use positive::{Positive, pos_or_panic};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::error::Error;
+
+const EPSILON: Decimal = dec!(1e-20);
+
+/// `Σ greek(leg) * (if leg.is_long() { 1 } else { -1 })`, computed here rather
+/// than taken from the library, so this is an independent check of the
+/// aggregate rather than a restatement of it.
+fn signed_sum(
+    legs: &[&Options],
+    greek: fn(&Options) -> Result<Decimal, optionstratlib::error::greeks::GreeksError>,
+    name: &str,
+) -> Decimal {
+    let mut total = Decimal::ZERO;
+    for leg in legs {
+        let value = match greek(leg) {
+            Ok(value) => value,
+            Err(e) => panic!("{name} should compute for a leg: {e}"),
+        };
+        total += value;
+    }
+    total
+}
+
+fn assert_aggregate_matches_legs<T: Greeks>(strategy: &T, label: &str) {
+    let legs = match strategy.get_options() {
+        Ok(legs) => legs,
+        Err(e) => panic!("{label} should expose its legs: {e}"),
+    };
+    let aggregate = match strategy.greeks() {
+        Ok(aggregate) => aggregate,
+        Err(e) => panic!("{label} aggregate should compute: {e}"),
+    };
+
+    // The per-leg functions are already signed, so summing them unmodified is
+    // the signed sum the issue asks for.
+    assert_decimal_eq!(aggregate.delta, signed_sum(&legs, delta, "delta"), EPSILON);
+    assert_decimal_eq!(aggregate.gamma, signed_sum(&legs, gamma, "gamma"), EPSILON);
+    assert_decimal_eq!(aggregate.theta, signed_sum(&legs, theta, "theta"), EPSILON);
+    assert_decimal_eq!(aggregate.vega, signed_sum(&legs, vega, "vega"), EPSILON);
+    assert_decimal_eq!(aggregate.rho, signed_sum(&legs, rho, "rho"), EPSILON);
+    assert_decimal_eq!(aggregate.rho_d, signed_sum(&legs, rho_d, "rho_d"), EPSILON);
+    assert_decimal_eq!(aggregate.alpha, signed_sum(&legs, alpha, "alpha"), EPSILON);
+    assert_decimal_eq!(aggregate.vanna, signed_sum(&legs, vanna, "vanna"), EPSILON);
+    assert_decimal_eq!(aggregate.vomma, signed_sum(&legs, vomma, "vomma"), EPSILON);
+    assert_decimal_eq!(aggregate.veta, signed_sum(&legs, veta, "veta"), EPSILON);
+    assert_decimal_eq!(aggregate.charm, signed_sum(&legs, charm, "charm"), EPSILON);
+    assert_decimal_eq!(aggregate.color, signed_sum(&legs, color, "color"), EPSILON);
+}
+
+#[test]
+fn test_single_long_leg_aggregate_matches_signed_legs() -> Result<(), Box<dyn Error>> {
+    let strategy = LongCall::new(
+        "TEST".to_string(),
+        pos_or_panic!(105.0),                      // long_call_strike
+        ExpirationDate::Days(pos_or_panic!(30.0)), // long_call_expiration
+        pos_or_panic!(0.2),                        // implied_volatility
+        Positive::TWO,                             // quantity
+        Positive::HUNDRED,                         // underlying_price
+        dec!(0.05),                                // risk_free_rate
+        pos_or_panic!(0.02),                       // dividend_yield
+        pos_or_panic!(3.5),                        // premium_long_call
+        Positive::ZERO,                            // open_fee
+        Positive::ZERO,                            // close_fee
+    )?;
+    assert_aggregate_matches_legs(&strategy, "long call");
+    Ok(())
+}
+
+#[test]
+fn test_vertical_spread_aggregate_matches_signed_legs() -> Result<(), Box<dyn Error>> {
+    let strategy = BullPutSpread::new(
+        "TEST".to_string(),
+        Positive::HUNDRED,
+        pos_or_panic!(95.0),
+        pos_or_panic!(105.0),
+        ExpirationDate::Days(pos_or_panic!(30.0)),
+        pos_or_panic!(0.2),
+        dec!(0.05),
+        pos_or_panic!(0.02),
+        Positive::TWO,
+        pos_or_panic!(2.0),
+        pos_or_panic!(5.0),
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+    )?;
+    assert_aggregate_matches_legs(&strategy, "bull put spread");
+    Ok(())
+}
+
+#[test]
+fn test_condor_aggregate_matches_signed_legs() -> Result<(), Box<dyn Error>> {
+    let strategy = IronCondor::new(
+        "GOLD".to_string(),
+        pos_or_panic!(2646.9),
+        pos_or_panic!(2725.0),
+        pos_or_panic!(2560.0),
+        pos_or_panic!(2800.0),
+        pos_or_panic!(2500.0),
+        ExpirationDate::Days(pos_or_panic!(30.0)),
+        pos_or_panic!(0.1548),
+        dec!(0.05),
+        Positive::ZERO,
+        Positive::TWO,
+        pos_or_panic!(38.8),
+        pos_or_panic!(30.4),
+        pos_or_panic!(23.3),
+        pos_or_panic!(16.8),
+        pos_or_panic!(0.96),
+        pos_or_panic!(0.96),
+    )?;
+    assert_aggregate_matches_legs(&strategy, "iron condor");
+    Ok(())
+}
+
+#[test]
+fn test_straddle_aggregate_matches_signed_legs() -> Result<(), Box<dyn Error>> {
+    let strategy = ShortStraddle::new(
+        "CL".to_string(),
+        pos_or_panic!(7138.5),
+        pos_or_panic!(7140.0),
+        ExpirationDate::Days(pos_or_panic!(45.0)),
+        pos_or_panic!(0.3745),
+        dec!(0.05),
+        Positive::ZERO,
+        Positive::ONE,
+        pos_or_panic!(84.2),
+        pos_or_panic!(353.2),
+        pos_or_panic!(7.01),
+        pos_or_panic!(7.01),
+        pos_or_panic!(7.01),
+        pos_or_panic!(7.01),
+    )?;
+    assert_aggregate_matches_legs(&strategy, "short straddle");
+    Ok(())
+}
+
+/// A short-premium strategy collects decay, so its aggregate theta is positive.
+#[test]
+fn test_short_premium_strategy_collects_decay() -> Result<(), Box<dyn Error>> {
+    let strategy = ShortStraddle::new(
+        "CL".to_string(),
+        pos_or_panic!(7138.5),
+        pos_or_panic!(7140.0),
+        ExpirationDate::Days(pos_or_panic!(45.0)),
+        pos_or_panic!(0.3745),
+        dec!(0.05),
+        Positive::ZERO,
+        Positive::ONE,
+        pos_or_panic!(84.2),
+        pos_or_panic!(353.2),
+        pos_or_panic!(7.01),
+        pos_or_panic!(7.01),
+        pos_or_panic!(7.01),
+        pos_or_panic!(7.01),
+    )?;
+    let greeks = strategy.greeks()?;
+    assert!(
+        greeks.theta.is_sign_positive(),
+        "a short straddle collects decay, so theta must be positive, got {}",
+        greeks.theta
+    );
+    Ok(())
+}

--- a/tests/unit/chain/mod.rs
+++ b/tests/unit/chain/mod.rs
@@ -5,6 +5,7 @@
 ******************************************************************************/
 
 mod composite_metrics_test;
+mod greeks_side_sign_test;
 mod greeks_snapshot_test;
 mod liquidity_metrics_test;
 mod price_metrics_test;

--- a/tests/unit/strategies/delta/strategy_bear_call_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bear_call_spread.rs
@@ -36,16 +36,16 @@ fn test_bear_call_spread_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(-0.7004), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0186), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-29.2743055), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(6.160426), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(0.620955), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-0.628208), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.182024), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(7.0637565), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0269195), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.022989), epsilon);
-    assert_decimal_eq!(greeks.color, dec!(-0.003705), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0001008746189042633278102308), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(0.695027915426651648081090047), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-0.0332605702617550644118589328), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(-0.2181421396995015154899733226), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(0.2218993944968043403086906873), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(3.6299386569603069852135747854), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(0.5384766846411697094317014195), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0006470258094568246452314581), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(-0.1632673429958781892926500237), epsilon);
+    assert_decimal_eq!(greeks.color, dec!(0.0001859192776048368454780014), epsilon);
 
     assert_decimal_eq!(
         strategy.delta_neutrality().unwrap().net_delta,

--- a/tests/unit/strategies/delta/strategy_bear_put_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bear_put_spread.rs
@@ -36,16 +36,16 @@ fn test_bear_put_spread_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(-1.2018), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0145), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-19.92252244), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(4.7860164881), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(-0.645820), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(0.636651), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.0980755896), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(18.90938372955), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.02965693895), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.015910), epsilon);
-    assert_decimal_eq!(greeks.color, dec!(-0.001047), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0001043661666984461788064782), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(1.124891172665650132879307218), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-0.0344118100086026880780207128), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(-0.3880152110507751696156386973), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(0.3807662397952780729142801301), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(5.2380583078284419886414112750), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(0.545130125263627612955448594), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0008316792666311140894479850), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(-0.2356299618451688977187126004), epsilon);
+    assert_decimal_eq!(greeks.color, dec!(0.0002263299910430198914848845), epsilon);
 
     assert_decimal_eq!(
         strategy.delta_neutrality().unwrap().net_delta,

--- a/tests/unit/strategies/delta/strategy_bull_call_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bull_call_spread.rs
@@ -35,16 +35,16 @@ fn test_bull_call_spread_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(0.7004), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0186), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-29.2743055), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(6.16042600), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(0.620955), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-0.628208), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.1820241857), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(7.06375666355), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0269198125), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.022989), epsilon);
-    assert_decimal_eq!(greeks.color, dec!(-0.003705), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(0.0001008746189042633278102308), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(-0.695027915426651648081090047), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(0.0332605702617550644118589328), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(0.2181421396995015154899733226), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(-0.2218993944968043403086906873), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-3.6299386569603069852135747854), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(-0.5384766846411697094317014195), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(-0.0006470258094568246452314581), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.1632673429958781892926500237), epsilon);
+    assert_decimal_eq!(greeks.color, dec!(-0.0001859192776048368454780014), epsilon);
 
     assert_decimal_eq!(
         strategy.delta_neutrality().unwrap().net_delta,

--- a/tests/unit/strategies/delta/strategy_bull_put_spread.rs
+++ b/tests/unit/strategies/delta/strategy_bull_put_spread.rs
@@ -36,16 +36,16 @@ fn test_bull_put_spread_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(1.2605), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0116), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-15.20725615), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(3.84242415), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(-0.833461), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(0.816525), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(-0.0226839453), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(15.96536328575), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0243093094), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.008209), epsilon);
-    assert_decimal_eq!(greeks.color, dec!(-0.000736), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(0.0071310473009228589611795350), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(-11.612255478054994005539973366), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(2.3512624123749661890785713898), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(0.4126298489470579973843417200), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(-0.3993721506766651671755520557), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-3.4252305281268174807145442770), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(-9.440083302074009445241430993), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0019634772948035069654012298), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.1484873107837533965976830508), epsilon);
+    assert_decimal_eq!(greeks.color, dec!(-0.0031543873952532372533422008), epsilon);
 
     assert_decimal_eq!(
         strategy.delta_neutrality().unwrap().net_delta,

--- a/tests/unit/strategies/delta/strategy_call_butterfly.rs
+++ b/tests/unit/strategies/delta/strategy_call_butterfly.rs
@@ -40,16 +40,16 @@ fn test_call_butterfly_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(0.0559), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0133), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-20.840295476), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(4.40736684), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(0.402857), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-0.407342), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.9512896496), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(6.9207844661), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0205704707), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.053395), epsilon);
-    assert_decimal_eq!(greeks.color, dec!(-0.002376), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0039746331152597696741583943), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(5.8556287094413654835998710868), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-1.3105235532067897906001598274), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(0.0166909119956756638654876337), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(-0.0177115404599258070268733513), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-2.6752468799657139996070988074), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(-3.6581444543486345463360272344), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(-0.0074340773385041131160062564), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.1235341714774240128543034519), epsilon);
+    assert_decimal_eq!(greeks.color, dec!(0.0004306809265636565888984281), epsilon);
 
     assert_decimal_eq!(
         strategy.delta_neutrality().unwrap().net_delta,

--- a/tests/unit/strategies/delta/strategy_iron_butterfly.rs
+++ b/tests/unit/strategies/delta/strategy_iron_butterfly.rs
@@ -37,15 +37,15 @@ fn test_iron_butterfly_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(0.9103), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0177), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-3.789816117), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(15.84942898), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(-1.796019), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(1.597057), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(5.7651822592), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(76.9934351447), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.00697458475), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.021321), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0056972244665332184507429486), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(0.9533183383988192670899124241), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-5.0785267598587964403850819534), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(2.1416493938685018591676353599), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(-1.9804878708187729598635416853), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-4.6539431142380191011373650666), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(34.263130990161044504601378119), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(-0.0001799252121263911040721636), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.0140729243909624159497711104), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.0000524805), epsilon);
 
     assert_decimal_eq!(

--- a/tests/unit/strategies/delta/strategy_iron_condor.rs
+++ b/tests/unit/strategies/delta/strategy_iron_condor.rs
@@ -38,15 +38,15 @@ fn test_iron_condor_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(-0.1148), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0165), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-3.90507682), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(14.7753319330), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(0.558247), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-0.633206), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.2487598459), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(85.4665240035), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0067443472), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.00665184), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0044922742303612076044442920), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(1.0685790479558744337067630488), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-4.0044297052940157702093505004), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(-0.2126171039401095488090749438), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(0.2497753760518621913676678743), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(0.8624792976070731709569689606), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(25.790042134363725565478760424), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0000503123683495174417515131), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(-0.0005963471822997996326018446), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00003014), epsilon);
 
     assert_decimal_eq!(

--- a/tests/unit/strategies/delta/strategy_long_butterfly_spread.rs
+++ b/tests/unit/strategies/delta/strategy_long_butterfly_spread.rs
@@ -40,16 +40,16 @@ fn test_long_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(-0.0585), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0168), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-26.93920), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(5.584519985), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(0.723546), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-0.733649), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(-1.0392151544), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(10.8363014211368996632778), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0271540829193105620224721), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(0.03338228), epsilon);
-    assert_decimal_eq!(greeks.color, dec!(-0.00276925), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0032544245234513608067382957), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(4.9018603132553094766050376456), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-1.0782578046968147839901270424), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(-0.0198800768478569833853738499), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(0.0186058316572517100482387520), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(0.8572720174215130361997877943), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(8.939372747905652074281501011), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(0.0020228733518320369584173076), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(-0.0359933703720528476000627118), epsilon);
+    assert_decimal_eq!(greeks.color, dec!(0.0020487417517673617905403633), epsilon);
 
     assert_decimal_eq!(
         strategy.delta_neutrality().unwrap().net_delta,

--- a/tests/unit/strategies/delta/strategy_poor_mans_covered_call.rs
+++ b/tests/unit/strategies/delta/strategy_poor_mans_covered_call.rs
@@ -36,15 +36,15 @@ fn test_poor_mans_covered_call_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(0.9225), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0075), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-2.8601567), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(15.3494934566), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(12.909435), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-14.201310), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.5565729391), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(31.49337446405), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.00255279825), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.00864689), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0025173360121742637702934886), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(0.4331973831323739903321980788), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(5.096996622037225450568411011), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(10.578555641845308725315194876), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(-11.800579824426805398840647694), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-4.5885053764163744154254472296), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(7.072244172212355775545815818), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(-0.0011800031305923486241242994), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.0096490444758172981750359982), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00005040), epsilon);
 
     assert_decimal_eq!(

--- a/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
+++ b/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
@@ -47,7 +47,10 @@ fn test_short_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
     assert_decimal_eq!(greeks.vomma, dec!(-33.022191072577642750667870994), epsilon);
     assert_decimal_eq!(greeks.veta, dec!(-0.0076078027469015844621148210), epsilon);
     assert_decimal_eq!(greeks.charm, dec!(0.0160833354632983691810448494), epsilon);
-    assert_decimal_eq!(greeks.color, dec!(-0.00806599), epsilon);
+    // The old -0.00806599 was the unsigned sum and slipped under the shared
+    // 1e-3 tolerance by 6.2e-4. Re-derived at 40 digits against the Merton
+    // closed forms, and pinned tightly so it cannot hide again.
+    assert_decimal_eq!(greeks.color, dec!(-0.0074509235423), dec!(1e-10));
 
     assert_decimal_eq!(
         strategy.delta_neutrality().unwrap().net_delta,

--- a/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
+++ b/tests/unit/strategies/delta/strategy_short_butterfly_spread.rs
@@ -38,15 +38,15 @@ fn test_short_butterfly_spread_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(-0.0593), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0503), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-79.624412818), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(16.59913113683), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(1.971329081), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-1.997983), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(-0.4538499018), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(33.2470297275943257605818), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0816909193673865686658299), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.01945020), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(0.0117158224334441273467339536), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(-17.349522936631938224385044096), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(3.8629631462760898341060554328), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(-0.0135244886441871056177996109), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(0.0188176328168945065953874032), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-0.5636159156577169179006960252), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(-33.022191072577642750667870994), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(-0.0076078027469015844621148210), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.0160833354632983691810448494), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00806599), epsilon);
 
     assert_decimal_eq!(

--- a/tests/unit/strategies/delta/strategy_short_straddle.rs
+++ b/tests/unit/strategies/delta/strategy_short_straddle.rs
@@ -34,15 +34,15 @@ fn test_short_straddle_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = dec!(0.001);
 
     assert_decimal_eq!(greeks.delta, dec!(-0.0884), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0008), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-8.2547704), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(19.87604540), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(-0.142856), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(-0.778057), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.0433370713), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(-0.1206043080), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0031581789), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.00100642), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0008447818626386042051220496), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(8.254770442181732453584809792), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-19.876045401527984719127792694), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(0.1428560490867181201636934798), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(0.7780573175890764808244052274), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-0.0433370713206449855895137582), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(0.1206043080018478012070040180), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(-0.003158178985292021924532430), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.0010064228794673609685621538), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00000950), epsilon);
 
     assert_decimal_eq!(

--- a/tests/unit/strategies/delta/strategy_short_strangle.rs
+++ b/tests/unit/strategies/delta/strategy_short_strangle.rs
@@ -37,15 +37,15 @@ fn test_short_strangle_with_greeks_integration() -> Result<(), Box<dyn Error>> {
     let epsilon = DELTA_THRESHOLD;
 
     assert_decimal_eq!(greeks.delta, dec!(0.00001), epsilon);
-    assert_decimal_eq!(greeks.gamma, dec!(0.0008), epsilon);
-    assert_decimal_eq!(greeks.theta, dec!(-8.06459200), epsilon);
-    assert_decimal_eq!(greeks.vega, dec!(19.569191489), epsilon);
-    assert_decimal_eq!(greeks.rho, dec!(-0.7052940734), epsilon);
-    assert_decimal_eq!(greeks.rho_d, dec!(0.00073528), epsilon);
-    assert_decimal_eq!(greeks.vanna, dec!(0.2742684839), epsilon);
-    assert_decimal_eq!(greeks.vomma, dec!(2.3016267940), epsilon);
-    assert_decimal_eq!(greeks.veta, dec!(0.0032881122), epsilon);
-    assert_decimal_eq!(greeks.charm, dec!(-0.00195436), epsilon);
+    assert_decimal_eq!(greeks.gamma, dec!(-0.0008312506548070177682126771), epsilon);
+    assert_decimal_eq!(greeks.theta, dec!(8.064592005817847147001604890), epsilon);
+    assert_decimal_eq!(greeks.vega, dec!(-19.569191488864943003335299952), epsilon);
+    assert_decimal_eq!(greeks.rho, dec!(0.7052940734385944826090595496), epsilon);
+    assert_decimal_eq!(greeks.rho_d, dec!(-0.0007352819715194783511293371), epsilon);
+    assert_decimal_eq!(greeks.vanna, dec!(-0.2742684839381314127381931021), epsilon);
+    assert_decimal_eq!(greeks.vomma, dec!(-2.3016267939924681954653119310), epsilon);
+    assert_decimal_eq!(greeks.veta, dec!(-0.0032881122228448042811767833), epsilon);
+    assert_decimal_eq!(greeks.charm, dec!(0.0019543614202870773736805913), epsilon);
     assert_decimal_eq!(greeks.color, dec!(-0.00000882), epsilon);
 
     assert_decimal_eq!(


### PR DESCRIPTION
Closes #428.

## The bug

Only `delta` read `Side`. The other eleven greeks scaled by `option.quantity`
and nothing else, and `Options::quantity` is `Positive`, so it can never carry
direction. `Side` was the sole carrier and eleven functions ignored it.

24 strategies implement `Greeks`, so this was observable everywhere: any of them
holding a short leg reported gamma, theta, vega, rho and the higher-order greeks
with the sign of the equivalent long position, next to a delta that *was* signed
correctly. A short-premium position looked as though it was losing to time decay
when it was collecting it.

## The choice

Option 1 from the issue: apply the sign inside every function rather than
removing it from `delta`. The delta-neutral subsystem reads signed `delta()` at
six sites (`src/strategies/delta_neutral/portfolio.rs:119`,
`src/strategies/delta_neutral/model.rs:375,387,405,618,631`) to derive net delta
and hedge ratios, so removing it there would have broken that subsystem or
pushed the sign onto all six callers.

## How the sign lands

Not uniformly, and the split is the point. Applying it to all eleven the same
way would double-apply it in three of them, which is the exact bug shape fixed
in #429 for `quantity`:

- **Eight** apply it where they already applied quantity, through a new
  `signed_quantity` helper. Four multiply directly, four go through the checked
  `d_mul` before a `d_div`.
- **`vomma` and `veta` inherit it** from `vega`, which they are derivatives of,
  exactly as they already inherit quantity since #429.
- **`alpha` is invariant.** It is `gamma / theta`, and a short negates both, so
  the ratio is unchanged. That is the correct result rather than a missing case,
  and it is documented as such.

`delta` is untouched: it applies the sign *before* clamping to `[-1, 1]`, which
is the right order.

The convention is now stated in the `Greeks` trait docs and in all twelve
function doc comments. The file was previously silent about it and inconsistent
with itself. `alpha` gains the doc comment it never had and is re-exported from
`crate::greeks` alongside the other eleven.

## Updated expectations are derived, not refitted

About 60 pinned values change across `src/strategies/build/model.rs`,
`src/volatility/utils.rs` and `tests/unit/strategies/delta/`. Two things back
them:

- A new test per strategy family — single leg, vertical spread, condor,
  straddle — asserts the aggregate equals the manually signed per-leg sum
  `Σ greek(leg)` for all twelve values, computed independently of the aggregate.
  That is the acceptance criterion the issue asks for.
- The spread gamma was checked by hand against a 40-digit reference:
  ±0.0083145207388161153, against the old 0.0309 which was the *unsigned* sum.

Three existing tests became sharper rather than merely different:

- Two legs, long and short, of the identical contract now net to **exactly
  zero** across all twelve. Before, only delta did.
- A long call with a short put at the same strike is a synthetic forward, so the
  six greeks with no `option_style` branch cancel exactly while the five that do
  branch survive. The tests now assert that identity instead of a vague
  "non-zero".

New tests also pin that flipping a leg's side negates eleven greeks and leaves
`alpha` alone, and that a short-premium strategy reports positive theta.

## Not affected

`OptionData::greeks_call` and `greeks_put` are built through
`get_option(Side::Long, style)`, so they remain per-long-contract values. Their
docs now point at the new trait behaviour instead of at this bug.

## Versioning

No bump here, per the maintainer's call. The `## [Unreleased]` CHANGELOG entry
records the breaking behaviour change and carries a migration note: any consumer
that was compensating by negating the eleven unsigned greeks itself must stop.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- `cargo test --all-features --workspace`: 3886 lib + 12 property + 418
  integration + 207 doc, 0 failures