### PR TITLE
Fix Black-76 and GK position Greek signs (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Breaking behaviour change.** Every greek now respects `Side`. Only `delta`
-  did before, so any strategy holding a short leg reported gamma, theta, vega,
-  rho and the higher-order greeks with the sign of the equivalent long position,
-  next to a delta that was signed correctly. A short-premium position looked as
-  though it was losing to time decay when it was collecting it. `Options::
-  quantity` is `Positive` and can never carry direction, so `Side` is the only
-  carrier of it (#428).
+- **Breaking behaviour change.** Every Black-Scholes/Merton greek in
+  `greeks::equations` now respects `Side`. Only `delta` did before, so any
+  strategy holding a short leg reported gamma, theta, vega, rho and the
+  higher-order greeks with the sign of the equivalent long position, next to a
+  delta that was signed correctly. A short-premium position looked as though it
+  was losing to time decay when it was collecting it. `Options::quantity` is
+  `Positive` and can never carry direction, so `Side` is the only carrier of it
+  (#428).
 
   Migration: any consumer that was compensating for the old behaviour, by
   negating the eleven unsigned greeks itself, must stop. A long and a short of
@@ -25,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   `OptionData::greeks_call` and `greeks_put` are unaffected: they are built
   through `get_option(Side::Long, style)` and remain per-long-contract values.
+
+- **Breaking behaviour change.** The Black-76 and Garman-Kohlhagen greek
+  families now use the same position-sign convention. Previously only their
+  deltas respected `Side`; a short futures or FX option therefore reported
+  gamma, vega, theta and rho with the sign of the equivalent long. All greeks in
+  both families are now signed by `Side` exactly once and scale linearly with
+  `quantity` (#436).
+
+  Migration: consumers that negated non-delta Black-76 or Garman-Kohlhagen
+  greeks for short positions must stop doing so.
 
 ### Changed
 

--- a/src/greeks/black_76.rs
+++ b/src/greeks/black_76.rs
@@ -18,14 +18,15 @@
 //!
 //! Greek units mirror the BSM module:
 //!
-//! * `delta_b76` — per unit move in `F`, applies long/short sign.
+//! * `delta_b76` — per unit move in `F`.
 //! * `gamma_b76` — per unit move in `F` (second order).
 //! * `vega_b76`  — per **1%** change in volatility.
 //! * `theta_b76` — per **calendar day** (annual figure divided by 365).
 //! * `rho_b76`   — per **1%** change in the risk-free rate.
 //!
-//! All quantities are returned as `Decimal` and scale linearly with
-//! `option.quantity`.
+//! Every value is the sensitivity of the position: [`Side::Long`] keeps the
+//! analytic long-option sign, [`Side::Short`] negates it, and
+//! `option.quantity` scales it linearly. All values are returned as `Decimal`.
 //!
 //! See `src/pricing/black_76.rs` for the matching pricing kernel.
 
@@ -56,6 +57,7 @@ fn ensure_european(option: &Options) -> Result<(), GreeksError> {
     }
 }
 
+#[inline]
 fn side_sign(option: &Options) -> Decimal {
     if matches!(option.side, Side::Long) {
         Decimal::ONE
@@ -119,8 +121,13 @@ pub fn delta_b76(option: &Options) -> Result<Decimal, GreeksError> {
 ///
 /// `Γ = e^(-rT) · n(d1) / (F · σ · √T)`
 ///
-/// Gamma is identical for calls and puts and does not flip with `Side`. Result
-/// is multiplied by `option.quantity`.
+/// The long-option gamma is identical for calls and puts.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position reports the negative of the
+/// equivalent long.
 ///
 /// # Errors
 ///
@@ -146,8 +153,9 @@ pub fn gamma_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let numer = d_mul(df, n(d1)?, "greeks::black_76::gamma::numer")?;
     let raw = d_div(numer, denom, "greeks::black_76::gamma::raw")?;
 
+    let signed = d_mul(side_sign(option), raw, "greeks::black_76::gamma::sign")?;
     let result = d_mul(
-        raw,
+        signed,
         option.quantity.to_dec(),
         "greeks::black_76::gamma::quantity",
     )?;
@@ -164,9 +172,15 @@ pub fn gamma_b76(option: &Options) -> Result<Decimal, GreeksError> {
 /// # Formula
 ///
 /// `ν = F · e^(-rT) · n(d1) · √T`, divided by 100 to express the sensitivity per
-/// 1 percentage point of volatility, then multiplied by `option.quantity`.
+/// 1 percentage point of volatility.
 ///
-/// Vega is identical for calls and puts and does not flip with `Side`.
+/// The long-option vega is identical for calls and puts.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position reports the negative of the
+/// equivalent long.
 ///
 /// # Errors
 ///
@@ -188,8 +202,9 @@ pub fn vega_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let leg2 = d_mul(leg1, n(d1)?, "greeks::black_76::vega::times_n")?;
     let raw = d_mul(leg2, sqrt_t, "greeks::black_76::vega::times_sqrt_t")?;
 
+    let signed = d_mul(side_sign(option), raw, "greeks::black_76::vega::sign")?;
     let weighted = d_mul(
-        raw,
+        signed,
         option.quantity.to_dec(),
         "greeks::black_76::vega::quantity",
     )?;
@@ -212,10 +227,13 @@ pub fn vega_b76(option: &Options) -> Result<Decimal, GreeksError> {
 /// - `Θ_call_year = -F·e^(-rT)·n(d1)·σ/(2√T) + r·F·e^(-rT)·N(d1) - r·K·e^(-rT)·N(d2)`
 /// - `Θ_put_year  = -F·e^(-rT)·n(d1)·σ/(2√T) - r·F·e^(-rT)·N(-d1) + r·K·e^(-rT)·N(-d2)`
 ///
-/// The annual figure is divided by 365 to express decay per calendar day, then
-/// multiplied by `option.quantity`.
+/// The annual figure is divided by 365 to express decay per calendar day.
 ///
-/// Theta does not flip with `Side`; the sign is governed by the formula itself.
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position therefore reports a positive theta
+/// when the equivalent long position loses value to time decay.
 ///
 /// # Errors
 ///
@@ -264,8 +282,9 @@ pub fn theta_b76(option: &Options) -> Result<Decimal, GreeksError> {
         }
     };
 
+    let signed = d_mul(side_sign(option), annual, "greeks::black_76::theta::sign")?;
     let weighted = d_mul(
-        annual,
+        signed,
         option.quantity.to_dec(),
         "greeks::black_76::theta::quantity",
     )?;
@@ -294,8 +313,13 @@ pub fn theta_b76(option: &Options) -> Result<Decimal, GreeksError> {
 /// And symmetrically `ρ_put = -T · P`.
 ///
 /// The annual figure is divided by 100 to express the sensitivity per 1
-/// percentage point of rate, then multiplied by `option.quantity`. Rho does not
-/// flip with `Side`.
+/// percentage point of rate.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position reports the negative of the
+/// equivalent long.
 ///
 /// # Errors
 ///
@@ -332,8 +356,9 @@ pub fn rho_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let neg_t_df = d_mul(-t_dec, df, "greeks::black_76::rho::neg_t_df")?;
     let annual = d_mul(neg_t_df, bracket, "greeks::black_76::rho::annual")?;
 
+    let signed = d_mul(side_sign(option), annual, "greeks::black_76::rho::sign")?;
     let weighted = d_mul(
-        annual,
+        signed,
         option.quantity.to_dec(),
         "greeks::black_76::rho::quantity",
     )?;
@@ -420,6 +445,15 @@ mod tests {
 
     fn close(a: Decimal, b: Decimal, tol: Decimal) -> bool {
         (a - b).abs() < tol
+    }
+
+    type GreekCalculator = fn(&Options) -> Result<Decimal, GreeksError>;
+
+    fn greek_value(label: &str, result: Result<Decimal, GreeksError>) -> Decimal {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("{label} failed: {error:?}"),
+        }
     }
 
     // ---- delta ----------------------------------------------------------
@@ -684,22 +718,52 @@ mod tests {
     // ---- side and quantity ---------------------------------------------
 
     #[test]
-    fn test_side_short_negates_delta() {
-        let long = create_option(100.0, 95.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+    fn test_side_short_negates_every_greek() {
+        let mut long = create_option(100.0, 95.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        long.quantity = pos_or_panic!(3.0);
         let mut short = long.clone();
         short.side = Side::Short;
-        let dl = delta_b76(&long).unwrap();
-        let ds = delta_b76(&short).unwrap();
-        assert_eq!(dl, -ds);
+
+        let calculators: [(&str, GreekCalculator); 5] = [
+            ("delta", delta_b76),
+            ("gamma", gamma_b76),
+            ("vega", vega_b76),
+            ("theta", theta_b76),
+            ("rho", rho_b76),
+        ];
+
+        for (label, calculate) in calculators {
+            let long_value = greek_value(label, calculate(&long));
+            let short_value = greek_value(label, calculate(&short));
+            assert_eq!(
+                long_value, -short_value,
+                "{label} did not negate for Side::Short"
+            );
+        }
     }
 
     #[test]
     fn test_quantity_scales_linearly() {
-        let mut opt = create_option(100.0, 95.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
-        let d1 = delta_b76(&opt).unwrap();
-        opt.quantity = pos_or_panic!(3.0);
-        let d3 = delta_b76(&opt).unwrap();
-        assert!(close(d3, d1 * Decimal::from(3), dec!(1e-15)));
+        let one = create_option(100.0, 95.0, dec!(0.05), 180.0, 0.2, OptionStyle::Call);
+        let mut three = one.clone();
+        three.quantity = pos_or_panic!(3.0);
+
+        let calculators: [(&str, GreekCalculator); 5] = [
+            ("delta", delta_b76),
+            ("gamma", gamma_b76),
+            ("vega", vega_b76),
+            ("theta", theta_b76),
+            ("rho", rho_b76),
+        ];
+
+        for (label, calculate) in calculators {
+            let one_value = greek_value(label, calculate(&one));
+            let three_value = greek_value(label, calculate(&three));
+            assert!(
+                close(three_value, one_value * Decimal::from(3), dec!(1e-15)),
+                "{label} did not scale linearly with quantity"
+            );
+        }
     }
 
     // ---- trait ----------------------------------------------------------

--- a/src/greeks/garman_kohlhagen.rs
+++ b/src/greeks/garman_kohlhagen.rs
@@ -26,12 +26,16 @@
 //!
 //! Mirrors the BSM module:
 //!
-//! * `delta_gk` — per unit move in `S`, applies long/short sign.
+//! * `delta_gk` — per unit move in `S`.
 //! * `gamma_gk` — per unit move in `S` (second order).
 //! * `vega_gk`  — per **1%** change in volatility.
 //! * `theta_gk` — per **calendar day** (annual figure ÷ 365).
 //! * `rho_domestic_gk` — per **1%** change in `r_d`.
 //! * `rho_foreign_gk`  — per **1%** change in `r_f`.
+//!
+//! Every value is the sensitivity of the position: [`Side::Long`] keeps the
+//! analytic long-option sign, [`Side::Short`] negates it, and
+//! `option.quantity` scales it linearly.
 //!
 //! ## Two rhos
 //!
@@ -81,6 +85,7 @@ fn ensure_european(option: &Options) -> Result<(), GreeksError> {
     }
 }
 
+#[inline]
 fn side_sign(option: &Options) -> Decimal {
     if matches!(option.side, Side::Long) {
         Decimal::ONE
@@ -212,8 +217,14 @@ pub fn delta_gk(option: &Options) -> Result<Decimal, GreeksError> {
 ///
 /// # Formula
 ///
-/// `Γ = e^(-r_f·T) · n(d1) / (S · σ · √T)` — identical for calls and puts,
-/// independent of `Side`. Result is multiplied by `option.quantity`.
+/// `Γ = e^(-r_f·T) · n(d1) / (S · σ · √T)` — identical for long calls and
+/// long puts.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position reports the negative of the
+/// equivalent long.
 ///
 /// # Errors
 ///
@@ -243,7 +254,12 @@ pub fn gamma_gk(option: &Options) -> Result<Decimal, GreeksError> {
     let numer = d_mul(exp_neg_rf_t, n(d1_v)?, "greeks::gk::gamma::numer")?;
     let raw = d_div(numer, denom, "greeks::gk::gamma::raw")?;
 
-    let result = d_mul(raw, option.quantity.to_dec(), "greeks::gk::gamma::quantity")?;
+    let signed = d_mul(side_sign(option), raw, "greeks::gk::gamma::sign")?;
+    let result = d_mul(
+        signed,
+        option.quantity.to_dec(),
+        "greeks::gk::gamma::quantity",
+    )?;
     Ok(result)
 }
 
@@ -252,8 +268,14 @@ pub fn gamma_gk(option: &Options) -> Result<Decimal, GreeksError> {
 ///
 /// # Formula
 ///
-/// `ν = S · e^(-r_f·T) · n(d1) · √T`, divided by 100. Identical for calls
-/// and puts, independent of `Side`.
+/// `ν = S · e^(-r_f·T) · n(d1) · √T`, divided by 100. It is identical for
+/// long calls and long puts.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position reports the negative of the
+/// equivalent long.
 ///
 /// # Errors
 ///
@@ -278,7 +300,12 @@ pub fn vega_gk(option: &Options) -> Result<Decimal, GreeksError> {
     let leg2 = d_mul(leg1, n(d1_v)?, "greeks::gk::vega::times_n")?;
     let raw = d_mul(leg2, sqrt_t, "greeks::gk::vega::times_sqrt_t")?;
 
-    let weighted = d_mul(raw, option.quantity.to_dec(), "greeks::gk::vega::quantity")?;
+    let signed = d_mul(side_sign(option), raw, "greeks::gk::vega::sign")?;
+    let weighted = d_mul(
+        signed,
+        option.quantity.to_dec(),
+        "greeks::gk::vega::quantity",
+    )?;
     let result = d_div(weighted, Decimal::ONE_HUNDRED, "greeks::gk::vega::per_pct")?;
     Ok(result)
 }
@@ -291,8 +318,13 @@ pub fn vega_gk(option: &Options) -> Result<Decimal, GreeksError> {
 /// - Call: `Θ_call = -S·e^(-r_f T)·n(d1)·σ/(2√T) − r_d·K·e^(-r_d T)·N(d2) + r_f·S·e^(-r_f T)·N(d1)`
 /// - Put:  `Θ_put  = -S·e^(-r_f T)·n(d1)·σ/(2√T) + r_d·K·e^(-r_d T)·N(-d2) − r_f·S·e^(-r_f T)·N(-d1)`
 ///
-/// Annual figure divided by 365 to express decay per calendar day,
-/// multiplied by `option.quantity`.
+/// Annual figure divided by 365 to express decay per calendar day.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position therefore reports a positive theta
+/// when the equivalent long position loses value to time decay.
 ///
 /// # Errors
 ///
@@ -349,8 +381,9 @@ pub fn theta_gk(option: &Options) -> Result<Decimal, GreeksError> {
         }
     };
 
+    let signed = d_mul(side_sign(option), annual, "greeks::gk::theta::sign")?;
     let weighted = d_mul(
-        annual,
+        signed,
         option.quantity.to_dec(),
         "greeks::gk::theta::quantity",
     )?;
@@ -366,8 +399,14 @@ pub fn theta_gk(option: &Options) -> Result<Decimal, GreeksError> {
 /// - Call: `ρ_d^call =  K · T · e^(-r_d·T) · N(d2)`
 /// - Put:  `ρ_d^put  = -K · T · e^(-r_d·T) · N(-d2)`
 ///
-/// Annual figure divided by 100, multiplied by `option.quantity`. Long
-/// calls have positive domestic rho; long puts have negative.
+/// Annual figure divided by 100. Long calls have positive domestic rho; long
+/// puts have negative domestic rho.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position reports the negative of the
+/// equivalent long.
 ///
 /// # Errors
 ///
@@ -396,7 +435,12 @@ pub fn rho_domestic_gk(option: &Options) -> Result<Decimal, GreeksError> {
         OptionStyle::Call => d_mul(base, big_n(d2_v)?, "greeks::gk::rho_d::call")?,
         OptionStyle::Put => -d_mul(base, big_n(-d2_v)?, "greeks::gk::rho_d::put")?,
     };
-    let weighted = d_mul(raw, option.quantity.to_dec(), "greeks::gk::rho_d::quantity")?;
+    let signed = d_mul(side_sign(option), raw, "greeks::gk::rho_d::sign")?;
+    let weighted = d_mul(
+        signed,
+        option.quantity.to_dec(),
+        "greeks::gk::rho_d::quantity",
+    )?;
     let result = d_div(weighted, Decimal::ONE_HUNDRED, "greeks::gk::rho_d::per_pct")?;
     Ok(result)
 }
@@ -409,8 +453,14 @@ pub fn rho_domestic_gk(option: &Options) -> Result<Decimal, GreeksError> {
 /// - Call: `ρ_f^call = -S · T · e^(-r_f·T) · N(d1)`
 /// - Put:  `ρ_f^put  =  S · T · e^(-r_f·T) · N(-d1)`
 ///
-/// Annual figure divided by 100, multiplied by `option.quantity`. Long
-/// calls have negative foreign rho; long puts have positive.
+/// Annual figure divided by 100. Long calls have negative foreign rho; long
+/// puts have positive foreign rho.
+///
+/// # Sign convention
+///
+/// Returns the sensitivity of the **position**: signed by [`Side`] and scaled
+/// by `option.quantity`. A short position reports the negative of the
+/// equivalent long.
 ///
 /// # Errors
 ///
@@ -439,7 +489,12 @@ pub fn rho_foreign_gk(option: &Options) -> Result<Decimal, GreeksError> {
         OptionStyle::Call => -d_mul(base, big_n(d1_v)?, "greeks::gk::rho_f::call")?,
         OptionStyle::Put => d_mul(base, big_n(-d1_v)?, "greeks::gk::rho_f::put")?,
     };
-    let weighted = d_mul(raw, option.quantity.to_dec(), "greeks::gk::rho_f::quantity")?;
+    let signed = d_mul(side_sign(option), raw, "greeks::gk::rho_f::sign")?;
+    let weighted = d_mul(
+        signed,
+        option.quantity.to_dec(),
+        "greeks::gk::rho_f::quantity",
+    )?;
     let result = d_div(weighted, Decimal::ONE_HUNDRED, "greeks::gk::rho_f::per_pct")?;
     Ok(result)
 }
@@ -521,6 +576,15 @@ mod tests {
 
     fn close(a: Decimal, b: Decimal, tol: Decimal) -> bool {
         (a - b).abs() < tol
+    }
+
+    type GreekCalculator = fn(&Options) -> Result<Decimal, GreeksError>;
+
+    fn greek_value(label: &str, result: Result<Decimal, GreeksError>) -> Decimal {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("{label} failed: {error:?}"),
+        }
     }
 
     // ---- delta range and parity ----------------------------------------
@@ -660,19 +724,33 @@ mod tests {
     /// a known issue (d1 not carry-adjusted) — covered separately.
     #[test]
     fn test_matches_bsm_greeks_when_q_is_zero() {
-        let opt = create_fx_option(
-            100.0,
-            100.0,
-            dec!(0.05),
-            0.0,
-            180.0,
-            0.20,
-            OptionStyle::Call,
-        );
-        // delta and gamma agree exactly when q=0.
-        assert_eq!(delta_gk(&opt).unwrap(), delta(&opt).unwrap());
-        assert_eq!(gamma_gk(&opt).unwrap(), gamma(&opt).unwrap());
-        assert_eq!(vega_gk(&opt).unwrap(), vega(&opt).unwrap());
+        let calculators: [(&str, GreekCalculator, GreekCalculator); 3] = [
+            ("delta", delta_gk, delta),
+            ("gamma", gamma_gk, gamma),
+            ("vega", vega_gk, vega),
+        ];
+
+        for side in [Side::Long, Side::Short] {
+            let mut option = create_fx_option(
+                100.0,
+                100.0,
+                dec!(0.05),
+                0.0,
+                180.0,
+                0.20,
+                OptionStyle::Call,
+            );
+            option.side = side;
+
+            for (label, gk_calculator, bsm_calculator) in calculators {
+                let gk_value = greek_value(label, gk_calculator(&option));
+                let bsm_value = greek_value(label, bsm_calculator(&option));
+                assert_eq!(
+                    gk_value, bsm_value,
+                    "{label} differs for position side {side:?}"
+                );
+            }
+        }
     }
 
     // ---- theta vs numerical differentiation ----------------------------
@@ -783,20 +861,55 @@ mod tests {
     // ---- side and quantity --------------------------------------------
 
     #[test]
-    fn test_side_short_negates_delta() {
-        let long = create_fx_option(1.12, 1.10, dec!(0.04), 0.02, 90.0, 0.10, OptionStyle::Call);
+    fn test_side_short_negates_every_greek() {
+        let mut long =
+            create_fx_option(1.12, 1.10, dec!(0.04), 0.02, 90.0, 0.10, OptionStyle::Call);
+        long.quantity = pos_or_panic!(3.0);
         let mut short = long.clone();
         short.side = Side::Short;
-        assert_eq!(delta_gk(&long).unwrap(), -delta_gk(&short).unwrap());
+
+        let calculators: [(&str, GreekCalculator); 6] = [
+            ("delta", delta_gk),
+            ("gamma", gamma_gk),
+            ("vega", vega_gk),
+            ("theta", theta_gk),
+            ("rho_domestic", rho_domestic_gk),
+            ("rho_foreign", rho_foreign_gk),
+        ];
+
+        for (label, calculate) in calculators {
+            let long_value = greek_value(label, calculate(&long));
+            let short_value = greek_value(label, calculate(&short));
+            assert_eq!(
+                long_value, -short_value,
+                "{label} did not negate for Side::Short"
+            );
+        }
     }
 
     #[test]
     fn test_quantity_scales_linearly() {
-        let mut opt = create_fx_option(1.12, 1.10, dec!(0.04), 0.02, 90.0, 0.10, OptionStyle::Call);
-        let d1_value = delta_gk(&opt).unwrap();
-        opt.quantity = pos_or_panic!(4.0);
-        let d4 = delta_gk(&opt).unwrap();
-        assert!(close(d4, d1_value * Decimal::from(4), dec!(1e-15)));
+        let one = create_fx_option(1.12, 1.10, dec!(0.04), 0.02, 90.0, 0.10, OptionStyle::Call);
+        let mut four = one.clone();
+        four.quantity = pos_or_panic!(4.0);
+
+        let calculators: [(&str, GreekCalculator); 6] = [
+            ("delta", delta_gk),
+            ("gamma", gamma_gk),
+            ("vega", vega_gk),
+            ("theta", theta_gk),
+            ("rho_domestic", rho_domestic_gk),
+            ("rho_foreign", rho_foreign_gk),
+        ];
+
+        for (label, calculate) in calculators {
+            let one_value = greek_value(label, calculate(&one));
+            let four_value = greek_value(label, calculate(&four));
+            assert!(
+                close(four_value, one_value * Decimal::from(4), dec!(1e-15)),
+                "{label} did not scale linearly with quantity"
+            );
+        }
     }
 
     // ---- trait --------------------------------------------------------


### PR DESCRIPTION
## Summary

Black-76 and Garman-Kohlhagen exposed the same position Greeks as the core Black-Scholes family but only signed delta by `Side`. This change makes every Greek in both model families return the sensitivity of the full position, consistently signed by `Side` and scaled by `quantity`.

## Changes

- Apply the long/short sign exactly once to Black-76 gamma, vega, theta, and rho.
- Apply the long/short sign exactly once to Garman-Kohlhagen gamma, vega, theta, domestic rho, and foreign rho.
- Document the position-sign convention on every migrated function and in both module overviews.
- Extend long/short antisymmetry and quantity-linearity coverage to every Greek in both families.
- Verify Garman-Kohlhagen and Black-Scholes delta, gamma, and vega agree for both sides when the foreign rate is zero.
- Record the breaking behavioral change and migration guidance in the changelog.

## Testing

- [x] Unit tests added or updated
- [x] Reference regression test updated for both position sides
- [x] `cargo test --all-features --workspace` — 4,539 passed; 0 failed
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release`
- [x] `cargo doc --all-features --no-deps`

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All affected public items document the position-sign convention and retain their `# Errors` sections
- [x] No `.unwrap()` / `.expect()` / unchecked indexing added to production code
- [x] Checked arithmetic used for the new sign application
- [x] `rust_decimal::Decimal` remains the public numeric boundary
- [x] Module boundaries remain unchanged
- [x] No dependencies or feature flags added
- [x] `tracing` remains the only production logging API

Closes #436
