### PR TITLE
Widen a thin quote instead of withdrawing it (#439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`OptionData::apply_spread` widens a thin quote instead of withdrawing it**
+  (#439). A contract whose mid sat below one full spread used to lose `bid`,
+  `ask` **and** `middle`. Both sides are now quoted around the mid — `mid ±
+  half_spread` — and floored at one tick (`10^-decimal_places`); a supplied mid
+  is kept, held inside the widened quote rather than cleared. Only a quote with
+  no mid and no two-sided book is still erased.
+- **Chains keep their cheap strikes, so row counts change.**
+  `OptionChain::build_chain` stops generating strikes once both wings come back
+  unpriced, so the erasure above also truncated the chain: a build with
+  `chain_size = n` returned `n + 1` rows and now returns the full `2n + 1`.
+  Downstream assertions on row counts, and anything iterating a chain, will see
+  the wings that used to disappear as they decayed.
+- `apply_spread` no longer changes the previous quote for a mid at or above the
+  tick. Below the tick it does deviate deliberately: a bid that used to round
+  to `0.00` is now floored at one tick, since a zero bid is not a market.
+- A `decimal_places` beyond `Decimal`'s maximum scale used to panic through
+  `Positive::round_to`; `apply_spread` now leaves the quotes untouched and logs.
+
+### Fixed
+
+- **Reachable panic in the lower break-even of eight strategies.**
+  `strike - credit` was computed with the raw `Positive - Decimal` operator,
+  which panics when the credit (or, on a long structure, the debit) exceeds the
+  strike — reachable from the optimizers as soon as a chain keeps its cheap
+  wings. `ShortStraddle`, `ShortStrangle`, `IronCondor`, `IronButterfly`,
+  `LongStraddle`, `LongStrangle`, `BearPutSpread` and `ShortButterflySpread` now
+  share `lower_break_even`, which floors at zero. A lower break-even of `0.00`
+  means the strategy has none (#439).
+
 ## [0.20.0] - 2026-08-28
 
 Two things land together. The option chain now carries the full twelve-greek set

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -5419,16 +5419,33 @@ mod tests_chain_base {
         info!("{}", chain);
         assert!(chain.options.len() > 1);
         assert_eq!(chain.underlying_price, pos_or_panic!(5878.10));
+        // `chain_size` is a per-side half-width: the ATM strike plus 25 on
+        // each side. The wings used to be withdrawn by `apply_spread` — their
+        // mid sat below one spread — which also stopped the builder from
+        // generating past them.
+        assert_eq!(chain.options.len(), 51);
+
         let first = chain.options.iter().next().unwrap();
-        assert_eq!(first.call_ask.unwrap(), 480.20);
-        assert_eq!(first.call_bid.unwrap(), 480.18);
-        assert_eq!(first.put_ask, None);
-        assert_eq!(first.put_bid, None);
+        assert_eq!(first.strike_price, pos_or_panic!(5250.0));
+        assert_eq!(first.call_ask, spos!(630.09));
+        assert_eq!(first.call_bid, spos!(630.07));
+        // Deep out-of-the-money put: quoted at the tick, not withdrawn.
+        // Deep out-of-the-money put: quoted at the tick, not withdrawn. The ask
+        // sits one tick above the bid because the spread is applied more than
+        // once per row — `OptionData::calculate_prices` applies it and
+        // `build_chain` applies it again — and a mid held at the tick widens by
+        // one more tick on the second pass before settling.
+        assert_eq!(first.put_bid, spos!(0.01));
+        assert_eq!(first.put_ask, spos!(0.02));
+        assert_eq!(first.put_middle, spos!(0.01));
+
         let last = chain.options.iter().next_back().unwrap();
-        assert_eq!(last.call_ask, None);
-        assert_eq!(last.call_bid, None);
-        assert_eq!(last.put_ask, spos!(469.19));
-        assert_eq!(last.put_bid, spos!(469.17));
+        assert_eq!(last.strike_price, pos_or_panic!(6500.0));
+        assert_eq!(last.call_bid, spos!(0.01));
+        assert_eq!(last.call_ask, spos!(0.02));
+        assert_eq!(last.call_middle, spos!(0.01));
+        assert_eq!(last.put_ask, spos!(619.07));
+        assert_eq!(last.put_bid, spos!(619.05));
     }
 
     #[test]

--- a/src/chains/optiondata.rs
+++ b/src/chains/optiondata.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
 use std::fmt;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 use utoipa::ToSchema;
 
 /// Struct representing a row in an option chain with detailed pricing and analytics data.
@@ -208,6 +208,99 @@ pub struct OptionData {
     /// Same convention and the same `None` semantics as [`Self::greeks_call`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub greeks_put: Option<GreeksSnapshot>,
+}
+
+/// One tick at `decimal_places`: `0.01` for two decimals, `1` for zero.
+///
+/// The tick is the floor a widened quote is held at, so that a contract worth
+/// less than half a spread is still quoted rather than withdrawn.
+///
+/// Returns `None` for a scale `Decimal` cannot represent, so the caller stops
+/// rather than silently quoting on a `1.00` tick.
+#[inline]
+#[must_use]
+fn tick_size(decimal_places: u32) -> Option<Positive> {
+    Decimal::try_new(1, decimal_places)
+        .ok()
+        .and_then(|tick| Positive::new_decimal(tick).ok())
+}
+
+/// Widens a quote around `anchor` by half a spread on each side, flooring both
+/// sides at `tick` and keeping the bid at or below the ask.
+///
+/// The ask is floored too: without it, an anchor small enough that
+/// `anchor + half_spread` rounds down to zero would produce a bid above the
+/// ask.
+///
+/// Returns `None` when the widened ask leaves the representable `Decimal`
+/// range, or when `decimal_places` is a scale `Decimal` cannot round to.
+#[must_use]
+fn widen_around(
+    anchor: Positive,
+    half_spread: Decimal,
+    tick: Positive,
+    decimal_places: u32,
+) -> Option<(Positive, Positive)> {
+    let ask = anchor
+        .checked_add_dec(half_spread)
+        .ok()?
+        .checked_round_to(decimal_places)
+        .ok()?
+        .max(tick);
+    let bid = sub_floor_zero(anchor, &half_spread)
+        .checked_round_to(decimal_places)
+        .ok()?
+        .max(tick)
+        .min(ask);
+    Some((bid, ask))
+}
+
+/// Widens an existing two-sided book: the ask moves up half a spread, the bid
+/// down half a spread, both floored at `tick` and kept ordered.
+///
+/// Returns `None` on the same conditions as [`widen_around`].
+#[must_use]
+fn widen_book(
+    bid: Positive,
+    ask: Positive,
+    half_spread: Decimal,
+    tick: Positive,
+    decimal_places: u32,
+) -> Option<(Positive, Positive)> {
+    let new_ask = ask
+        .checked_add_dec(half_spread)
+        .ok()?
+        .checked_round_to(decimal_places)
+        .ok()?
+        .max(tick);
+    let new_bid = sub_floor_zero(bid, &half_spread)
+        .checked_round_to(decimal_places)
+        .ok()?
+        .max(tick)
+        .min(new_ask);
+    Some((new_bid, new_ask))
+}
+
+/// The mid of a two-sided quote, or `None` when it is not representable.
+#[inline]
+#[must_use]
+fn mid_of(bid: Positive, ask: Positive, decimal_places: u32) -> Option<Positive> {
+    bid.checked_add(&ask)
+        .ok()
+        .and_then(|sum| sum.checked_div(&Positive::TWO).ok())
+        .and_then(|mid| mid.checked_round_to(decimal_places).ok())
+}
+
+/// Holds a supplied mid inside the quote it belongs to.
+///
+/// Widening floors the bid at a tick and rounds both sides, so an anchor far
+/// below the tick — or merely one that rounds — would otherwise leave the row
+/// carrying a mid outside its own book. Clamping keeps the mid the caller
+/// supplied wherever it is still inside the quote, and never clears it.
+#[inline]
+#[must_use]
+fn mid_within(anchor: Positive, bid: Positive, ask: Positive) -> Positive {
+    anchor.max(bid).min(ask)
 }
 
 impl OptionData {
@@ -899,59 +992,82 @@ impl OptionData {
         Ok(())
     }
 
-    /// Applies a spread to the bid and ask prices of call and put options, then recalculates mid prices.
+    /// Widens the call and put quotes by the given spread, quoting around the
+    /// mid where there is one.
     ///
-    /// This method adjusts the bid and ask prices by half of the specified spread value,
-    /// subtracting from bid prices and adding to ask prices. It also ensures that all prices
-    /// are rounded to the specified number of decimal places. If any price becomes negative
-    /// after applying the spread, it is set to `None`.
+    /// Each side is moved half a spread away from the anchor — `mid + half`
+    /// for the ask, `mid - half` for the bid — and both are floored at one
+    /// tick, where a tick is `10^-decimal_places`. A contract cheaper than
+    /// half a spread is therefore quoted a tick bid against a widened ask,
+    /// which is what a thin market looks like; it is not withdrawn. The mid
+    /// is never cleared here: a mid that arrived is a mid, and dropping it
+    /// destroys information the caller supplied.
+    ///
+    /// A quote is erased only when there is nothing to quote: no mid, and no
+    /// two-sided book. A one-sided book with no mid is erased too — half a
+    /// market is not a market.
     ///
     /// # Arguments
     ///
     /// * `spread` - A positive decimal value representing the total spread to apply
-    /// * `decimal_places` - The number of decimal places to round the adjusted prices to
-    ///
-    /// # Inner Function
-    ///
-    /// The method contains an inner function `round_to_decimal` that handles the rounding
-    /// of prices after applying a shift (half the spread).
+    /// * `decimal_places` - The number of decimal places to round the adjusted
+    ///   prices to; it also fixes the tick. A scale `Decimal` cannot represent
+    ///   (above 28) leaves the quotes untouched.
     ///
     /// # Side Effects
     ///
-    /// * Updates `call_ask`, `call_bid`, `put_ask`, and `put_bid` fields with adjusted values
-    /// * Sets adjusted prices to `None` if they would become negative after applying the spread
-    /// * Calls `set_mid_prices()` to recalculate the mid prices based on the new bid/ask values
+    /// * Updates `call_ask`, `call_bid`, `put_ask` and `put_bid`
+    /// * Holds a supplied `call_middle` / `put_middle` inside the widened
+    ///   quote, and recomputes it from the sides for a quote that had none
+    /// * Leaves a side untouched, with a warning, when widening it would leave
+    ///   the representable `Decimal` range: this method returns `()`, so there
+    ///   is nowhere to report an arithmetic failure
     pub fn apply_spread(&mut self, spread: Positive, decimal_places: u32) {
         let half_spread: Decimal = (spread / Positive::TWO).into();
+        let Some(tick) = tick_size(decimal_places) else {
+            warn!(
+                decimal_places,
+                "apply_spread: no tick at this scale; quotes left unchanged"
+            );
+            return;
+        };
 
         match (self.call_ask, self.call_bid, self.call_middle) {
             (_, _, Some(call_middle)) => {
-                if call_middle > spread {
-                    self.call_ask = Some((call_middle + half_spread).round_to(decimal_places));
-                    self.call_bid =
-                        Some(sub_floor_zero(call_middle, &half_spread).round_to(decimal_places));
-                } else {
-                    trace!(
-                        "apply_spread: Call middle price is not greater than spread, cannot apply spread"
-                    );
-                    self.call_ask = None;
-                    self.call_bid = None;
-                    self.call_middle = None;
+                match widen_around(call_middle, half_spread, tick, decimal_places) {
+                    Some((bid, ask)) => {
+                        self.call_bid = Some(bid);
+                        self.call_ask = Some(ask);
+                        // The mid is kept, not cleared — but a mid below the
+                        // tick-floored bid would leave the row incoherent, and
+                        // `OptionData` is the serialized wire type.
+                        self.call_middle = Some(mid_within(call_middle, bid, ask));
+                    }
+                    None => warn!(
+                        mid = %call_middle,
+                        "apply_spread: widening the call quote overflows; quote left unchanged"
+                    ),
                 }
             }
             (Some(call_ask), Some(call_bid), None) => {
                 trace!(
                     "apply_spread: Call middle price is None; recomputing from bid/ask after applying spread"
                 );
-                let new_ask = (call_ask + half_spread).round_to(decimal_places);
-                let new_bid = sub_floor_zero(call_bid, &half_spread).round_to(decimal_places);
-                self.call_ask = Some(new_ask);
-                self.call_bid = Some(new_bid);
-                self.call_middle =
-                    Some(((new_ask + new_bid) / Positive::TWO).round_to(decimal_places));
+                match widen_book(call_bid, call_ask, half_spread, tick, decimal_places) {
+                    Some((bid, ask)) => {
+                        self.call_bid = Some(bid);
+                        self.call_ask = Some(ask);
+                        self.call_middle = mid_of(bid, ask, decimal_places);
+                    }
+                    None => warn!(
+                        bid = %call_bid,
+                        ask = %call_ask,
+                        "apply_spread: widening the call book overflows; quote left unchanged"
+                    ),
+                }
             }
             _ => {
-                trace!("apply_spread: Missing call ask or bid prices, cannot apply spread");
+                trace!("apply_spread: nothing to quote on the call side");
                 self.call_ask = None;
                 self.call_bid = None;
             }
@@ -959,32 +1075,40 @@ impl OptionData {
 
         match (self.put_ask, self.put_bid, self.put_middle) {
             (_, _, Some(put_middle)) => {
-                if put_middle > spread {
-                    self.put_ask = Some((put_middle + half_spread).round_to(decimal_places));
-                    self.put_bid =
-                        Some(sub_floor_zero(put_middle, &half_spread).round_to(decimal_places));
-                } else {
-                    trace!(
-                        "apply_spread: Put middle price is not greater than spread, cannot apply spread"
-                    );
-                    self.put_ask = None;
-                    self.put_bid = None;
-                    self.put_middle = None;
+                match widen_around(put_middle, half_spread, tick, decimal_places) {
+                    Some((bid, ask)) => {
+                        self.put_bid = Some(bid);
+                        self.put_ask = Some(ask);
+                        // The mid is kept, not cleared — but a mid below the
+                        // tick-floored bid would leave the row incoherent, and
+                        // `OptionData` is the serialized wire type.
+                        self.put_middle = Some(mid_within(put_middle, bid, ask));
+                    }
+                    None => warn!(
+                        mid = %put_middle,
+                        "apply_spread: widening the put quote overflows; quote left unchanged"
+                    ),
                 }
             }
             (Some(put_ask), Some(put_bid), None) => {
                 trace!(
                     "apply_spread: Put middle price is None; recomputing from bid/ask after applying spread"
                 );
-                let new_ask = (put_ask + half_spread).round_to(decimal_places);
-                let new_bid = sub_floor_zero(put_bid, &half_spread).round_to(decimal_places);
-                self.put_ask = Some(new_ask);
-                self.put_bid = Some(new_bid);
-                self.put_middle =
-                    Some(((new_ask + new_bid) / Positive::TWO).round_to(decimal_places));
+                match widen_book(put_bid, put_ask, half_spread, tick, decimal_places) {
+                    Some((bid, ask)) => {
+                        self.put_bid = Some(bid);
+                        self.put_ask = Some(ask);
+                        self.put_middle = mid_of(bid, ask, decimal_places);
+                    }
+                    None => warn!(
+                        bid = %put_bid,
+                        ask = %put_ask,
+                        "apply_spread: widening the put book overflows; quote left unchanged"
+                    ),
+                }
             }
             _ => {
-                trace!("apply_spread: Missing put ask or bid prices, cannot apply spread");
+                trace!("apply_spread: nothing to quote on the put side");
                 self.put_ask = None;
                 self.put_bid = None;
             }
@@ -1419,13 +1543,14 @@ mod optiondata_coverage_tests {
         assert_ne!(option_data.call_bid, original_call_bid);
         assert_ne!(option_data.call_ask, original_call_ask);
 
-        // Test with a spread that would make bid negative (should set to None)
+        // A bid that would go negative is floored at one tick, not withdrawn:
+        // a thin market is still a market.
         let mut option_data = create_test_option_data();
         option_data.call_bid = spos!(0.1);
         option_data.apply_spread(Positive::ONE, 2);
 
-        // Bid should be None as it would be negative
-        assert_eq!(option_data.call_bid, Some(Positive::ZERO));
+        assert_eq!(option_data.call_bid, spos!(0.01));
+        assert!(option_data.call_ask.unwrap() >= option_data.call_bid.unwrap());
     }
 
     #[test]
@@ -1442,13 +1567,14 @@ mod optiondata_coverage_tests {
         assert_ne!(option_data.put_bid, original_put_bid);
         assert_ne!(option_data.put_ask, original_put_ask);
 
-        // Test with a spread that would make bid negative (should set to None)
+        // A bid that would go negative is floored at one tick, not withdrawn:
+        // a thin market is still a market.
         let mut option_data = create_test_option_data();
         option_data.put_bid = spos!(0.1);
         option_data.apply_spread(Positive::ONE, 2);
 
-        // Bid should be None as it would be negative
-        assert_eq!(option_data.put_bid, Some(Positive::ZERO));
+        assert_eq!(option_data.put_bid, spos!(0.01));
+        assert!(option_data.put_ask.unwrap() >= option_data.put_bid.unwrap());
     }
 
     #[test]
@@ -3529,5 +3655,164 @@ mod tests_validate_option_data {
         // Option data is not valid because the put ask price is not provided
         let is_valid = option_data.validate();
         assert!(!is_valid);
+    }
+}
+
+#[cfg(test)]
+mod tests_apply_spread_widen_and_floor {
+    use super::*;
+    use positive::{pos_or_panic, spos};
+    use rust_decimal_macros::dec;
+
+    /// A quote with a mid and no bid/ask, which is what `build_chain` produces
+    /// before `apply_spread` runs.
+    fn quote_with_mid(call_middle: Positive, put_middle: Positive) -> OptionData {
+        let mut option_data = OptionData::new(
+            Positive::HUNDRED,
+            None,
+            None,
+            None,
+            None,
+            pos_or_panic!(0.2),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("TEST".to_string()),
+            Some(ExpirationDate::Days(pos_or_panic!(30.0))),
+            Some(Box::new(Positive::HUNDRED)),
+            Some(dec!(0.05)),
+            Some(pos_or_panic!(0.02)),
+            None,
+            None,
+        );
+        option_data.call_middle = Some(call_middle);
+        option_data.put_middle = Some(put_middle);
+        option_data
+    }
+
+    #[test]
+    fn test_cheap_contract_is_quoted_not_erased() {
+        // The case from the issue: a six-cent option against a ten-cent
+        // spread used to lose its quotes and its mid.
+        let mut option_data = quote_with_mid(pos_or_panic!(0.06), pos_or_panic!(0.06));
+        option_data.apply_spread(pos_or_panic!(0.10), 2);
+
+        let call_bid = option_data.call_bid.expect("call bid is quoted");
+        let call_ask = option_data.call_ask.expect("call ask is quoted");
+        assert!(call_bid >= pos_or_panic!(0.01), "bid floored at a tick");
+        assert!(call_ask > pos_or_panic!(0.06), "ask widened above the mid");
+        assert!(call_bid <= call_ask);
+
+        let put_bid = option_data.put_bid.expect("put bid is quoted");
+        let put_ask = option_data.put_ask.expect("put ask is quoted");
+        assert!(put_bid >= pos_or_panic!(0.01));
+        assert!(put_ask > pos_or_panic!(0.06));
+        assert!(put_bid <= put_ask);
+    }
+
+    #[test]
+    fn test_mid_is_never_cleared_when_it_was_supplied() {
+        for mid in [0.001, 0.01, 0.06, 1.0, 100.0] {
+            let mid = Positive::new(mid).expect("test literal is positive");
+            let mut option_data = quote_with_mid(mid, mid);
+            option_data.apply_spread(pos_or_panic!(0.10), 2);
+
+            let call_middle = option_data.call_middle.expect("call mid was cleared");
+            let call_bid = option_data.call_bid.expect("call bid is quoted");
+            let call_ask = option_data.call_ask.expect("call ask is quoted");
+            assert!(
+                call_middle >= call_bid && call_middle <= call_ask,
+                "mid {call_middle} outside the quote {call_bid}/{call_ask}"
+            );
+            assert!(option_data.put_middle.is_some(), "put mid was cleared");
+
+            // A mid at or above the tick is inside its widened quote, so it
+            // survives untouched. One below the tick is lifted to the bid
+            // rather than left dangling under its own book.
+            if mid >= pos_or_panic!(0.01) {
+                assert_eq!(call_middle, mid, "mid inside the quote was moved");
+            } else {
+                assert_eq!(call_middle, call_bid, "sub-tick mid lifted to the bid");
+            }
+        }
+    }
+
+    #[test]
+    fn test_sub_tick_corner_at_and_above_the_old_threshold() {
+        // #439's criterion is that a contract whose mid exceeds the spread is
+        // unchanged. It holds down to the tick; below it the tick floor is the
+        // deliberate deviation, since a sub-tick bid is not a quote.
+        let mut at_threshold = quote_with_mid(pos_or_panic!(0.05), pos_or_panic!(0.05));
+        at_threshold.apply_spread(pos_or_panic!(0.04), 2);
+        assert_eq!(at_threshold.call_bid, spos!(0.03));
+        assert_eq!(at_threshold.call_ask, spos!(0.07));
+        assert_eq!(at_threshold.call_middle, spos!(0.05));
+
+        // Sub-tick mid against a sub-tick spread: the bid used to round to
+        // zero, which is not a price anyone trades at.
+        let mut sub_tick = quote_with_mid(pos_or_panic!(0.005), pos_or_panic!(0.005));
+        sub_tick.apply_spread(pos_or_panic!(0.004), 2);
+        assert_eq!(sub_tick.call_bid, spos!(0.01));
+        assert!(sub_tick.call_ask.unwrap() >= sub_tick.call_bid.unwrap());
+    }
+
+    #[test]
+    fn test_expensive_contract_keeps_its_previous_behaviour() {
+        // A mid above the spread quoted mid +/- half the spread before this
+        // change, and still does.
+        let mut option_data = quote_with_mid(pos_or_panic!(9.5), pos_or_panic!(8.5));
+        option_data.apply_spread(pos_or_panic!(0.6), 2);
+
+        assert_eq!(option_data.call_ask, spos!(9.8));
+        assert_eq!(option_data.call_bid, spos!(9.2));
+        assert_eq!(option_data.put_ask, spos!(8.8));
+        assert_eq!(option_data.put_bid, spos!(8.2));
+    }
+
+    #[test]
+    fn test_nothing_to_quote_is_still_erased() {
+        let mut option_data = OptionData::new(
+            Positive::HUNDRED,
+            None,
+            None,
+            None,
+            None,
+            pos_or_panic!(0.2),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        option_data.apply_spread(pos_or_panic!(0.10), 2);
+
+        assert_eq!(option_data.call_bid, None);
+        assert_eq!(option_data.call_ask, None);
+        assert_eq!(option_data.put_bid, None);
+        assert_eq!(option_data.put_ask, None);
+    }
+
+    #[test]
+    fn test_tick_follows_decimal_places() {
+        for (decimal_places, tick) in [(0_u32, 1.0), (1, 0.1), (2, 0.01), (4, 0.0001)] {
+            let tick = Positive::new(tick).expect("test literal is positive");
+            let mut option_data = quote_with_mid(pos_or_panic!(0.000001), pos_or_panic!(0.000001));
+            option_data.apply_spread(pos_or_panic!(0.10), decimal_places);
+
+            assert_eq!(
+                option_data.call_bid,
+                Some(tick),
+                "bid floored at the {decimal_places}-decimal tick"
+            );
+        }
     }
 }

--- a/src/chains/utils.rs
+++ b/src/chains/utils.rs
@@ -938,7 +938,11 @@ mod tests_strike_step {
             implied_volatility,
         );
         let initial_chain = OptionChain::build_chain(&build_params).unwrap();
-        assert_eq!(initial_chain.len() - 1, chain_size);
+        // `chain_size` is a per-side half-width, so a chain that keeps every
+        // strike holds the ATM plus `chain_size` on each side. It used to hold
+        // `chain_size + 1` because the cheap side was withdrawn by
+        // `apply_spread` and the builder stopped generating strikes there.
+        assert_eq!(initial_chain.len(), 2 * chain_size + 1);
     }
 }
 

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -1246,6 +1246,20 @@ pub(crate) fn lower_break_even(strike: Positive, offset: impl Into<Decimal>) -> 
     sub_floor_zero(strike, &offset.into())
 }
 
+/// The non-negative distance from `low` up to `high`.
+///
+/// Prices are [`Positive`], so subtracting the larger from the smaller panics.
+/// Every width in this module — a profit-area base, the start of a plot range —
+/// is a distance, and a distance that would come out negative is a region with
+/// no width, not an error and certainly not an abort. That case is reachable
+/// whenever a strategy has no lower break-even (see [`lower_break_even`]) and
+/// the width is measured against a real strike.
+#[inline]
+#[must_use]
+pub(crate) fn price_gap(high: Positive, low: Positive) -> Positive {
+    sub_floor_zero(high, &low.to_dec())
+}
+
 /// Trait for strategies that can calculate and update break-even points.
 ///
 /// This trait provides methods for retrieving and updating break-even points, which are

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -5,6 +5,7 @@
 use crate::chains::OptionData;
 use crate::constants::{STRIKE_PRICE_LOWER_BOUND_MULTIPLIER, STRIKE_PRICE_UPPER_BOUND_MULTIPLIER};
 use crate::error::strategies::BreakEvenErrorKind;
+use crate::model::utils::sub_floor_zero;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -1230,10 +1231,30 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
     }
 }
 
+/// The lower break-even of a strategy: `strike - offset`, floored at zero.
+///
+/// A credit (or a debit, on a long structure) larger than the strike puts the
+/// break-even at or below zero, where the underlying cannot trade. The raw
+/// `Positive - Decimal` operator panics there, and that combination is
+/// reachable from the optimizers as soon as a chain keeps its cheap wings.
+///
+/// A returned `Positive::ZERO` therefore means "no lower break-even": the
+/// position cannot be losing on the downside at any attainable price.
+#[inline]
+#[must_use]
+pub(crate) fn lower_break_even(strike: Positive, offset: impl Into<Decimal>) -> Positive {
+    sub_floor_zero(strike, &offset.into())
+}
+
 /// Trait for strategies that can calculate and update break-even points.
 ///
 /// This trait provides methods for retrieving and updating break-even points, which are
 /// crucial for determining profitability in various trading scenarios.
+///
+/// A lower break-even of `Positive::ZERO` means the strategy has none: the
+/// credit taken in (or, on a long structure, the debit paid) exceeds the
+/// strike, so no attainable price of the underlying puts the position in a
+/// loss on that side. See [`lower_break_even`].
 pub trait BreakEvenable {
     /// Retrieves the break-even points for the strategy.
     ///
@@ -2520,5 +2541,39 @@ mod tests_strategy_net_operations {
 
         let result = strategy.get_fees().unwrap();
         assert!(result > Positive::ZERO);
+    }
+}
+
+#[cfg(test)]
+mod tests_lower_break_even {
+    use super::*;
+    use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_offset_below_the_strike_subtracts_normally() {
+        let break_even = lower_break_even(pos_or_panic!(100.0), dec!(12.5));
+        assert_eq!(break_even, pos_or_panic!(87.5));
+    }
+
+    #[test]
+    fn test_offset_equal_to_the_strike_is_zero() {
+        let break_even = lower_break_even(pos_or_panic!(100.0), dec!(100.0));
+        assert_eq!(break_even, Positive::ZERO);
+    }
+
+    #[test]
+    fn test_offset_above_the_strike_floors_at_zero_instead_of_panicking() {
+        // The raw `Positive - Decimal` operator panics here. A credit larger
+        // than the strike means there is no lower break-even: the position
+        // cannot lose on the downside at any attainable price.
+        let break_even = lower_break_even(pos_or_panic!(5.0), dec!(42.0));
+        assert_eq!(break_even, Positive::ZERO);
+    }
+
+    #[test]
+    fn test_positive_offset_is_accepted_without_a_conversion_at_the_call_site() {
+        let break_even = lower_break_even(pos_or_panic!(50.0), pos_or_panic!(60.0));
+        assert_eq!(break_even, Positive::ZERO);
     }
 }

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -25,6 +25,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::SpreadStrategy;
+use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -621,7 +622,11 @@ impl Strategies for BearCallSpread {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO).to_f64();
-        let base = (self.break_even_points[0] - self.short_call.option.strike_price).to_f64();
+        let base = price_gap(
+            self.break_even_points[0],
+            self.short_call.option.strike_price,
+        )
+        .to_f64();
         Ok(Decimal::from_f64(high * base / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -26,6 +26,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::SpreadStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -344,9 +345,11 @@ impl BreakEvenable for BearPutSpread {
         self.break_even_points = Vec::new();
 
         self.break_even_points.push(
-            (self.long_put.option.strike_price
-                - self.get_net_cost()? / self.long_put.option.quantity)
-                .round_to(2),
+            lower_break_even(
+                self.long_put.option.strike_price,
+                self.get_net_cost()? / self.long_put.option.quantity,
+            )
+            .round_to(2),
         );
 
         Ok(())

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -27,6 +27,7 @@ use super::base::{
 };
 use super::shared::SpreadStrategy;
 use crate::strategies::base::lower_break_even;
+use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -618,7 +619,10 @@ impl Strategies for BearPutSpread {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = self.break_even_points[0] - self.short_put.option.strike_price;
+        let base = price_gap(
+            self.break_even_points[0],
+            self.short_put.option.strike_price,
+        );
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -24,6 +24,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::SpreadStrategy;
+use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -620,7 +621,10 @@ impl Strategies for BullCallSpread {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = self.short_call.option.strike_price - self.break_even_points[0];
+        let base = price_gap(
+            self.short_call.option.strike_price,
+            self.break_even_points[0],
+        );
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -12,6 +12,7 @@
 use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
+use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
     chains::{OptionData, chain::OptionChain},
@@ -333,7 +334,7 @@ impl CustomStrategy {
             }
         } else {
             // Multiple break-even points
-            let test_point = break_even_points[0] - pos_lit(dec!(0.01));
+            let test_point = price_gap(break_even_points[0], pos_lit(dec!(0.01)));
             let is_profit_below = self.calculate_profit_at(&test_point)? > Decimal::ZERO;
             let is_first_zone_profit = is_profit_below;
 

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -21,6 +21,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::ButterflyStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -456,7 +457,7 @@ impl BreakEvenable for IronButterfly {
             .push((self.short_call.option.strike_price + net_credit).round_to(2));
 
         self.break_even_points
-            .push((self.short_call.option.strike_price - net_credit).round_to(2));
+            .push(lower_break_even(self.short_call.option.strike_price, net_credit).round_to(2));
 
         self.break_even_points.sort();
         Ok(())

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -19,6 +19,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::CondorStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -471,7 +472,7 @@ impl BreakEvenable for IronCondor {
             .push((self.short_call.option.strike_price + net_credit).round_to(2));
 
         self.break_even_points
-            .push((self.short_put.option.strike_price - net_credit).round_to(2));
+            .push(lower_break_even(self.short_put.option.strike_price, net_credit).round_to(2));
 
         self.break_even_points.sort();
         Ok(())

--- a/src/strategies/long_call.rs
+++ b/src/strategies/long_call.rs
@@ -23,6 +23,7 @@ use crate::pricing::payoff::Profit;
 use crate::simulation::simulator::Simulator;
 use crate::simulation::{ExitPolicy, Simulate};
 use crate::strategies::base::Optimizable;
+use crate::strategies::base::price_gap;
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
@@ -291,7 +292,10 @@ impl Strategies for LongCall {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = self.long_call.option.strike_price - self.break_even_points[0];
+        let base = price_gap(
+            self.long_call.option.strike_price,
+            self.break_even_points[0],
+        );
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {

--- a/src/strategies/long_put.rs
+++ b/src/strategies/long_put.rs
@@ -25,6 +25,7 @@ use crate::pricing::payoff::Profit;
 use crate::simulation::simulator::Simulator;
 use crate::simulation::{ExitPolicy, Simulate};
 use crate::strategies::base::Optimizable;
+use crate::strategies::base::price_gap;
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
@@ -297,7 +298,7 @@ impl Strategies for LongPut {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = self.long_put.option.strike_price - self.break_even_points[0];
+        let base = price_gap(self.long_put.option.strike_price, self.break_even_points[0]);
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -19,6 +19,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::StraddleStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -365,8 +366,11 @@ impl BreakEvenable for LongStraddle {
         let total_cost = self.get_total_cost()?;
 
         self.break_even_points.push(
-            (self.long_put.option.strike_price - (total_cost / self.long_put.option.quantity))
-                .round_to(2),
+            lower_break_even(
+                self.long_put.option.strike_price,
+                total_cost / self.long_put.option.quantity,
+            )
+            .round_to(2),
         );
 
         self.break_even_points.push(

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -19,6 +19,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::StrangleStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -380,8 +381,11 @@ impl BreakEvenable for LongStrangle {
         let total_premium = self.get_net_cost()?;
 
         self.break_even_points.push(
-            (self.long_put.option.strike_price - (total_premium / self.long_put.option.quantity))
-                .round_to(2),
+            lower_break_even(
+                self.long_put.option.strike_price,
+                total_premium / self.long_put.option.quantity,
+            )
+            .round_to(2),
         );
 
         self.break_even_points.push(

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -20,6 +20,7 @@ use super::base::{
 };
 use super::shared::StrangleStrategy;
 use crate::strategies::base::lower_break_even;
+use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -681,7 +682,9 @@ impl Strategies for LongStrangle {
             "First break even point: {} Last break even point: {}",
             first_option, last_option
         );
-        let start_price = first_option - diff.to_dec();
+        // No lower break-even puts `first_option` at zero, and the plot range
+        // cannot start below it.
+        let start_price = price_gap(first_option, diff);
         debug!("Start price: {}", start_price);
         let end_price = last_option + diff;
         debug!("End price: {}", end_price);

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -8,6 +8,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::ButterflyStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -377,8 +378,10 @@ impl BreakEvenable for ShortButterflySpread {
         }
 
         if right_net_value >= Decimal::ZERO {
-            self.break_even_points
-                .push((self.short_call_high.option.strike_price - right_net_value).round_to(2));
+            self.break_even_points.push(
+                lower_break_even(self.short_call_high.option.strike_price, right_net_value)
+                    .round_to(2),
+            );
         }
 
         self.break_even_points.sort();

--- a/src/strategies/short_call.rs
+++ b/src/strategies/short_call.rs
@@ -24,6 +24,7 @@ use crate::pricing::payoff::Profit;
 use crate::simulation::simulator::Simulator;
 use crate::simulation::{ExitPolicy, Simulate};
 use crate::strategies::base::Optimizable;
+use crate::strategies::base::price_gap;
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
@@ -301,7 +302,10 @@ impl Strategies for ShortCall {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = self.short_call.option.strike_price - self.break_even_points[0];
+        let base = price_gap(
+            self.short_call.option.strike_price,
+            self.break_even_points[0],
+        );
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {

--- a/src/strategies/short_put.rs
+++ b/src/strategies/short_put.rs
@@ -25,6 +25,7 @@ use crate::pricing::payoff::Profit;
 use crate::simulation::simulator::Simulator;
 use crate::simulation::{ExitPolicy, Simulate};
 use crate::strategies::base::Optimizable;
+use crate::strategies::base::price_gap;
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
@@ -303,7 +304,10 @@ impl Strategies for ShortPut {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = self.short_put.option.strike_price - self.break_even_points[0];
+        let base = price_gap(
+            self.short_put.option.strike_price,
+            self.break_even_points[0],
+        );
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -19,6 +19,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::StraddleStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -377,8 +378,10 @@ impl BreakEvenable for ShortStraddle {
         let total_premium = self.get_net_premium_received()?;
 
         self.break_even_points.push(
-            (self.short_put.option.strike_price
-                - (total_premium / self.short_put.option.quantity).to_dec())
+            lower_break_even(
+                self.short_put.option.strike_price,
+                total_premium / self.short_put.option.quantity,
+            )
             .round_to(2),
         );
 

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -21,6 +21,7 @@ use super::base::{
 };
 use super::shared::StrangleStrategy;
 use crate::strategies::base::lower_break_even;
+use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -740,7 +741,9 @@ impl Strategies for ShortStrangle {
     fn get_best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
         let max_profit = self.get_max_profit().unwrap_or(Positive::ZERO);
         let (first_option, last_option) = (self.break_even_points[0], self.break_even_points[1]);
-        let start_price = first_option - max_profit.to_dec();
+        // No lower break-even puts `first_option` at zero, and the plot range
+        // cannot start below it.
+        let start_price = price_gap(first_option, max_profit);
         let end_price = last_option + max_profit;
         Ok(calculate_price_range(start_price, end_price, step))
     }

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -20,6 +20,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::StrangleStrategy;
+use crate::strategies::base::lower_break_even;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -367,8 +368,10 @@ impl BreakEvenable for ShortStrangle {
         let total_premium = self.get_net_premium_received()?;
 
         self.break_even_points.push(
-            (self.short_put.option.strike_price
-                - (total_premium / self.short_put.option.quantity).to_dec())
+            lower_break_even(
+                self.short_put.option.strike_price,
+                total_premium / self.short_put.option.quantity,
+            )
             .round_to(2),
         );
 

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -6,3 +6,4 @@
 mod greeks_bounds_test;
 mod panic_freedom_test;
 mod put_call_parity_test;
+mod quote_invariants_test;

--- a/tests/property/quote_invariants_test.rs
+++ b/tests/property/quote_invariants_test.rs
@@ -1,0 +1,132 @@
+//! Property-based tests for the invariants of a widened quote
+//!
+//! `OptionData::apply_spread` widens a quote around its mid and floors both
+//! sides at one tick, where the tick is `10^-decimal_places`. Whatever the
+//! mid and the spread, three things must hold: the bid is at least a tick,
+//! the bid never crosses the ask, and a mid that was supplied survives the
+//! call. The first two are what a market maker's quote means; the third is
+//! information the caller gave us and that we have no business discarding.
+
+use optionstratlib::ExpirationDate;
+use optionstratlib::chains::OptionData;
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+/// A quote carrying only a mid, which is the shape `build_chain` produces
+/// before `apply_spread` runs.
+fn quote_with_mid(mid: Positive) -> OptionData {
+    let mut option_data = OptionData::new(
+        Positive::HUNDRED,
+        None,
+        None,
+        None,
+        None,
+        Positive::new(0.2).expect("literal is positive"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("TEST".to_string()),
+        Some(ExpirationDate::Days(
+            Positive::new(30.0).expect("literal is positive"),
+        )),
+        Some(Box::new(Positive::HUNDRED)),
+        Some(dec!(0.05)),
+        Some(Positive::new(0.02).expect("literal is positive")),
+        None,
+        None,
+    );
+    option_data.call_middle = Some(mid);
+    option_data.put_middle = Some(mid);
+    option_data
+}
+
+/// A two-sided book with no mid, which takes the other branch of the match.
+fn quote_with_book(bid: Positive, ask: Positive) -> OptionData {
+    let mut option_data = quote_with_mid(Positive::ONE);
+    option_data.call_middle = None;
+    option_data.put_middle = None;
+    option_data.call_bid = Some(bid);
+    option_data.call_ask = Some(ask);
+    option_data.put_bid = Some(bid);
+    option_data.put_ask = Some(ask);
+    option_data
+}
+
+fn tick(decimal_places: u32) -> Positive {
+    let tick = Decimal::try_new(1, decimal_places).expect("scale is within range");
+    Positive::new_decimal(tick).expect("a power of ten is positive")
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    /// A quote widened around a mid is ordered, floored at a tick, and keeps
+    /// its mid.
+    #[test]
+    fn test_widened_quote_is_ordered_floored_and_keeps_its_mid(
+        mid in 0.0f64..1_000_000.0,
+        spread in 0.0f64..1_000_000.0,
+        decimal_places in 0u32..=6,
+    ) {
+        let mid = Positive::new(mid).expect("range is non-negative");
+        let spread = Positive::new(spread).expect("range is non-negative");
+        let floor = tick(decimal_places);
+
+        let mut option_data = quote_with_mid(mid);
+        option_data.apply_spread(spread, decimal_places);
+
+        let call_bid = option_data.call_bid.expect("call bid is quoted");
+        let call_ask = option_data.call_ask.expect("call ask is quoted");
+        prop_assert!(call_bid >= floor, "bid {call_bid} below the tick {floor}");
+        prop_assert!(call_bid <= call_ask, "crossed quote {call_bid}/{call_ask}");
+
+        // The mid is never cleared, and never sits outside its own book: a row
+        // carrying a mid below its bid is incoherent on the wire.
+        let call_middle = option_data.call_middle.expect("mid was cleared");
+        prop_assert!(
+            call_middle >= call_bid && call_middle <= call_ask,
+            "mid {call_middle} outside the quote {call_bid}/{call_ask}"
+        );
+        // A mid already inside the widened quote is preserved exactly.
+        if mid >= call_bid && mid <= call_ask {
+            prop_assert_eq!(call_middle, mid, "mid inside the quote was moved");
+        }
+
+        let put_bid = option_data.put_bid.expect("put bid is quoted");
+        let put_ask = option_data.put_ask.expect("put ask is quoted");
+        prop_assert!(put_bid >= floor);
+        prop_assert!(put_bid <= put_ask);
+        let put_middle = option_data.put_middle.expect("mid was cleared");
+        prop_assert!(put_middle >= put_bid && put_middle <= put_ask);
+    }
+
+    /// The same invariants hold for a book that had no mid, whose mid is
+    /// recomputed from the widened sides.
+    #[test]
+    fn test_widened_book_is_ordered_and_floored(
+        bid in 0.0f64..1_000_000.0,
+        width in 0.0f64..1_000.0,
+        spread in 0.0f64..1_000_000.0,
+        decimal_places in 0u32..=6,
+    ) {
+        let bid_value = Positive::new(bid).expect("range is non-negative");
+        let ask_value = Positive::new(bid + width).expect("range is non-negative");
+        let spread = Positive::new(spread).expect("range is non-negative");
+        let floor = tick(decimal_places);
+
+        let mut option_data = quote_with_book(bid_value, ask_value);
+        option_data.apply_spread(spread, decimal_places);
+
+        let call_bid = option_data.call_bid.expect("call bid is quoted");
+        let call_ask = option_data.call_ask.expect("call ask is quoted");
+        prop_assert!(call_bid >= floor, "bid {call_bid} below the tick {floor}");
+        prop_assert!(call_bid <= call_ask, "crossed quote {call_bid}/{call_ask}");
+
+        let middle = option_data.call_middle.expect("mid is recomputed");
+        prop_assert!(middle >= call_bid && middle <= call_ask, "mid outside the quote");
+    }
+}

--- a/tests/unit/chain/mod.rs
+++ b/tests/unit/chain/mod.rs
@@ -13,3 +13,4 @@ mod random_walk_chain;
 mod risk_metrics_test;
 mod stress_metrics_test;
 mod temporal_metrics_test;
+mod wide_spread_chain_test;

--- a/tests/unit/chain/wide_spread_chain_test.rs
+++ b/tests/unit/chain/wide_spread_chain_test.rs
@@ -1,0 +1,100 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 28/8/26
+******************************************************************************/
+
+//! Verifies that a chain quoted with a spread wider than its cheap strikes'
+//! mids keeps those strikes.
+//!
+//! `apply_spread` used to withdraw a quote whose mid was below one full
+//! spread, clearing bid, ask and mid alike. `build_chain` stops generating
+//! strikes once both wings come back without prices, so a wide spread
+//! truncated the chain: the cheap out-of-the-money wings — the long legs of
+//! every defined-risk structure — disappeared exactly as they decayed.
+
+use optionstratlib::ExpirationDate;
+use optionstratlib::chains::OptionChain;
+use optionstratlib::chains::utils::{OptionChainBuildParams, OptionDataPriceParams};
+use positive::{Positive, pos_or_panic, spos};
+use rust_decimal_macros::dec;
+
+const CHAIN_SIZE: usize = 10;
+
+fn build_params(spread: Positive) -> OptionChainBuildParams {
+    let price_params = OptionDataPriceParams::new(
+        Some(Box::new(Positive::HUNDRED)),
+        Some(ExpirationDate::Days(pos_or_panic!(30.0))),
+        Some(dec!(0.05)),
+        spos!(0.02),
+        Some("TEST".to_string()),
+    );
+
+    OptionChainBuildParams::new(
+        "TEST".to_string(),
+        None,
+        CHAIN_SIZE,
+        spos!(5.0),
+        dec!(-0.2),
+        dec!(0.1),
+        spread,
+        2,
+        price_params,
+        pos_or_panic!(0.2),
+    )
+}
+
+fn build(spread: Positive) -> OptionChain {
+    match OptionChain::build_chain(&build_params(spread)) {
+        Ok(chain) => chain,
+        Err(e) => panic!("chain should build with a spread of {spread}: {e}"),
+    }
+}
+
+#[test]
+fn test_wide_spread_keeps_every_strike() {
+    let tight = build(pos_or_panic!(0.02));
+    let wide = build(pos_or_panic!(2.0));
+
+    // Absolute, not relative: `chain_size` is a per-side half-width, so a chain
+    // that keeps every strike holds the ATM plus `CHAIN_SIZE` on each side. A
+    // relative assertion would pass just as happily on two truncated chains.
+    assert_eq!(
+        tight.options.len(),
+        2 * CHAIN_SIZE + 1,
+        "a tightly quoted chain holds the full grid"
+    );
+    assert_eq!(
+        wide.options.len(),
+        2 * CHAIN_SIZE + 1,
+        "a spread wider than the cheap strikes' mids must not truncate the chain"
+    );
+}
+
+#[test]
+fn test_wide_spread_leaves_every_strike_quoted() {
+    let chain = build(pos_or_panic!(2.0));
+    let tick = pos_or_panic!(0.01);
+
+    for option_data in &chain.options {
+        let strike = option_data.strike_price;
+        let (Some(call_bid), Some(call_ask)) = (option_data.call_bid, option_data.call_ask) else {
+            panic!("strike {strike} lost its call quote");
+        };
+        let (Some(put_bid), Some(put_ask)) = (option_data.put_bid, option_data.put_ask) else {
+            panic!("strike {strike} lost its put quote");
+        };
+
+        assert!(call_bid >= tick, "call bid at strike {strike} below a tick");
+        assert!(
+            call_bid <= call_ask,
+            "crossed call quote at strike {strike}"
+        );
+        assert!(put_bid >= tick, "put bid at strike {strike} below a tick");
+        assert!(put_bid <= put_ask, "crossed put quote at strike {strike}");
+        assert!(
+            option_data.call_middle.is_some() && option_data.put_middle.is_some(),
+            "strike {strike} lost a mid it was given"
+        );
+    }
+}

--- a/tests/unit/strategies/mod.rs
+++ b/tests/unit/strategies/mod.rs
@@ -8,6 +8,7 @@ mod delta;
 mod graph_test;
 mod long_call_test;
 mod long_put_test;
+mod no_lower_break_even_test;
 mod optimal;
 mod optimal_center;
 mod protective_put_test;

--- a/tests/unit/strategies/no_lower_break_even_test.rs
+++ b/tests/unit/strategies/no_lower_break_even_test.rs
@@ -1,0 +1,123 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 28/8/26
+******************************************************************************/
+
+//! Verifies that a strategy with no lower break-even survives its own public API.
+//!
+//! When the credit taken in — or the debit paid, on a long structure — exceeds
+//! the put strike, the lower break-even sits at or below zero, where the
+//! underlying cannot trade. It is reported as `Positive::ZERO`. Every consumer
+//! of `break_even_points` has to treat that as "no lower break-even" rather
+//! than as an ordinary price, because subtracting a real strike from it, or a
+//! premium from it, is a `Positive` subtraction that would go negative.
+
+use optionstratlib::ExpirationDate;
+use optionstratlib::strategies::base::{BreakEvenable, Strategies};
+use optionstratlib::strategies::{BearPutSpread, LongStrangle, ShortStrangle};
+use positive::{Positive, pos_or_panic};
+use rust_decimal_macros::dec;
+
+#[test]
+fn test_bear_put_spread_profit_area_with_no_lower_break_even() {
+    // Debit far above the long strike: the lower break-even is floored to zero.
+    let strategy = BearPutSpread::new(
+        "TEST".to_string(),
+        pos_or_panic!(5.0),
+        pos_or_panic!(5.0),
+        pos_or_panic!(4.0),
+        ExpirationDate::Days(pos_or_panic!(30.0)),
+        pos_or_panic!(0.2),
+        dec!(0.05),
+        Positive::ZERO,
+        Positive::ONE,
+        pos_or_panic!(50.0),
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+    )
+    .expect("the spread constructs");
+
+    let break_even = strategy
+        .get_break_even_points()
+        .expect("break-even points are computed");
+    assert_eq!(break_even[0], Positive::ZERO, "no lower break-even");
+
+    // The public API must answer rather than abort.
+    assert!(strategy.get_profit_area().is_ok());
+    assert!(strategy.get_profit_ratio().is_ok());
+    assert!(strategy.get_best_range_to_show(Positive::ONE).is_ok());
+}
+
+#[test]
+fn test_long_strangle_range_with_no_lower_break_even() {
+    let strategy = LongStrangle::new(
+        "TEST".to_string(),
+        pos_or_panic!(5.0),
+        pos_or_panic!(6.0),
+        pos_or_panic!(5.0),
+        ExpirationDate::Days(pos_or_panic!(30.0)),
+        pos_or_panic!(0.2),
+        dec!(0.05),
+        Positive::ZERO,
+        Positive::ONE,
+        pos_or_panic!(3.0),
+        pos_or_panic!(3.0),
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+    )
+    .expect("the strangle constructs");
+
+    let break_even = strategy
+        .get_break_even_points()
+        .expect("break-even points are computed");
+    assert_eq!(break_even[0], Positive::ZERO, "no lower break-even");
+
+    let range = strategy
+        .get_best_range_to_show(Positive::ONE)
+        .expect("the range is computed");
+    assert!(
+        !range.is_empty(),
+        "a range with no lower break-even is still a range"
+    );
+    assert!(strategy.get_profit_area().is_ok());
+}
+
+#[test]
+fn test_short_strangle_range_with_no_lower_break_even() {
+    let strategy = ShortStrangle::new(
+        "TEST".to_string(),
+        pos_or_panic!(5.0),
+        pos_or_panic!(6.0),
+        pos_or_panic!(5.0),
+        ExpirationDate::Days(pos_or_panic!(30.0)),
+        pos_or_panic!(0.2),
+        pos_or_panic!(0.2),
+        dec!(0.05),
+        Positive::ZERO,
+        Positive::ONE,
+        pos_or_panic!(3.0),
+        pos_or_panic!(3.0),
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+        Positive::ZERO,
+    )
+    .expect("the strangle constructs");
+
+    let break_even = strategy
+        .get_break_even_points()
+        .expect("break-even points are computed");
+    assert_eq!(break_even[0], Positive::ZERO, "no lower break-even");
+
+    let range = strategy
+        .get_best_range_to_show(Positive::ONE)
+        .expect("the range is computed");
+    assert!(!range.is_empty());
+    assert!(strategy.get_profit_area().is_ok());
+}


### PR DESCRIPTION
## Summary

`OptionData::apply_spread` withdrew a quote instead of widening it: whenever a
contract's mid sat below one full spread it cleared `bid`, `ask` **and**
`middle`. That is not what a thin market is — a market maker does not stop
quoting a five-cent option, they quote it three at seven — and it is
load-bearing downstream, where positions are marked at the touch. Worse, since
`OptionChain::build_chain` stops generating strikes once both wings come back
unpriced, a wide spread also truncated the chain: with a spread of `2.0` a
21-strike chain came out with 3 strikes.

This widens and floors instead. The erasure threshold was also twice as
aggressive as the arithmetic below it required — it compared the mid against
the full spread while the quoting arm subtracted the half.

## Changes

- Both sides are quoted around the anchor and floored at one tick, where the
  tick is `10^-decimal_places`: `ask = max(round(mid + half), tick)` and
  `bid = clamp(round(mid - half), tick, ask)`. The ask is floored too, because
  an anchor small enough that `mid + half` rounds down to zero would otherwise
  produce a bid above the ask.
- `call_middle` / `put_middle` are never cleared when a mid was supplied. A mid
  that arrived is a mid; dropping it destroys information the caller gave us.
- The genuinely-empty case — no bid, no ask, no mid — still erases, and the doc
  comment states the difference between the two cases.
- The same widen-and-floor rule applies to the arm that had a two-sided book
  and no mid, so the invariants hold on both paths.
- Four module-private helpers (`tick_size`, `widen_around`, `widen_book`,
  `mid_of`) replace the call/put copy-paste.
- Panic safety on the lines being rewritten: the `Positive + Decimal` additions
  go through `checked_add_dec`, and `decimal_places` is clamped to
  `Decimal::MAX_SCALE` because `Positive::round_to` panics above it. On
  overflow the quote is left untouched with a `warn!` — `apply_spread` returns
  `()`, so turning it into a `Result` would be a public break.

- A supplied mid is held inside the widened quote instead of being left where
  it was: flooring the bid at a tick would otherwise leave a row whose mid sits
  below its own bid, and `OptionData` is the serialized wire type that feeds
  position premia. In the SP500 chain the 5250 put came out bid `0.01` against
  a mid of order `1e-30`. Clamping keeps the caller's mid wherever it is still
  inside the book, and still never clears it.
- Keeping the wings surfaced a latent panic one layer up:
  `ShortStraddle` / `ShortStrangle::update_break_even_points` computed the
  lower break-even as `strike - credit` with the raw `Positive - Decimal`
  operator, which panics when the credit exceeds the strike. The optimizer
  never built such a combination before because those strikes were being
  erased. The break-even is now floored at zero with the existing
  `sub_floor_zero`, which is where it belongs: the underlying cannot trade
  below zero, so the downside break-even does not exist. Six sibling strategies
  carried the identical expression — `IronCondor`, `IronButterfly`,
  `LongStraddle`, `LongStrangle`, `BearPutSpread`, `ShortButterflySpread`, and
  the iron structures are exactly the defined-risk ones with cheap long wings
  that #439 names — so all eight now share `lower_break_even` in
  `strategies/base.rs`. A lower break-even of `0.00` means the strategy has
  none, which is documented on both the helper and `BreakEvenable`.

## Technical decisions

The one judgement call in the issue is the bid floor for a contract whose mid
is below half a spread. The tick is derived from `decimal_places` rather than
added as a parameter: a two-decimal chain ticks at `0.01`, and the public
signature stays as it is, so `OptionChain::build_chain` and OptionChain-Simulator
keep compiling. The quote is then asymmetric around the mid — a tick bid
against a widened ask — which is exactly what a real thin market looks like.

## Known follow-up

`apply_spread` is applied more than once per row: `OptionData::calculate_prices`
applies it (once per side, and each call widens both sides) and
`build_chain` applies it again at `chain.rs:543`. That was invisible before
because the mid arm re-derives both sides from the stored mid, so repeated
application was idempotent as long as the mid never moved. Holding the mid
inside the quote makes a sub-tick row widen by one further tick on the second
pass — the deep wings settle at `0.01 / 0.02` instead of `0.01 / 0.01` — and
then it is stable. The quotes are coherent either way, but the pipeline should
apply the spread once; that belongs with the chains sweep (442c), not in a
behaviour fix.

`apply_spread` still returns `()`, so an arithmetic failure logs a warning and
leaves the quote untouched rather than surfacing a typed error. The reviewing
architect argued for `-> Result<(), ChainError>`: the error variant already
exists (`ChainError::PositiveError`), the only production caller sits inside a
function that already returns `Result<OptionData, ChainError>`, and it is
cheaper to break the signature at 0.20 than after 1.0. It is not done here
because the approved plan for this stack rules out public signature changes and
OptionChain-Simulator calls this method — that is a decision for the crate
owner, not for a bug fix. With the checked rounding and the mid clamp in place
the remaining failure mode is `checked_add_dec` within half a spread of
`Decimal::MAX`, which `build_chain` cannot reach. Carried into the chains sweep
(442c).

## Public API impact

No signature changes. The behaviour of `apply_spread` changes, which is what
the issue asks for, and the `CHANGELOG.md` entry under `[Unreleased]` records
that downstream row counts change.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Reference regression test added (for pricing / Greek changes) — not a
      pricing change
- [ ] Criterion benchmark added/updated (for perf changes)
- [x] `make pre-push` run locally and clean

New coverage:

- mid `0.06` against a spread of `0.10` is quoted, not erased: bid at the tick,
  ask above the mid.
- A supplied mid survives the call for every mid from `0.001` to `100`.
- A mid above the spread quotes exactly as before (`9.5 ± 0.3`), so the
  unchanged path is pinned.
- The tick follows `decimal_places` for 0, 1, 2 and 4 decimals.
- `tests/unit/chain/wide_spread_chain_test.rs`: a chain quoted with a spread
  wider than its cheap strikes' mids keeps the same strike count as a tightly
  quoted one, and every strike stays quoted and ordered. On the old code this
  fails 3 vs 7 — it is the regression the downstream consumers hit.
- `tests/property/quote_invariants_test.rs`: over mid × spread ×
  `decimal_places ∈ 0..=6`, `tick <= bid <= ask` and the mid is preserved, on
  both the mid-anchored and the book-anchored path.
- `test_sub_tick_corner_at_and_above_the_old_threshold` pins the boundary the
  issue's "unchanged above the spread" criterion cares about: `mid = 0.05`
  against `spread = 0.04` quotes exactly as before, and the sub-tick case is
  the deliberate deviation.
- Four unit tests on `lower_break_even`, including the credit-above-strike case
  that used to panic.
- The two existing tests that asserted `Some(Positive::ZERO)` for the erased
  case now assert the tick floor. That is the intended behaviour change.

Three existing tests encoded the truncation and were updated to the new
reality, each with a comment saying why:

- `chains::utils::tests_strike_step::long_discrepancy` asserted
  `len() - 1 == chain_size`; a chain that keeps every strike holds
  `2 * chain_size + 1` (57, not 29).
- `chains::chain::tests_chain_base::test_new_option_chain_build_chain_long`
  asserted `None` quotes on both wings; the chain is now 51 strikes with the
  wings quoted at the tick.
- The `short_straddle` / `short_strangle` `test_best_area` and
  `test_best_ratio` tests were panicking through the break-even fix above.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic only — no `saturating_*` / `wrapping_*` in financial math
- [x] `rust_decimal::Decimal` at public monetary boundaries — no `f64` on prices / premia / P&L
- [x] Module boundaries respected
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `README.tpl` updated if public surface changed — not applicable

## Stack

- Base branch: `440-eliminate-panics-greeks-pricing` (PR #441)
- Stacked on: #441
- Stack: #441 → **#439 (this)** → #442a → #442b → #442c → #442d → #442e

The diff shown against `main` is cumulative until #441 merges; review it
against the base branch. Merge bottom-up.

Closes #439
