### PR TITLE
Eliminate reachable panics in the Greeks and pricing core (#440)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Lint
         run: make lint
+
+      - name: Scan banned constructs
+        run: make scan-banned

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,61 @@ clean:
 .PHONY: check
 check: test fmt-check lint scan-banned
 
-# Fails when a panicking construct reappears in production code (test modules
-# and doc comments are skipped). A reviewed exception carries a trailing
+# Fails when a panicking construct reappears in production code. A bare
+# `#[cfg(test)]` never truncates the scan; only the braced body of the item
+# it actually gates is skipped, brace counted (files may carry several):
+# `mod`/`fn`/`impl`/`trait`/`struct`/`enum`/`union` (any `pub(..)` visibility,
+# `async`/`unsafe`, generics or return type before the `{`, spanning multiple
+# signature lines if needed), and a bare `#[cfg(test)] { ... }` block. A
+# body-less item behind `#[cfg(test)]` (`use`, `const`, `static`, `type`
+# alias, or a `;`-terminated declaration such as a tuple struct or a trait
+# method signature) skips nothing; scanning resumes right after it as usual.
+# Doc comments are skipped too. A reviewed exception carries a trailing
 # `// scan-banned: allow -- <reason>` marker on the same line.
 .PHONY: scan-banned
 scan-banned:
 	@found=$$(for f in $$(find src -name '*.rs'); do \
-		awk -v file="$$f" '/#\[cfg\(test\)\]/ { exit } { print file ":" NR ":" $$0 }' "$$f"; \
+		awk -v file="$$f" ' \
+			BEGIN { skip = 0; depth = 0; pending = 0; awaiting = 0 } \
+			function braces(line,   tmp, o, c) { \
+				tmp = line; o = gsub(/{/, "{", tmp); \
+				tmp = line; c = gsub(/}/, "}", tmp); \
+				return o - c; \
+			} \
+			{ \
+				raw = $$0; \
+				if (skip) { \
+					depth += braces(raw); \
+					if (depth <= 0) { skip = 0; depth = 0 } \
+					next; \
+				} \
+				if (awaiting) { \
+					depth += braces(raw); \
+					if (depth > 0) { awaiting = 0; skip = 1; next } \
+					if (raw ~ /;[[:space:]]*$$/) { awaiting = 0; depth = 0 } \
+					next; \
+				} \
+				if (pending) { \
+					if (raw ~ /^[[:space:]]*#\[/) { next } \
+					pending = 0; \
+					trimmed = raw; sub(/^[[:space:]]+/, "", trimmed); \
+					if (trimmed ~ /^\{/) { \
+						depth = braces(raw); \
+						if (depth > 0) { skip = 1 } \
+						next; \
+					} \
+					if (trimmed ~ /^(pub([[:space:]]*\([^)]*\))?[[:space:]]+)?(async[[:space:]]+)?(unsafe[[:space:]]+)?(mod|fn|impl|trait|struct|enum|union)([[:space:]<(]|$$)/) { \
+						depth = braces(raw); \
+						if (depth > 0) { skip = 1 } \
+						else if (raw ~ /;[[:space:]]*$$/) { depth = 0 } \
+						else { awaiting = 1; depth = 0 } \
+						next; \
+					} \
+				} \
+				if (raw ~ /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$$/) { pending = 1; next } \
+				print file ":" NR ":" raw; \
+			} \
+		' "$$f"; \
 	done \
 		| grep -E '\.unwrap\(\)|\.expect\(' \
 		| grep -v -E ':[0-9]+:[[:space:]]*(///|//!|//|\*)' \

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,25 @@ clean:
 
 # Pre-push checks
 .PHONY: check
-check: test fmt-check lint
+check: test fmt-check lint scan-banned
+
+# Fails when a panicking construct reappears in production code (test modules
+# and doc comments are skipped). A reviewed exception carries a trailing
+# `// scan-banned: allow -- <reason>` marker on the same line.
+.PHONY: scan-banned
+scan-banned:
+	@found=$$(for f in $$(find src -name '*.rs'); do \
+		awk -v file="$$f" '/#\[cfg\(test\)\]/ { exit } { print file ":" NR ":" $$0 }' "$$f"; \
+	done \
+		| grep -E '\.unwrap\(\)|\.expect\(' \
+		| grep -v -E ':[0-9]+:[[:space:]]*(///|//!|//|\*)' \
+		| grep -v 'scan-banned: allow' || true); \
+	if [ -n "$$found" ]; then \
+		echo "Banned patterns found in production code:"; \
+		echo "$$found"; \
+		exit 1; \
+	fi; \
+	echo "OK: no .unwrap()/.expect() in production code"
 
 # Run the project
 .PHONY: run

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -31,7 +31,7 @@ use crate::surfaces::{BasicSurfaces, Point3D, Surface};
 use crate::utils::Len;
 use crate::utils::others::get_random_element;
 use crate::volatility::VolatilitySmile;
-use chrono::{NaiveDate, Utc};
+use chrono::{Duration, NaiveDate, Utc};
 use num_traits::{FromPrimitive, ToPrimitive};
 use positive::Positive;
 #[cfg(test)]
@@ -253,6 +253,35 @@ impl<'de> Deserialize<'de> for OptionChain {
     }
 }
 
+/// Rejects a relative expiration that no calendar date can represent.
+///
+/// [`ExpirationDate::get_date_string`] resolves `Days(n)` as `now + n days`
+/// with `DateTime + TimeDelta`, which panics on overflow instead of
+/// reporting it. A chain built from a caller-supplied day count reaches that
+/// addition directly, so the span is validated here first.
+///
+/// # Errors
+///
+/// Returns [`ChainError::invalid_parameters`] when the day count is outside
+/// the range a `DateTime<Utc>` can hold.
+fn reject_unrepresentable_expiration(expiration_date: &ExpirationDate) -> Result<(), ChainError> {
+    let ExpirationDate::Days(days) = expiration_date else {
+        return Ok(());
+    };
+    let out_of_range = || {
+        ChainError::invalid_parameters(
+            "expiration_date",
+            &format!("expiration of {days} days is outside the representable calendar range"),
+        )
+    };
+    let whole_days = days.to_dec().trunc().to_i64().ok_or_else(out_of_range)?;
+    let span = Duration::try_days(whole_days).ok_or_else(out_of_range)?;
+    Utc::now()
+        .checked_add_signed(span)
+        .ok_or_else(out_of_range)?;
+    Ok(())
+}
+
 impl OptionChain {
     /// Creates a new `OptionChain` for a specific underlying instrument and expiration date.
     ///
@@ -391,6 +420,7 @@ impl OptionChain {
                 "missing expiration date in price params",
             )
         })?;
+        reject_unrepresentable_expiration(&expiration_date)?;
 
         let strike_interval = if let Some(strike_interval) = params.strike_interval {
             strike_interval
@@ -551,16 +581,36 @@ impl OptionChain {
                 break;
             }
 
-            let next_upper_strike = atm_strike + (strike_interval * counter);
+            // `Positive`'s operators panic on overflow, and both the offset
+            // and the upper strike overflow once the ATM strike sits near the
+            // top of the `Decimal` range. A grid that cannot be represented
+            // is a bad parameter set, not a chain to truncate silently.
+            let offset = strike_interval.checked_mul(&counter).map_err(|e| {
+                ChainError::invalid_parameters(
+                    "strike_interval",
+                    &format!("strike offset overflows at step {counter}: {e}"),
+                )
+            })?;
+            let next_upper_strike = atm_strike.checked_add(&offset).map_err(|e| {
+                ChainError::invalid_parameters(
+                    "underlying_price",
+                    &format!("strike {atm_strike} + {offset} is not representable: {e}"),
+                )
+            })?;
             let next_upper_option_data =
                 create_chain_data(&next_upper_strike, params, underlying_price)?;
             option_chain.options.insert(next_upper_option_data.clone());
 
-            let strike_step = (strike_interval * counter).to_dec();
+            let strike_step = offset.to_dec();
             if strike_step > atm_strike.to_dec() {
                 break;
             }
-            let next_lower_strike = atm_strike - (strike_interval * counter).to_dec();
+            let next_lower_strike = atm_strike.checked_sub(&offset).map_err(|e| {
+                ChainError::invalid_parameters(
+                    "strike_interval",
+                    &format!("strike {atm_strike} - {offset} is not representable: {e}"),
+                )
+            })?;
             if next_lower_strike == Positive::ZERO {
                 break;
             }

--- a/src/chains/utils.rs
+++ b/src/chains/utils.rs
@@ -11,9 +11,10 @@ use crate::chains::OptionData;
 use crate::chains::chain::{SKEW_SLOPE, SKEW_SMILE_CURVE};
 use crate::error::chains::ChainError;
 use crate::model::ExpirationDate;
+use crate::model::decimal::f64_to_decimal;
 use crate::model::utils::ToRound;
 use num_traits::ToPrimitive;
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -646,13 +647,19 @@ pub fn adjust_volatility(
             );
             0.0
         });
-    let m = (strike / underlying_price.to_f64())
-        .ln()
-        .to_f64()
+    // `Positive / f64` panics when the quotient underflows the positivity
+    // invariant (a huge underlying against an ordinary strike), and `ln`
+    // panics on a ratio that rounded to zero. Both are reachable from a
+    // chain build, so the log-moneyness is computed on the checked path and
+    // degrades to a flat 0.0 — no skew — exactly like the branches above.
+    let m = strike
+        .to_dec()
+        .checked_div(underlying_price.to_dec())
+        .filter(|ratio| *ratio > Decimal::ZERO)
+        .and_then(|ratio| ratio.checked_ln())
+        .and_then(|log_moneyness| log_moneyness.to_f64())
         .unwrap_or_else(|| {
-            tracing::warn!(
-                "adjust_volatility: moneyness ln to_f64 returned None; defaulting to 0.0"
-            );
+            tracing::warn!("adjust_volatility: moneyness is not representable; defaulting to 0.0");
             0.0
         });
     let factor: f64 = 1.0 + skew_slope * m + smile_curve * m * m;
@@ -661,7 +668,16 @@ pub fn adjust_volatility(
     // Deep wings can legitimately exceed 100% IV (short-dated equities,
     // crypto); cap at 200% instead of 100% so real smiles survive, and log
     // when the cap actually engages.
-    let adjusted = base_vol * clamped;
+    let adjusted = match f64_to_decimal(clamped)
+        .ok()
+        .and_then(|factor| base_vol.to_dec().checked_mul(factor))
+        .and_then(|value| Positive::new_decimal(value).ok())
+    {
+        Some(value) => value,
+        // The product left the `Decimal` range, which puts it far above the
+        // 200% cap applied on the next line, so the cap is the answer.
+        None => Positive::TWO,
+    };
     let capped = adjusted.clamp(Positive::ZERO, Positive::TWO);
     if capped != adjusted {
         tracing::debug!(

--- a/src/greeks/black_76.rs
+++ b/src/greeks/black_76.rs
@@ -34,9 +34,11 @@ use crate::Options;
 use crate::error::PricingError;
 use crate::error::greeks::GreeksError;
 use crate::greeks::utils::{big_n, calculate_d_values_black_76, n};
-use crate::model::decimal::{d_div, d_mul, d_sub};
+use crate::model::decimal::{d_div, d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
+#[cfg(test)]
+use rust_decimal::MathematicalOps;
 use tracing::{instrument, trace};
 
 /// Reject any option type that is not European; Black-76 only prices European
@@ -66,8 +68,14 @@ fn side_sign(option: &Options) -> Decimal {
     }
 }
 
-fn discount_factor(option: &Options, t: Decimal) -> Decimal {
-    (-option.risk_free_rate * t).exp()
+/// `e^(-rT)`, shared by every Black-76 greek.
+///
+/// Fallible because `Decimal::exp` panics on overflow and on underflow; a
+/// discount factor below the representable scale flushes to zero, which is
+/// its limit.
+fn discount_factor(option: &Options, t: Decimal) -> Result<Decimal, GreeksError> {
+    let exponent = d_mul(-option.risk_free_rate, t, "greeks::b76::discount::exponent")?;
+    Ok(d_exp(exponent, "greeks::b76::discount")?)
 }
 
 /// Computes the delta of an option under the Black-76 model.
@@ -95,7 +103,7 @@ pub fn delta_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let t = option.expiration_date.get_years()?.to_dec();
     let (d1, _d2) = calculate_d_values_black_76(option)?;
 
-    let df = discount_factor(option, t);
+    let df = discount_factor(option, t)?;
     let raw = match option.option_style {
         OptionStyle::Call => d_mul(df, big_n(d1)?, "greeks::black_76::delta::call")?,
         OptionStyle::Put => -d_mul(df, big_n(-d1)?, "greeks::black_76::delta::put")?,
@@ -140,10 +148,10 @@ pub fn gamma_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let t = option.expiration_date.get_years()?;
     let (d1, _d2) = calculate_d_values_black_76(option)?;
 
-    let df = discount_factor(option, t.to_dec());
+    let df = discount_factor(option, t.to_dec())?;
     let f = option.underlying_price.to_dec();
     let sigma = option.implied_volatility.to_dec();
-    let sqrt_t = t.sqrt().to_dec();
+    let sqrt_t = t.checked_sqrt()?.to_dec();
 
     let denom = d_mul(
         f,
@@ -193,9 +201,9 @@ pub fn vega_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let t = option.expiration_date.get_years()?;
     let (d1, _d2) = calculate_d_values_black_76(option)?;
 
-    let df = discount_factor(option, t.to_dec());
+    let df = discount_factor(option, t.to_dec())?;
     let f = option.underlying_price.to_dec();
-    let sqrt_t = t.sqrt().to_dec();
+    let sqrt_t = t.checked_sqrt()?.to_dec();
 
     // F * e^(-rT) * n(d1) * √T
     let leg1 = d_mul(f, df, "greeks::black_76::vega::f_df")?;
@@ -246,12 +254,12 @@ pub fn theta_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let t = option.expiration_date.get_years()?;
     let (d1, d2) = calculate_d_values_black_76(option)?;
 
-    let df = discount_factor(option, t.to_dec());
+    let df = discount_factor(option, t.to_dec())?;
     let f = option.underlying_price.to_dec();
     let k = option.strike_price.to_dec();
     let r = option.risk_free_rate;
     let sigma = option.implied_volatility.to_dec();
-    let sqrt_t = t.sqrt().to_dec();
+    let sqrt_t = t.checked_sqrt()?.to_dec();
 
     // Common (volatility-decay) term, negative: -F·e^(-rT)·n(d1)·σ/(2·√T)
     let two_sqrt_t = d_mul(Decimal::TWO, sqrt_t, "greeks::black_76::theta::two_sqrt_t")?;
@@ -332,7 +340,7 @@ pub fn rho_b76(option: &Options) -> Result<Decimal, GreeksError> {
     let t = option.expiration_date.get_years()?;
     let (d1, d2) = calculate_d_values_black_76(option)?;
 
-    let df = discount_factor(option, t.to_dec());
+    let df = discount_factor(option, t.to_dec())?;
     let f = option.underlying_price.to_dec();
     let k = option.strike_price.to_dec();
     let t_dec = t.to_dec();

--- a/src/greeks/black_76.rs
+++ b/src/greeks/black_76.rs
@@ -34,7 +34,7 @@ use crate::Options;
 use crate::error::PricingError;
 use crate::error::greeks::GreeksError;
 use crate::greeks::utils::{big_n, calculate_d_values_black_76, n};
-use crate::model::decimal::{d_div, d_exp, d_mul, d_sub};
+use crate::model::decimal::{d_add, d_div, d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
 use rust_decimal::Decimal;
 #[cfg(test)]
@@ -280,13 +280,15 @@ pub fn theta_b76(option: &Options) -> Result<Decimal, GreeksError> {
             // Θ_call = common + r·F·e^(-rT)·N(d1) − r·K·e^(-rT)·N(d2)
             let plus = d_mul(r_f_df, big_n(d1)?, "greeks::black_76::theta::call::plus")?;
             let minus = d_mul(r_k_df, big_n(d2)?, "greeks::black_76::theta::call::minus")?;
-            d_sub(common + plus, minus, "greeks::black_76::theta::call::sum")?
+            let sum = d_add(common, plus, "greeks::black_76::theta::call::common_plus")?;
+            d_sub(sum, minus, "greeks::black_76::theta::call::sum")?
         }
         OptionStyle::Put => {
             // Θ_put = common − r·F·e^(-rT)·N(−d1) + r·K·e^(-rT)·N(−d2)
             let minus = d_mul(r_f_df, big_n(-d1)?, "greeks::black_76::theta::put::minus")?;
             let plus = d_mul(r_k_df, big_n(-d2)?, "greeks::black_76::theta::put::plus")?;
-            d_sub(common + plus, minus, "greeks::black_76::theta::put::sum")?
+            let sum = d_add(common, plus, "greeks::black_76::theta::put::common_plus")?;
+            d_sub(sum, minus, "greeks::black_76::theta::put::sum")?
         }
     };
 
@@ -810,5 +812,65 @@ mod tests {
             d,
             expected
         );
+    }
+}
+
+#[cfg(test)]
+mod tests_b76_extreme_inputs {
+    use super::*;
+    use crate::ExpirationDate;
+    use positive::{Positive, pos_or_panic};
+
+    /// A forward and a strike near the top of the  range against a
+    /// large negative rate: the intermediate  inside theta
+    /// overflows, which the raw operator turns into an abort.
+    fn near_max_option(style: OptionStyle) -> Options {
+        let near_max = Positive::new_decimal(Decimal::MAX * Decimal::new(98, 2))
+            .expect("98% of Decimal::MAX is positive");
+        Options::new(
+            OptionType::European,
+            Side::Long,
+            "CL".to_string(),
+            near_max,
+            ExpirationDate::Days(pos_or_panic!(3.65)),
+            pos_or_panic!(0.3),
+            Positive::ONE,
+            near_max,
+            Decimal::new(-9, 1),
+            style,
+            Positive::ZERO,
+            None,
+        )
+    }
+
+    #[test]
+    fn test_theta_reports_the_overflow_instead_of_aborting() {
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            let option = near_max_option(style);
+            assert!(
+                theta_b76(&option).is_err(),
+                "theta_b76 returned a value for a sum that is not representable"
+            );
+        }
+    }
+
+    #[test]
+    fn test_ordinary_inputs_still_price_theta() {
+        // The guard above must not have cost the normal path its answer.
+        let option = Options::new(
+            OptionType::European,
+            Side::Long,
+            "CL".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(180.0)),
+            pos_or_panic!(0.2),
+            Positive::ONE,
+            Positive::HUNDRED,
+            Decimal::new(5, 2),
+            OptionStyle::Call,
+            Positive::ZERO,
+            None,
+        );
+        assert!(theta_b76(&option).is_ok());
     }
 }

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -6,12 +6,12 @@
 use crate::constants::{TRADING_DAYS, ZERO};
 use crate::error::greeks::GreeksError;
 use crate::greeks::utils::{big_n, d1, n};
-use crate::model::decimal::{d_div, d_mul};
+use crate::model::decimal::{d_add, d_div, d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType};
 use crate::{Options, Side};
 use positive::Positive;
 use pretty_simple_display::{DebugPretty, DisplaySimple};
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::cell::OnceCell;
 use utoipa::ToSchema;
@@ -514,8 +514,14 @@ impl BlackScholesKernels {
     /// re-derived because every caller has already obtained it to test its own
     /// degenerate branch.
     fn new(option: &Options, t: Positive) -> Result<Self, GreeksError> {
-        let carry_rate = option.risk_free_rate - option.dividend_yield.to_dec();
-        let sqrt_t = t.sqrt();
+        let carry_rate = d_sub(
+            option.risk_free_rate,
+            option.dividend_yield.to_dec(),
+            "greeks::kernels::carry_rate",
+        )?;
+        // `Positive::sqrt` panics on overflow; the checked counterpart
+        // surfaces it as a `PositiveError` instead.
+        let sqrt_t = t.checked_sqrt()?;
         let d1 = d1(
             option.underlying_price,
             option.strike_price,
@@ -557,8 +563,18 @@ impl BlackScholesKernels {
     }
 
     /// `d2 = d1 - sigma * sqrt(T)`, exactly as [`crate::greeks::d2`] derives it.
-    fn d2(&self) -> Decimal {
-        *self.d2.get_or_init(|| self.d1 - self.sigma * self.sqrt_t)
+    ///
+    /// Fallible because `sigma * sqrt(T)` overflows for extreme inputs, and
+    /// the raw operator panics rather than reporting it.
+    fn d2(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.d2, || {
+            let vol_time = d_mul(
+                self.sigma.to_dec(),
+                self.sqrt_t.to_dec(),
+                "greeks::kernels::d2::vol_time",
+            )?;
+            Ok(d_sub(self.d1, vol_time, "greeks::kernels::d2")?)
+        })
     }
 
     /// Normal pdf at `d1`; the most expensive single kernel.
@@ -575,23 +591,40 @@ impl BlackScholesKernels {
     }
 
     fn big_n_d2(&self) -> Result<Decimal, GreeksError> {
-        cached(&self.big_n_d2, || Ok(big_n(self.d2())?))
+        cached(&self.big_n_d2, || Ok(big_n(self.d2()?)?))
     }
 
     fn big_n_neg_d2(&self) -> Result<Decimal, GreeksError> {
-        cached(&self.big_n_neg_d2, || Ok(big_n(-self.d2())?))
+        cached(&self.big_n_neg_d2, || Ok(big_n(-self.d2()?)?))
     }
 
     /// `exp(-qT)`, the dividend discount factor.
-    fn exp_minus_qt(&self) -> Decimal {
-        *self
-            .exp_minus_qt
-            .get_or_init(|| (-self.t.to_dec() * self.q).exp())
+    ///
+    /// Fallible because both the exponent and the exponential overflow for
+    /// extreme inputs, where `Decimal`'s operators panic. An exponent so
+    /// negative that the factor is below the representable scale flushes to
+    /// zero, which is the discount factor's limit.
+    fn exp_minus_qt(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.exp_minus_qt, || {
+            let exponent = d_mul(
+                -self.t.to_dec(),
+                self.q,
+                "greeks::kernels::exp_minus_qt::exponent",
+            )?;
+            Ok(d_exp(exponent, "greeks::kernels::exp_minus_qt")?)
+        })
     }
 
-    /// `exp(-rT)`, the risk-free discount factor.
-    fn exp_minus_rt(&self) -> Decimal {
-        *self.exp_minus_rt.get_or_init(|| (-self.r * self.t).exp())
+    /// `exp(-rT)`, the risk-free discount factor. See [`Self::exp_minus_qt`].
+    fn exp_minus_rt(&self) -> Result<Decimal, GreeksError> {
+        cached(&self.exp_minus_rt, || {
+            let exponent = d_mul(
+                -self.r,
+                self.t.to_dec(),
+                "greeks::kernels::exp_minus_rt::exponent",
+            )?;
+            Ok(d_exp(exponent, "greeks::kernels::exp_minus_rt")?)
+        })
     }
 }
 
@@ -663,7 +696,7 @@ fn greeks_for(option: &Options) -> Result<Greek, GreeksError> {
             vega: vega(option)?,
             rho: rho(option)?,
             rho_d: rho_d(option)?,
-            alpha: alpha_from(gamma, theta),
+            alpha: alpha_from(gamma, theta)?,
             vanna: vanna(option)?,
             vomma: vomma(option)?,
             veta: veta(option)?,
@@ -682,7 +715,7 @@ fn greeks_for(option: &Options) -> Result<Greek, GreeksError> {
         rho: rho_with(option, &kernels)?,
         rho_d: rho_d_with(option, &kernels)?,
         // Reuses the gamma and theta above instead of recomputing both.
-        alpha: alpha_from(gamma, theta),
+        alpha: alpha_from(gamma, theta)?,
         vanna: vanna_with(option, &kernels)?,
         vomma: vomma_with(option, &kernels)?,
         veta: veta_with(option, &kernels)?,
@@ -873,14 +906,20 @@ fn delta_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     } else {
         Decimal::NEGATIVE_ONE
     };
-    let div_date = k.exp_minus_qt();
+    let div_date = k.exp_minus_qt()?;
+    let n_d1 = k.big_n_d1()?;
     let delta = match option.option_style {
-        OptionStyle::Call => sign * k.big_n_d1()? * div_date,
-        OptionStyle::Put => sign * (k.big_n_d1()? - Decimal::ONE) * div_date,
+        OptionStyle::Call => d_mul(sign, n_d1, "greeks::delta::call_sign")?,
+        OptionStyle::Put => d_mul(
+            sign,
+            d_sub(n_d1, Decimal::ONE, "greeks::delta::put_shift")?,
+            "greeks::delta::put_sign",
+        )?,
     };
+    let delta = d_mul(delta, div_date, "greeks::delta::discounted")?;
     let delta: Decimal = delta.clamp(Decimal::NEGATIVE_ONE, Decimal::ONE);
     let quantity: Decimal = option.quantity.into();
-    Ok(delta * quantity)
+    Ok(d_mul(delta, quantity, "greeks::delta::position_weighted")?)
 }
 
 /// Computes the gamma of an option.
@@ -1008,8 +1047,22 @@ fn gamma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let underlying_price: Decimal = option.underlying_price.into();
     let implied_volatility: Positive = option.implied_volatility;
 
-    let gamma: Decimal = k.exp_minus_qt() * k.n_d1()?
-        / (underlying_price * implied_volatility * k.sqrt_t().to_dec());
+    let numerator = d_mul(
+        k.exp_minus_qt()?,
+        k.n_d1()?,
+        "greeks::gamma::discounted_pdf",
+    )?;
+    let denominator = d_mul(
+        underlying_price,
+        implied_volatility.to_dec(),
+        "greeks::gamma::price_vol",
+    )?;
+    let denominator = d_mul(
+        denominator,
+        k.sqrt_t().to_dec(),
+        "greeks::gamma::price_vol_time",
+    )?;
+    let gamma: Decimal = d_div(numerator, denominator, "greeks::gamma")?;
 
     Ok(d_mul(
         gamma,
@@ -1151,23 +1204,48 @@ fn theta_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal
     let q = option.dividend_yield.to_dec();
     let sigma = option.implied_volatility.to_dec();
 
-    let exp_minus_rt = kernels.exp_minus_rt();
-    let exp_minus_qt = kernels.exp_minus_qt();
+    let exp_minus_rt = kernels.exp_minus_rt()?;
+    let exp_minus_qt = kernels.exp_minus_qt()?;
 
     // Common term using n. The e^{-qT} factor discounts the S·n(d1) term to
     // present value (the underlying contributes S·e^{-qT} to the payoff);
     // omitting it made |theta| too large for dividend-paying underlyings.
-    let common_term =
-        -(exp_minus_qt * s * kernels.n_d1()? * sigma) / (Decimal::TWO * kernels.sqrt_t());
+    let decay = d_mul(exp_minus_qt, s, "greeks::theta::decay_spot")?;
+    let decay = d_mul(decay, kernels.n_d1()?, "greeks::theta::decay_pdf")?;
+    let decay = d_mul(decay, sigma, "greeks::theta::decay_vol")?;
+    let decay_denominator = d_mul(
+        Decimal::TWO,
+        kernels.sqrt_t().to_dec(),
+        "greeks::theta::decay_time",
+    )?;
+    let common_term = -d_div(decay, decay_denominator, "greeks::theta::decay")?;
+
+    // Rate term: r · K · e^{-rT} · N(±d2); carry term: q · S · e^{-qT} · N(±d1).
+    let rate_term = d_mul(r, k, "greeks::theta::rate_strike")?;
+    let rate_term = d_mul(rate_term, exp_minus_rt, "greeks::theta::rate_discounted")?;
+    let carry_term = d_mul(q, s, "greeks::theta::carry_spot")?;
+    let carry_term = d_mul(carry_term, exp_minus_qt, "greeks::theta::carry_discounted")?;
 
     let theta = match option.option_style {
         OptionStyle::Call => {
-            common_term - r * k * exp_minus_rt * kernels.big_n_d2()?
-                + q * s * exp_minus_qt * kernels.big_n_d1()?
+            let rate = d_mul(rate_term, kernels.big_n_d2()?, "greeks::theta::call_rate")?;
+            let carry = d_mul(carry_term, kernels.big_n_d1()?, "greeks::theta::call_carry")?;
+            let theta = d_sub(common_term, rate, "greeks::theta::call_decay_rate")?;
+            d_add(theta, carry, "greeks::theta::call")?
         }
         OptionStyle::Put => {
-            common_term + r * k * exp_minus_rt * kernels.big_n_neg_d2()?
-                - q * s * exp_minus_qt * kernels.big_n_neg_d1()?
+            let rate = d_mul(
+                rate_term,
+                kernels.big_n_neg_d2()?,
+                "greeks::theta::put_rate",
+            )?;
+            let carry = d_mul(
+                carry_term,
+                kernels.big_n_neg_d1()?,
+                "greeks::theta::put_carry",
+            )?;
+            let theta = d_add(common_term, rate, "greeks::theta::put_decay_rate")?;
+            d_sub(theta, carry, "greeks::theta::put")?
         }
     };
 
@@ -1295,8 +1373,15 @@ pub fn vega(option: &Options) -> Result<Decimal, GreeksError> {
 fn vega_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, GreeksError> {
     let underlying_price: Decimal = option.underlying_price.to_dec();
 
-    let vega: Decimal =
-        underlying_price * k.exp_minus_qt() * k.n_d1()? * k.sqrt_t() / Decimal::ONE_HUNDRED; // percentage of change in volatility
+    let vega = d_mul(
+        underlying_price,
+        k.exp_minus_qt()?,
+        "greeks::vega::discounted_spot",
+    )?;
+    let vega = d_mul(vega, k.n_d1()?, "greeks::vega::pdf")?;
+    let vega = d_mul(vega, k.sqrt_t().to_dec(), "greeks::vega::sqrt_time")?;
+    // percentage of change in volatility
+    let vega: Decimal = d_div(vega, Decimal::ONE_HUNDRED, "greeks::vega::per_percent")?;
 
     Ok(d_mul(
         vega,
@@ -1431,12 +1516,13 @@ fn rho_with(option: &Options, kernels: &BlackScholesKernels) -> Result<Decimal, 
     let k = option.strike_price.to_dec();
 
     // Base rho without sign; the discount uses the risk-free rate, not the carry.
-    let base_rho = k * t * kernels.exp_minus_rt();
+    let base_rho = d_mul(k, t.to_dec(), "greeks::rho::strike_time")?;
+    let base_rho = d_mul(base_rho, kernels.exp_minus_rt()?, "greeks::rho::discounted")?;
 
     // Calculate final rho based on option type
     let rho = match option.option_style {
-        OptionStyle::Call => base_rho * kernels.big_n_d2()?,
-        OptionStyle::Put => -base_rho * kernels.big_n_neg_d2()?,
+        OptionStyle::Call => d_mul(base_rho, kernels.big_n_d2()?, "greeks::rho::call")?,
+        OptionStyle::Put => d_mul(-base_rho, kernels.big_n_neg_d2()?, "greeks::rho::put")?,
     };
 
     // Adjust for quantity and convert to basis points (banker's rounding).
@@ -1573,13 +1659,16 @@ fn rho_d_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let expiration_date = k.t();
     let underlying_price: Decimal = option.underlying_price.to_dec();
 
+    let base = d_mul(
+        expiration_date.to_dec(),
+        underlying_price,
+        "greeks::rho_d::time_spot",
+    )?;
+    let base = d_mul(base, k.exp_minus_qt()?, "greeks::rho_d::discounted")?;
+
     let rhod = match option.option_style {
-        OptionStyle::Call => {
-            -expiration_date.to_dec() * underlying_price * k.exp_minus_qt() * k.big_n_d1()?
-        }
-        OptionStyle::Put => {
-            expiration_date.to_dec() * underlying_price * k.exp_minus_qt() * k.big_n_neg_d1()?
-        }
+        OptionStyle::Call => d_mul(-base, k.big_n_d1()?, "greeks::rho_d::call")?,
+        OptionStyle::Put => d_mul(base, k.big_n_neg_d1()?, "greeks::rho_d::put")?,
     };
 
     let weighted = d_mul(
@@ -1618,7 +1707,7 @@ fn rho_d_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
 pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
     let gamma = gamma(option)?;
     let theta = theta(option)?;
-    Ok(alpha_from(gamma, theta))
+    alpha_from(gamma, theta)
 }
 
 /// Alpha from a gamma and a theta that have already been computed.
@@ -1629,11 +1718,16 @@ pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
 /// Returns `Decimal::MAX` as a sentinel when theta vanishes but gamma does not.
 /// Callers that publish the value are responsible for mapping it to something
 /// meaningful; see `OptionData::calculate_greeks`.
-fn alpha_from(gamma: Decimal, theta: Decimal) -> Decimal {
+///
+/// # Errors
+///
+/// Returns [`GreeksError`] when `gamma / theta` overflows the `Decimal`
+/// range; the raw operator would panic instead.
+fn alpha_from(gamma: Decimal, theta: Decimal) -> Result<Decimal, GreeksError> {
     match (gamma, theta) {
-        (val, _) if val == Decimal::ZERO => Decimal::ZERO,
-        (_, val) if val == Decimal::ZERO => Decimal::MAX,
-        _ => gamma / theta,
+        (val, _) if val == Decimal::ZERO => Ok(Decimal::ZERO),
+        (_, val) if val == Decimal::ZERO => Ok(Decimal::MAX),
+        _ => Ok(d_div(gamma, theta, "greeks::alpha")?),
     }
 }
 
@@ -1754,7 +1848,17 @@ fn vanna_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     // vanna = dDelta/dsigma = e^{-qT} * n(d1) * (dd1/dsigma), and the standard
     // result dd1/dsigma = -d2/sigma introduces an explicit minus sign, so the
     // closed form is -e^{-qT} * n(d1) * d2 / sigma (sign is opposite to d2).
-    let vanna: Decimal = -(k.exp_minus_qt() * k.n_d1()? * (k.d2() / implied_volatility));
+    let standardised_d2 = d_div(
+        k.d2()?,
+        implied_volatility.to_dec(),
+        "greeks::vanna::d2_over_sigma",
+    )?;
+    let vanna = d_mul(
+        k.exp_minus_qt()?,
+        k.n_d1()?,
+        "greeks::vanna::discounted_pdf",
+    )?;
+    let vanna: Decimal = -d_mul(vanna, standardised_d2, "greeks::vanna")?;
 
     Ok(d_mul(
         vanna,
@@ -1880,7 +1984,17 @@ fn vomma_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let vega = vega_with(option, k)?;
     let implied_volatility: Positive = option.implied_volatility;
 
-    Ok(vega * (k.d1() * k.d2() / implied_volatility))
+    // `d1 · d2 / sigma` is the site that aborted a live request: a volatility
+    // approaching zero pushes the quotient out of `Decimal`'s range, and both
+    // the multiplication and the division panic there.
+    let d1_d2 = d_mul(k.d1(), k.d2()?, "greeks::vomma::d1_d2")?;
+    let scaled = d_div(
+        d1_d2,
+        implied_volatility.to_dec(),
+        "greeks::vomma::d1_d2_over_sigma",
+    )?;
+
+    Ok(d_mul(vega, scaled, "greeks::vomma")?)
 }
 
 /// Computes the veta of an option.
@@ -1991,17 +2105,39 @@ fn veta_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Greek
     let implied_volatility: Positive = option.implied_volatility;
     let dividend_yield: Decimal = option.dividend_yield.into();
     let risk_free_rate: Decimal = option.risk_free_rate;
-    let add1 = (risk_free_rate - dividend_yield) * k.d1() / (implied_volatility * k.sqrt_t());
-    let add2 = (Decimal::ONE + k.d1() * k.d2()) / (Decimal::TWO * expiration_date);
+    let carry = d_sub(risk_free_rate, dividend_yield, "greeks::veta::carry")?;
+    let add1_numerator = d_mul(carry, k.d1(), "greeks::veta::carry_d1")?;
+    let add1_denominator = d_mul(
+        implied_volatility.to_dec(),
+        k.sqrt_t().to_dec(),
+        "greeks::veta::vol_time",
+    )?;
+    let add1 = d_div(add1_numerator, add1_denominator, "greeks::veta::carry_term")?;
 
-    let veta: Decimal = -vega * (dividend_yield + add1 - add2);
+    let d1_d2 = d_mul(k.d1(), k.d2()?, "greeks::veta::d1_d2")?;
+    let add2_numerator = d_add(Decimal::ONE, d1_d2, "greeks::veta::one_plus_d1_d2")?;
+    let add2_denominator = d_mul(
+        Decimal::TWO,
+        expiration_date.to_dec(),
+        "greeks::veta::two_tau",
+    )?;
+    let add2 = d_div(add2_numerator, add2_denominator, "greeks::veta::time_term")?;
+
+    let bracket = d_add(dividend_yield, add1, "greeks::veta::bracket_carry")?;
+    let bracket = d_sub(bracket, add2, "greeks::veta::bracket")?;
+    let veta: Decimal = d_mul(-vega, bracket, "greeks::veta")?;
     // It is common practice to divide the mathematical result of veta by
     // 100 times the number of days per year to reduce the value to the
     // percentage change in vega per one day
     // `vega` already carries `option.quantity`. Veta is a first derivative of
     // vega and is linear in position size, so the quantity must not be applied
     // a second time here.
-    Ok(veta / (*TRADING_DAYS * Decimal::ONE_HUNDRED))
+    let scale = d_mul(
+        TRADING_DAYS.to_dec(),
+        Decimal::ONE_HUNDRED,
+        "greeks::veta::scale",
+    )?;
+    Ok(d_div(veta, scale, "greeks::veta::per_day_percent")?)
 }
 
 /// Computes the Charm of an option.
@@ -2143,15 +2279,36 @@ fn charm_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let r = option.risk_free_rate;
     let q = option.dividend_yield.to_dec();
     let sigma = option.implied_volatility;
-    let exp_minus_qt = k.exp_minus_qt();
-    let common_term = (Decimal::TWO * (r - q) * tau - k.d2() * sigma * k.sqrt_t())
-        / (Decimal::TWO * tau * sigma * k.sqrt_t());
+    let exp_minus_qt = k.exp_minus_qt()?;
+
+    // common_term = (2(r-q)τ − d2·σ·√τ) / (2τ·σ·√τ)
+    let carry = d_sub(r, q, "greeks::charm::carry")?;
+    let carry_term = d_mul(Decimal::TWO, carry, "greeks::charm::two_carry")?;
+    let carry_term = d_mul(carry_term, tau.to_dec(), "greeks::charm::carry_tau")?;
+    let vol_time = d_mul(
+        sigma.to_dec(),
+        k.sqrt_t().to_dec(),
+        "greeks::charm::vol_time",
+    )?;
+    let d2_term = d_mul(k.d2()?, vol_time, "greeks::charm::d2_vol_time")?;
+    let numerator = d_sub(carry_term, d2_term, "greeks::charm::numerator")?;
+    let denominator = d_mul(Decimal::TWO, tau.to_dec(), "greeks::charm::two_tau")?;
+    let denominator = d_mul(denominator, vol_time, "greeks::charm::denominator")?;
+    let common_term = d_div(numerator, denominator, "greeks::charm::common_term")?;
+
+    let pdf_term = d_mul(exp_minus_qt, k.n_d1()?, "greeks::charm::discounted_pdf")?;
+    let pdf_term = d_mul(pdf_term, common_term, "greeks::charm::pdf_common")?;
+
     let charm = match option.option_style {
         OptionStyle::Call => {
-            (q * exp_minus_qt * k.big_n_d1()?) - (exp_minus_qt * k.n_d1()? * common_term)
+            let carry_leg = d_mul(q, exp_minus_qt, "greeks::charm::call_carry")?;
+            let carry_leg = d_mul(carry_leg, k.big_n_d1()?, "greeks::charm::call_carry_cdf")?;
+            d_sub(carry_leg, pdf_term, "greeks::charm::call")?
         }
         OptionStyle::Put => {
-            (-q * exp_minus_qt * k.big_n_neg_d1()?) - (exp_minus_qt * k.n_d1()? * common_term)
+            let carry_leg = d_mul(-q, exp_minus_qt, "greeks::charm::put_carry")?;
+            let carry_leg = d_mul(carry_leg, k.big_n_neg_d1()?, "greeks::charm::put_carry_cdf")?;
+            d_sub(carry_leg, pdf_term, "greeks::charm::put")?
         }
     };
     // Adjust for quantity and convert to daily value.
@@ -2291,11 +2448,31 @@ fn color_with(option: &Options, k: &BlackScholesKernels) -> Result<Decimal, Gree
     let s = option.underlying_price;
     let q = option.dividend_yield.to_dec();
     let sigma = option.implied_volatility;
-    let exp_minus_qt = k.exp_minus_qt();
-    let factor1 = k.n_d1()? / (Decimal::TWO * s * tau * sigma * k.sqrt_t());
-    let numerator = (Decimal::TWO * (r - q) * tau) - (k.d2() * sigma * k.sqrt_t());
-    let denominator = sigma * k.sqrt_t();
-    let factor2 = (Decimal::TWO * q * tau) + Decimal::ONE + ((numerator / denominator) * k.d1());
+    let exp_minus_qt = k.exp_minus_qt()?;
+
+    // factor1 = n(d1) / (2·S·τ·σ·√τ)
+    let scale = d_mul(Decimal::TWO, s.to_dec(), "greeks::color::two_spot")?;
+    let scale = d_mul(scale, tau.to_dec(), "greeks::color::two_spot_tau")?;
+    let vol_time = d_mul(
+        sigma.to_dec(),
+        k.sqrt_t().to_dec(),
+        "greeks::color::vol_time",
+    )?;
+    let scale = d_mul(scale, vol_time, "greeks::color::factor1_denominator")?;
+    let factor1 = d_div(k.n_d1()?, scale, "greeks::color::factor1")?;
+
+    // factor2 = 2qτ + 1 + d1·(2(r-q)τ − d2·σ·√τ) / (σ·√τ)
+    let carry = d_sub(r, q, "greeks::color::carry")?;
+    let carry_term = d_mul(Decimal::TWO, carry, "greeks::color::two_carry")?;
+    let carry_term = d_mul(carry_term, tau.to_dec(), "greeks::color::carry_tau")?;
+    let d2_term = d_mul(k.d2()?, vol_time, "greeks::color::d2_vol_time")?;
+    let numerator = d_sub(carry_term, d2_term, "greeks::color::factor2_numerator")?;
+    let ratio = d_div(numerator, vol_time, "greeks::color::factor2_ratio")?;
+    let ratio = d_mul(ratio, k.d1(), "greeks::color::factor2_ratio_d1")?;
+    let dividend_term = d_mul(Decimal::TWO, q, "greeks::color::two_q")?;
+    let dividend_term = d_mul(dividend_term, tau.to_dec(), "greeks::color::two_q_tau")?;
+    let factor2 = d_add(dividend_term, Decimal::ONE, "greeks::color::factor2_base")?;
+    let factor2 = d_add(factor2, ratio, "greeks::color::factor2")?;
     // Build the color numerator with checked multiplications so an
     // overflow on `-exp(-qt) * factor1 * factor2 * quantity` surfaces
     // a tagged `DecimalError::Overflow` instead of silently saturating
@@ -5161,7 +5338,7 @@ mod tests_shared_kernel_equivalence {
         };
 
         assert_eq!(kernels.d1(), fresh_d1, "d1");
-        assert_eq!(kernels.d2(), fresh_d2, "d2 derived from d1");
+        assert_eq!(kernels.d2().ok(), Some(fresh_d2), "d2 derived from d1");
         assert_eq!(kernels.sqrt_t(), t.sqrt(), "sqrt(T)");
         assert_eq!(kernels.n_d1().ok(), n(fresh_d1).ok(), "n(d1)");
         assert_eq!(kernels.big_n_d1().ok(), big_n(fresh_d1).ok(), "big_n(d1)");
@@ -5177,13 +5354,13 @@ mod tests_shared_kernel_equivalence {
             "big_n(-d2)"
         );
         assert_eq!(
-            kernels.exp_minus_qt(),
-            (-t.to_dec() * option.dividend_yield).exp(),
+            kernels.exp_minus_qt().ok(),
+            d_exp(-t.to_dec() * option.dividend_yield, "test::exp_minus_qt").ok(),
             "exp(-qT)"
         );
         assert_eq!(
-            kernels.exp_minus_rt(),
-            (-option.risk_free_rate * t).exp(),
+            kernels.exp_minus_rt().ok(),
+            d_exp(-option.risk_free_rate * t, "test::exp_minus_rt").ok(),
             "exp(-rT)"
         );
     }

--- a/src/greeks/garman_kohlhagen.rs
+++ b/src/greeks/garman_kohlhagen.rs
@@ -60,10 +60,12 @@ use crate::Options;
 use crate::error::PricingError;
 use crate::error::greeks::GreeksError;
 use crate::greeks::utils::{big_n, d1, d2, n};
-use crate::model::decimal::{d_add, d_div, d_mul, d_sub};
+use crate::model::decimal::{d_add, d_div, d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
 use positive::Positive;
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
+#[cfg(test)]
+use rust_decimal::MathematicalOps;
 use tracing::{instrument, trace};
 
 /// Reject any option type that is not European; Garman–Kohlhagen prices
@@ -194,7 +196,10 @@ pub fn delta_gk(option: &Options) -> Result<Decimal, GreeksError> {
     let (d1_v, _d2) = calculate_d_values_gk(option)?;
 
     let r_f = option.dividend_yield.to_dec();
-    let exp_neg_rf_t = (-r_f * t).exp();
+    let exp_neg_rf_t = d_exp(
+        d_mul(-r_f, t, "greeks::gk::discount_foreign::exponent")?,
+        "greeks::gk::discount_foreign",
+    )?;
 
     let raw = match option.option_style {
         OptionStyle::Call => d_mul(exp_neg_rf_t, big_n(d1_v)?, "greeks::gk::delta::call")?,
@@ -241,10 +246,13 @@ pub fn gamma_gk(option: &Options) -> Result<Decimal, GreeksError> {
     let (d1_v, _d2) = calculate_d_values_gk(option)?;
 
     let r_f = option.dividend_yield.to_dec();
-    let exp_neg_rf_t = (-r_f * t.to_dec()).exp();
+    let exp_neg_rf_t = d_exp(
+        d_mul(-r_f, t.to_dec(), "greeks::gk::discount_foreign::exponent")?,
+        "greeks::gk::discount_foreign",
+    )?;
     let s = option.underlying_price.to_dec();
     let sigma = option.implied_volatility.to_dec();
-    let sqrt_t = t.sqrt().to_dec();
+    let sqrt_t = t.checked_sqrt()?.to_dec();
 
     let denom = d_mul(
         s,
@@ -292,9 +300,12 @@ pub fn vega_gk(option: &Options) -> Result<Decimal, GreeksError> {
     let (d1_v, _d2) = calculate_d_values_gk(option)?;
 
     let r_f = option.dividend_yield.to_dec();
-    let exp_neg_rf_t = (-r_f * t.to_dec()).exp();
+    let exp_neg_rf_t = d_exp(
+        d_mul(-r_f, t.to_dec(), "greeks::gk::discount_foreign::exponent")?,
+        "greeks::gk::discount_foreign",
+    )?;
     let s = option.underlying_price.to_dec();
-    let sqrt_t = t.sqrt().to_dec();
+    let sqrt_t = t.checked_sqrt()?.to_dec();
 
     let leg1 = d_mul(s, exp_neg_rf_t, "greeks::gk::vega::s_df")?;
     let leg2 = d_mul(leg1, n(d1_v)?, "greeks::gk::vega::times_n")?;
@@ -345,9 +356,15 @@ pub fn theta_gk(option: &Options) -> Result<Decimal, GreeksError> {
     let s = option.underlying_price.to_dec();
     let k = option.strike_price.to_dec();
     let sigma = option.implied_volatility.to_dec();
-    let sqrt_t = t.sqrt().to_dec();
-    let exp_neg_rd_t = (-r_d * t.to_dec()).exp();
-    let exp_neg_rf_t = (-r_f * t.to_dec()).exp();
+    let sqrt_t = t.checked_sqrt()?.to_dec();
+    let exp_neg_rd_t = d_exp(
+        d_mul(-r_d, t.to_dec(), "greeks::gk::discount_domestic::exponent")?,
+        "greeks::gk::discount_domestic",
+    )?;
+    let exp_neg_rf_t = d_exp(
+        d_mul(-r_f, t.to_dec(), "greeks::gk::discount_foreign::exponent")?,
+        "greeks::gk::discount_foreign",
+    )?;
 
     // Volatility decay term: -S·e^(-r_f T)·n(d1)·σ/(2√T)
     let two_sqrt_t = d_mul(Decimal::TWO, sqrt_t, "greeks::gk::theta::two_sqrt_t")?;
@@ -424,7 +441,10 @@ pub fn rho_domestic_gk(option: &Options) -> Result<Decimal, GreeksError> {
 
     let r_d = option.risk_free_rate;
     let k = option.strike_price.to_dec();
-    let exp_neg_rd_t = (-r_d * t.to_dec()).exp();
+    let exp_neg_rd_t = d_exp(
+        d_mul(-r_d, t.to_dec(), "greeks::gk::discount_domestic::exponent")?,
+        "greeks::gk::discount_domestic",
+    )?;
 
     let base = d_mul(
         k,
@@ -478,7 +498,10 @@ pub fn rho_foreign_gk(option: &Options) -> Result<Decimal, GreeksError> {
 
     let r_f = option.dividend_yield.to_dec();
     let s = option.underlying_price.to_dec();
-    let exp_neg_rf_t = (-r_f * t.to_dec()).exp();
+    let exp_neg_rf_t = d_exp(
+        d_mul(-r_f, t.to_dec(), "greeks::gk::discount_foreign::exponent")?,
+        "greeks::gk::discount_foreign",
+    )?;
 
     let base = d_mul(
         s,

--- a/src/greeks/garman_kohlhagen.rs
+++ b/src/greeks/garman_kohlhagen.rs
@@ -97,8 +97,20 @@ fn side_sign(option: &Options) -> Decimal {
 }
 
 /// Cost of carry `b = r_d − r_f` for Garman–Kohlhagen.
-fn cost_of_carry(option: &Options) -> Decimal {
-    option.risk_free_rate - option.dividend_yield.to_dec()
+///
+/// Fallible because the raw `Decimal` subtraction panics on overflow, which a
+/// domestic rate at the edge of the range against any foreign rate reaches.
+///
+/// # Errors
+///
+/// Returns [`GreeksError`] when `r_d − r_f` leaves the representable
+/// `Decimal` range.
+fn cost_of_carry(option: &Options) -> Result<Decimal, GreeksError> {
+    Ok(d_sub(
+        option.risk_free_rate,
+        option.dividend_yield.to_dec(),
+        "greeks::gk::cost_of_carry",
+    )?)
 }
 
 /// Returns `Some(time_in_years)` when the option has not expired yet, or
@@ -140,7 +152,7 @@ fn delta_at_expiry(option: &Options) -> Decimal {
 /// drift term, mirroring the helper used by the GK pricing kernel.
 fn calculate_d_values_gk(option: &Options) -> Result<(Decimal, Decimal), GreeksError> {
     let years = option.expiration_date.get_years()?;
-    let b = cost_of_carry(option);
+    let b = cost_of_carry(option)?;
     let d1_value = d1(
         option.underlying_price,
         option.strike_price,
@@ -991,5 +1003,78 @@ mod tests {
         assert_eq!(theta_gk(&opt).unwrap(), Decimal::ZERO);
         assert_eq!(rho_domestic_gk(&opt).unwrap(), Decimal::ZERO);
         assert_eq!(rho_foreign_gk(&opt).unwrap(), Decimal::ZERO);
+    }
+}
+
+#[cfg(test)]
+mod tests_gk_extreme_rates {
+    use super::*;
+    use crate::ExpirationDate;
+    use positive::{Positive, pos_or_panic};
+
+    /// An FX option whose domestic rate sits at the edge of the `Decimal`
+    /// range: `r_d - r_f` overflows, which the raw operator turns into an
+    /// abort rather than an error.
+    fn extreme_rate_option(style: OptionStyle) -> Options {
+        Options::new(
+            OptionType::European,
+            Side::Long,
+            "EURUSD".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            pos_or_panic!(0.2),
+            Positive::ONE,
+            Positive::HUNDRED,
+            Decimal::MIN,
+            style,
+            Positive::ONE,
+            None,
+        )
+    }
+
+    #[test]
+    fn test_every_gk_greek_reports_a_carry_overflow_instead_of_aborting() {
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            let option = extreme_rate_option(style);
+            let greeks: [(&str, Result<Decimal, GreeksError>); 6] = [
+                ("delta_gk", delta_gk(&option)),
+                ("gamma_gk", gamma_gk(&option)),
+                ("vega_gk", vega_gk(&option)),
+                ("theta_gk", theta_gk(&option)),
+                ("rho_domestic_gk", rho_domestic_gk(&option)),
+                ("rho_foreign_gk", rho_foreign_gk(&option)),
+            ];
+            for (label, result) in greeks {
+                assert!(
+                    result.is_err(),
+                    "{label} returned a value for a cost of carry that is not representable"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ordinary_rates_still_price_the_gk_greeks() {
+        // The guard above must not have cost the normal path its answer.
+        let option = Options::new(
+            OptionType::European,
+            Side::Long,
+            "EURUSD".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            pos_or_panic!(0.2),
+            Positive::ONE,
+            Positive::HUNDRED,
+            Decimal::new(5, 2),
+            OptionStyle::Call,
+            pos_or_panic!(0.02),
+            None,
+        );
+        assert!(delta_gk(&option).is_ok());
+        assert!(gamma_gk(&option).is_ok());
+        assert!(vega_gk(&option).is_ok());
+        assert!(theta_gk(&option).is_ok());
+        assert!(rho_domestic_gk(&option).is_ok());
+        assert!(rho_foreign_gk(&option).is_ok());
     }
 }

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -60,6 +60,10 @@ use statrs::distribution::{ContinuousCDF, Normal};
 /// - **InvalidVolatility**: Triggered when `implied_volatility` is zero.
 /// - **InvalidTime**: Triggered when `expiration_date` is zero or less.
 ///
+/// Returns `GreeksError::MathError` or a `DecimalError` when an intermediate
+/// step leaves the representable `Decimal` range: `sigma²`, the moneyness
+/// `S / K`, the drift, or the final quotient.
+///
 /// # Example
 ///
 /// ```rust

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -2348,3 +2348,34 @@ mod tests_edge_cases_and_errors {
         assert!(n_result.to_f64().unwrap() == 0.0);
     }
 }
+
+#[cfg(test)]
+mod tests_delta_neutral_extremes {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_large_deltas_on_a_large_size_report_the_overflow() {
+        // `size · delta` leaves the `Decimal` range for a large book against
+        // large deltas. The raw operator aborts; the caller must get an error.
+        let result = calculate_delta_neutral_sizes(dec!(10), dec!(-10), Positive::MAX);
+        assert!(result.is_err(), "expected an error, got {result:?}");
+    }
+
+    #[test]
+    fn test_ordinary_deltas_still_size_the_pair() {
+        let (size1, size2) = match calculate_delta_neutral_sizes(
+            dec!(0.5),
+            dec!(-0.5),
+            Positive::new(10.0).expect("literal is positive"),
+        ) {
+            Ok(sizes) => sizes,
+            Err(e) => panic!("sizing should succeed: {e:?}"),
+        };
+        assert_eq!(size1, size2);
+        assert_eq!(
+            size1 + size2,
+            Positive::new(10.0).expect("literal is positive")
+        );
+    }
+}

--- a/src/greeks/utils.rs
+++ b/src/greeks/utils.rs
@@ -7,12 +7,14 @@
 use crate::Options;
 use crate::error::decimal::DecimalError;
 use crate::error::greeks::{DeltaNeutralityErrorKind, GreeksError, InputErrorKind, MathErrorKind};
-use crate::model::decimal::{d_div, d_mul, d_sub, f64_to_decimal};
+use crate::model::decimal::{
+    d_add, d_div, d_exp, d_ln, d_mul, d_powd, d_sqrt, d_sub, f64_to_decimal,
+};
 use crate::strategies::DELTA_THRESHOLD;
 use core::f64;
 use num_traits::ToPrimitive;
 use positive::Positive;
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use statrs::distribution::{ContinuousCDF, Normal};
 
@@ -122,18 +124,47 @@ pub fn d1(
     // d1 = (ln(S / K) + (b + σ² / 2) * T) / (σ * sqrt(T))
     // where b = carry_rate is the cost of carry: b = r − q for a
     // dividend-paying underlying (r − dividend_yield), r otherwise.
+    // Every step below goes through the checked helpers: the raw `Decimal`
+    // and `Positive` operators panic on overflow, and `ln` panics on zero,
+    // both of which are reachable from ordinary-looking inputs (a tiny
+    // strike, a huge underlying, a volatility at the edge of the scale).
     let underlying_price: Decimal = underlying_price.to_dec();
-    let implied_volatility_squared = implied_volatility.powd(Decimal::TWO);
+    let strike: Decimal = strike_price.to_dec();
+    let sigma: Decimal = implied_volatility.to_dec();
+    let time_to_expiry: Decimal = expiration_date.to_dec();
+
+    let implied_volatility_squared = d_powd(sigma, Decimal::TWO, "greeks::d1::sigma_squared")?;
     let ln_price_ratio = match strike_price {
         value if value == Positive::MAX => Decimal::MIN,
-        _ => (underlying_price / strike_price).ln(),
+        _ => {
+            let moneyness = d_div(underlying_price, strike, "greeks::d1::moneyness")?;
+            if moneyness.is_zero() {
+                // `S / K` fell below the smallest representable `Decimal`, so
+                // `ln` is `-inf`. Represented the same way as the
+                // `Positive::MAX` strike branch above.
+                Decimal::MIN
+            } else {
+                d_ln(moneyness, "greeks::d1::log_moneyness")?
+            }
+        }
     };
 
-    let rate_vol_term = carry_rate + implied_volatility_squared / Decimal::TWO;
-    let numerator = ln_price_ratio + rate_vol_term * expiration_date;
-    let denominator = implied_volatility * expiration_date.sqrt();
+    let half_variance = d_div(
+        implied_volatility_squared,
+        Decimal::TWO,
+        "greeks::d1::half_variance",
+    )?;
+    let rate_vol_term = d_add(carry_rate, half_variance, "greeks::d1::carry_term")?;
+    let drift = d_mul(rate_vol_term, time_to_expiry, "greeks::d1::drift")?;
+    let numerator = d_add(ln_price_ratio, drift, "greeks::d1::numerator")?;
+    let sqrt_time = d_sqrt(time_to_expiry, "greeks::d1::sqrt_time")?;
+    let denominator = d_mul(sigma, sqrt_time, "greeks::d1::denominator")?;
 
-    match numerator.checked_div(denominator.into()) {
+    if denominator.is_zero() {
+        return Err(GreeksError::MathError(MathErrorKind::DivisionByZero));
+    }
+
+    match numerator.checked_div(denominator) {
         Some(result) => Ok(result),
         None => Err(GreeksError::MathError(MathErrorKind::Overflow)),
     }
@@ -237,7 +268,13 @@ pub fn d2(
         implied_volatility,
     )?;
 
-    Ok(d1_value - implied_volatility * expiration_date.sqrt())
+    let sqrt_time = d_sqrt(expiration_date.to_dec(), "greeks::d2::sqrt_time")?;
+    let vol_time = d_mul(
+        implied_volatility.to_dec(),
+        sqrt_time,
+        "greeks::d2::vol_time",
+    )?;
+    Ok(d_sub(d1_value, vol_time, "greeks::d2::adjustment")?)
 }
 
 /// Computes the probability density function (PDF) of the standard normal distribution
@@ -301,15 +338,25 @@ pub fn n(x: Decimal) -> Result<Decimal, GreeksError> {
     // 1 / sqrt(2π) — standard normal PDF normalisation constant.
     // Precomputed so we avoid the runtime fallible sqrt on Decimal.
     const NORM_FACTOR: Decimal = dec!(0.3989422804014326779399461);
-    let pre_pdf = -x.powd(Decimal::TWO) / Decimal::TWO;
+
+    // `x²` overflows the `Decimal` range for a large `|x|`, and `powd`
+    // panics rather than reporting it. The pdf is already flushed to zero
+    // below `|x| = 4.84` (the `-11.7` cut-off underneath), so anything past
+    // 5 returns zero without ever squaring it.
+    if x.abs() > dec!(5) {
+        return Ok(Decimal::ZERO);
+    }
+
+    let x_squared = d_powd(x, Decimal::TWO, "greeks::n::x_squared")?;
+    let pre_pdf = -d_div(x_squared, Decimal::TWO, "greeks::n::half_x_squared")?;
 
     // avoid Exp underflowed
     if pre_pdf < dec!(-11.7) {
         return Ok(Decimal::ZERO);
     }
 
-    let pdf = pre_pdf.exp();
-    Ok(NORM_FACTOR * pdf) // N(x) = [1 / sqrt(2 * PI)] * e^(-x^2 / 2)
+    let pdf = d_exp(pre_pdf, "greeks::n::exp")?;
+    Ok(d_mul(NORM_FACTOR, pdf, "greeks::n::normalisation")?) // N(x) = [1 / sqrt(2 * PI)] * e^(-x^2 / 2)
 }
 
 /// Calculate the derivative of the function `n` at a given point `x`.
@@ -453,7 +500,13 @@ pub fn big_n(x: Decimal) -> Result<Decimal, DecimalError> {
 ///
 #[inline]
 pub(crate) fn calculate_d_values(option: &Options) -> Result<(Decimal, Decimal), GreeksError> {
-    let b = option.risk_free_rate - option.dividend_yield.to_dec();
+    // `Decimal`'s `-` panics on overflow, which a rate at the edge of the
+    // range reaches (`Decimal::MIN` minus any positive yield).
+    let b = d_sub(
+        option.risk_free_rate,
+        option.dividend_yield.to_dec(),
+        "greeks::carry_rate",
+    )?;
     let d1_value = d1(
         option.underlying_price,
         option.strike_price,

--- a/src/model/decimal.rs
+++ b/src/model/decimal.rs
@@ -420,6 +420,94 @@ pub(crate) fn d_div(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Deci
     Ok(raw.round_dp_with_strategy(DIV_DEFAULT_SCALE, RoundingStrategy::MidpointNearestEven))
 }
 
+/// Checked `e^x` with underflow flushed to zero.
+///
+/// Crate-private helper used by every kernel in place of
+/// [`MathematicalOps::exp`], which panics with `Exp overflowed` /
+/// `Exp underflowed` instead of reporting the failure.
+///
+/// A negative argument whose exponential is smaller than the smallest
+/// representable `Decimal` (`1e-28`) returns `Decimal::ZERO`: that is the
+/// value the discount factor takes at the limit, and it is the only
+/// representable answer. A positive argument that overflows is a real
+/// failure and is reported as such — the caller asked for a number the type
+/// cannot hold.
+///
+/// # Errors
+///
+/// Returns [`DecimalError::Overflow`] when `x` is positive and `e^x` is
+/// outside the representable `Decimal` range.
+#[inline]
+pub(crate) fn d_exp(x: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    if let Some(value) = x.checked_exp() {
+        return Ok(value);
+    }
+    if x.is_sign_negative() {
+        // e^x < 1e-28 for x <= -65: zero is the representable limit.
+        return Ok(Decimal::ZERO);
+    }
+    Err(DecimalError::overflow(op, x, Decimal::ZERO))
+}
+
+/// Checked natural logarithm.
+///
+/// Crate-private helper used in place of [`MathematicalOps::ln`], which
+/// panics on zero and on negative inputs. Note that a ratio such as `S / K`
+/// can round down to exactly zero for extreme operands, so the zero case is
+/// reachable from ordinary-looking code.
+///
+/// # Errors
+///
+/// Returns [`DecimalError::ArithmeticError`] when `x` is zero or negative,
+/// or when the series evaluation fails to converge to a representable
+/// value.
+#[inline]
+pub(crate) fn d_ln(x: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    if x <= Decimal::ZERO {
+        return Err(DecimalError::arithmetic_error(
+            op,
+            "logarithm of a non-positive value",
+        ));
+    }
+    x.checked_ln()
+        .ok_or_else(|| DecimalError::arithmetic_error(op, "logarithm is not representable"))
+}
+
+/// Checked `base^exponent`.
+///
+/// Crate-private helper used in place of [`MathematicalOps::powd`], which
+/// panics with `Pow overflowed` both when the result is too large and when
+/// it underflows below the representable scale.
+///
+/// # Errors
+///
+/// Returns [`DecimalError::Overflow`] when the power is outside the
+/// representable `Decimal` range.
+#[inline]
+pub(crate) fn d_powd(
+    base: Decimal,
+    exponent: Decimal,
+    op: &'static str,
+) -> Result<Decimal, DecimalError> {
+    base.checked_powd(exponent)
+        .ok_or_else(|| DecimalError::overflow(op, base, exponent))
+}
+
+/// Checked square root.
+///
+/// Crate-private helper wrapping [`MathematicalOps::sqrt`], which returns
+/// `None` for negative inputs rather than panicking, so this only has to
+/// give the failure a typed shape.
+///
+/// # Errors
+///
+/// Returns [`DecimalError::ArithmeticError`] when `x` is negative.
+#[inline]
+pub(crate) fn d_sqrt(x: Decimal, op: &'static str) -> Result<Decimal, DecimalError> {
+    x.sqrt()
+        .ok_or_else(|| DecimalError::arithmetic_error(op, "square root of a negative value"))
+}
+
 /// Converts a Decimal value to f64 without error checking.
 ///
 /// This macro converts a Decimal type to an f64 floating-point value.

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -5,6 +5,7 @@ use crate::error::{
     GreeksError, OptionsError, OptionsResult, PricingError, StrategyError, VolatilityError,
 };
 use crate::greeks::Greeks;
+use crate::model::decimal::d_sub;
 use crate::model::types::{OptionBasicType, OptionStyle, OptionType, Side};
 use crate::model::utils::calculate_optimal_price_range;
 use crate::pnl::utils::{PnL, PnLCalculator};
@@ -616,7 +617,10 @@ impl Options {
     pub fn time_value(&self) -> OptionsResult<Decimal> {
         let option_price = self.calculate_price_black_scholes()?.abs();
         let intrinsic_value = self.intrinsic_value(self.underlying_price)?;
-        Ok((option_price - intrinsic_value).max(Decimal::ZERO))
+        // `Decimal`'s `-` panics on overflow, which a price near the top of
+        // the range against a negative intrinsic value reaches.
+        let time_value = d_sub(option_price, intrinsic_value, "model::option::time_value")?;
+        Ok(time_value.max(Decimal::ZERO))
     }
 
     /// Validates that the option parameters are in a valid state for calculations.

--- a/src/pricing/black_76.rs
+++ b/src/pricing/black_76.rs
@@ -6,9 +6,11 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::{big_n, calculate_d_values_black_76};
-use crate::model::decimal::{d_mul, d_sub};
+use crate::model::decimal::{d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
+#[cfg(test)]
+use rust_decimal::MathematicalOps;
 use tracing::{instrument, trace};
 
 /// Computes the price of an option on a futures contract using the Black-76 model.
@@ -157,7 +159,7 @@ fn calculate_call_option_price(
 
     // e^(-rT) * [F * N(d1) - K * N(d2)]
     let rt = d_mul(-option.risk_free_rate, t, "pricing::black_76::call::rt")?;
-    let discount_factor = rt.exp();
+    let discount_factor = d_exp(rt, "pricing::black_76::call::discount")?;
 
     let f_leg = d_mul(
         option.underlying_price.to_dec(),
@@ -194,7 +196,7 @@ fn calculate_put_option_price(
 
     // e^(-rT) * [K * N(-d2) - F * N(-d1)]
     let rt = d_mul(-option.risk_free_rate, t, "pricing::black_76::put::rt")?;
-    let discount_factor = rt.exp();
+    let discount_factor = d_exp(rt, "pricing::black_76::put::discount")?;
 
     let k_leg = d_mul(
         option.strike_price.to_dec(),

--- a/src/pricing/black_scholes_model.rs
+++ b/src/pricing/black_scholes_model.rs
@@ -6,9 +6,9 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::{big_n, calculate_d_values};
-use crate::model::decimal::{d_mul, d_sub};
+use crate::model::decimal::{d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
 use tracing::{instrument, trace};
 
 /// Computes the price of an option using the Black-Scholes model.
@@ -209,13 +209,18 @@ fn calculate_call_option_price(
         t,
         "pricing::black_scholes::call::rt",
     )?;
+    // `Decimal::exp` panics on overflow and on underflow; the checked
+    // helper flushes an underflowing discount factor to zero, which is its
+    // limit, and reports a genuine overflow as an error.
+    let discount_q = d_exp(qt, "pricing::black_scholes::call::exp_qt")?;
+    let discount_r = d_exp(rt, "pricing::black_scholes::call::exp_rt")?;
     let s_discounted = d_mul(
         option.underlying_price.to_dec(),
-        qt.exp(),
+        discount_q,
         "pricing::black_scholes::call::discount_s",
     )?;
     let k_discounted = d_mul(
-        rt.exp(),
+        discount_r,
         option.strike_price.to_dec(),
         "pricing::black_scholes::call::discount_k",
     )?;
@@ -233,11 +238,7 @@ fn calculate_call_option_price(
     let result = d_sub(s_leg, k_leg, "pricing::black_scholes::call::price")?;
     trace!(
         "Call Option Price: {} - {} * {} * {} = {}",
-        option.underlying_price,
-        option.strike_price,
-        rt.exp(),
-        big_n_d2,
-        result
+        option.underlying_price, option.strike_price, discount_r, big_n_d2, result
     );
     Ok(result)
 }
@@ -288,14 +289,16 @@ fn calculate_put_option_price(
         "pricing::black_scholes::put::qt",
     )?;
     let rt = d_mul(-option.risk_free_rate, t, "pricing::black_scholes::put::rt")?;
+    let discount_q = d_exp(qt, "pricing::black_scholes::put::exp_qt")?;
+    let discount_r = d_exp(rt, "pricing::black_scholes::put::exp_rt")?;
     let s_discounted = d_mul(
         option.underlying_price.to_dec(),
-        qt.exp(),
+        discount_q,
         "pricing::black_scholes::put::discount_s",
     )?;
     let k_discounted = d_mul(
         option.strike_price.to_dec(),
-        rt.exp(),
+        discount_r,
         "pricing::black_scholes::put::discount_k",
     )?;
 
@@ -1030,6 +1033,7 @@ mod tests_black_scholes_bis {
     use crate::model::types::{OptionStyle, Side};
     use crate::{ExpirationDate, assert_decimal_eq};
     use positive::{Positive, pos_or_panic};
+    use rust_decimal::MathematicalOps;
     use rust_decimal_macros::dec;
 
     fn create_base_option(side: Side, style: OptionStyle) -> Options {

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -4,4 +4,5 @@
 //! mathematical invariants and bounds across a wide range of inputs.
 
 mod greeks_bounds_test;
+mod panic_freedom_test;
 mod put_call_parity_test;

--- a/tests/property/panic_freedom_test.proptest-regressions
+++ b/tests/property/panic_freedom_test.proptest-regressions
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4071547f72cdad8478547737ea0b05ba5f39c89128393483ca7ddae76754f4ac # shrinks to spot = 0, strike = 0, volatility = 0, days = 0, quantity = 0, dividend_yield = 1, rate = -79228162514264337593543950335, style = OptionStyle::Call, side = Side::Long
+cc a68696c1ce14319236d0941bc881a843f7476f1061ef4fa2c454dd0db9de0af1 # shrinks to spot = 30, volatility = 0.000000000000000000000000001, days = 0.000000000000000000000000001, dividend_yield = 30, rate = -79228162514264337593543950335, greek_snapshots = false
+cc 75865739d475859105ad9647b57e984c4dbcb2ff9bf6fc680bf68d9730ca02f9 # shrinks to spot = 79228162514264337593543950335, strike = 30, volatility = 0.0000000000001, days = 1, quantity = 0.0000000000001, dividend_yield = 0.000000000000000000000000001, rate = 0, style = OptionStyle::Call, side = Side::Short

--- a/tests/property/panic_freedom_test.rs
+++ b/tests/property/panic_freedom_test.rs
@@ -1,0 +1,193 @@
+//! Property-based tests for panic freedom
+//!
+//! The library is embedded in long-running services, where a panic kills the
+//! worker thread and takes the in-flight request with it. Every failure must
+//! therefore come back as a `Result`, including for inputs that are extreme
+//! but structurally valid.
+//!
+//! These tests drive the Greeks, the three closed-form pricing models and the
+//! chain builder across the edges of the `Decimal` domain — volatilities and
+//! strikes at the smallest representable scale, times to expiry and prices at
+//! the largest, rates far outside anything a market quotes. The assertion is
+//! deliberately weak: whatever comes back, it must come back.
+
+use optionstratlib::chains::OptionChain;
+use optionstratlib::chains::utils::{OptionChainBuildParams, OptionDataPriceParams};
+use optionstratlib::greeks::Greeks;
+use optionstratlib::model::ExpirationDate;
+use optionstratlib::model::Options;
+use optionstratlib::model::types::{OptionStyle, OptionType, Side};
+use optionstratlib::pricing::{black_76, black_scholes, garman_kohlhagen};
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::str::FromStr;
+
+/// The extremes that reach the arithmetic panics: the smallest representable
+/// `Decimal`, the largest, and the ordinary values in between.
+fn extreme_positive() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(Positive::ONE),
+        Just(Positive::MAX),
+        Just(pos("0.000000000000000000000000001")),
+        Just(pos("0.0000000000001")),
+        Just(pos("0.2")),
+        Just(pos("30")),
+        Just(pos("100")),
+        Just(pos("1000000")),
+        Just(pos("1000000000")),
+    ]
+}
+
+/// Rates well outside anything quotable, in both directions.
+fn extreme_rate() -> impl Strategy<Value = Decimal> {
+    prop_oneof![
+        Just(Decimal::ZERO),
+        Just(dec!(0.05)),
+        Just(dec!(-0.05)),
+        Just(dec!(1000000)),
+        Just(dec!(-1000000)),
+        Just(Decimal::MAX),
+        Just(Decimal::MIN),
+    ]
+}
+
+fn pos(value: &str) -> Positive {
+    let decimal = Decimal::from_str(value).expect("literal is a valid Decimal");
+    Positive::new_decimal(decimal).expect("literal is non-negative")
+}
+
+fn option_style() -> impl Strategy<Value = OptionStyle> {
+    prop_oneof![Just(OptionStyle::Call), Just(OptionStyle::Put)]
+}
+
+fn side() -> impl Strategy<Value = Side> {
+    prop_oneof![Just(Side::Long), Just(Side::Short)]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_option(
+    spot: Positive,
+    strike: Positive,
+    volatility: Positive,
+    days: Positive,
+    quantity: Positive,
+    dividend_yield: Positive,
+    rate: Decimal,
+    style: OptionStyle,
+    side: Side,
+) -> Options {
+    Options::new(
+        OptionType::European,
+        side,
+        "TEST".to_string(),
+        strike,
+        ExpirationDate::Days(days),
+        volatility,
+        quantity,
+        spot,
+        rate,
+        style,
+        dividend_yield,
+        None,
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Every Greek returns for every combination of extremes.
+    #[test]
+    fn test_greeks_never_panic_on_extreme_inputs(
+        spot in extreme_positive(),
+        strike in extreme_positive(),
+        volatility in extreme_positive(),
+        days in extreme_positive(),
+        quantity in extreme_positive(),
+        dividend_yield in extreme_positive(),
+        rate in extreme_rate(),
+        style in option_style(),
+        side in side(),
+    ) {
+        let option = build_option(
+            spot, strike, volatility, days, quantity, dividend_yield, rate, style, side,
+        );
+
+        let _ = option.delta();
+        let _ = option.gamma();
+        let _ = option.theta();
+        let _ = option.vega();
+        let _ = option.rho();
+        let _ = option.rho_d();
+        let _ = option.alpha();
+        let _ = option.vanna();
+        let _ = option.vomma();
+        let _ = option.veta();
+        let _ = option.charm();
+        let _ = option.color();
+        let _ = option.greeks();
+    }
+
+    /// The closed-form pricing models return for every combination of extremes.
+    #[test]
+    fn test_pricing_never_panics_on_extreme_inputs(
+        spot in extreme_positive(),
+        strike in extreme_positive(),
+        volatility in extreme_positive(),
+        days in extreme_positive(),
+        quantity in extreme_positive(),
+        dividend_yield in extreme_positive(),
+        rate in extreme_rate(),
+        style in option_style(),
+        side in side(),
+    ) {
+        let option = build_option(
+            spot, strike, volatility, days, quantity, dividend_yield, rate, style, side,
+        );
+
+        let _ = black_scholes(&option);
+        let _ = black_76(&option);
+        let _ = garman_kohlhagen(&option);
+        let _ = option.calculate_price_black_scholes();
+        let _ = option.intrinsic_value(spot);
+        let _ = option.time_value();
+        let _ = option.payoff();
+    }
+
+    /// Chain construction returns for every combination of extremes, with and
+    /// without the per-strike greek snapshots.
+    #[test]
+    fn test_build_chain_never_panics_on_extreme_inputs(
+        spot in extreme_positive(),
+        volatility in extreme_positive(),
+        days in extreme_positive(),
+        dividend_yield in extreme_positive(),
+        rate in extreme_rate(),
+        greek_snapshots in any::<bool>(),
+    ) {
+        let price_params = OptionDataPriceParams::new(
+            Some(Box::new(spot)),
+            Some(ExpirationDate::Days(days)),
+            Some(rate),
+            Some(dividend_yield),
+            Some("TEST".to_string()),
+        );
+        let params = OptionChainBuildParams::new(
+            "TEST".to_string(),
+            Some(Positive::ONE),
+            5,
+            Some(pos("5")),
+            dec!(-0.2),
+            dec!(0.1),
+            pos("0.02"),
+            2,
+            price_params,
+            volatility,
+        )
+        .with_greek_snapshots(greek_snapshots);
+
+        let _ = OptionChain::build_chain(&params);
+    }
+}


### PR DESCRIPTION
## Summary

The Greeks and Black-Scholes surface aborted the calling process for inputs
that passed every validation gate the library has. A `catch_unwind` probe over
the public API produced 119 panics across the twelve Greeks and the pricing
entry points; the library runs inside long-running services, where each of
those kills a tokio worker and the in-flight request with it. This makes that
whole surface panic-free by moving it onto checked arithmetic, and adds a
property test plus a CI scan so it stays that way.

The reported `vomma` abort is one instance of the pattern: `vomma = vega · d1 ·
d2 / sigma`, so a volatility approaching zero pushed the quotient out of
`Decimal`'s range and `Positive`'s `Div` panicked. It was never a `vomma` bug —
`rust_decimal` and `positive` panic by default on the operator path, and the
kernels used operators throughout.

## Changes

- Four new checked helpers in `src/model/decimal.rs`, alongside the existing
  `d_add` / `d_sub` / `d_mul` / `d_div`: `d_exp`, `d_ln`, `d_powd`, `d_sqrt`.
  `d_exp` flushes an underflowing discount factor to zero — that is the value
  at the limit and the only representable one — and reports a genuine overflow
  as an error.
- `d1`, `d2` and `n` are panic-free, including the case that had no guard at
  all: `S / K` rounding below the smallest representable `Decimal`, where
  `ln(0)` panicked. Each input was checked for zero individually, and each one
  was non-zero.
- `BlackScholesKernels` computes `sqrt(T)`, `d2`, `exp(-qT)` and `exp(-rT)` on
  the checked path; `d2` and the two discount factors are now fallible and
  stay memoised in their `OnceCell`s.
- All twelve Greeks (`delta`, `gamma`, `theta`, `vega`, `rho`, `rho_d`,
  `alpha`, `vanna`, `vomma`, `veta`, `charm`, `color`) use checked arithmetic
  end to end, each operation tagged with its call site.
- Black-Scholes, Black-76 and Garman-Kohlhagen pricing and Greeks: every
  discount factor and every `sqrt(T)` goes through the checked helpers.
- `Options::time_value` no longer panics when the price sits near the top of
  the range against a negative intrinsic value.
- `calculate_d_values` computes the cost of carry `b = r - q` with a checked
  subtraction; `Decimal::MIN` as a rate reached the raw operator.
- Chain building: `adjust_volatility` computes log-moneyness on the checked
  path and degrades to a flat smile when it is not representable (matching the
  function's existing fallbacks), the strike grid uses checked `Positive`
  arithmetic, and a relative expiry that no calendar date can represent is
  rejected up front instead of reaching `DateTime + TimeDelta`, which panics.
- `tests/property/panic_freedom_test.rs`: proptest over the extremes of the
  `Decimal` domain — volatilities and strikes at the smallest representable
  scale, prices and times to expiry at the largest, rates far outside anything
  quotable — asserting the Greeks, the three pricing models and the chain
  builder return rather than abort. It found two panics this PR would
  otherwise have missed (`Decimal::MIN` rate, `time_value` overflow).
- `make scan-banned` (same convention as the `positive` crate, with
  `// scan-banned: allow -- <reason>` escapes), wired into the lint workflow
  and into `make check`.

## Technical decisions

- **Errors, not clamps.** Where a result is genuinely not representable the
  call returns `Err`; no silent saturation, no invented number. The two
  exceptions are mathematically defined limits: `e^x` underflowing to zero,
  and `ln(S/K)` for a moneyness that rounded to zero, which keeps the existing
  `Decimal::MIN` sentinel the `Positive::MAX` strike branch already used.
- **Numerics unchanged for well-formed inputs.** `d_div` rounds at
  `DIV_DEFAULT_SCALE = 28`, which is `Decimal`'s maximum scale, so replacing
  `/` with `d_div` is value-preserving. The existing unit tests pass
  unmodified; the only test edits are the three assertions in
  `tests_black_scholes_kernels` that had to follow `d2` / `exp_minus_qt` /
  `exp_minus_rt` becoming fallible.
- **Probe over inspection.** Every panic listed in #440 was reproduced before
  being fixed and re-checked afterwards, rather than argued from the source.

## Public API impact

`d1`, `d2`, `n` and the twelve Greek functions keep their signatures — they
were already fallible. `alpha_from` (crate-private) became fallible. No public
item was added, removed or renamed, so `README.tpl` needs no update.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests added or updated (property test for panic freedom)
- [x] Reference regression test added (for pricing / Greek changes) — existing
      reference and put-call-parity tests pass unchanged, which is the
      regression bar for this PR
- [ ] Criterion benchmark added/updated (for perf changes)
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --all-features --workspace` clean
- [x] `make scan-banned` clean

The probe that produced the panic list is a throwaway crate with a path
dependency on this repo; the property test is the committed, repeatable form
of it.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic only — no `saturating_*` / `wrapping_*` in financial math
- [x] `rust_decimal::Decimal` at public monetary boundaries — no `f64` on prices / premia / P&L
- [x] Module boundaries respected (`model/` has no deps on `strategies/`, `backtesting/`, `visualization/`)
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `README.tpl` updated (and README regenerated via `make readme`) if public surface changed — not applicable, public surface unchanged

## Not in this PR

The sweep stops at the surface the probes reach. Still on raw operators, and
worth their own issues: `src/pricing/` exotics (asian, barrier, lookback,
compound, american, cliquet, chooser, rainbow, spread, quanto, power,
exchange), `src/curves/`, `src/surfaces/`, `src/strategies/`, and
`src/simulation/`. The current inventory of production code is 595 divisions,
102 `.exp()`, 91 `.sqrt()`, 60 `.powd()`, 23 `.ln()`, 14 `unreachable!` and 5
`panic!`. Two further items observed while working and deliberately left
alone: `Options::intrinsic_value` swallows a non-finite payoff through
`Decimal::from_f64(..).unwrap_or_default()`, returning zero instead of an
error, and `expiration_date` 0.3.0 panics on calendar overflow inside
`get_date_with_options`, which is guarded here at the call site but belongs
upstream.

Closes #440

---

**Blocks:** #443 (issue #439), which is stacked on this branch. Merge this one first.
