### PR TITLE
Make the pricing exotics and numeric engines panic-free (#444)

### DIFF
--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -11,6 +11,7 @@ pub use option_type::{
 };
 
 use crate::constants::ZERO;
+use crate::model::decimal::finite_decimal;
 use crate::pricing::payoff::{Payoff, PayoffInfo, standard_payoff};
 use chrono::{DateTime, Utc};
 use positive::Positive;
@@ -60,15 +61,29 @@ impl Payoff for OptionType {
                 _ => standard_payoff(info),
             },
             OptionType::Compound { underlying_option } => underlying_option.payoff(info),
-            OptionType::Chooser { .. } => (info.spot - info.strike)
-                .max(Positive::ZERO)
-                .max(
-                    Positive::new_decimal(
-                        (info.strike.to_dec() - info.spot.to_dec()).max(Decimal::ZERO),
-                    )
-                    .unwrap_or(Positive::ZERO),
-                )
-                .to_f64(),
+            OptionType::Chooser { .. } => {
+                // The chooser is worth the better of the two intrinsics at
+                // expiry. `Positive - Positive` aborts whenever the result
+                // would be negative, i.e. for every out-of-the-money chooser,
+                // so both legs are formed on `Decimal` — where the difference
+                // of two values in `[0, Decimal::MAX]` is always
+                // representable — and floored at zero before the comparison.
+                let call_intrinsic = info
+                    .spot
+                    .to_dec()
+                    .checked_sub(info.strike.to_dec())
+                    .unwrap_or(Decimal::ZERO)
+                    .max(Decimal::ZERO);
+                let put_intrinsic = info
+                    .strike
+                    .to_dec()
+                    .checked_sub(info.spot.to_dec())
+                    .unwrap_or(Decimal::ZERO)
+                    .max(Decimal::ZERO);
+                Positive::new_decimal(call_intrinsic.max(put_intrinsic))
+                    .unwrap_or(Positive::ZERO)
+                    .to_f64()
+            }
             OptionType::Cliquet { .. } => standard_payoff(info),
             OptionType::Rainbow { .. }
             | OptionType::Spread { .. }
@@ -78,9 +93,28 @@ impl Payoff for OptionType {
                 OptionStyle::Call => {
                     (info.spot.to_f64().powf(exponent.to_f64()) - info.strike).max(ZERO)
                 }
-                OptionStyle::Put => (info.strike - info.spot.to_f64().powf(exponent.to_f64()))
-                    .max(Positive::ZERO)
-                    .to_f64(),
+                OptionStyle::Put => {
+                    // `Positive - f64` aborts whenever the result would be
+                    // negative, i.e. for every out-of-the-money power put, and
+                    // also when `S^n` has no `Decimal` representation. The
+                    // difference keeps the `Decimal` arithmetic the `Positive`
+                    // operator performed and is floored at zero; an `S^n` that
+                    // leaves the representable range is `+∞` in the limit,
+                    // where the put is worthless.
+                    let powered = info.spot.to_f64().powf(exponent.to_f64());
+                    match finite_decimal(powered) {
+                        Some(powered_dec) => Positive::new_decimal(
+                            info.strike
+                                .to_dec()
+                                .checked_sub(powered_dec)
+                                .unwrap_or(Decimal::ZERO)
+                                .max(Decimal::ZERO),
+                        )
+                        .unwrap_or(Positive::ZERO)
+                        .to_f64(),
+                        None => ZERO,
+                    }
+                }
             },
             // `OptionType` is `#[non_exhaustive]`: a variant added upstream falls
             // back to the plain intrinsic value until it gets its own arm.
@@ -447,6 +481,122 @@ mod tests_payoff {
             ..Default::default()
         };
         assert_eq!(option.payoff(&info), 10.0);
+    }
+
+    /// An out-of-the-money chooser used to abort with
+    /// `Positive invariant broken in sub: result would be non-positive`,
+    /// because `info.spot - info.strike` is a `Positive` subtraction. The
+    /// chooser keeps the better of the two intrinsics, so `S < K` is worth
+    /// `K - S`, never a panic.
+    #[test]
+    fn test_chooser_out_of_the_money_call_returns_put_intrinsic() {
+        let option = OptionType::Chooser {
+            choice_date: Positive::ONE,
+        };
+        let info = PayoffInfo {
+            spot: Positive::HUNDRED,
+            strike: pos_or_panic!(110.0),
+            style: OptionStyle::Call,
+            side: Side::Long,
+            ..Default::default()
+        };
+        assert_eq!(option.payoff(&info), 10.0);
+    }
+
+    #[test]
+    fn test_chooser_in_the_money_call_keeps_its_value() {
+        let option = OptionType::Chooser {
+            choice_date: Positive::ONE,
+        };
+        let info = PayoffInfo {
+            spot: pos_or_panic!(110.0),
+            strike: Positive::HUNDRED,
+            style: OptionStyle::Call,
+            side: Side::Long,
+            ..Default::default()
+        };
+        assert_eq!(option.payoff(&info), 10.0);
+    }
+
+    #[test]
+    fn test_chooser_at_the_money_is_zero() {
+        let option = OptionType::Chooser {
+            choice_date: Positive::ONE,
+        };
+        let info = PayoffInfo {
+            spot: Positive::HUNDRED,
+            strike: Positive::HUNDRED,
+            style: OptionStyle::Call,
+            side: Side::Long,
+            ..Default::default()
+        };
+        assert_eq!(option.payoff(&info), ZERO);
+    }
+
+    /// A power put with `S^n > K` used to abort with
+    /// `Positive invariant broken in sub_f64: result would be non-positive`.
+    /// `100² = 10000` is far above the strike, so the put is worthless.
+    #[test]
+    fn test_power_put_out_of_the_money_is_zero() {
+        let option = OptionType::Power {
+            exponent: pos_or_panic!(2.0),
+        };
+        let info = PayoffInfo {
+            spot: Positive::HUNDRED,
+            strike: pos_or_panic!(110.0),
+            style: OptionStyle::Put,
+            side: Side::Long,
+            ..Default::default()
+        };
+        assert_eq!(option.payoff(&info), ZERO);
+    }
+
+    #[test]
+    fn test_power_put_in_the_money_keeps_its_value() {
+        let option = OptionType::Power {
+            exponent: pos_or_panic!(2.0),
+        };
+        let info = PayoffInfo {
+            spot: pos_or_panic!(10.0),
+            strike: pos_or_panic!(110.0),
+            style: OptionStyle::Put,
+            side: Side::Long,
+            ..Default::default()
+        };
+        // 110 - 10² = 10
+        assert_eq!(option.payoff(&info), 10.0);
+    }
+
+    #[test]
+    fn test_power_put_at_the_money_is_zero() {
+        let option = OptionType::Power {
+            exponent: pos_or_panic!(2.0),
+        };
+        let info = PayoffInfo {
+            spot: pos_or_panic!(10.0),
+            strike: Positive::HUNDRED,
+            style: OptionStyle::Put,
+            side: Side::Long,
+            ..Default::default()
+        };
+        assert_eq!(option.payoff(&info), ZERO);
+    }
+
+    /// `S^n` beyond the `Decimal` range is `+∞` in the limit, where the put is
+    /// worthless. It used to abort inside the `Positive` conversion.
+    #[test]
+    fn test_power_put_unrepresentable_power_is_zero() {
+        let option = OptionType::Power {
+            exponent: Positive::MAX,
+        };
+        let info = PayoffInfo {
+            spot: Positive::HUNDRED,
+            strike: Positive::HUNDRED,
+            style: OptionStyle::Put,
+            side: Side::Long,
+            ..Default::default()
+        };
+        assert_eq!(option.payoff(&info), ZERO);
     }
 }
 

--- a/src/pricing/american.rs
+++ b/src/pricing/american.rs
@@ -45,7 +45,7 @@
 
 use crate::error::PricingError;
 use crate::greeks::big_n;
-use crate::model::decimal::{d_add, d_mul, d_sub};
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_powd, d_sqrt, d_sub};
 use crate::model::types::OptionStyle;
 use positive::Positive;
 use rust_decimal::{Decimal, MathematicalOps};
@@ -123,12 +123,13 @@ const TOLERANCE: f64 = 1e-6;
 ///
 /// # Errors
 ///
-/// Returns `PricingError::MethodError` (with method
-/// `barone_adesi_whaley`) when the intermediate Newton–Raphson
-/// iteration cannot converge on the early-exercise boundary
-/// `Sx`, and [`PricingError::SqrtFailure`] when the quadratic
-/// formula receives a negative discriminant from the approximation
-/// parameters.
+/// - [`PricingError::MethodError`] when the quadratic formula receives a
+///   negative discriminant, or when the internal `d1` rejects its inputs (a
+///   non-positive time, volatility, underlying or strike).
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range, or when a moneyness ratio underflows to
+///   zero: the BAW parameters `M`, `N`, `q1` / `q2`, the Newton-Raphson
+///   boundary iteration, or the early-exercise premium.
 pub fn barone_adesi_whaley(
     spot: Positive,
     strike: Positive,
@@ -162,8 +163,8 @@ pub fn barone_adesi_whaley(
         // Zero volatility: deterministic pricing
         let neg_rt = d_mul(-r, t, "pricing::american::zero_vol::rt")?;
         let neg_qt = d_mul(-q, t, "pricing::american::zero_vol::qt")?;
-        let discount_r = neg_rt.exp();
-        let discount_q = neg_qt.exp();
+        let discount_r = d_exp(neg_rt, "pricing::american::zero_vol::discount_r")?;
+        let discount_q = d_exp(neg_qt, "pricing::american::zero_vol::discount_q")?;
         let s_disc = d_mul(s, discount_q, "pricing::american::zero_vol::s_disc")?;
         let k_disc = d_mul(k, discount_r, "pricing::american::zero_vol::k_disc")?;
         return Ok(match option_style {
@@ -185,21 +186,68 @@ pub fn barone_adesi_whaley(
     }
 
     // Calculate BAW parameters
-    let sigma_sq = sigma * sigma;
-    let m = dec!(2) * r / sigma_sq;
-    let n = dec!(2) * (r - q) / sigma_sq;
-    let k_factor = dec!(1) - (-r * t).exp();
+    let sigma_sq = d_mul(sigma, sigma, "pricing::american::sigma_sq")?;
+    let m = d_div(
+        d_mul(dec!(2), r, "pricing::american::two_r")?,
+        sigma_sq,
+        "pricing::american::m",
+    )?;
+    let n = d_div(
+        d_mul(
+            dec!(2),
+            d_sub(r, q, "pricing::american::carry")?,
+            "pricing::american::two_carry",
+        )?,
+        sigma_sq,
+        "pricing::american::n",
+    )?;
+    let k_factor = d_sub(
+        dec!(1),
+        d_exp(
+            d_mul(-r, t, "pricing::american::neg_rt")?,
+            "pricing::american::discount",
+        )?,
+        "pricing::american::k_factor",
+    )?;
+
+    // `4M / K` with `K = 1 - e^(-rT)`. `K` is exactly zero at `r = 0` (and
+    // whenever `rT` rounds `e^(-rT)` back to one), where `M` is zero too. The
+    // limit of `4M / K = (8r/σ²) / (1 - e^(-rT))` as `rT → 0` is `8 / (σ² T)`,
+    // which is what the ratio is replaced by there.
+    let four_m_over_k = if k_factor.is_zero() {
+        d_div(
+            dec!(8),
+            d_mul(sigma_sq, t, "pricing::american::variance_time")?,
+            "pricing::american::four_m_over_k_limit",
+        )?
+    } else {
+        d_div(
+            d_mul(dec!(4), m, "pricing::american::four_m")?,
+            k_factor,
+            "pricing::american::four_m_over_k",
+        )?
+    };
+
+    let n_minus_one = d_sub(n, dec!(1), "pricing::american::n_minus_one")?;
+    let discriminant = d_add(
+        d_powd(n_minus_one, Decimal::TWO, "pricing::american::n_squared")?,
+        four_m_over_k,
+        "pricing::american::discriminant",
+    )?;
+    let sqrt_disc = discriminant.sqrt().ok_or_else(|| {
+        PricingError::method_error(
+            "baw",
+            "cannot calculate square root of negative discriminant",
+        )
+    })?;
 
     match option_style {
         OptionStyle::Call => {
-            let discriminant = (n - dec!(1)).powi(2) + dec!(4) * m / k_factor;
-            let sqrt_disc = discriminant.sqrt().ok_or_else(|| {
-                PricingError::method_error(
-                    "baw",
-                    "cannot calculate square root of negative discriminant",
-                )
-            })?;
-            let q2 = (-(n - dec!(1)) + sqrt_disc) / dec!(2);
+            let q2 = d_div(
+                d_add(-n_minus_one, sqrt_disc, "pricing::american::q2_numerator")?,
+                dec!(2),
+                "pricing::american::q2",
+            )?;
 
             // Find critical price S*
             let s_star = find_critical_price_call(s, k, t, r, q, sigma, q2)?;
@@ -212,8 +260,31 @@ pub fn barone_adesi_whaley(
                 // Early exercise premium
                 let d1_val = d1(s_star, k, t, r, q, sigma)?;
                 let n_d1 = big_n(d1_val)?;
-                let a2 = (s_star / q2) * (dec!(1) - (-q * t).exp() * n_d1);
-                let early_exercise_premium = a2 * (s / s_star).powd(q2);
+                let a2 = d_mul(
+                    d_div(s_star, q2, "pricing::american::call::a2_scale")?,
+                    d_sub(
+                        dec!(1),
+                        d_mul(
+                            d_exp(
+                                d_mul(-q, t, "pricing::american::call::neg_qt")?,
+                                "pricing::american::call::dividend_discount",
+                            )?,
+                            n_d1,
+                            "pricing::american::call::a2_weight",
+                        )?,
+                        "pricing::american::call::a2_bracket",
+                    )?,
+                    "pricing::american::call::a2",
+                )?;
+                let early_exercise_premium = d_mul(
+                    a2,
+                    d_powd(
+                        d_div(s, s_star, "pricing::american::call::moneyness")?,
+                        q2,
+                        "pricing::american::call::power",
+                    )?,
+                    "pricing::american::call::premium",
+                )?;
                 d_add(
                     european_price,
                     early_exercise_premium,
@@ -223,14 +294,11 @@ pub fn barone_adesi_whaley(
             }
         }
         OptionStyle::Put => {
-            let discriminant = (n - dec!(1)).powi(2) + dec!(4) * m / k_factor;
-            let sqrt_disc = discriminant.sqrt().ok_or_else(|| {
-                PricingError::method_error(
-                    "baw",
-                    "cannot calculate square root of negative discriminant",
-                )
-            })?;
-            let q1 = (-(n - dec!(1)) - sqrt_disc) / dec!(2);
+            let q1 = d_div(
+                d_sub(-n_minus_one, sqrt_disc, "pricing::american::q1_numerator")?,
+                dec!(2),
+                "pricing::american::q1",
+            )?;
 
             // Find critical price S**
             let s_star_star = find_critical_price_put(s, k, t, r, q, sigma, q1)?;
@@ -243,8 +311,31 @@ pub fn barone_adesi_whaley(
                 // Early exercise premium
                 let d1_val = d1(s_star_star, k, t, r, q, sigma)?;
                 let n_minus_d1 = big_n(-d1_val)?;
-                let a1 = -(s_star_star / q1) * (dec!(1) - (-q * t).exp() * n_minus_d1);
-                let early_exercise_premium = a1 * (s / s_star_star).powd(q1);
+                let a1 = d_mul(
+                    -d_div(s_star_star, q1, "pricing::american::put::a1_scale")?,
+                    d_sub(
+                        dec!(1),
+                        d_mul(
+                            d_exp(
+                                d_mul(-q, t, "pricing::american::put::neg_qt")?,
+                                "pricing::american::put::dividend_discount",
+                            )?,
+                            n_minus_d1,
+                            "pricing::american::put::a1_weight",
+                        )?,
+                        "pricing::american::put::a1_bracket",
+                    )?,
+                    "pricing::american::put::a1",
+                )?;
+                let early_exercise_premium = d_mul(
+                    a1,
+                    d_powd(
+                        d_div(s, s_star_star, "pricing::american::put::moneyness")?,
+                        q1,
+                        "pricing::american::put::power",
+                    )?,
+                    "pricing::american::put::premium",
+                )?;
                 d_add(
                     european_price,
                     early_exercise_premium,
@@ -269,22 +360,41 @@ fn black_scholes_european(
     option_style: &OptionStyle,
 ) -> Result<Decimal, PricingError> {
     let d1_val = d1(s, k, t, r, q, sigma)?;
-    let sqrt_t = t.sqrt().ok_or_else(|| {
-        PricingError::method_error("black_scholes", "cannot calculate square root of time")
-    })?;
-    let d2_val = d1_val - sigma * sqrt_t;
+    let sqrt_t = d_sqrt(t, "pricing::american::european::sqrt_t")?;
+    let d2_val = d_sub(
+        d1_val,
+        d_mul(sigma, sqrt_t, "pricing::american::european::sigma_sqrt_t")?,
+        "pricing::american::european::d2",
+    )?;
 
-    let discount = (-r * t).exp();
-    let forward_factor = (-q * t).exp();
+    let discount = d_exp(
+        d_mul(-r, t, "pricing::american::european::neg_rt")?,
+        "pricing::american::european::discount",
+    )?;
+    let forward_factor = d_exp(
+        d_mul(-q, t, "pricing::american::european::neg_qt")?,
+        "pricing::american::european::forward_factor",
+    )?;
 
     let n_d1 = big_n(d1_val)?;
     let n_d2 = big_n(d2_val)?;
     let n_minus_d1 = big_n(-d1_val)?;
     let n_minus_d2 = big_n(-d2_val)?;
 
+    let s_pv = d_mul(s, forward_factor, "pricing::american::european::s_pv")?;
+    let k_pv = d_mul(k, discount, "pricing::american::european::k_pv")?;
+
     match option_style {
-        OptionStyle::Call => Ok(s * forward_factor * n_d1 - k * discount * n_d2),
-        OptionStyle::Put => Ok(k * discount * n_minus_d2 - s * forward_factor * n_minus_d1),
+        OptionStyle::Call => Ok(d_sub(
+            d_mul(s_pv, n_d1, "pricing::american::european::call::spot")?,
+            d_mul(k_pv, n_d2, "pricing::american::european::call::strike")?,
+            "pricing::american::european::call",
+        )?),
+        OptionStyle::Put => Ok(d_sub(
+            d_mul(k_pv, n_minus_d2, "pricing::american::european::put::strike")?,
+            d_mul(s_pv, n_minus_d1, "pricing::american::european::put::spot")?,
+            "pricing::american::european::put",
+        )?),
     }
 }
 
@@ -303,11 +413,40 @@ fn d1(
             "time and volatility must be positive",
         ));
     }
-    let sqrt_t = t
-        .sqrt()
-        .ok_or_else(|| PricingError::method_error("d1", "cannot calculate square root of time"))?;
-    let ln_s_k = (s / k).ln();
-    Ok((ln_s_k + (r - q + sigma * sigma / dec!(2)) * t) / (sigma * sqrt_t))
+    // `ln(S / K)` is undefined for a zero underlying or a zero strike, so both
+    // are rejected before the ratio is formed.
+    if s <= Decimal::ZERO || k <= Decimal::ZERO {
+        return Err(PricingError::method_error(
+            "d1",
+            "underlying price and strike must be positive",
+        ));
+    }
+    let sqrt_t = d_sqrt(t, "pricing::american::d1::sqrt_t")?;
+    let ln_s_k = d_ln(
+        d_div(s, k, "pricing::american::d1::moneyness")?,
+        "pricing::american::d1::log_moneyness",
+    )?;
+    Ok(d_div(
+        d_add(
+            ln_s_k,
+            d_mul(
+                d_add(
+                    d_sub(r, q, "pricing::american::d1::carry")?,
+                    d_div(
+                        d_mul(sigma, sigma, "pricing::american::d1::variance")?,
+                        dec!(2),
+                        "pricing::american::d1::half_variance",
+                    )?,
+                    "pricing::american::d1::drift_rate",
+                )?,
+                t,
+                "pricing::american::d1::drift",
+            )?,
+            "pricing::american::d1::numerator",
+        )?,
+        d_mul(sigma, sqrt_t, "pricing::american::d1::denominator")?,
+        "pricing::american::d1",
+    )?)
 }
 
 /// Finds the critical price S* for American calls using Newton-Raphson.
@@ -323,41 +462,78 @@ fn find_critical_price_call(
     q2: Decimal,
 ) -> Result<Decimal, PricingError> {
     // Initial guess: use strike as starting point
-    let mut s_star = strike * dec!(1.1);
+    let mut s_star = d_mul(strike, dec!(1.1), "pricing::american::call::s_star_seed")?;
+    let exp_qt = d_exp(
+        d_mul(-q, t, "pricing::american::call::neg_qt_seed")?,
+        "pricing::american::call::dividend_discount_seed",
+    )?;
+    let tolerance = Decimal::from_f64_retain(TOLERANCE).unwrap_or(dec!(1e-6));
+
+    // `C_euro(S) + (S / q2)(1 - e^(-qT) N(d1(S)))`: the right-hand side of the
+    // BAW boundary condition, evaluated at `S` and at the bumped `S + ΔS`.
+    let boundary_rhs = |spot: Decimal| -> Result<Decimal, PricingError> {
+        let d1_val = d1(spot, strike, t, r, q, sigma)?;
+        let n_d1 = big_n(d1_val)?;
+        let c_euro = black_scholes_european(spot, strike, t, r, q, sigma, &OptionStyle::Call)?;
+        Ok(d_add(
+            c_euro,
+            d_mul(
+                d_div(spot, q2, "pricing::american::call::boundary_scale")?,
+                d_sub(
+                    dec!(1),
+                    d_mul(exp_qt, n_d1, "pricing::american::call::boundary_weight")?,
+                    "pricing::american::call::boundary_bracket",
+                )?,
+                "pricing::american::call::boundary_premium",
+            )?,
+            "pricing::american::call::boundary_rhs",
+        )?)
+    };
 
     for _ in 0..MAX_ITERATIONS {
-        let d1_val = d1(s_star, strike, t, r, q, sigma)?;
-        let n_d1 = big_n(d1_val)?;
-        let exp_qt = (-q * t).exp();
-
         // Function: f(S*) = S* - K - C_european(S*) - (S*/q2)(1 - e^(-qT) * N(d1))
-        let c_euro = black_scholes_european(s_star, strike, t, r, q, sigma, &OptionStyle::Call)?;
-        let lhs = s_star - strike;
-        let rhs = c_euro + (s_star / q2) * (dec!(1) - exp_qt * n_d1);
-        let f = lhs - rhs;
+        let f = d_sub(
+            d_sub(s_star, strike, "pricing::american::call::lhs")?,
+            boundary_rhs(s_star)?,
+            "pricing::american::call::f",
+        )?;
 
         // Derivative approximation
-        let delta_s = s_star * dec!(0.0001);
-        let d1_plus = d1(s_star + delta_s, strike, t, r, q, sigma)?;
-        let n_d1_plus = big_n(d1_plus)?;
-        let c_euro_plus =
-            black_scholes_european(s_star + delta_s, strike, t, r, q, sigma, &OptionStyle::Call)?;
-        let rhs_plus = c_euro_plus + ((s_star + delta_s) / q2) * (dec!(1) - exp_qt * n_d1_plus);
-        let f_plus = (s_star + delta_s) - strike - rhs_plus;
+        let delta_s = d_mul(s_star, dec!(0.0001), "pricing::american::call::delta_s")?;
+        if delta_s.is_zero() {
+            // The bump underflowed below the representable scale, so no
+            // derivative is available: fall back to the current estimate.
+            break;
+        }
+        let bumped = d_add(s_star, delta_s, "pricing::american::call::bumped")?;
+        let f_plus = d_sub(
+            d_sub(bumped, strike, "pricing::american::call::lhs_plus")?,
+            boundary_rhs(bumped)?,
+            "pricing::american::call::f_plus",
+        )?;
 
-        let f_prime: Decimal = (f_plus - f) / delta_s;
+        let f_prime: Decimal = d_div(
+            d_sub(f_plus, f, "pricing::american::call::df")?,
+            delta_s,
+            "pricing::american::call::f_prime",
+        )?;
 
         if f_prime.abs() < dec!(1e-10) {
             break;
         }
 
-        let s_star_new = s_star - f / f_prime;
+        let s_star_new = d_sub(
+            s_star,
+            d_div(f, f_prime, "pricing::american::call::newton_step")?,
+            "pricing::american::call::s_star_new",
+        )?;
 
-        if (s_star_new - s_star).abs() < Decimal::from_f64_retain(TOLERANCE).unwrap_or(dec!(1e-6)) {
+        if d_sub(s_star_new, s_star, "pricing::american::call::convergence")?.abs() < tolerance {
             return Ok(s_star_new.max(strike)); // S* must be >= K for calls
         }
 
-        s_star = s_star_new.max(strike * dec!(0.5)); // Keep S* reasonable
+        // Keep S* reasonable
+        s_star = s_star_new.max(d_mul(strike, dec!(0.5), "pricing::american::call::floor")?);
     }
 
     // Return best estimate
@@ -377,43 +553,82 @@ fn find_critical_price_put(
     q1: Decimal,
 ) -> Result<Decimal, PricingError> {
     // Initial guess: use strike as starting point
-    let mut s_star = strike * dec!(0.9);
+    let mut s_star = d_mul(strike, dec!(0.9), "pricing::american::put::s_star_seed")?;
+    let exp_qt = d_exp(
+        d_mul(-q, t, "pricing::american::put::neg_qt_seed")?,
+        "pricing::american::put::dividend_discount_seed",
+    )?;
+    let tolerance = Decimal::from_f64_retain(TOLERANCE).unwrap_or(dec!(1e-6));
+
+    // `P_euro(S) - (S / q1)(1 - e^(-qT) N(-d1(S)))`: the right-hand side of the
+    // BAW boundary condition, evaluated at `S` and at the bumped `S + ΔS`.
+    let boundary_rhs = |spot: Decimal| -> Result<Decimal, PricingError> {
+        let d1_val = d1(spot, strike, t, r, q, sigma)?;
+        let n_minus_d1 = big_n(-d1_val)?;
+        let p_euro = black_scholes_european(spot, strike, t, r, q, sigma, &OptionStyle::Put)?;
+        Ok(d_sub(
+            p_euro,
+            d_mul(
+                d_div(spot, q1, "pricing::american::put::boundary_scale")?,
+                d_sub(
+                    dec!(1),
+                    d_mul(
+                        exp_qt,
+                        n_minus_d1,
+                        "pricing::american::put::boundary_weight",
+                    )?,
+                    "pricing::american::put::boundary_bracket",
+                )?,
+                "pricing::american::put::boundary_premium",
+            )?,
+            "pricing::american::put::boundary_rhs",
+        )?)
+    };
 
     for _ in 0..MAX_ITERATIONS {
-        let d1_val = d1(s_star, strike, t, r, q, sigma)?;
-        let n_minus_d1 = big_n(-d1_val)?;
-        let exp_qt = (-q * t).exp();
-
         // Function: f(S**) = K - S** - P_european(S**) + (S**/q1)(1 - e^(-qT) * N(-d1))
-        let p_euro = black_scholes_european(s_star, strike, t, r, q, sigma, &OptionStyle::Put)?;
-        let lhs = strike - s_star;
-        let rhs = p_euro - (s_star / q1) * (dec!(1) - exp_qt * n_minus_d1);
-        let f = lhs - rhs;
+        let f = d_sub(
+            d_sub(strike, s_star, "pricing::american::put::lhs")?,
+            boundary_rhs(s_star)?,
+            "pricing::american::put::f",
+        )?;
 
         // Derivative approximation
-        let delta_s = s_star * dec!(0.0001);
-        let delta_s = delta_s.max(dec!(0.01)); // Ensure minimum step
-        let d1_plus = d1(s_star + delta_s, strike, t, r, q, sigma)?;
-        let n_minus_d1_plus = big_n(-d1_plus)?;
-        let p_euro_plus =
-            black_scholes_european(s_star + delta_s, strike, t, r, q, sigma, &OptionStyle::Put)?;
-        let rhs_plus =
-            p_euro_plus - ((s_star + delta_s) / q1) * (dec!(1) - exp_qt * n_minus_d1_plus);
-        let f_plus = strike - (s_star + delta_s) - rhs_plus;
+        let delta_s =
+            d_mul(s_star, dec!(0.0001), "pricing::american::put::delta_s")?.max(dec!(0.01)); // Ensure minimum step
+        let bumped = d_add(s_star, delta_s, "pricing::american::put::bumped")?;
+        let f_plus = d_sub(
+            d_sub(strike, bumped, "pricing::american::put::lhs_plus")?,
+            boundary_rhs(bumped)?,
+            "pricing::american::put::f_plus",
+        )?;
 
-        let f_prime: Decimal = (f_plus - f) / delta_s;
+        let f_prime: Decimal = d_div(
+            d_sub(f_plus, f, "pricing::american::put::df")?,
+            delta_s,
+            "pricing::american::put::f_prime",
+        )?;
 
         if f_prime.abs() < dec!(1e-10) {
             break;
         }
 
-        let s_star_new = s_star - f / f_prime;
+        let s_star_new = d_sub(
+            s_star,
+            d_div(f, f_prime, "pricing::american::put::newton_step")?,
+            "pricing::american::put::s_star_new",
+        )?;
 
-        if (s_star_new - s_star).abs() < Decimal::from_f64_retain(TOLERANCE).unwrap_or(dec!(1e-6)) {
+        if d_sub(s_star_new, s_star, "pricing::american::put::convergence")?.abs() < tolerance {
             return Ok(s_star_new.max(dec!(0.01)).min(strike)); // 0 < S** <= K for puts
         }
 
-        s_star = s_star_new.max(dec!(0.01)).min(strike * dec!(1.5)); // Keep S** reasonable
+        // Keep S** reasonable
+        s_star = s_star_new.max(dec!(0.01)).min(d_mul(
+            strike,
+            dec!(1.5),
+            "pricing::american::put::ceiling",
+        )?);
     }
 
     // Return best estimate

--- a/src/pricing/asian.rs
+++ b/src/pricing/asian.rs
@@ -25,6 +25,7 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::{big_n, d1, d2};
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_powd, d_sqrt, d_sub};
 use crate::model::types::{AsianAveragingType, OptionStyle, OptionType};
 use positive::Positive;
 use rust_decimal::Decimal;
@@ -43,9 +44,16 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns `PricingError` if:
-/// - The option type is not Asian
-/// - Required parameters are invalid (zero volatility, etc.)
+/// - [`PricingError::MethodError`] when the option type is not
+///   `OptionType::Asian`, when the averaging type is an unsupported
+///   `#[non_exhaustive]` variant, or when the expiration cannot be converted
+///   to a year fraction.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range: the discount factor, the forward, either
+///   Turnbull-Wakeman moment, the moment-matched variance, or the final
+///   Black legs.
+/// - [`PricingError::Positive`] when the `σ / √3` geometric adjustment is not
+///   representable as a `Positive`.
 pub fn asian_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
         OptionType::Asian { averaging_type } => match averaging_type {
@@ -84,26 +92,64 @@ fn geometric_asian_price(option: &Options) -> Result<Decimal, PricingError> {
         .map_err(|e| PricingError::other(&e.to_string()))?;
 
     if t == Positive::ZERO {
-        return Ok(intrinsic_value(option));
+        return intrinsic_value(option);
     }
 
     if sigma == Positive::ZERO {
-        // Deterministic case
-        let discount = (-r * t).exp();
-        let forward = s * ((r - q) * t).exp();
+        // Deterministic case: the average of a driftless-variance path is the
+        // forward itself, so the option collapses to a discounted intrinsic.
+        let t_dec = t.to_dec();
+        let discount = d_exp(
+            d_mul(-r, t_dec, "pricing::asian::geometric::det::neg_rt")?,
+            "pricing::asian::geometric::det::discount",
+        )?;
+        let carry = d_sub(r, q, "pricing::asian::geometric::det::carry")?;
+        let forward = d_mul(
+            s.to_dec(),
+            d_exp(
+                d_mul(carry, t_dec, "pricing::asian::geometric::det::carry_t")?,
+                "pricing::asian::geometric::det::growth",
+            )?,
+            "pricing::asian::geometric::det::forward",
+        )?;
         let intrinsic = match option.option_style {
-            OptionStyle::Call => (forward - k).max(Positive::ZERO).to_dec(),
-            OptionStyle::Put => (k - forward).max(Positive::ZERO).to_dec(),
+            OptionStyle::Call => {
+                d_sub(forward, k.to_dec(), "pricing::asian::geometric::det::call")?
+                    .max(Decimal::ZERO)
+            }
+            OptionStyle::Put => d_sub(k.to_dec(), forward, "pricing::asian::geometric::det::put")?
+                .max(Decimal::ZERO),
         };
-        return Ok(apply_side(intrinsic * discount, option));
+        let price = d_mul(intrinsic, discount, "pricing::asian::geometric::det::price")?;
+        return Ok(apply_side(price, option));
     }
 
     // Geometric average adjustments (Kemna-Vorst)
-    let sigma_sq = sigma * sigma;
+    let sigma_sq = d_mul(
+        sigma.to_dec(),
+        sigma.to_dec(),
+        "pricing::asian::geometric::sigma_sq",
+    )?;
     let sqrt_three = Positive::new(3.0_f64.sqrt())
         .map_err(|e| PricingError::method_error("geometric_asian_price", &e.to_string()))?;
-    let sigma_adj = sigma / sqrt_three;
-    let b_adj = (r - q - sigma_sq / dec!(6)) / dec!(2);
+    let sigma_adj = Positive::new_decimal(d_div(
+        sigma.to_dec(),
+        sqrt_three.to_dec(),
+        "pricing::asian::geometric::sigma_adj",
+    )?)?;
+    let b_adj = d_div(
+        d_sub(
+            d_sub(r, q, "pricing::asian::geometric::carry")?,
+            d_div(
+                sigma_sq,
+                dec!(6),
+                "pricing::asian::geometric::variance_drag",
+            )?,
+            "pricing::asian::geometric::b_numerator",
+        )?,
+        dec!(2),
+        "pricing::asian::geometric::b_adj",
+    )?;
 
     // Calculate d1 and d2 with adjusted parameters
     let d1_val = d1(s, k, b_adj, t, sigma_adj)
@@ -111,18 +157,49 @@ fn geometric_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     let d2_val = d2(s, k, b_adj, t, sigma_adj)
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
 
-    let discount = (-r * t).exp();
+    let t_dec = t.to_dec();
+    let discount = d_exp(
+        d_mul(-r, t_dec, "pricing::asian::geometric::neg_rt")?,
+        "pricing::asian::geometric::discount",
+    )?;
+    // e^((b_adj - r) T): the geometric-average carry replaces the spot drift.
+    let carry_discount = d_exp(
+        d_mul(
+            d_sub(b_adj, r, "pricing::asian::geometric::carry_spread")?,
+            t_dec,
+            "pricing::asian::geometric::carry_spread_t",
+        )?,
+        "pricing::asian::geometric::carry_discount",
+    )?;
+    let s_leg = d_mul(
+        s.to_dec(),
+        carry_discount,
+        "pricing::asian::geometric::spot_leg",
+    )?;
+    let k_leg = d_mul(
+        k.to_dec(),
+        discount,
+        "pricing::asian::geometric::strike_leg",
+    )?;
 
     let price = match option.option_style {
         OptionStyle::Call => {
             let n_d1 = big_n(d1_val).unwrap_or(Decimal::ZERO);
             let n_d2 = big_n(d2_val).unwrap_or(Decimal::ZERO);
-            s.to_dec() * ((b_adj - r) * t).exp() * n_d1 - k.to_dec() * discount * n_d2
+            d_sub(
+                d_mul(s_leg, n_d1, "pricing::asian::geometric::call::spot")?,
+                d_mul(k_leg, n_d2, "pricing::asian::geometric::call::strike")?,
+                "pricing::asian::geometric::call",
+            )?
         }
         OptionStyle::Put => {
             let n_neg_d1 = big_n(-d1_val).unwrap_or(Decimal::ZERO);
             let n_neg_d2 = big_n(-d2_val).unwrap_or(Decimal::ZERO);
-            k.to_dec() * discount * n_neg_d2 - s.to_dec() * ((b_adj - r) * t).exp() * n_neg_d1
+            d_sub(
+                d_mul(k_leg, n_neg_d2, "pricing::asian::geometric::put::strike")?,
+                d_mul(s_leg, n_neg_d1, "pricing::asian::geometric::put::spot")?,
+                "pricing::asian::geometric::put",
+            )?
         }
     };
 
@@ -147,94 +224,255 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
         .map_err(|e| PricingError::other(&e.to_string()))?;
 
     if t == Positive::ZERO {
-        return Ok(intrinsic_value(option));
+        return intrinsic_value(option);
     }
 
+    let t_dec = t.to_dec();
+    let discount = d_exp(
+        d_mul(-r, t_dec, "pricing::asian::arithmetic::neg_rt")?,
+        "pricing::asian::arithmetic::discount",
+    )?;
+
     if sigma == Positive::ZERO {
-        let discount = (-r * t).exp();
-        let forward = s * ((r - q) * t).exp();
-        let intrinsic = match option.option_style {
-            OptionStyle::Call => (forward - k).max(Positive::ZERO).to_dec(),
-            OptionStyle::Put => (k - forward).max(Positive::ZERO).to_dec(),
-        };
-        return Ok(apply_side(intrinsic * discount, option));
+        let carry = d_sub(r, q, "pricing::asian::arithmetic::det::carry")?;
+        let forward = d_mul(
+            s.to_dec(),
+            d_exp(
+                d_mul(carry, t_dec, "pricing::asian::arithmetic::det::carry_t")?,
+                "pricing::asian::arithmetic::det::growth",
+            )?,
+            "pricing::asian::arithmetic::det::forward",
+        )?;
+        return deterministic_price(forward, k.to_dec(), discount, option);
     }
 
     // Turnbull-Wakeman approximation
-    let b = r - q; // cost of carry
-    let sigma_sq = sigma * sigma;
-    let t_dec = t.to_dec();
+    let b = d_sub(r, q, "pricing::asian::arithmetic::carry")?; // cost of carry
+    let sigma_dec = sigma.to_dec();
+    let sigma_sq = d_mul(sigma_dec, sigma_dec, "pricing::asian::arithmetic::sigma_sq")?;
+    let s_dec = s.to_dec();
+    let s_sq = d_powd(s_dec, Decimal::TWO, "pricing::asian::arithmetic::s_sq")?;
+    let t_sq = d_powd(t_dec, Decimal::TWO, "pricing::asian::arithmetic::t_sq")?;
+    let bt = d_mul(b, t_dec, "pricing::asian::arithmetic::bt")?;
+    let two_b_plus_var = d_add(
+        d_mul(dec!(2), b, "pricing::asian::arithmetic::two_b")?,
+        sigma_sq,
+        "pricing::asian::arithmetic::two_b_plus_var",
+    )?;
+    let b_plus_var = d_add(b, sigma_sq, "pricing::asian::arithmetic::b_plus_var")?;
 
     // First moment of arithmetic average (M1)
     let m1 = if b.abs() < dec!(1e-10) {
-        s.to_dec()
+        s_dec
     } else {
-        s.to_dec() * (((b * t).exp() - dec!(1)) / (b * t_dec))
+        d_mul(
+            s_dec,
+            d_div(
+                d_sub(
+                    d_exp(bt, "pricing::asian::arithmetic::m1::exp_bt")?,
+                    dec!(1),
+                    "pricing::asian::arithmetic::m1::numerator",
+                )?,
+                bt,
+                "pricing::asian::arithmetic::m1::ratio",
+            )?,
+            "pricing::asian::arithmetic::m1",
+        )?
     };
 
     // Second moment of arithmetic average (M2)
     let m2 = if b.abs() < dec!(1e-10) {
-        let term = (sigma_sq * t_dec).exp();
-        s.to_dec().powi(2) * term
+        let term = d_exp(
+            d_mul(sigma_sq, t_dec, "pricing::asian::arithmetic::m2::var_t")?,
+            "pricing::asian::arithmetic::m2::exp_var_t",
+        )?;
+        d_mul(s_sq, term, "pricing::asian::arithmetic::m2::driftless")?
     } else {
-        let term1_exp = ((dec!(2) * b + sigma_sq) * t_dec).exp();
-        let term1 = (dec!(2) * s.to_dec().powi(2) * term1_exp)
-            / ((b + sigma_sq) * (dec!(2) * b + sigma_sq) * t_dec.powi(2));
+        let term1_exp = d_exp(
+            d_mul(
+                two_b_plus_var,
+                t_dec,
+                "pricing::asian::arithmetic::m2::term1_exponent",
+            )?,
+            "pricing::asian::arithmetic::m2::term1_exp",
+        )?;
+        let term1 = d_div(
+            d_mul(
+                d_mul(dec!(2), s_sq, "pricing::asian::arithmetic::m2::two_s_sq")?,
+                term1_exp,
+                "pricing::asian::arithmetic::m2::term1_numerator",
+            )?,
+            d_mul(
+                d_mul(
+                    b_plus_var,
+                    two_b_plus_var,
+                    "pricing::asian::arithmetic::m2::term1_roots",
+                )?,
+                t_sq,
+                "pricing::asian::arithmetic::m2::term1_denominator",
+            )?,
+            "pricing::asian::arithmetic::m2::term1",
+        )?;
 
-        let term2 = (dec!(2) * s.to_dec().powi(2)) / (b * t_dec.powi(2))
-            * (dec!(1) / (dec!(2) * b + sigma_sq) - (b * t_dec).exp() / (b + sigma_sq));
+        let term2 = d_mul(
+            d_div(
+                d_mul(dec!(2), s_sq, "pricing::asian::arithmetic::m2::two_s_sq2")?,
+                d_mul(b, t_sq, "pricing::asian::arithmetic::m2::b_t_sq")?,
+                "pricing::asian::arithmetic::m2::term2_scale",
+            )?,
+            d_sub(
+                d_div(
+                    dec!(1),
+                    two_b_plus_var,
+                    "pricing::asian::arithmetic::m2::term2_first",
+                )?,
+                d_div(
+                    d_exp(bt, "pricing::asian::arithmetic::m2::exp_bt")?,
+                    b_plus_var,
+                    "pricing::asian::arithmetic::m2::term2_second",
+                )?,
+                "pricing::asian::arithmetic::m2::term2_bracket",
+            )?,
+            "pricing::asian::arithmetic::m2::term2",
+        )?;
 
-        term1 + term2
+        d_add(term1, term2, "pricing::asian::arithmetic::m2")?
     };
-
-    // Adjusted volatility from moment matching
-    let variance = (m2 / m1.powi(2)).ln() / t_dec;
-    let sigma_adj = variance.sqrt().unwrap_or(sigma.to_dec());
-    let floor_pos = Positive::new(0.0001)
-        .map_err(|e| PricingError::method_error("arithmetic_asian_price", &e.to_string()))?;
-    let sigma_adj_pos = Positive::new_decimal(sigma_adj.max(dec!(0.0001))).unwrap_or(floor_pos);
 
     // Forward price of the average
     let f_adj = m1;
 
-    // Use Black-Scholes with adjusted parameters
-    let sqrt_t = t_dec.sqrt().ok_or_else(|| {
-        PricingError::method_error("arithmetic_asian_price", "non-finite sqrt(t)")
-    })?;
-    let d1_val =
-        ((f_adj / k).ln() + sigma_adj * sigma_adj * t_dec / dec!(2)) / (sigma_adj * sqrt_t);
-    let d2_val = d1_val - sigma_adj * sqrt_t;
+    // A non-positive first moment leaves the moment matching undefined: the
+    // average is known to be `f_adj`, so the option is worth its discounted
+    // intrinsic (the σ → 0 limit of the Black formula below).
+    if f_adj <= Decimal::ZERO {
+        return deterministic_price(f_adj, k.to_dec(), discount, option);
+    }
 
-    let discount = (-r * t).exp();
+    // Adjusted volatility from moment matching
+    let m1_sq = d_powd(m1, Decimal::TWO, "pricing::asian::arithmetic::m1_sq")?;
+    let moment_ratio = d_div(m2, m1_sq, "pricing::asian::arithmetic::moment_ratio")?;
+    let variance = if moment_ratio > Decimal::ZERO {
+        d_div(
+            d_ln(moment_ratio, "pricing::asian::arithmetic::log_moment_ratio")?,
+            t_dec,
+            "pricing::asian::arithmetic::variance",
+        )?
+    } else {
+        // `M2 / M1²` collapsed below the representable scale: the matched
+        // lognormal has no spread left, which the `sqrt` fallback below maps
+        // back onto the input volatility.
+        Decimal::ZERO
+    };
+    let sigma_adj = variance.sqrt().unwrap_or(sigma_dec);
+
+    // Use Black-Scholes with adjusted parameters
+    let sqrt_t = d_sqrt(t_dec, "pricing::asian::arithmetic::sqrt_t")?;
+    let denominator = d_mul(sigma_adj, sqrt_t, "pricing::asian::arithmetic::denominator")?;
+    if denominator.is_zero() {
+        // Zero matched volatility (or zero maturity in the limit): the average
+        // is deterministic and the price is the discounted intrinsic.
+        return deterministic_price(f_adj, k.to_dec(), discount, option);
+    }
+
+    let moneyness = d_div(f_adj, k.to_dec(), "pricing::asian::arithmetic::moneyness")?;
+    let log_moneyness = if moneyness.is_zero() {
+        // `F / K` rounded below the smallest representable `Decimal`, so the
+        // logarithm diverges; `Decimal::MIN` is the representable stand-in and
+        // drives `big_n` to the same 0 / 1 saturation the limit produces.
+        Decimal::MIN
+    } else {
+        d_ln(moneyness, "pricing::asian::arithmetic::log_moneyness")?
+    };
+    let half_variance_t = d_div(
+        d_mul(
+            d_mul(
+                sigma_adj,
+                sigma_adj,
+                "pricing::asian::arithmetic::sigma_adj_sq",
+            )?,
+            t_dec,
+            "pricing::asian::arithmetic::variance_t",
+        )?,
+        dec!(2),
+        "pricing::asian::arithmetic::half_variance_t",
+    )?;
+    let d1_val = d_div(
+        d_add(
+            log_moneyness,
+            half_variance_t,
+            "pricing::asian::arithmetic::d1_numerator",
+        )?,
+        denominator,
+        "pricing::asian::arithmetic::d1",
+    )?;
+    let d2_val = d_sub(d1_val, denominator, "pricing::asian::arithmetic::d2")?;
 
     let price = match option.option_style {
         OptionStyle::Call => {
             let n_d1 = big_n(d1_val).unwrap_or(Decimal::ZERO);
             let n_d2 = big_n(d2_val).unwrap_or(Decimal::ZERO);
-            discount * (f_adj * n_d1 - k.to_dec() * n_d2)
+            d_mul(
+                discount,
+                d_sub(
+                    d_mul(f_adj, n_d1, "pricing::asian::arithmetic::call::forward")?,
+                    d_mul(k.to_dec(), n_d2, "pricing::asian::arithmetic::call::strike")?,
+                    "pricing::asian::arithmetic::call::intrinsic",
+                )?,
+                "pricing::asian::arithmetic::call",
+            )?
         }
         OptionStyle::Put => {
             let n_neg_d1 = big_n(-d1_val).unwrap_or(Decimal::ZERO);
             let n_neg_d2 = big_n(-d2_val).unwrap_or(Decimal::ZERO);
-            discount * (k.to_dec() * n_neg_d2 - f_adj * n_neg_d1)
+            d_mul(
+                discount,
+                d_sub(
+                    d_mul(
+                        k.to_dec(),
+                        n_neg_d2,
+                        "pricing::asian::arithmetic::put::strike",
+                    )?,
+                    d_mul(f_adj, n_neg_d1, "pricing::asian::arithmetic::put::forward")?,
+                    "pricing::asian::arithmetic::put::intrinsic",
+                )?,
+                "pricing::asian::arithmetic::put",
+            )?
         }
     };
-
-    // Suppress unused variable warning
-    let _ = sigma_adj_pos;
 
     Ok(apply_side(price, option))
 }
 
-/// Calculates intrinsic value at expiration.
-fn intrinsic_value(option: &Options) -> Decimal {
-    let s = option.underlying_price;
-    let k = option.strike_price;
-    let value = match option.option_style {
-        OptionStyle::Call => (s - k).max(Positive::ZERO).to_dec(),
-        OptionStyle::Put => (k - s).max(Positive::ZERO).to_dec(),
+/// Discounted intrinsic on a known average, i.e. the `σ → 0` limit of the
+/// Black formula used by both Asian kernels.
+fn deterministic_price(
+    forward: Decimal,
+    strike: Decimal,
+    discount: Decimal,
+    option: &Options,
+) -> Result<Decimal, PricingError> {
+    let intrinsic = match option.option_style {
+        OptionStyle::Call => {
+            d_sub(forward, strike, "pricing::asian::deterministic::call")?.max(Decimal::ZERO)
+        }
+        OptionStyle::Put => {
+            d_sub(strike, forward, "pricing::asian::deterministic::put")?.max(Decimal::ZERO)
+        }
     };
-    apply_side(value, option)
+    let price = d_mul(intrinsic, discount, "pricing::asian::deterministic::price")?;
+    Ok(apply_side(price, option))
+}
+
+/// Calculates intrinsic value at expiration.
+fn intrinsic_value(option: &Options) -> Result<Decimal, PricingError> {
+    let s = option.underlying_price.to_dec();
+    let k = option.strike_price.to_dec();
+    let value = match option.option_style {
+        OptionStyle::Call => d_sub(s, k, "pricing::asian::intrinsic::call")?.max(Decimal::ZERO),
+        OptionStyle::Put => d_sub(k, s, "pricing::asian::intrinsic::put")?.max(Decimal::ZERO),
+    };
+    Ok(apply_side(value, option))
 }
 
 /// Applies the side (long/short) multiplier to the price.

--- a/src/pricing/asian.rs
+++ b/src/pricing/asian.rs
@@ -51,7 +51,9 @@ use rust_decimal_macros::dec;
 /// - [`PricingError::Decimal`] when an intermediate step leaves the
 ///   representable `Decimal` range: the discount factor, the forward, either
 ///   Turnbull-Wakeman moment, the moment-matched variance, or the final
-///   Black legs.
+///   Black legs. The two removable singularities of the Turnbull-Wakeman
+///   second moment, `b = -σ²` and `b = -σ²/2`, are evaluated at their limits
+///   and never raise.
 /// - [`PricingError::Positive`] when the `σ / √3` geometric adjustment is not
 ///   representable as a `Positive`.
 pub fn asian_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
@@ -280,13 +282,114 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
         )?
     };
 
-    // Second moment of arithmetic average (M2)
+    // Second moment of arithmetic average (M2).
+    //
+    // Writing `a = b + σ²` and `c = 2b + σ²`, the Turnbull-Wakeman second
+    // moment is the double integral of `E[S_t S_u] = S² e^{b(t+u)+σ² min(t,u)}`
+    // over the averaging window,
+    //
+    //     M2 = (2 S² / T²) ∫₀^T e^{b u} ∫₀^u e^{a t} dt du
+    //        = (2 S² / (a T²)) [ (e^{c T} - 1) / c - (e^{b T} - 1) / b ],
+    //
+    // which is the closed form expanded in the `else` branch below. Two of its
+    // three denominators are removable: at `a = 0` (`b = -σ²`) and at `c = 0`
+    // (`b = -σ²/2`) the vanishing factor is cancelled by a bracket that
+    // vanishes with it, and M2 stays finite. Both limits below were taken by
+    // going back to the integral and evaluating the degenerate exponential
+    // directly instead of dividing by its rate — `∫₀^u e^{0·t} dt = u` for
+    // `a = 0`, `∫₀^T e^{0·u} du = T` for `c = 0` — which is the same value as
+    // differentiating the bracket at the zero. They are exact, not
+    // approximations. `r = 0, q = 4%, σ = 20%, T = 1` lands exactly on `a = 0`
+    // and is an ordinary contract, so neither boundary may raise.
     let m2 = if b.abs() < dec!(1e-10) {
         let term = d_exp(
             d_mul(sigma_sq, t_dec, "pricing::asian::arithmetic::m2::var_t")?,
             "pricing::asian::arithmetic::m2::exp_var_t",
         )?;
         d_mul(s_sq, term, "pricing::asian::arithmetic::m2::driftless")?
+    } else if b_plus_var.abs() < dec!(1e-10) {
+        // `a → 0`, i.e. `b = -σ²`. The inner integral degenerates to
+        // `∫₀^u dt = u`, leaving
+        //
+        //     M2 = (2 S² / T²) [ T e^{b T} / b - (e^{b T} - 1) / b² ].
+        //
+        // `b ≈ -σ²` is non-zero here: the driftless branch above owns `b = 0`,
+        // and `σ = 0` returned long before this point.
+        let exp_bt = d_exp(bt, "pricing::asian::arithmetic::m2::a_limit::exp_bt")?;
+        let b_sq = d_mul(b, b, "pricing::asian::arithmetic::m2::a_limit::b_sq")?;
+        let bracket = d_sub(
+            d_div(
+                d_mul(
+                    t_dec,
+                    exp_bt,
+                    "pricing::asian::arithmetic::m2::a_limit::t_exp_bt",
+                )?,
+                b,
+                "pricing::asian::arithmetic::m2::a_limit::first",
+            )?,
+            d_div(
+                d_sub(
+                    exp_bt,
+                    dec!(1),
+                    "pricing::asian::arithmetic::m2::a_limit::exp_bt_less_one",
+                )?,
+                b_sq,
+                "pricing::asian::arithmetic::m2::a_limit::second",
+            )?,
+            "pricing::asian::arithmetic::m2::a_limit::bracket",
+        )?;
+        d_mul(
+            d_div(
+                d_mul(
+                    dec!(2),
+                    s_sq,
+                    "pricing::asian::arithmetic::m2::a_limit::two_s_sq",
+                )?,
+                t_sq,
+                "pricing::asian::arithmetic::m2::a_limit::scale",
+            )?,
+            bracket,
+            "pricing::asian::arithmetic::m2::a_limit",
+        )?
+    } else if two_b_plus_var.abs() < dec!(1e-10) {
+        // `c → 0`, i.e. `b = -σ²/2`. The outer integral's growth term
+        // degenerates to `∫₀^T du = T`, leaving
+        //
+        //     M2 = (2 S² / (a T²)) [ T - (e^{b T} - 1) / b ].
+        //
+        // `a ≈ σ²/2` and `b ≈ -σ²/2` are both non-zero here for the same
+        // reason as in the branch above.
+        let exp_bt = d_exp(bt, "pricing::asian::arithmetic::m2::c_limit::exp_bt")?;
+        let bracket = d_sub(
+            t_dec,
+            d_div(
+                d_sub(
+                    exp_bt,
+                    dec!(1),
+                    "pricing::asian::arithmetic::m2::c_limit::exp_bt_less_one",
+                )?,
+                b,
+                "pricing::asian::arithmetic::m2::c_limit::second",
+            )?,
+            "pricing::asian::arithmetic::m2::c_limit::bracket",
+        )?;
+        d_mul(
+            d_div(
+                d_mul(
+                    dec!(2),
+                    s_sq,
+                    "pricing::asian::arithmetic::m2::c_limit::two_s_sq",
+                )?,
+                d_mul(
+                    b_plus_var,
+                    t_sq,
+                    "pricing::asian::arithmetic::m2::c_limit::denominator",
+                )?,
+                "pricing::asian::arithmetic::m2::c_limit::scale",
+            )?,
+            bracket,
+            "pricing::asian::arithmetic::m2::c_limit",
+        )?
     } else {
         let term1_exp = d_exp(
             d_mul(
@@ -507,6 +610,126 @@ mod tests {
             Positive::ZERO, // dividend yield
             None,
         )
+    }
+
+    /// `S = K = 100`, `T = 1`, `σ = 20%`, `r = 0`, so the Turnbull-Wakeman
+    /// carry is `b = -q` and the dividend yield alone selects the boundary:
+    /// `q = 4%` puts `b` on `-σ²`, `q = 2%` puts it on `-σ² / 2`.
+    fn create_turnbull_wakeman_boundary_option(dividend_yield: Decimal) -> Options {
+        Options::new(
+            OptionType::Asian {
+                averaging_type: AsianAveragingType::Arithmetic,
+            },
+            Side::Long,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(365.0)),
+            Positive::new_decimal(dec!(0.2)).unwrap(),
+            Positive::ONE,
+            Positive::HUNDRED,
+            Decimal::ZERO,
+            OptionStyle::Call,
+            Positive::new_decimal(dividend_yield).unwrap(),
+            None,
+        )
+    }
+
+    /// `b = -σ²` zeroes the `b + σ²` factor of the Turnbull-Wakeman second
+    /// moment. The singularity is removable, so an ordinary contract must
+    /// price rather than raise.
+    #[test]
+    fn test_arithmetic_asian_carry_at_negative_variance_prices() {
+        let option = create_turnbull_wakeman_boundary_option(dec!(0.04));
+        let price = asian_black_scholes(&option).unwrap();
+
+        assert_decimal_eq!(price, dec!(3.6245129), dec!(1e-6));
+
+        let mut geometric = option.clone();
+        geometric.option_type = OptionType::Asian {
+            averaging_type: AsianAveragingType::Geometric,
+        };
+        let geometric_price = asian_black_scholes(&geometric).unwrap();
+        assert!(
+            geometric_price < price,
+            "geometric {} should sit below arithmetic {}",
+            geometric_price,
+            price
+        );
+    }
+
+    /// `b = -σ² / 2` zeroes the `2b + σ²` factor of the Turnbull-Wakeman
+    /// second moment. Removable for the same reason.
+    #[test]
+    fn test_arithmetic_asian_carry_at_half_negative_variance_prices() {
+        let option = create_turnbull_wakeman_boundary_option(dec!(0.02));
+        let price = asian_black_scholes(&option).unwrap();
+
+        assert_decimal_eq!(price, dec!(4.0977699), dec!(1e-6));
+
+        let mut geometric = option.clone();
+        geometric.option_type = OptionType::Asian {
+            averaging_type: AsianAveragingType::Geometric,
+        };
+        let geometric_price = asian_black_scholes(&geometric).unwrap();
+        assert!(
+            geometric_price < price,
+            "geometric {} should sit below arithmetic {}",
+            geometric_price,
+            price
+        );
+    }
+
+    /// The limit branch has to agree with the general formula evaluated a hair
+    /// off the boundary, otherwise it is merely a value and not the limit.
+    ///
+    /// The tolerance is `1e-7`. A `1e-9` shift in `q` moves the price by about
+    /// `2.3e-8` through the genuine `dP/dq` sensitivity, and the general
+    /// branch still carries roughly seventeen significant digits at
+    /// `|b + σ²| = 1e-9` despite the cancellation between its two terms, so
+    /// `1e-7` clears the real sensitivity with room to spare while a wrong
+    /// limiting expression would miss by order one.
+    #[test]
+    fn test_arithmetic_asian_negative_variance_boundary_is_continuous() {
+        let at = asian_black_scholes(&create_turnbull_wakeman_boundary_option(dec!(0.04))).unwrap();
+        let below =
+            asian_black_scholes(&create_turnbull_wakeman_boundary_option(dec!(0.039999999)))
+                .unwrap();
+        let above =
+            asian_black_scholes(&create_turnbull_wakeman_boundary_option(dec!(0.040000001)))
+                .unwrap();
+
+        assert_decimal_eq!(at, below, dec!(1e-7));
+        assert_decimal_eq!(at, above, dec!(1e-7));
+        assert!(
+            above < at && at < below,
+            "the price must stay monotone in q across the boundary: {} {} {}",
+            below,
+            at,
+            above
+        );
+    }
+
+    /// Same continuity check at the second removable singularity, same
+    /// tolerance and same reasoning.
+    #[test]
+    fn test_arithmetic_asian_half_negative_variance_boundary_is_continuous() {
+        let at = asian_black_scholes(&create_turnbull_wakeman_boundary_option(dec!(0.02))).unwrap();
+        let below =
+            asian_black_scholes(&create_turnbull_wakeman_boundary_option(dec!(0.019999999)))
+                .unwrap();
+        let above =
+            asian_black_scholes(&create_turnbull_wakeman_boundary_option(dec!(0.020000001)))
+                .unwrap();
+
+        assert_decimal_eq!(at, below, dec!(1e-7));
+        assert_decimal_eq!(at, above, dec!(1e-7));
+        assert!(
+            above < at && at < below,
+            "the price must stay monotone in q across the boundary: {} {} {}",
+            below,
+            at,
+            above
+        );
     }
 
     #[test]

--- a/src/pricing/barrier.rs
+++ b/src/pricing/barrier.rs
@@ -7,7 +7,7 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
-use crate::model::decimal::{d_add, d_sub};
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_powd, d_sqrt, d_sub};
 use crate::model::types::{BarrierType, OptionStyle, OptionType};
 use positive::Positive;
 use rust_decimal::{Decimal, MathematicalOps};
@@ -18,11 +18,16 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns [`PricingError::UnsupportedOptionType`] when `option`
-/// is not a [`OptionType::Barrier`] variant, and propagates any
-/// `PricingError` raised by the underlying Black\u2013Scholes closed
-/// form on the decomposed vanilla components (typically
-/// `PricingError::ExpirationDate` or [`PricingError::Positive`]).
+/// - [`PricingError::UnsupportedOptionType`] when `option` is not a
+///   [`OptionType::Barrier`] variant.
+/// - [`PricingError::MethodError`] when the volatility is zero, when the
+///   underlying, the strike or the barrier level is zero (the closed form
+///   divides by all three), or when the `λ` discriminant is negative.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range, or when a log-moneyness ratio underflows
+///   to zero: `μ`, the `x` / `y` / `z` arguments, the reflection powers,
+///   the discount factors, or the final price composition.
+/// - `PricingError::ExpirationDate` when the expiration cannot be converted.
 pub fn barrier_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let (barrier_type, barrier_level, rebate) = match &option.option_type {
         OptionType::Barrier {
@@ -63,25 +68,122 @@ pub fn barrier_black_scholes(option: &Options) -> Result<Decimal, PricingError> 
         ));
     }
 
-    let b = r - q; // Cost of carry
-    let sigma2 = sigma * sigma;
-    let mu = (b - sigma2 / dec!(2.0)) / sigma2;
-    let lambda = (mu * mu + dec!(2.0) * r / sigma2).sqrt().ok_or_else(|| {
+    // The closed form divides by `S`, by `K` and by the barrier, and takes
+    // logarithms of their ratios: a zero on any of the three has no financial
+    // meaning here and is rejected before any arithmetic runs.
+    if s == Decimal::ZERO {
+        return Err(PricingError::other(
+            "Underlying price cannot be zero for barrier options pricing",
+        ));
+    }
+    if k == Decimal::ZERO {
+        return Err(PricingError::other(
+            "Strike price cannot be zero for barrier options pricing",
+        ));
+    }
+    if barrier_level == Decimal::ZERO {
+        return Err(PricingError::other(
+            "Barrier level cannot be zero for barrier options pricing",
+        ));
+    }
+
+    let b = d_sub(r, q, "pricing::barrier::carry")?; // Cost of carry
+    let sigma2 = d_mul(sigma, sigma, "pricing::barrier::sigma2")?;
+    let mu = d_div(
+        d_sub(
+            b,
+            d_div(sigma2, dec!(2.0), "pricing::barrier::half_variance")?,
+            "pricing::barrier::mu_numerator",
+        )?,
+        sigma2,
+        "pricing::barrier::mu",
+    )?;
+    let lambda_discriminant = d_add(
+        d_mul(mu, mu, "pricing::barrier::mu_squared")?,
+        d_div(
+            d_mul(dec!(2.0), r, "pricing::barrier::two_r")?,
+            sigma2,
+            "pricing::barrier::rate_over_variance",
+        )?,
+        "pricing::barrier::lambda_discriminant",
+    )?;
+    let lambda = lambda_discriminant.sqrt().ok_or_else(|| {
         PricingError::method_error("barrier_black_scholes", "non-finite lambda discriminant")
     })?;
 
-    let sqrt_t = t
-        .sqrt()
-        .ok_or_else(|| PricingError::method_error("barrier_black_scholes", "non-finite sqrt(t)"))?;
-    let sigma_sqrt_t = sigma * sqrt_t;
+    let sqrt_t = d_sqrt(t, "pricing::barrier::sqrt_t")?;
+    let sigma_sqrt_t = d_mul(sigma, sqrt_t, "pricing::barrier::sigma_sqrt_t")?;
+    let mu_plus_one_term = d_mul(
+        d_add(mu, dec!(1.0), "pricing::barrier::mu_plus_one")?,
+        sigma_sqrt_t,
+        "pricing::barrier::drift_term",
+    )?;
+    // `H / S` drives `y2`, `z` and every reflection power below, so it is
+    // computed once.
+    let h_over_s = d_div(barrier_level, s, "pricing::barrier::h_over_s")?;
+    let log_h_over_s = d_ln(h_over_s, "pricing::barrier::log_h_over_s")?;
 
     // Components used across different barrier types
-    let x1 = (s / k).ln() / sigma_sqrt_t + (mu + dec!(1.0)) * sigma_sqrt_t;
-    let x2 = (s / barrier_level).ln() / sigma_sqrt_t + (mu + dec!(1.0)) * sigma_sqrt_t;
-    let y1 = (barrier_level * barrier_level / (s * k)).ln() / sigma_sqrt_t
-        + (mu + dec!(1.0)) * sigma_sqrt_t;
-    let y2 = (barrier_level / s).ln() / sigma_sqrt_t + (mu + dec!(1.0)) * sigma_sqrt_t;
-    let z = (barrier_level / s).ln() / sigma_sqrt_t + lambda * sigma_sqrt_t;
+    let x1 = d_add(
+        d_div(
+            d_ln(
+                d_div(s, k, "pricing::barrier::moneyness")?,
+                "pricing::barrier::log_moneyness",
+            )?,
+            sigma_sqrt_t,
+            "pricing::barrier::x1_ratio",
+        )?,
+        mu_plus_one_term,
+        "pricing::barrier::x1",
+    )?;
+    let x2 = d_add(
+        d_div(
+            d_ln(
+                d_div(s, barrier_level, "pricing::barrier::s_over_h")?,
+                "pricing::barrier::log_s_over_h",
+            )?,
+            sigma_sqrt_t,
+            "pricing::barrier::x2_ratio",
+        )?,
+        mu_plus_one_term,
+        "pricing::barrier::x2",
+    )?;
+    let y1 = d_add(
+        d_div(
+            d_ln(
+                d_div(
+                    d_mul(barrier_level, barrier_level, "pricing::barrier::h_squared")?,
+                    d_mul(s, k, "pricing::barrier::s_times_k")?,
+                    "pricing::barrier::h2_over_sk",
+                )?,
+                "pricing::barrier::log_h2_over_sk",
+            )?,
+            sigma_sqrt_t,
+            "pricing::barrier::y1_ratio",
+        )?,
+        mu_plus_one_term,
+        "pricing::barrier::y1",
+    )?;
+    let y2 = d_add(
+        d_div(log_h_over_s, sigma_sqrt_t, "pricing::barrier::y2_ratio")?,
+        mu_plus_one_term,
+        "pricing::barrier::y2",
+    )?;
+    let z = d_add(
+        d_div(log_h_over_s, sigma_sqrt_t, "pricing::barrier::z_ratio")?,
+        d_mul(lambda, sigma_sqrt_t, "pricing::barrier::z_drift")?,
+        "pricing::barrier::z",
+    )?;
+
+    // Shared discount factors: every closure below uses both.
+    let discount_q = d_exp(
+        d_mul(-q, t, "pricing::barrier::neg_qt")?,
+        "pricing::barrier::discount_q",
+    )?;
+    let discount_r = d_exp(
+        d_mul(-r, t, "pricing::barrier::neg_rt")?,
+        "pricing::barrier::discount_r",
+    )?;
 
     let _phi = match option.option_style {
         OptionStyle::Call => dec!(1.0),
@@ -96,65 +198,193 @@ pub fn barrier_black_scholes(option: &Options) -> Result<Decimal, PricingError> 
         _ => dec!(1.0),
     };
 
-    let f_a = |phi_val: Decimal, x_val: Decimal| -> Result<Decimal, PricingError> {
-        let n1 = big_n(phi_val * x_val)?;
-        let n2 = big_n(phi_val * (x_val - sigma_sqrt_t))?;
-        Ok(phi_val * s * (-q * t).exp() * n1 - phi_val * k * (-r * t).exp() * n2)
+    // `(H / S)^e`: the reflection factor shared by the `C`, `D`, `E` and `F`
+    // terms of Reiner-Rubinstein.
+    let reflect_pow = |exponent: Decimal, tag: &'static str| -> Result<Decimal, PricingError> {
+        Ok(d_powd(h_over_s, exponent, tag)?)
     };
 
-    let f_b = |phi_val: Decimal, x_val: Decimal| -> Result<Decimal, PricingError> {
-        let n1 = big_n(phi_val * x_val)?;
-        let n2 = big_n(phi_val * (x_val - sigma_sqrt_t))?;
-        Ok(phi_val * s * (-q * t).exp() * n1 - phi_val * k * (-r * t).exp() * n2)
+    // `φ S e^(-qT) N(·) − φ K e^(-rT) N(·)`, the vanilla leg of the decomposition.
+    let vanilla_leg = |phi_val: Decimal, x_val: Decimal| -> Result<Decimal, PricingError> {
+        let n1 = big_n(d_mul(phi_val, x_val, "pricing::barrier::vanilla::arg1")?)?;
+        let n2 = big_n(d_mul(
+            phi_val,
+            d_sub(x_val, sigma_sqrt_t, "pricing::barrier::vanilla::shift")?,
+            "pricing::barrier::vanilla::arg2",
+        )?)?;
+        let spot = d_mul(
+            d_mul(
+                d_mul(phi_val, s, "pricing::barrier::vanilla::phi_s")?,
+                discount_q,
+                "pricing::barrier::vanilla::spot_pv",
+            )?,
+            n1,
+            "pricing::barrier::vanilla::spot_leg",
+        )?;
+        let strike = d_mul(
+            d_mul(
+                d_mul(phi_val, k, "pricing::barrier::vanilla::phi_k")?,
+                discount_r,
+                "pricing::barrier::vanilla::strike_pv",
+            )?,
+            n2,
+            "pricing::barrier::vanilla::strike_leg",
+        )?;
+        Ok(d_sub(spot, strike, "pricing::barrier::vanilla")?)
     };
 
-    let f_c =
+    let f_a = &vanilla_leg;
+    let f_b = &vanilla_leg;
+
+    // `φ S e^(-qT) (H/S)^(2(μ+1)) N(·) − φ K e^(-rT) (H/S)^(2μ) N(·)`.
+    let reflected_leg =
         |phi_val: Decimal, eta_val: Decimal, y_val: Decimal| -> Result<Decimal, PricingError> {
-            let n1 = big_n(eta_val * y_val)?;
-            let n2 = big_n(eta_val * (y_val - sigma_sqrt_t))?;
-            let h_s_ratio = (barrier_level / s).powd(dec!(2.0) * (mu + dec!(1.0)));
-            let h_s_ratio_mu = (barrier_level / s).powd(dec!(2.0) * mu);
-            Ok(phi_val * s * (-q * t).exp() * h_s_ratio * n1
-                - phi_val * k * (-r * t).exp() * h_s_ratio_mu * n2)
+            let n1 = big_n(d_mul(eta_val, y_val, "pricing::barrier::reflected::arg1")?)?;
+            let n2 = big_n(d_mul(
+                eta_val,
+                d_sub(y_val, sigma_sqrt_t, "pricing::barrier::reflected::shift")?,
+                "pricing::barrier::reflected::arg2",
+            )?)?;
+            let h_s_ratio = reflect_pow(
+                d_mul(
+                    dec!(2.0),
+                    d_add(mu, dec!(1.0), "pricing::barrier::reflected::mu_plus_one")?,
+                    "pricing::barrier::reflected::exponent_spot",
+                )?,
+                "pricing::barrier::reflected::pow_spot",
+            )?;
+            let h_s_ratio_mu = reflect_pow(
+                d_mul(
+                    dec!(2.0),
+                    mu,
+                    "pricing::barrier::reflected::exponent_strike",
+                )?,
+                "pricing::barrier::reflected::pow_strike",
+            )?;
+            let spot = d_mul(
+                d_mul(
+                    d_mul(
+                        d_mul(phi_val, s, "pricing::barrier::reflected::phi_s")?,
+                        discount_q,
+                        "pricing::barrier::reflected::spot_pv",
+                    )?,
+                    h_s_ratio,
+                    "pricing::barrier::reflected::spot_reflected",
+                )?,
+                n1,
+                "pricing::barrier::reflected::spot_leg",
+            )?;
+            let strike = d_mul(
+                d_mul(
+                    d_mul(
+                        d_mul(phi_val, k, "pricing::barrier::reflected::phi_k")?,
+                        discount_r,
+                        "pricing::barrier::reflected::strike_pv",
+                    )?,
+                    h_s_ratio_mu,
+                    "pricing::barrier::reflected::strike_reflected",
+                )?,
+                n2,
+                "pricing::barrier::reflected::strike_leg",
+            )?;
+            Ok(d_sub(spot, strike, "pricing::barrier::reflected")?)
         };
 
-    let f_d =
-        |phi_val: Decimal, eta_val: Decimal, y_val: Decimal| -> Result<Decimal, PricingError> {
-            let n1 = big_n(eta_val * y_val)?;
-            let n2 = big_n(eta_val * (y_val - sigma_sqrt_t))?;
-            let h_s_ratio = (barrier_level / s).powd(dec!(2.0) * (mu + dec!(1.0)));
-            let h_s_ratio_mu = (barrier_level / s).powd(dec!(2.0) * mu);
-            Ok(phi_val * s * (-q * t).exp() * h_s_ratio * n1
-                - phi_val * k * (-r * t).exp() * h_s_ratio_mu * n2)
-        };
+    let f_c = &reflected_leg;
+    let f_d = &reflected_leg;
 
+    // Rebate paid at expiry when the barrier is never hit.
     let f_e = |eta_val: Decimal| -> Result<Decimal, PricingError> {
         if rebate == Decimal::ZERO {
             return Ok(Decimal::ZERO);
         }
-        let n1 = big_n(eta_val * (x2 - sigma_sqrt_t))?;
-        let h_s_ratio_mu = (barrier_level / s).powd(dec!(2.0) * mu);
-        let n2 = big_n(eta_val * (y2 - sigma_sqrt_t))?;
-        Ok(rebate * (-r * t).exp() * (n1 - h_s_ratio_mu * n2))
+        let n1 = big_n(d_mul(
+            eta_val,
+            d_sub(x2, sigma_sqrt_t, "pricing::barrier::rebate_expiry::shift1")?,
+            "pricing::barrier::rebate_expiry::arg1",
+        )?)?;
+        let h_s_ratio_mu = reflect_pow(
+            d_mul(dec!(2.0), mu, "pricing::barrier::rebate_expiry::exponent")?,
+            "pricing::barrier::rebate_expiry::pow",
+        )?;
+        let n2 = big_n(d_mul(
+            eta_val,
+            d_sub(y2, sigma_sqrt_t, "pricing::barrier::rebate_expiry::shift2")?,
+            "pricing::barrier::rebate_expiry::arg2",
+        )?)?;
+        Ok(d_mul(
+            d_mul(
+                rebate,
+                discount_r,
+                "pricing::barrier::rebate_expiry::rebate_pv",
+            )?,
+            d_sub(
+                n1,
+                d_mul(
+                    h_s_ratio_mu,
+                    n2,
+                    "pricing::barrier::rebate_expiry::reflected",
+                )?,
+                "pricing::barrier::rebate_expiry::bracket",
+            )?,
+            "pricing::barrier::rebate_expiry",
+        )?)
     };
 
+    // Rebate paid on the hit itself.
     let f_f = |eta_val: Decimal| -> Result<Decimal, PricingError> {
         if rebate == Decimal::ZERO {
             return Ok(Decimal::ZERO);
         }
-        let h_s_ratio_mu_lambda = (barrier_level / s).powd(mu + lambda);
-        let h_s_ratio_mu_lambda_neg = (barrier_level / s).powd(mu - lambda);
-        let n1 = big_n(eta_val * z)?;
-        let n2 = big_n(eta_val * (z - dec!(2.0) * lambda * sigma_sqrt_t))?;
-        Ok(rebate * (h_s_ratio_mu_lambda * n1 + h_s_ratio_mu_lambda_neg * n2))
+        let h_s_ratio_mu_lambda = reflect_pow(
+            d_add(mu, lambda, "pricing::barrier::rebate_hit::exponent_up")?,
+            "pricing::barrier::rebate_hit::pow_up",
+        )?;
+        let h_s_ratio_mu_lambda_neg = reflect_pow(
+            d_sub(mu, lambda, "pricing::barrier::rebate_hit::exponent_down")?,
+            "pricing::barrier::rebate_hit::pow_down",
+        )?;
+        let n1 = big_n(d_mul(eta_val, z, "pricing::barrier::rebate_hit::arg1")?)?;
+        let n2 = big_n(d_mul(
+            eta_val,
+            d_sub(
+                z,
+                d_mul(
+                    d_mul(
+                        dec!(2.0),
+                        lambda,
+                        "pricing::barrier::rebate_hit::two_lambda",
+                    )?,
+                    sigma_sqrt_t,
+                    "pricing::barrier::rebate_hit::shift",
+                )?,
+                "pricing::barrier::rebate_hit::z_shifted",
+            )?,
+            "pricing::barrier::rebate_hit::arg2",
+        )?)?;
+        Ok(d_mul(
+            rebate,
+            d_add(
+                d_mul(
+                    h_s_ratio_mu_lambda,
+                    n1,
+                    "pricing::barrier::rebate_hit::up_leg",
+                )?,
+                d_mul(
+                    h_s_ratio_mu_lambda_neg,
+                    n2,
+                    "pricing::barrier::rebate_hit::down_leg",
+                )?,
+                "pricing::barrier::rebate_hit::bracket",
+            )?,
+            "pricing::barrier::rebate_hit",
+        )?)
     };
 
-    // Each closure return is an addend of the final barrier price. The
-    // intermediate products inside each closure stay on the raw `*` / `-`
-    // operators because they are numerical-kernel internals; the final
-    // price composition that fuses them into the returned value is routed
-    // through `d_add` / `d_sub` so an overflow of the user-visible price
-    // surfaces a `DecimalError::Overflow` instead of wrapping silently.
+    // Each closure return is an addend of the final barrier price; the
+    // composition that fuses them into the returned value goes through
+    // `d_add` / `d_sub` so an overflow of the user-visible price surfaces a
+    // `DecimalError::Overflow` instead of aborting.
     const OP: &str = "pricing::barrier::price";
     match (option.option_style, barrier_type) {
         // Down-and-out call

--- a/src/pricing/binary.rs
+++ b/src/pricing/binary.rs
@@ -31,11 +31,10 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::{big_n, d1, d2};
-use crate::model::decimal::{d_mul, d_sub};
+use crate::model::decimal::{d_exp, d_mul, d_sub};
 use crate::model::types::{BinaryType, OptionStyle, OptionType};
 use positive::Positive;
 use rust_decimal::Decimal;
-use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 
 /// Default cash payout for cash-or-nothing options (when not specified).
@@ -53,11 +52,15 @@ const DEFAULT_CASH_PAYOUT: Decimal = dec!(1.0);
 ///
 /// # Errors
 ///
-/// Returns [`PricingError::UnsupportedOptionType`] when `option` is
-/// not an [`OptionType::Binary`] variant, and propagates any
-/// `PricingError` raised by intermediate Black–Scholes kernels
-/// (typically `PricingError::ExpirationDate` or
-/// [`PricingError::Positive`]).
+/// - [`PricingError::UnsupportedOptionType`] when `option` is not an
+///   [`OptionType::Binary`] variant.
+/// - [`PricingError::MethodError`] when the expiration cannot be converted to
+///   a year fraction, when the binary sub-type is an unsupported
+///   `#[non_exhaustive]` variant, or when the `d1` / `d2` kernels reject the
+///   inputs.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range: the discount factors, the zero-volatility
+///   forward, or the payout legs.
 pub fn binary_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
         OptionType::Binary { binary_type } => match binary_type {
@@ -98,14 +101,27 @@ fn cash_or_nothing_price(option: &Options, payout: Decimal) -> Result<Decimal, P
         return Ok(intrinsic_cash_or_nothing(option, payout));
     }
 
+    let t_dec = t.to_dec();
+    let b = d_sub(r, q, "pricing::binary::cash::carry")?;
+    let discount = d_exp(
+        d_mul(-r, t_dec, "pricing::binary::cash::neg_rt")?,
+        "pricing::binary::cash::discount",
+    )?;
+
     if sigma == Positive::ZERO {
         // At zero vol, price is deterministic
-        let forward = s * ((r - q) * t).exp();
+        let forward = d_mul(
+            s.to_dec(),
+            d_exp(
+                d_mul(b, t_dec, "pricing::binary::cash::zero_vol::carry_t")?,
+                "pricing::binary::cash::zero_vol::growth",
+            )?,
+            "pricing::binary::cash::zero_vol::forward",
+        )?;
         let itm = match option.option_style {
-            OptionStyle::Call => forward > k,
-            OptionStyle::Put => k > forward,
+            OptionStyle::Call => forward > k.to_dec(),
+            OptionStyle::Put => k.to_dec() > forward,
         };
-        let discount = (-r * t).exp();
         let value = if itm {
             d_mul(payout, discount, "pricing::binary::cash::zero_vol")?
         } else {
@@ -115,11 +131,8 @@ fn cash_or_nothing_price(option: &Options, payout: Decimal) -> Result<Decimal, P
     }
 
     // Calculate d2 for cash-or-nothing
-    let b = r - q;
     let d2_val = d2(s, k, b, t, sigma)
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
-
-    let discount = (-r * t).exp();
 
     let price = match option.option_style {
         OptionStyle::Call => {
@@ -160,26 +173,40 @@ fn asset_or_nothing_price(option: &Options) -> Result<Decimal, PricingError> {
         return Ok(intrinsic_asset_or_nothing(option));
     }
 
+    let t_dec = t.to_dec();
+    let b = d_sub(r, q, "pricing::binary::asset::carry")?;
+    let dividend_discount = d_exp(
+        d_mul(-q, t_dec, "pricing::binary::asset::neg_qt")?,
+        "pricing::binary::asset::dividend_discount",
+    )?;
+
     if sigma == Positive::ZERO {
-        let forward = s * ((r - q) * t).exp();
+        let forward = d_mul(
+            s.to_dec(),
+            d_exp(
+                d_mul(b, t_dec, "pricing::binary::asset::zero_vol::carry_t")?,
+                "pricing::binary::asset::zero_vol::growth",
+            )?,
+            "pricing::binary::asset::zero_vol::forward",
+        )?;
         let itm = match option.option_style {
-            OptionStyle::Call => forward > k,
-            OptionStyle::Put => k > forward,
+            OptionStyle::Call => forward > k.to_dec(),
+            OptionStyle::Put => k.to_dec() > forward,
         };
-        let discount = (-q * t).exp();
         let value = if itm {
-            d_mul(s.to_dec(), discount, "pricing::binary::asset::zero_vol")?
+            d_mul(
+                s.to_dec(),
+                dividend_discount,
+                "pricing::binary::asset::zero_vol",
+            )?
         } else {
             Decimal::ZERO
         };
         return Ok(apply_side(value, option));
     }
 
-    let b = r - q;
     let d1_val = d1(s, k, b, t, sigma)
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
-
-    let dividend_discount = (-q * t).exp();
 
     let price = match option.option_style {
         OptionStyle::Call => {
@@ -230,8 +257,16 @@ fn gap_binary_price(option: &Options) -> Result<Decimal, PricingError> {
     // `side_multiplier` is ±1 so the signed renormalisation cannot overflow,
     // but the strike·unit_cash product and the following subtraction must be
     // checked because they fuse two monetary flows into one.
-    let asset_unsigned = asset_price * side_multiplier;
-    let unit_cash_unsigned = unit_cash * side_multiplier;
+    let asset_unsigned = d_mul(
+        asset_price,
+        side_multiplier,
+        "pricing::binary::gap::asset_unsigned",
+    )?;
+    let unit_cash_unsigned = d_mul(
+        unit_cash,
+        side_multiplier,
+        "pricing::binary::gap::unit_cash_unsigned",
+    )?;
     let strike_cash = d_mul(
         option.strike_price.to_dec(),
         unit_cash_unsigned,
@@ -242,7 +277,11 @@ fn gap_binary_price(option: &Options) -> Result<Decimal, PricingError> {
     // Suppress unused variable warning
     let _ = cash_price;
 
-    Ok(gap_unsigned * side_multiplier)
+    Ok(d_mul(
+        gap_unsigned,
+        side_multiplier,
+        "pricing::binary::gap::signed",
+    )?)
 }
 
 /// Calculates intrinsic value for cash-or-nothing at expiration.
@@ -284,6 +323,7 @@ mod tests {
     use crate::assert_decimal_eq;
     use crate::model::types::{OptionStyle, OptionType, Side};
     use positive::pos_or_panic;
+    use rust_decimal::MathematicalOps;
     use rust_decimal_macros::dec;
 
     fn create_binary_option(style: OptionStyle, binary_type: BinaryType) -> Options {

--- a/src/pricing/binomial_model.rs
+++ b/src/pricing/binomial_model.rs
@@ -5,12 +5,13 @@
 #![allow(clippy::indexing_slicing)]
 
 use crate::error::PricingError;
+use crate::model::decimal::{d_div, d_mul, d_powd, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
 use crate::pricing::payoff::{Payoff, PayoffInfo};
 use crate::pricing::utils::*;
 use crate::{d2f, f2d};
 use positive::Positive;
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
 use std::num::NonZeroUsize;
 use tracing::instrument;
 
@@ -141,6 +142,12 @@ pub fn price_binomial(params: BinomialPricingParams) -> Result<Decimal, PricingE
     let dt = (params.expiry / Positive::new(no_steps_raw as f64)?).to_dec();
     let u = calculate_up_factor(params.volatility, dt)?;
     let d = calculate_down_factor(params.volatility, dt)?;
+    if u == d {
+        // `σ√dt` underflowed below the representable scale, so the lattice has
+        // collapsed onto a single deterministic path: same answer as the
+        // zero-volatility branch above.
+        return calculate_discounted_payoff(params);
+    }
     let p = calculate_probability(params.int_rate, dt, d, u)?;
     let discount_factor = calculate_discount_factor(params.int_rate, dt)?;
 
@@ -148,34 +155,60 @@ pub fn price_binomial(params: BinomialPricingParams) -> Result<Decimal, PricingE
         .map(|i| calculate_option_price(params.clone(), u, d, i))
         .collect::<Result<Vec<_>, _>>()?;
 
+    let half_dt = d_div(dt, Decimal::TWO, "pricing::binomial::half_dt")?;
     for step in (0..no_steps_raw).rev() {
         for i in 0..=step {
-            let option_value = option_node_value(p, prices[i + 1], prices[i], discount_factor)?;
+            let price_up = *prices
+                .get(i + 1)
+                .ok_or(PricingError::BinomialNodeMissing { node: "price_up" })?;
+            let price_down = *prices
+                .get(i)
+                .ok_or(PricingError::BinomialNodeMissing { node: "price_down" })?;
+            let option_value = option_node_value(p, price_up, price_down, discount_factor)?;
+            let slot = prices
+                .get_mut(i)
+                .ok_or(PricingError::BinomialNodeMissing { node: "price_slot" })?;
             match params.option_type {
                 OptionType::American => {
-                    let spot = params.asset * u.powi(i as i64) * d.powi((step - i) as i64);
-                    info.spot = spot;
+                    info.spot = lattice_spot(params.asset, u, d, i, step)?;
                     let intrinsic_value = f2d!(params.option_type.payoff(&info));
-                    prices[i] = option_value.max(intrinsic_value);
+                    *slot = option_value.max(intrinsic_value);
                 }
                 OptionType::Bermuda { exercise_dates } => {
                     // Calculate time at this step
-                    let time_at_step = dt * Decimal::from(step as u32);
+                    let time_at_step = d_mul(
+                        dt,
+                        Decimal::from(step as u64),
+                        "pricing::binomial::time_at_step",
+                    )?;
                     // Check if this step is an exercise date
-                    let is_exercise_date = exercise_dates
-                        .iter()
-                        .any(|t| (time_at_step - t.to_dec()).abs() < dt / Decimal::TWO);
+                    let mut is_exercise_date = false;
+                    for exercise in exercise_dates {
+                        let gap = d_sub(
+                            time_at_step,
+                            exercise.to_dec(),
+                            "pricing::binomial::exercise_gap",
+                        )?;
+                        if gap.abs() < half_dt {
+                            is_exercise_date = true;
+                            break;
+                        }
+                    }
                     if is_exercise_date {
-                        let spot = params.asset * u.powi(i as i64) * d.powi((step - i) as i64);
+                        let spot = lattice_spot(params.asset, u, d, i, step)?;
+                        let slot_value = option_value;
                         info.spot = spot;
                         let intrinsic_value = f2d!(params.option_type.payoff(&info));
-                        prices[i] = option_value.max(intrinsic_value);
+                        let slot = prices
+                            .get_mut(i)
+                            .ok_or(PricingError::BinomialNodeMissing { node: "price_slot" })?;
+                        *slot = slot_value.max(intrinsic_value);
                     } else {
-                        prices[i] = option_value;
+                        *slot = option_value;
                     }
                 }
                 OptionType::European => {
-                    prices[i] = option_value;
+                    *slot = option_value;
                 }
                 _ => {
                     return Err(PricingError::other(
@@ -185,7 +218,50 @@ pub fn price_binomial(params: BinomialPricingParams) -> Result<Decimal, PricingE
             }
         }
     }
-    Ok(prices[0])
+    prices
+        .first()
+        .copied()
+        .ok_or(PricingError::BinomialNodeMissing { node: "root" })
+}
+
+/// Spot price at lattice node `(step, i)`: `S · u^i · d^(step - i)`.
+///
+/// # Errors
+///
+/// Returns [`PricingError::Decimal`] when either power or the product leaves
+/// the representable `Decimal` range, [`PricingError::Positive`] when the
+/// result is not a valid `Positive`, and [`PricingError::BinomialNodeMissing`]
+/// when `i` walks past `step`.
+fn lattice_spot(
+    asset: Positive,
+    u: Decimal,
+    d: Decimal,
+    i: usize,
+    step: usize,
+) -> Result<Positive, PricingError> {
+    let down_steps = step
+        .checked_sub(i)
+        .ok_or(PricingError::BinomialNodeMissing { node: "down_steps" })?;
+    let up_power = d_powd(
+        u,
+        Decimal::from(i as u64),
+        "pricing::binomial::lattice_spot::up",
+    )?;
+    let down_power = d_powd(
+        d,
+        Decimal::from(down_steps as u64),
+        "pricing::binomial::lattice_spot::down",
+    )?;
+    let spot = d_mul(
+        d_mul(
+            asset.to_dec(),
+            up_power,
+            "pricing::binomial::lattice_spot::spot_up",
+        )?,
+        down_power,
+        "pricing::binomial::lattice_spot::spot",
+    )?;
+    Ok(Positive::new_decimal(spot)?)
 }
 
 /// Generates a binomial tree for option pricing.
@@ -271,25 +347,70 @@ pub fn generate_binomial_tree(params: &BinomialPricingParams) -> BinomialTreeRes
 
     for (step, step_vec) in asset_tree.iter_mut().enumerate() {
         for (node, node_val) in step_vec.iter_mut().enumerate().take(step + 1) {
-            *node_val =
-                up_factor.powi((step - node) as i64) * down_factor.powi(node as i64) * params.asset;
+            let up_steps = step
+                .checked_sub(node)
+                .ok_or(PricingError::BinomialNodeMissing { node: "up_steps" })?;
+            let up_power = d_powd(
+                up_factor,
+                Decimal::from(up_steps as u64),
+                "pricing::binomial::tree::up_power",
+            )?;
+            let down_power = d_powd(
+                down_factor,
+                Decimal::from(node as u64),
+                "pricing::binomial::tree::down_power",
+            )?;
+            *node_val = d_mul(
+                d_mul(up_power, down_power, "pricing::binomial::tree::factor")?,
+                params.asset.to_dec(),
+                "pricing::binomial::tree::asset_price",
+            )?;
         }
     }
 
-    for (node, node_val) in asset_tree[no_steps_raw]
-        .iter()
-        .enumerate()
-        .take(no_steps_raw + 1)
-    {
+    let terminal_assets = asset_tree
+        .get(no_steps_raw)
+        .ok_or(PricingError::BinomialNodeMissing {
+            node: "terminal_step",
+        })?
+        .clone();
+    let terminal_options =
+        option_tree
+            .get_mut(no_steps_raw)
+            .ok_or(PricingError::BinomialNodeMissing {
+                node: "terminal_step",
+            })?;
+    for (node, node_val) in terminal_assets.iter().enumerate().take(no_steps_raw + 1) {
         info.spot = Positive::new_decimal(*node_val)?;
-        option_tree[no_steps_raw][node] = f2d!(params.option_type.payoff(&info));
+        let slot = terminal_options
+            .get_mut(node)
+            .ok_or(PricingError::BinomialNodeMissing {
+                node: "terminal_node",
+            })?;
+        *slot = f2d!(params.option_type.payoff(&info));
     }
 
+    let half_dt = d_div(dt, Decimal::TWO, "pricing::binomial::tree::half_dt")?;
     for step in (0..no_steps_raw).rev() {
+        let step_assets = asset_tree
+            .get(step)
+            .ok_or(PricingError::BinomialNodeMissing { node: "asset_step" })?
+            .clone();
         let (current_step_arr, next_step_arr) = option_tree.split_at_mut(step + 1);
-        for (node_idx, node_val) in current_step_arr[step].iter_mut().enumerate().take(step + 1) {
+        let current = current_step_arr
+            .get_mut(step)
+            .ok_or(PricingError::BinomialNodeMissing {
+                node: "option_step",
+            })?;
+        for (node_idx, node_val) in current.iter_mut().enumerate().take(step + 1) {
             let node_value =
                 option_node_value_wrapper(probability, next_step_arr, node_idx, discount_factor)?;
+            let node_asset = || -> Result<Positive, PricingError> {
+                let raw = step_assets
+                    .get(node_idx)
+                    .ok_or(PricingError::BinomialNodeMissing { node: "asset_node" })?;
+                Ok(Positive::new_decimal(*raw)?)
+            };
             match params.option_type {
                 OptionType::European => {
                     *node_val = node_value;
@@ -298,7 +419,7 @@ pub fn generate_binomial_tree(params: &BinomialPricingParams) -> BinomialTreeRes
                     if (step == 0) & (node_idx == 0) {
                         *node_val = node_value;
                     } else {
-                        info.spot = Positive::new_decimal(asset_tree[step][node_idx])?;
+                        info.spot = node_asset()?;
                         let intrinsic_value = params.option_type.payoff(&info);
                         let dec_node_val = d2f!(node_value);
                         *node_val = f2d!(intrinsic_value.max(dec_node_val));
@@ -306,13 +427,26 @@ pub fn generate_binomial_tree(params: &BinomialPricingParams) -> BinomialTreeRes
                 }
                 OptionType::Bermuda { exercise_dates } => {
                     // Calculate time at this step
-                    let time_at_step = dt * Decimal::from(step as u32);
+                    let time_at_step = d_mul(
+                        dt,
+                        Decimal::from(step as u64),
+                        "pricing::binomial::tree::time_at_step",
+                    )?;
                     // Check if this step is an exercise date
-                    let is_exercise_date = exercise_dates
-                        .iter()
-                        .any(|t| (time_at_step - t.to_dec()).abs() < dt / Decimal::TWO);
+                    let mut is_exercise_date = false;
+                    for exercise in exercise_dates {
+                        let gap = d_sub(
+                            time_at_step,
+                            exercise.to_dec(),
+                            "pricing::binomial::tree::exercise_gap",
+                        )?;
+                        if gap.abs() < half_dt {
+                            is_exercise_date = true;
+                            break;
+                        }
+                    }
                     if is_exercise_date && !((step == 0) & (node_idx == 0)) {
-                        info.spot = Positive::new_decimal(asset_tree[step][node_idx])?;
+                        info.spot = node_asset()?;
                         let intrinsic_value = params.option_type.payoff(&info);
                         let dec_node_val = d2f!(node_value);
                         *node_val = f2d!(intrinsic_value.max(dec_node_val));
@@ -337,6 +471,7 @@ mod tests_price_binomial {
     use super::*;
     use crate::assert_decimal_eq;
     use crate::model::types::OptionType;
+    use rust_decimal::MathematicalOps;
     use rust_decimal_macros::dec;
 
     const EPSILON: Decimal = dec!(1e-6);

--- a/src/pricing/chooser.rs
+++ b/src/pricing/chooser.rs
@@ -26,12 +26,12 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::{big_n, d1, d2};
-use crate::model::decimal::{d_add, d_mul, d_sub};
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_sqrt, d_sub};
 use crate::model::types::OptionType;
 use positive::Positive;
 use rust_decimal::Decimal;
-use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
+use std::cmp::Ordering;
 
 /// Prices a Chooser option using Rubinstein (1991) simple chooser formula.
 ///
@@ -45,10 +45,14 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns [`PricingError::UnsupportedOptionType`] when `option` is
-/// not an [`OptionType::Chooser`] variant, and propagates any
-/// `PricingError` raised by the Black–Scholes evaluation at the
-/// chooser date (call and put side).
+/// - [`PricingError::MethodError`] when `option` is not an
+///   [`OptionType::Chooser`] variant, when the expiration cannot be converted
+///   to a year fraction, when the `d1` / `d2` kernels reject the inputs, or
+///   when both the choice-date diffusion `σ√t` and the log-moneyness collapse
+///   to zero, which leaves `y1` genuinely undefined.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range: the discount factors, the zero-volatility
+///   forward, `y1` / `y2`, or the four price legs.
 pub fn chooser_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
         OptionType::Chooser { choice_date } => simple_chooser_price(option, choice_date.to_f64()),
@@ -93,8 +97,22 @@ fn simple_chooser_price(option: &Options, choice_date_days: f64) -> Result<Decim
 
     if sigma == Positive::ZERO {
         // Zero vol: deterministic choice
-        let discount_t = (-r * t_big).exp();
-        let forward = s.to_dec() * ((r - q) * t_big.to_dec()).exp();
+        let discount_t = d_exp(
+            d_mul(-r, t_big.to_dec(), "pricing::chooser::zero_vol::neg_rt")?,
+            "pricing::chooser::zero_vol::discount",
+        )?;
+        let forward = d_mul(
+            s.to_dec(),
+            d_exp(
+                d_mul(
+                    d_sub(r, q, "pricing::chooser::zero_vol::carry")?,
+                    t_big.to_dec(),
+                    "pricing::chooser::zero_vol::carry_t",
+                )?,
+                "pricing::chooser::zero_vol::growth",
+            )?,
+            "pricing::chooser::zero_vol::forward",
+        )?;
         let call_intrinsic = d_sub(
             forward,
             k.to_dec(),
@@ -120,13 +138,13 @@ fn simple_chooser_price(option: &Options, choice_date_days: f64) -> Result<Decim
         return Ok(apply_side(call_val.max(put_val), option));
     }
 
-    let b = r - q;
+    let b = d_sub(r, q, "pricing::chooser::carry")?;
     let t_big_dec = t_big.to_dec();
     let t_choice_dec = t_choice.to_dec();
-    let _sqrt_t_big = t_big_dec.sqrt().unwrap_or(Decimal::ZERO);
-    let sqrt_t_choice = t_choice_dec.sqrt().unwrap_or(dec!(0.001));
+    let sqrt_t_choice = d_sqrt(t_choice_dec, "pricing::chooser::sqrt_t_choice")?;
 
-    // Standard BS d-values for the final expiration T
+    // Standard BS d-values for the final expiration T. Both reject a zero
+    // underlying or strike, so `S / K` below is a ratio of two positives.
     let d1_val = d1(s, k, b, t_big, sigma)
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
     let d2_val = d2(s, k, b, t_big, sigma)
@@ -135,21 +153,85 @@ fn simple_chooser_price(option: &Options, choice_date_days: f64) -> Result<Decim
     // d-values for the choice date t
     // y1 = [ln(S/K) + (b + σ²/2)*t] / (σ√t)
     // y2 = y1 - σ√t
-    let y1 = ((s.to_dec() / k.to_dec()).ln() + (b + sigma * sigma / dec!(2)) * t_choice_dec)
-        / (sigma.to_dec() * sqrt_t_choice);
-    let y2 = y1 - sigma.to_dec() * sqrt_t_choice;
+    let sigma_dec = sigma.to_dec();
+    let sigma_sqrt_t_choice = d_mul(
+        sigma_dec,
+        sqrt_t_choice,
+        "pricing::chooser::sigma_sqrt_t_choice",
+    )?;
+    let drift = d_mul(
+        d_add(
+            b,
+            d_div(
+                d_mul(sigma_dec, sigma_dec, "pricing::chooser::variance")?,
+                dec!(2),
+                "pricing::chooser::half_variance",
+            )?,
+            "pricing::chooser::drift_rate",
+        )?,
+        t_choice_dec,
+        "pricing::chooser::drift",
+    )?;
+    let moneyness = d_div(s.to_dec(), k.to_dec(), "pricing::chooser::moneyness")?;
+    // `None` carries the `ln(S / K) = -∞` limit reached when the moneyness
+    // rounds below the smallest representable `Decimal`.
+    let y1_numerator = if moneyness.is_zero() {
+        None
+    } else {
+        Some(d_add(
+            d_ln(moneyness, "pricing::chooser::log_moneyness")?,
+            drift,
+            "pricing::chooser::y1_numerator",
+        )?)
+    };
+
+    // `N(-y)` at the choice date. When the choice-date diffusion `σ√t`
+    // collapses to zero the exponents diverge and the CDF saturates at the
+    // sign of the numerator; `0 / 0` stays genuinely undefined and is
+    // reported rather than guessed.
+    let (n_neg_y1, n_neg_y2) = match (y1_numerator, sigma_sqrt_t_choice.is_zero()) {
+        (None, _) => (Decimal::ONE, Decimal::ONE),
+        (Some(numerator), true) => match numerator.cmp(&Decimal::ZERO) {
+            Ordering::Greater => (Decimal::ZERO, Decimal::ZERO),
+            Ordering::Less => (Decimal::ONE, Decimal::ONE),
+            Ordering::Equal => {
+                return Err(PricingError::method_error(
+                    "simple_chooser_price",
+                    "choice-date diffusion and log-moneyness both collapsed to zero",
+                ));
+            }
+        },
+        (Some(numerator), false) => {
+            let y1 = d_div(numerator, sigma_sqrt_t_choice, "pricing::chooser::y1")?;
+            let y2 = d_sub(y1, sigma_sqrt_t_choice, "pricing::chooser::y2")?;
+            (
+                big_n(-y1).unwrap_or(Decimal::ZERO),
+                big_n(-y2).unwrap_or(Decimal::ZERO),
+            )
+        }
+    };
 
     // Get cumulative normal values
     let n_d1 = big_n(d1_val).unwrap_or(Decimal::ZERO);
     let n_d2 = big_n(d2_val).unwrap_or(Decimal::ZERO);
-    let n_neg_y1 = big_n(-y1).unwrap_or(Decimal::ZERO);
-    let n_neg_y2 = big_n(-y2).unwrap_or(Decimal::ZERO);
 
     // Discount factors
-    let dividend_discount_t = (-q * t_big_dec).exp();
-    let discount_t = (-r * t_big_dec).exp();
-    let dividend_discount_choice = (-q * t_choice_dec).exp();
-    let discount_choice = (-r * t_choice_dec).exp();
+    let dividend_discount_t = d_exp(
+        d_mul(-q, t_big_dec, "pricing::chooser::neg_qt")?,
+        "pricing::chooser::dividend_discount_t",
+    )?;
+    let discount_t = d_exp(
+        d_mul(-r, t_big_dec, "pricing::chooser::neg_rt")?,
+        "pricing::chooser::discount_t",
+    )?;
+    let dividend_discount_choice = d_exp(
+        d_mul(-q, t_choice_dec, "pricing::chooser::neg_qt_choice")?,
+        "pricing::chooser::dividend_discount_choice",
+    )?;
+    let discount_choice = d_exp(
+        d_mul(-r, t_choice_dec, "pricing::chooser::neg_rt_choice")?,
+        "pricing::chooser::discount_choice",
+    )?;
 
     // Rubinstein (1991) simple chooser formula:
     // V = S*e^(-qT)*N(d1) - K*e^(-rT)*N(d2) + K*e^(-rt)*N(-y2) - S*e^(-qt)*N(-y1)
@@ -228,7 +310,7 @@ fn price_at_choice_equals_expiry(option: &Options) -> Result<Decimal, PricingErr
     }
 
     // Price as call + put (straddle) since choice is at expiry
-    let b = r - q;
+    let b = d_sub(r, q, "pricing::chooser::expiry::carry")?;
     let d1_val = d1(s, k, b, t, sigma)
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
     let d2_val = d2(s, k, b, t, sigma)
@@ -239,14 +321,27 @@ fn price_at_choice_equals_expiry(option: &Options) -> Result<Decimal, PricingErr
     let n_neg_d1 = big_n(-d1_val).unwrap_or(Decimal::ZERO);
     let n_neg_d2 = big_n(-d2_val).unwrap_or(Decimal::ZERO);
 
-    let dividend_discount = (-q * t).exp();
-    let discount = (-r * t).exp();
+    let t_dec = t.to_dec();
+    let dividend_discount = d_exp(
+        d_mul(-q, t_dec, "pricing::chooser::expiry::neg_qt")?,
+        "pricing::chooser::expiry::dividend_discount",
+    )?;
+    let discount = d_exp(
+        d_mul(-r, t_dec, "pricing::chooser::expiry::neg_rt")?,
+        "pricing::chooser::expiry::discount",
+    )?;
 
     // Call + Put = Straddle
-    let call_s_leg = s.to_dec() * dividend_discount * n_d1;
-    let call_k_leg = k.to_dec() * discount * n_d2;
-    let put_k_leg = k.to_dec() * discount * n_neg_d2;
-    let put_s_leg = s.to_dec() * dividend_discount * n_neg_d1;
+    let s_pv = d_mul(
+        s.to_dec(),
+        dividend_discount,
+        "pricing::chooser::expiry::s_pv",
+    )?;
+    let k_pv = d_mul(k.to_dec(), discount, "pricing::chooser::expiry::k_pv")?;
+    let call_s_leg = d_mul(s_pv, n_d1, "pricing::chooser::expiry::call_s_leg")?;
+    let call_k_leg = d_mul(k_pv, n_d2, "pricing::chooser::expiry::call_k_leg")?;
+    let put_k_leg = d_mul(k_pv, n_neg_d2, "pricing::chooser::expiry::put_k_leg")?;
+    let put_s_leg = d_mul(s_pv, n_neg_d1, "pricing::chooser::expiry::put_s_leg")?;
     let call_price = d_sub(call_s_leg, call_k_leg, "pricing::chooser::expiry::call")?;
     let put_price = d_sub(put_k_leg, put_s_leg, "pricing::chooser::expiry::put")?;
     let price = d_add(call_price, put_price, "pricing::chooser::expiry::price")?;

--- a/src/pricing/cliquet.rs
+++ b/src/pricing/cliquet.rs
@@ -30,12 +30,10 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
-use crate::model::decimal::{d_add, d_mul, d_sub, finite_decimal};
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_sqrt, d_sub, finite_decimal};
 use crate::model::types::OptionType;
-use num_traits::Inv;
 use positive::Positive;
 use rust_decimal::Decimal;
-use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 
 /// Prices a Cliquet option using an analytical approach (sum of forward-starting options).
@@ -50,10 +48,14 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns [`PricingError::UnsupportedOptionType`] when `option` is
-/// not an [`OptionType::Cliquet`] variant, and propagates any
-/// `PricingError` raised by intermediate Black–Scholes kernels on
-/// the per-reset forward components.
+/// - [`PricingError::MethodError`] when `option` is not an
+///   [`OptionType::Cliquet`] variant, when `reset_dates` contains a `NaN`, or
+///   when the expiration cannot be converted to a year fraction.
+/// - [`PricingError::NonFinite`] when a reset offset is not representable as
+///   a `Decimal`.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range: the per-period discount factors, the
+///   capped/floored strikes, the unit-call `d1` / `d2`, or the running total.
 pub fn cliquet_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
         OptionType::Cliquet { reset_dates } => {
@@ -108,12 +110,11 @@ fn price_cliquet(option: &Options, reset_dates: &[f64]) -> Result<Decimal, Prici
 
     let mut total_price = dec!(0.0);
 
-    for i in 1..reset_times_years.len() {
-        let t_prev = reset_times_years[i - 1];
-        let t_curr = reset_times_years[i];
+    for window in reset_times_years.windows(2) {
+        let [t_prev, t_curr] = window else { continue };
         let dt = t_curr - t_prev;
 
-        let delta_price = price_period(option, t_prev, dt, local_cap, local_floor)?;
+        let delta_price = price_period(option, *t_prev, dt, local_cap, local_floor)?;
         total_price = d_add(total_price, delta_price, "pricing::cliquet::total")?;
     }
 
@@ -155,7 +156,14 @@ fn price_period(
     })?;
 
     // S_0 * e^(-q * t_start) is the present value of the expected S_{t_prev}
-    let s_prev_pv = s0 * (-q * t_start_dec).exp();
+    let s_prev_pv = d_mul(
+        s0,
+        d_exp(
+            d_mul(-q, t_start_dec, "pricing::cliquet::period::neg_q_t_start")?,
+            "pricing::cliquet::period::dividend_discount",
+        )?,
+        "pricing::cliquet::period::s_prev_pv",
+    )?;
 
     // The component at t_start: E[S_{t_prev}] = S_0 * e^{(r-q)*t_start}
     // But we need value at t=0 of S_{t_prev} * Payoff(Δt)
@@ -176,10 +184,29 @@ fn price_period(
     // Since E[S_{t_prev}] = S_0 * e^{(r-q)*t_start}
     // V_0 = S_0 * e^{-q*t_start} * [ floor * e^{-r*Δt} + Call(S=1, K=1+floor, Δt) - Call(S=1, K=1+cap, Δt) ]
 
-    let call_f = call_price_on_unit(r, q, sigma, dt_dec, dec!(1.0) + floor)?;
-    let call_c = call_price_on_unit(r, q, sigma, dt_dec, dec!(1.0) + cap)?;
+    let call_f = call_price_on_unit(
+        r,
+        q,
+        sigma,
+        dt_dec,
+        d_add(dec!(1.0), floor, "pricing::cliquet::period::floor_strike")?,
+    )?;
+    let call_c = call_price_on_unit(
+        r,
+        q,
+        sigma,
+        dt_dec,
+        d_add(dec!(1.0), cap, "pricing::cliquet::period::cap_strike")?,
+    )?;
 
-    let floor_part = floor * (-r * dt_dec).exp();
+    let floor_part = d_mul(
+        floor,
+        d_exp(
+            d_mul(-r, dt_dec, "pricing::cliquet::period::neg_r_dt")?,
+            "pricing::cliquet::period::discount",
+        )?,
+        "pricing::cliquet::period::floor_part",
+    )?;
 
     let step = d_add(
         floor_part,
@@ -204,17 +231,39 @@ fn call_price_on_unit(
     t: Decimal,
     k: Decimal,
 ) -> Result<Decimal, PricingError> {
+    let dividend_discount = d_exp(
+        d_mul(-q, t, "pricing::cliquet::unit_call::neg_qt")?,
+        "pricing::cliquet::unit_call::dividend_discount",
+    )?;
+    let discount = d_exp(
+        d_mul(-r, t, "pricing::cliquet::unit_call::neg_rt")?,
+        "pricing::cliquet::unit_call::discount",
+    )?;
+
     if k <= dec!(0.0) {
         // If K <= 0, the call is always in the money.
         // Value = S*e^{-qT} - K*e^{-rT}
-        let s_pv = (-q * t).exp();
-        let k_pv = d_mul(k, (-r * t).exp(), "pricing::cliquet::unit_call::itm::k_pv")?;
-        return d_sub(s_pv, k_pv, "pricing::cliquet::unit_call::itm::price")
-            .map_err(PricingError::from);
+        let k_pv = d_mul(k, discount, "pricing::cliquet::unit_call::itm::k_pv")?;
+        return d_sub(
+            dividend_discount,
+            k_pv,
+            "pricing::cliquet::unit_call::itm::price",
+        )
+        .map_err(PricingError::from);
     }
 
-    if sigma == dec!(0.0) || t == dec!(0.0) {
-        let forward = ((r - q) * t).exp();
+    let b = d_sub(r, q, "pricing::cliquet::unit_call::carry")?;
+    let sqrt_t = d_sqrt(t, "pricing::cliquet::unit_call::sqrt_t")?;
+    let denominator = d_mul(sigma, sqrt_t, "pricing::cliquet::unit_call::denominator")?;
+
+    // Zero volatility, zero maturity, or a `σ√t` that underflowed below the
+    // representable scale: the unit forward is deterministic and the call is
+    // worth its discounted intrinsic.
+    if sigma == dec!(0.0) || t == dec!(0.0) || denominator.is_zero() {
+        let forward = d_exp(
+            d_mul(b, t, "pricing::cliquet::unit_call::zero_vol::carry_t")?,
+            "pricing::cliquet::unit_call::zero_vol::forward",
+        )?;
         let intrinsic = d_sub(
             forward,
             k,
@@ -223,32 +272,47 @@ fn call_price_on_unit(
         .max(dec!(0.0));
         return d_mul(
             intrinsic,
-            (-r * t).exp(),
+            discount,
             "pricing::cliquet::unit_call::zero_vol::discounted",
         )
         .map_err(PricingError::from);
     }
 
-    let sqrt_t = t.sqrt().unwrap_or(dec!(0.0));
-    let b = r - q;
-
-    let d1 = (k.inv().ln() + (b + sigma * sigma / dec!(2.0)) * t) / (sigma * sqrt_t);
-    let d2 = d1 - sigma * sqrt_t;
+    let inv_k = d_div(Decimal::ONE, k, "pricing::cliquet::unit_call::inv_k")?;
+    if inv_k.is_zero() {
+        // `1 / K` underflowed below the smallest representable `Decimal`, so
+        // both normal arguments diverge to `-∞` and the call is worthless.
+        return Ok(Decimal::ZERO);
+    }
+    let d1 = d_div(
+        d_add(
+            d_ln(inv_k, "pricing::cliquet::unit_call::log_inv_k")?,
+            d_mul(
+                d_add(
+                    b,
+                    d_div(
+                        d_mul(sigma, sigma, "pricing::cliquet::unit_call::variance")?,
+                        dec!(2.0),
+                        "pricing::cliquet::unit_call::half_variance",
+                    )?,
+                    "pricing::cliquet::unit_call::drift_rate",
+                )?,
+                t,
+                "pricing::cliquet::unit_call::drift",
+            )?,
+            "pricing::cliquet::unit_call::d1_numerator",
+        )?,
+        denominator,
+        "pricing::cliquet::unit_call::d1",
+    )?;
+    let d2 = d_sub(d1, denominator, "pricing::cliquet::unit_call::d2")?;
 
     let n1 = big_n(d1).unwrap_or(dec!(0.0));
     let n2 = big_n(d2).unwrap_or(dec!(0.0));
 
-    // `s_leg` is a unit-forward so its monetary boundary starts at
-    // `exp(-qt)`; no extra checked product is needed there.
-    let s_leg = d_mul((-q * t).exp(), n1, "pricing::cliquet::unit_call::s_leg")?;
-    // `k_leg` was `k * exp(-rt) * n2` with the first `*` unchecked,
-    // so build the discounted strike through `d_mul` first and then
-    // fold in `n2` so an overflow on either product is tagged.
-    let discounted_k = d_mul(
-        k,
-        (-r * t).exp(),
-        "pricing::cliquet::unit_call::discounted_k",
-    )?;
+    // `s_leg` is a unit-forward so its monetary boundary starts at `exp(-qt)`.
+    let s_leg = d_mul(dividend_discount, n1, "pricing::cliquet::unit_call::s_leg")?;
+    let discounted_k = d_mul(k, discount, "pricing::cliquet::unit_call::discounted_k")?;
     let k_leg = d_mul(discounted_k, n2, "pricing::cliquet::unit_call::k_leg")?;
     d_sub(s_leg, k_leg, "pricing::cliquet::unit_call::price").map_err(PricingError::from)
 }

--- a/src/pricing/compound.rs
+++ b/src/pricing/compound.rs
@@ -34,7 +34,7 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::{big_n, d1, d2};
-use crate::model::decimal::{d_add, d_mul, d_sub, finite_decimal};
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_sqrt, d_sub, finite_decimal};
 use crate::model::types::{OptionStyle, OptionType};
 use positive::Positive;
 use rust_decimal::Decimal;
@@ -56,7 +56,11 @@ fn bivariate_normal_cdf(a: Decimal, b: Decimal, rho: Decimal) -> Result<Decimal,
         // Independent case: P(X <= a, Y <= b) = N(a) * N(b)
         let n_a = big_n(a).unwrap_or(Decimal::ZERO);
         let n_b = big_n(b).unwrap_or(Decimal::ZERO);
-        return Ok(n_a * n_b);
+        return Ok(d_mul(
+            n_a,
+            n_b,
+            "pricing::compound::bivariate::independent",
+        )?);
     }
 
     if rho_f >= 1.0 - 1e-10 {
@@ -66,8 +70,9 @@ fn bivariate_normal_cdf(a: Decimal, b: Decimal, rho: Decimal) -> Result<Decimal,
     }
 
     if rho_f <= -1.0 + 1e-10 {
-        // Perfect negative correlation
-        if a + b >= Decimal::ZERO {
+        // Perfect negative correlation. `a` and `b` are raw `d` values, so
+        // their sum is checked before the comparison.
+        if d_add(a, b, "pricing::compound::bivariate::perfect_negative")? >= Decimal::ZERO {
             return Ok(big_n(a).unwrap_or(Decimal::ZERO));
         } else {
             return Ok(Decimal::ZERO);
@@ -221,10 +226,19 @@ fn standard_normal_cdf(x: f64) -> f64 {
 ///
 /// # Errors
 ///
-/// Returns [`PricingError::UnsupportedOptionType`] when `option` is
-/// not an [`OptionType::Compound`] variant, and propagates any
-/// `PricingError` raised by the Black–Scholes evaluation of the
-/// outer option on the inner-option implied value.
+/// - [`PricingError::MethodError`] when `option` is not an
+///   [`OptionType::Compound`] variant, when the expiration cannot be converted
+///   to a year fraction, or when the `d1` / `d2` kernels reject the inputs.
+/// - [`PricingError::NonFinite`] when the Drezner-Wesolowsky bivariate
+///   quadrature produces a non-finite value.
+/// - [`PricingError::Positive`] when the derived `T2 = 2·T1` maturity is not
+///   representable as a `Positive`.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range, or when `σ√T1` or the critical-price
+///   moneyness collapses to zero: the discount factors, the critical price,
+///   `d1_t1` / `d2_t1`, or the final leg composition.
+/// - Whatever the inner Black-Scholes valuation of the underlying option
+///   propagates.
 pub fn compound_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
         OptionType::Compound { underlying_option } => price_compound(option, underlying_option),
@@ -273,9 +287,22 @@ fn price_compound(
 
     if sigma == Positive::ZERO {
         // Degenerate case
-        let discount = (-r * t1).exp();
-        let forward_value =
-            value_underlying_option(compound, underlying_type)? * ((r - q) * t1).exp();
+        let discount = d_exp(
+            d_mul(-r, t1.to_dec(), "pricing::compound::zero_vol::neg_rt")?,
+            "pricing::compound::zero_vol::discount",
+        )?;
+        let forward_value = d_mul(
+            value_underlying_option(compound, underlying_type)?,
+            d_exp(
+                d_mul(
+                    d_sub(r, q, "pricing::compound::zero_vol::carry")?,
+                    t1.to_dec(),
+                    "pricing::compound::zero_vol::carry_t",
+                )?,
+                "pricing::compound::zero_vol::growth",
+            )?,
+            "pricing::compound::zero_vol::forward",
+        )?;
         let intrinsic = match compound.option_style {
             OptionStyle::Call => d_mul(
                 d_sub(
@@ -305,27 +332,51 @@ fn price_compound(
     // - T1: time to compound expiry (we have this)
     // - T2: time to underlying expiry (assume we're given an underlying with its own expiry)
     // For simplicity, assume underlying expires at 2*T1 if not specified differently
-    let two = Positive::new(2.0)
-        .map_err(|e| PricingError::method_error("price_compound", &e.to_string()))?;
-    let t2 = t1 * two; // Underlying expires at 2*T1
-
-    let b = r - q;
     let t1_dec = t1.to_dec();
-    let t2_dec = t2.to_dec();
-    let sqrt_t1 = t1_dec.sqrt().unwrap_or(Decimal::ZERO);
-    let _sqrt_t2 = t2_dec.sqrt().unwrap_or(Decimal::ZERO);
+    let t2_dec = d_mul(t1_dec, dec!(2), "pricing::compound::t2")?; // Underlying expires at 2*T1
+    let t2 = Positive::new_decimal(t2_dec)?;
+
+    let b = d_sub(r, q, "pricing::compound::carry")?;
+    let sqrt_t1 = d_sqrt(t1_dec, "pricing::compound::sqrt_t1")?;
 
     // Correlation between values at T1 and T2
-    let rho = (t1_dec / t2_dec).sqrt().unwrap_or(dec!(0.5));
+    let rho = d_div(t1_dec, t2_dec, "pricing::compound::rho_ratio")?
+        .sqrt()
+        .unwrap_or(dec!(0.5));
 
     // Calculate critical price S* where underlying option value = K1
     // For simplicity, use an approximation
     let s_star = find_critical_price(s, k1, underlying_type, t1, sigma, r, q)?;
 
     // d values for the bivariate formula
-    let d1_t1 = ((s.to_dec() / s_star).ln() + (b + sigma * sigma / dec!(2)) * t1_dec)
-        / (sigma.to_dec() * sqrt_t1);
-    let d2_t1 = d1_t1 - sigma.to_dec() * sqrt_t1;
+    let sigma_dec = sigma.to_dec();
+    let sigma_sqrt_t1 = d_mul(sigma_dec, sqrt_t1, "pricing::compound::sigma_sqrt_t1")?;
+    let critical_moneyness = d_div(s.to_dec(), s_star, "pricing::compound::critical_moneyness")?;
+    let d1_t1 = d_div(
+        d_add(
+            d_ln(
+                critical_moneyness,
+                "pricing::compound::log_critical_moneyness",
+            )?,
+            d_mul(
+                d_add(
+                    b,
+                    d_div(
+                        d_mul(sigma_dec, sigma_dec, "pricing::compound::variance")?,
+                        dec!(2),
+                        "pricing::compound::half_variance",
+                    )?,
+                    "pricing::compound::drift_rate",
+                )?,
+                t1_dec,
+                "pricing::compound::drift",
+            )?,
+            "pricing::compound::d1_t1_numerator",
+        )?,
+        sigma_sqrt_t1,
+        "pricing::compound::d1_t1",
+    )?;
+    let d2_t1 = d_sub(d1_t1, sigma_sqrt_t1, "pricing::compound::d2_t1")?;
 
     // Get underlying strike (K2)
     let k2 = get_underlying_strike(underlying_type, compound.strike_price);
@@ -335,9 +386,18 @@ fn price_compound(
     let d2_t2 = d2(s, k2, b, t2, sigma)
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
 
-    let discount_t1 = (-r * t1).exp();
-    let discount_t2 = (-r * t2).exp();
-    let dividend_discount_t2 = (-q * t2).exp();
+    let discount_t1 = d_exp(
+        d_mul(-r, t1_dec, "pricing::compound::neg_rt1")?,
+        "pricing::compound::discount_t1",
+    )?;
+    let discount_t2 = d_exp(
+        d_mul(-r, t2_dec, "pricing::compound::neg_rt2")?,
+        "pricing::compound::discount_t2",
+    )?;
+    let dividend_discount_t2 = d_exp(
+        d_mul(-q, t2_dec, "pricing::compound::neg_qt2")?,
+        "pricing::compound::dividend_discount_t2",
+    )?;
 
     // Determine compound type for pricing
     let is_compound_call = matches!(compound.option_style, OptionStyle::Call);
@@ -501,20 +561,52 @@ fn find_critical_price(
 
     // Simple approximation for critical price
     let _is_call = is_underlying_option_call(underlying_type);
-    let b = r - q;
+    let b = d_sub(r, q, "pricing::compound::critical::carry")?;
     let t_dec = t.to_dec();
-    let sqrt_t = t_dec.sqrt().unwrap_or(Decimal::ZERO);
+    let sqrt_t = d_sqrt(t_dec, "pricing::compound::critical::sqrt_t")?;
 
     // For ATM-ish options, critical price is approximately related to the strike
     // Use forward price adjusted formula
-    let forward = s.to_dec() * (b * t_dec).exp();
+    let forward = d_mul(
+        s.to_dec(),
+        d_exp(
+            d_mul(b, t_dec, "pricing::compound::critical::carry_t")?,
+            "pricing::compound::critical::growth",
+        )?,
+        "pricing::compound::critical::forward",
+    )?;
 
     // Approximate critical price using Black-Scholes structure
-    let vol_adjustment = sigma.to_dec() * sqrt_t * dec!(0.4);
-    let critical = if k1.to_dec() < forward * dec!(0.5) {
-        forward * (dec!(1) - vol_adjustment)
+    let vol_adjustment = d_mul(
+        d_mul(
+            sigma.to_dec(),
+            sqrt_t,
+            "pricing::compound::critical::sigma_sqrt_t",
+        )?,
+        dec!(0.4),
+        "pricing::compound::critical::vol_adjustment",
+    )?;
+    let half_forward = d_mul(forward, dec!(0.5), "pricing::compound::critical::half")?;
+    let critical = if k1.to_dec() < half_forward {
+        d_mul(
+            forward,
+            d_sub(
+                dec!(1),
+                vol_adjustment,
+                "pricing::compound::critical::down_factor",
+            )?,
+            "pricing::compound::critical::down",
+        )?
     } else {
-        forward * (dec!(1) + vol_adjustment)
+        d_mul(
+            forward,
+            d_add(
+                dec!(1),
+                vol_adjustment,
+                "pricing::compound::critical::up_factor",
+            )?,
+            "pricing::compound::critical::up",
+        )?
     };
 
     Ok(critical.max(dec!(0.01)))

--- a/src/pricing/exchange.rs
+++ b/src/pricing/exchange.rs
@@ -26,6 +26,7 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_sqrt, d_sub};
 use crate::model::types::{OptionType, Side};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
@@ -43,10 +44,13 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - The option type is not `Exchange`
-/// - Required exotic parameters are missing
-/// - Correlation is outside the valid range [-1, 1]
+/// - [`PricingError::MethodError`] when the option type is not `Exchange`,
+///   when the required exotic parameters are missing, when the correlation is
+///   outside `[-1, 1]`, or when the combined variance is negative.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range: the combined variance, the two present
+///   values, `d1` / `d2`, or the final leg difference.
+/// - `PricingError::ExpirationDate` when the expiration cannot be converted.
 pub fn exchange_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let second_asset_price = match &option.option_type {
         OptionType::Exchange { second_asset } => second_asset.to_dec(),
@@ -124,30 +128,98 @@ fn margrabe_formula(
     t: Decimal,
 ) -> Result<Decimal, PricingError> {
     if t <= dec!(0.0) {
-        return Ok((s1 - s2).max(dec!(0.0)));
+        return Ok(d_sub(s1, s2, "pricing::exchange::intrinsic")?.max(dec!(0.0)));
     }
 
-    let sigma_sq = sigma1 * sigma1 + sigma2 * sigma2 - dec!(2.0) * rho * sigma1 * sigma2;
+    let sigma_sq = d_sub(
+        d_add(
+            d_mul(sigma1, sigma1, "pricing::exchange::var1")?,
+            d_mul(sigma2, sigma2, "pricing::exchange::var2")?,
+            "pricing::exchange::variance_sum",
+        )?,
+        d_mul(
+            d_mul(
+                d_mul(dec!(2.0), rho, "pricing::exchange::two_rho")?,
+                sigma1,
+                "pricing::exchange::two_rho_sigma1",
+            )?,
+            sigma2,
+            "pricing::exchange::covariance",
+        )?,
+        "pricing::exchange::sigma_sq",
+    )?;
 
     let sigma = sigma_sq
         .sqrt()
         .ok_or_else(|| PricingError::other("Failed to compute combined volatility"))?;
 
-    if sigma <= dec!(0.0) {
-        return Ok((s1 * (-q1 * t).exp() - s2 * (-q2 * t).exp()).max(dec!(0.0)));
+    let s1_pv = d_mul(
+        s1,
+        d_exp(
+            d_mul(-q1, t, "pricing::exchange::neg_q1t")?,
+            "pricing::exchange::discount1",
+        )?,
+        "pricing::exchange::s1_pv",
+    )?;
+    let s2_pv = d_mul(
+        s2,
+        d_exp(
+            d_mul(-q2, t, "pricing::exchange::neg_q2t")?,
+            "pricing::exchange::discount2",
+        )?,
+        "pricing::exchange::s2_pv",
+    )?;
+
+    let sqrt_t = d_sqrt(t, "pricing::exchange::sqrt_t")?;
+    let denominator = d_mul(sigma, sqrt_t, "pricing::exchange::denominator")?;
+
+    // Zero combined volatility, or a `σ√T` that underflowed below the
+    // representable scale: the exchange ratio is deterministic and the option
+    // is worth the difference of the two present values.
+    if sigma <= dec!(0.0) || denominator.is_zero() {
+        return Ok(d_sub(s1_pv, s2_pv, "pricing::exchange::deterministic")?.max(dec!(0.0)));
     }
 
-    let sqrt_t = t
-        .sqrt()
-        .ok_or_else(|| PricingError::other("Failed to compute sqrt(t)"))?;
+    // `S2 = 0`: the exchange ratio diverges, `N(d1) = N(d2) = 1` and the
+    // option collapses to the present value of the first asset.
+    if s2.is_zero() {
+        return Ok(s1_pv.max(dec!(0.0)));
+    }
+    let ratio = d_div(s1, s2, "pricing::exchange::ratio")?;
+    // `S1 = 0` (or a ratio that rounded below the representable scale): both
+    // normal arguments diverge to `-∞`, `N(d1) = N(d2) = 0`, price zero.
+    if ratio.is_zero() {
+        return Ok(dec!(0.0));
+    }
 
-    let d1 = ((s1 / s2).ln() + (q2 - q1 + sigma * sigma / dec!(2.0)) * t) / (sigma * sqrt_t);
-    let d2 = d1 - sigma * sqrt_t;
+    let d1 = d_div(
+        d_add(
+            d_ln(ratio, "pricing::exchange::log_ratio")?,
+            d_mul(
+                d_add(
+                    d_sub(q2, q1, "pricing::exchange::carry")?,
+                    d_div(
+                        d_mul(sigma, sigma, "pricing::exchange::variance")?,
+                        dec!(2.0),
+                        "pricing::exchange::half_variance",
+                    )?,
+                    "pricing::exchange::drift_rate",
+                )?,
+                t,
+                "pricing::exchange::drift",
+            )?,
+            "pricing::exchange::d1_numerator",
+        )?,
+        denominator,
+        "pricing::exchange::d1",
+    )?;
+    let d2 = d_sub(d1, denominator, "pricing::exchange::d2")?;
 
-    let s1_pv = s1 * (-q1 * t).exp();
-    let s2_pv = s2 * (-q2 * t).exp();
-
-    let price = s1_pv * big_n(d1)? - s2_pv * big_n(d2)?;
+    let price = d_sub(
+        d_mul(s1_pv, big_n(d1)?, "pricing::exchange::leg1")?,
+        d_mul(s2_pv, big_n(d2)?, "pricing::exchange::leg2")?,
+        "pricing::exchange::price",
+    )?;
 
     Ok(price.max(dec!(0.0)))
 }

--- a/src/pricing/exchange.rs
+++ b/src/pricing/exchange.rs
@@ -49,7 +49,8 @@ use rust_decimal_macros::dec;
 ///   outside `[-1, 1]`, or when the combined variance is negative.
 /// - [`PricingError::Decimal`] when an intermediate step leaves the
 ///   representable `Decimal` range: the combined variance, the two present
-///   values, `d1` / `d2`, or the final leg difference.
+///   values, either spot logarithm, `d1` / `d2`, or the final leg
+///   difference.
 /// - `PricingError::ExpirationDate` when the expiration cannot be converted.
 pub fn exchange_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let second_asset_price = match &option.option_type {
@@ -185,16 +186,29 @@ fn margrabe_formula(
     if s2.is_zero() {
         return Ok(s1_pv.max(dec!(0.0)));
     }
-    let ratio = d_div(s1, s2, "pricing::exchange::ratio")?;
-    // `S1 = 0` (or a ratio that rounded below the representable scale): both
-    // normal arguments diverge to `-∞`, `N(d1) = N(d2) = 0`, price zero.
-    if ratio.is_zero() {
+    // `S1 = 0`: the payoff `max(S1 - S2, 0)` is identically zero, and so is
+    // `S1`'s present value.
+    if s1.is_zero() {
         return Ok(dec!(0.0));
     }
 
+    // Log-moneyness as `ln(S1) - ln(S2)`, never as `ln(S1 / S2)`: the quotient
+    // underflows to zero below `1e-28` and drags the `(q2 - q1)T` carry down
+    // with it. A tiny-but-nonzero `S1` against a `q2` large enough to wipe out
+    // `S2`'s present value is worth `S1`'s present value, not zero, and only
+    // the carry knows that. The difference of the two logarithms is exact
+    // where the quotient is not, and both logarithms exist: the two spot
+    // branches above are the only non-positive inputs `d_ln` could see. Same
+    // convention as `pricing::asian`'s log-moneyness.
+    let log_ratio = d_sub(
+        d_ln(s1, "pricing::exchange::log_s1")?,
+        d_ln(s2, "pricing::exchange::log_s2")?,
+        "pricing::exchange::log_ratio",
+    )?;
+
     let d1 = d_div(
         d_add(
-            d_ln(ratio, "pricing::exchange::log_ratio")?,
+            log_ratio,
             d_mul(
                 d_add(
                     d_sub(q2, q1, "pricing::exchange::carry")?,
@@ -432,6 +446,67 @@ mod tests {
         assert!(
             price > dec!(0.0),
             "Exchange option with zero dividends should have positive value"
+        );
+    }
+
+    /// `S1` small enough that `S1 / S2` rounds below the representable
+    /// `Decimal` scale, against a `q2` large enough that `S2`'s present value
+    /// has vanished. The `(q2 - q1)T` carry offsets the log-moneyness, so both
+    /// CDFs saturate at one and the option is worth `S1`'s present value, not
+    /// zero.
+    #[test]
+    fn test_exchange_underflowing_ratio_with_offsetting_carry_prices_first_pv() {
+        let mut option = create_exchange_option();
+        option.underlying_price = Positive::new_decimal(Decimal::new(1, 27)).unwrap();
+        option.option_type = OptionType::Exchange {
+            second_asset: pos_or_panic!(100.0),
+        };
+        option.expiration_date = ExpirationDate::Days(pos_or_panic!(365.0));
+        option.implied_volatility = pos_or_panic!(0.2);
+        option.dividend_yield = Positive::ZERO;
+        if let Some(ref mut params) = option.exotic_params {
+            params.exchange_second_asset_volatility = Some(pos_or_panic!(0.2));
+            params.exchange_second_asset_dividend = Some(pos_or_panic!(100.0));
+            params.exchange_correlation = Some(dec!(0.5));
+        }
+
+        let price = exchange_black_scholes(&option).unwrap();
+
+        // `S2 e^{-100} = 0` at `Decimal` scale and `N(d1) = N(d2) = 1`, so the
+        // price is `S1 e^{-q1 T} = 1e-27`.
+        assert_eq!(
+            price,
+            Decimal::new(1, 27),
+            "vanished S2 present value should leave S1's present value, got {}",
+            price
+        );
+    }
+
+    /// The mirror case: with no carry to offset it, the same underflowing
+    /// ratio really does drive both CDFs to zero and the option is worthless.
+    #[test]
+    fn test_exchange_underflowing_ratio_without_carry_is_zero() {
+        let mut option = create_exchange_option();
+        option.underlying_price = Positive::new_decimal(Decimal::new(1, 27)).unwrap();
+        option.option_type = OptionType::Exchange {
+            second_asset: pos_or_panic!(100.0),
+        };
+        option.expiration_date = ExpirationDate::Days(pos_or_panic!(365.0));
+        option.implied_volatility = pos_or_panic!(0.2);
+        option.dividend_yield = Positive::ZERO;
+        if let Some(ref mut params) = option.exotic_params {
+            params.exchange_second_asset_volatility = Some(pos_or_panic!(0.2));
+            params.exchange_second_asset_dividend = Some(Positive::ZERO);
+            params.exchange_correlation = Some(dec!(0.5));
+        }
+
+        let price = exchange_black_scholes(&option).unwrap();
+
+        assert_eq!(
+            price,
+            Decimal::ZERO,
+            "a ratio that vanishes in the limit should still price at zero, got {}",
+            price
         );
     }
 

--- a/src/pricing/lookback.rs
+++ b/src/pricing/lookback.rs
@@ -27,11 +27,10 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::{big_n, d1, d2};
-use crate::model::decimal::{d_add, d_mul, d_sub};
+use crate::model::decimal::{d_add, d_div, d_exp, d_mul, d_sqrt, d_sub};
 use crate::model::types::{LookbackType, OptionStyle, OptionType};
 use positive::Positive;
 use rust_decimal::Decimal;
-use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 
 /// Prices a Lookback option using appropriate closed-form formula.
@@ -46,10 +45,15 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns [`PricingError::UnsupportedOptionType`] when `option` is
-/// not an [`OptionType::Lookback`] variant, and propagates any
-/// `PricingError` raised by intermediate Black–Scholes kernels
-/// on the running extremum decomposition.
+/// - [`PricingError::MethodError`] when `option` is not an
+///   [`OptionType::Lookback`] variant, when the lookback sub-type is an
+///   unsupported `#[non_exhaustive]` variant, when the expiration cannot be
+///   converted to a year fraction, or when the `d1` / `d2` kernels reject the
+///   inputs.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range, or when `σ√T` collapses to zero: the
+///   discount factors, the Goldman-Sosin-Gatto `a1` / `a2`, the reflection
+///   weight `σ²/(2b)`, the Conze-Viswanathan `λ`, or the final legs.
 pub fn lookback_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
         OptionType::Lookback { lookback_type } => match lookback_type {
@@ -89,21 +93,87 @@ fn floating_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
         return Ok(Decimal::ZERO);
     }
 
+    let t_dec = t.to_dec();
+    let b = d_sub(r, q, "pricing::lookback::floating::carry")?; // cost of carry
+    let discount = d_exp(
+        d_mul(-r, t_dec, "pricing::lookback::floating::neg_rt")?,
+        "pricing::lookback::floating::discount",
+    )?;
+    let dividend_discount = d_exp(
+        d_mul(-q, t_dec, "pricing::lookback::floating::neg_qt")?,
+        "pricing::lookback::floating::dividend_discount",
+    )?;
+
     if sigma == Positive::ZERO {
         // Zero volatility: no path variation, lookback equals vanilla
-        let discount = (-r * t).exp();
-        let forward = s * ((r - q) * t).exp();
-        let value = match option.option_style {
-            OptionStyle::Call => (forward - s).max(Positive::ZERO).to_dec() * discount,
-            OptionStyle::Put => (s - forward).max(Positive::ZERO).to_dec() * discount,
+        let forward = d_mul(
+            s.to_dec(),
+            d_exp(
+                d_mul(b, t_dec, "pricing::lookback::floating::zero_vol::carry_t")?,
+                "pricing::lookback::floating::zero_vol::growth",
+            )?,
+            "pricing::lookback::floating::zero_vol::forward",
+        )?;
+        let intrinsic = match option.option_style {
+            OptionStyle::Call => d_sub(
+                forward,
+                s.to_dec(),
+                "pricing::lookback::floating::zero_vol::call",
+            )?
+            .max(Decimal::ZERO),
+            OptionStyle::Put => d_sub(
+                s.to_dec(),
+                forward,
+                "pricing::lookback::floating::zero_vol::put",
+            )?
+            .max(Decimal::ZERO),
         };
+        let value = d_mul(
+            intrinsic,
+            discount,
+            "pricing::lookback::floating::zero_vol::discounted",
+        )?;
         return Ok(apply_side(value, option));
     }
 
-    let b = r - q; // cost of carry
-    let sigma_sq = sigma * sigma;
-    let t_dec = t.to_dec();
-    let sqrt_t = t_dec.sqrt().unwrap_or(Decimal::ZERO);
+    let sigma_dec = sigma.to_dec();
+    let sigma_sq = d_mul(
+        sigma_dec,
+        sigma_dec,
+        "pricing::lookback::floating::sigma_sq",
+    )?;
+    let sqrt_t = d_sqrt(t_dec, "pricing::lookback::floating::sqrt_t")?;
+    let sigma_sqrt_t = d_mul(
+        sigma_dec,
+        sqrt_t,
+        "pricing::lookback::floating::sigma_sqrt_t",
+    )?;
+    let s_dec = s.to_dec();
+    // `a1 = (b + σ²/2) T / (σ√T)`, shared by both styles outside the `b ≈ 0`
+    // special case.
+    let a1_general = || -> Result<Decimal, PricingError> {
+        Ok(d_div(
+            d_mul(
+                d_add(
+                    b,
+                    d_div(sigma_sq, dec!(2), "pricing::lookback::floating::half_var")?,
+                    "pricing::lookback::floating::drift_rate",
+                )?,
+                t_dec,
+                "pricing::lookback::floating::drift",
+            )?,
+            sigma_sqrt_t,
+            "pricing::lookback::floating::a1",
+        )?)
+    };
+    // `σ² / (2b)`, the Goldman-Sosin-Gatto reflection weight.
+    let reflection_weight = || -> Result<Decimal, PricingError> {
+        Ok(d_div(
+            sigma_sq,
+            d_mul(dec!(2), b, "pricing::lookback::floating::two_b")?,
+            "pricing::lookback::floating::reflection_weight",
+        )?)
+    };
 
     // For a new floating strike lookback (S_min = S_max = S):
     // Use Goldman-Sosin-Gatto formulas
@@ -116,36 +186,110 @@ fn floating_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
 
             if b.abs() < dec!(1e-10) {
                 // Special case when b ≈ 0 (ATM forward)
-                let a1 = sigma.to_dec() * sqrt_t / dec!(2);
+                let a1 = d_div(
+                    sigma_sqrt_t,
+                    dec!(2),
+                    "pricing::lookback::floating::call::flat::a1",
+                )?;
                 let n_a1 = big_n(a1).unwrap_or(Decimal::ZERO);
                 let n_neg_a1 = big_n(-a1).unwrap_or(Decimal::ZERO);
 
                 // Simplified formula for b = 0
-                s.to_dec() * (dec!(2) * n_a1 - dec!(1))
-                    + s.to_dec()
-                        * sigma.to_dec()
-                        * sqrt_t
-                        * (dec!(2) * n_a1 - dec!(1)
-                            + dec!(2) / (dec!(2.506628274631) * dec!(1))
-                                * (a1 * n_neg_a1).exp().min(dec!(10)))
-                        .min(s.to_dec())
+                let centred = d_sub(
+                    d_mul(
+                        dec!(2),
+                        n_a1,
+                        "pricing::lookback::floating::call::flat::two_n",
+                    )?,
+                    dec!(1),
+                    "pricing::lookback::floating::call::flat::centred",
+                )?;
+                let bracket = d_add(
+                    centred,
+                    d_mul(
+                        d_div(
+                            dec!(2),
+                            dec!(2.506628274631),
+                            "pricing::lookback::floating::call::flat::coefficient",
+                        )?,
+                        d_exp(
+                            d_mul(
+                                a1,
+                                n_neg_a1,
+                                "pricing::lookback::floating::call::flat::exponent",
+                            )?,
+                            "pricing::lookback::floating::call::flat::exp",
+                        )?
+                        .min(dec!(10)),
+                        "pricing::lookback::floating::call::flat::tail",
+                    )?,
+                    "pricing::lookback::floating::call::flat::bracket",
+                )?
+                .min(s_dec);
+                d_add(
+                    d_mul(
+                        s_dec,
+                        centred,
+                        "pricing::lookback::floating::call::flat::level",
+                    )?,
+                    d_mul(
+                        d_mul(
+                            s_dec,
+                            sigma_sqrt_t,
+                            "pricing::lookback::floating::call::flat::scale",
+                        )?,
+                        bracket,
+                        "pricing::lookback::floating::call::flat::spread",
+                    )?,
+                    "pricing::lookback::floating::call::flat::price",
+                )?
             } else {
-                let a1 = ((b + sigma_sq / dec!(2)) * t_dec) / (sigma.to_dec() * sqrt_t);
-                let a2 = a1 - sigma.to_dec() * sqrt_t;
+                let a1 = a1_general()?;
+                let a2 = d_sub(a1, sigma_sqrt_t, "pricing::lookback::floating::call::a2")?;
 
                 let n_a1 = big_n(a1).unwrap_or(Decimal::ZERO);
                 let n_a2 = big_n(a2).unwrap_or(Decimal::ZERO);
                 let n_neg_a1 = big_n(-a1).unwrap_or(Decimal::ZERO);
 
-                let dividend_discount = (-q * t).exp();
-                let discount = (-r * t).exp();
-
-                let term1 = s.to_dec() * dividend_discount * n_a1;
-                let term2 = s.to_dec() * discount * n_a2;
-                let term3 = s.to_dec()
-                    * discount
-                    * (sigma_sq / (dec!(2) * b))
-                    * (n_a2 - (b * t_dec).exp() * n_neg_a1);
+                let term1 = d_mul(
+                    d_mul(
+                        s_dec,
+                        dividend_discount,
+                        "pricing::lookback::floating::call::s_pv",
+                    )?,
+                    n_a1,
+                    "pricing::lookback::floating::call::term1",
+                )?;
+                let s_discounted = d_mul(
+                    s_dec,
+                    discount,
+                    "pricing::lookback::floating::call::s_discounted",
+                )?;
+                let term2 = d_mul(
+                    s_discounted,
+                    n_a2,
+                    "pricing::lookback::floating::call::term2",
+                )?;
+                let term3 = d_mul(
+                    d_mul(
+                        s_discounted,
+                        reflection_weight()?,
+                        "pricing::lookback::floating::call::reflection",
+                    )?,
+                    d_sub(
+                        n_a2,
+                        d_mul(
+                            d_exp(
+                                d_mul(b, t_dec, "pricing::lookback::floating::call::bt")?,
+                                "pricing::lookback::floating::call::exp_bt",
+                            )?,
+                            n_neg_a1,
+                            "pricing::lookback::floating::call::reflected_cdf",
+                        )?,
+                        "pricing::lookback::floating::call::bracket",
+                    )?,
+                    "pricing::lookback::floating::call::term3",
+                )?;
 
                 let diff = d_sub(term1, term2, "pricing::lookback::floating::call::diff")?;
                 d_add(diff, term3, "pricing::lookback::floating::call::price")?
@@ -156,30 +300,87 @@ fn floating_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
             //                        + S*e^(-rT)*(sigma^2/(2b))*(e^(b*T)*N(a1) - N(a2))
 
             if b.abs() < dec!(1e-10) {
-                let a1 = sigma.to_dec() * sqrt_t / dec!(2);
+                let a1 = d_div(
+                    sigma_sqrt_t,
+                    dec!(2),
+                    "pricing::lookback::floating::put::flat::a1",
+                )?;
                 let n_neg_a1 = big_n(-a1).unwrap_or(Decimal::ZERO);
 
                 // Simplified for b = 0
-                s.to_dec() * (dec!(1) - dec!(2) * n_neg_a1)
-                    + s.to_dec() * sigma.to_dec() * sqrt_t * dec!(0.5)
+                d_add(
+                    d_mul(
+                        s_dec,
+                        d_sub(
+                            dec!(1),
+                            d_mul(
+                                dec!(2),
+                                n_neg_a1,
+                                "pricing::lookback::floating::put::flat::two_n",
+                            )?,
+                            "pricing::lookback::floating::put::flat::centred",
+                        )?,
+                        "pricing::lookback::floating::put::flat::level",
+                    )?,
+                    d_mul(
+                        d_mul(
+                            s_dec,
+                            sigma_sqrt_t,
+                            "pricing::lookback::floating::put::flat::scale",
+                        )?,
+                        dec!(0.5),
+                        "pricing::lookback::floating::put::flat::spread",
+                    )?,
+                    "pricing::lookback::floating::put::flat::price",
+                )?
             } else {
-                let a1 = ((b + sigma_sq / dec!(2)) * t_dec) / (sigma.to_dec() * sqrt_t);
-                let a2 = a1 - sigma.to_dec() * sqrt_t;
+                let a1 = a1_general()?;
+                let a2 = d_sub(a1, sigma_sqrt_t, "pricing::lookback::floating::put::a2")?;
 
                 let n_neg_a1 = big_n(-a1).unwrap_or(Decimal::ZERO);
                 let n_neg_a2 = big_n(-a2).unwrap_or(Decimal::ZERO);
                 let n_a1 = big_n(a1).unwrap_or(Decimal::ZERO);
                 let n_a2 = big_n(a2).unwrap_or(Decimal::ZERO);
 
-                let dividend_discount = (-q * t).exp();
-                let discount = (-r * t).exp();
-
-                let term1 = s.to_dec() * discount * n_neg_a2;
-                let term2 = s.to_dec() * dividend_discount * n_neg_a1;
-                let term3 = s.to_dec()
-                    * discount
-                    * (sigma_sq / (dec!(2) * b))
-                    * ((b * t_dec).exp() * n_a1 - n_a2);
+                let s_discounted = d_mul(
+                    s_dec,
+                    discount,
+                    "pricing::lookback::floating::put::s_discounted",
+                )?;
+                let term1 = d_mul(
+                    s_discounted,
+                    n_neg_a2,
+                    "pricing::lookback::floating::put::term1",
+                )?;
+                let term2 = d_mul(
+                    d_mul(
+                        s_dec,
+                        dividend_discount,
+                        "pricing::lookback::floating::put::s_pv",
+                    )?,
+                    n_neg_a1,
+                    "pricing::lookback::floating::put::term2",
+                )?;
+                let term3 = d_mul(
+                    d_mul(
+                        s_discounted,
+                        reflection_weight()?,
+                        "pricing::lookback::floating::put::reflection",
+                    )?,
+                    d_sub(
+                        d_mul(
+                            d_exp(
+                                d_mul(b, t_dec, "pricing::lookback::floating::put::bt")?,
+                                "pricing::lookback::floating::put::exp_bt",
+                            )?,
+                            n_a1,
+                            "pricing::lookback::floating::put::reflected_cdf",
+                        )?,
+                        n_a2,
+                        "pricing::lookback::floating::put::bracket",
+                    )?,
+                    "pricing::lookback::floating::put::term3",
+                )?;
 
                 let diff = d_sub(term1, term2, "pricing::lookback::floating::put::diff")?;
                 d_add(diff, term3, "pricing::lookback::floating::put::price")?
@@ -211,26 +412,112 @@ fn fixed_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
     if t == Positive::ZERO {
         // At expiration, for new contract S_max = S_min = S
         let intrinsic = match option.option_style {
-            OptionStyle::Call => (s - k).max(Positive::ZERO).to_dec(),
-            OptionStyle::Put => (k - s).max(Positive::ZERO).to_dec(),
+            OptionStyle::Call => d_sub(
+                s.to_dec(),
+                k.to_dec(),
+                "pricing::lookback::fixed::intrinsic::call",
+            )?
+            .max(Decimal::ZERO),
+            OptionStyle::Put => d_sub(
+                k.to_dec(),
+                s.to_dec(),
+                "pricing::lookback::fixed::intrinsic::put",
+            )?
+            .max(Decimal::ZERO),
         };
         return Ok(apply_side(intrinsic, option));
     }
+
+    let t_dec = t.to_dec();
+    let b = d_sub(r, q, "pricing::lookback::fixed::carry")?;
+    let discount = d_exp(
+        d_mul(-r, t_dec, "pricing::lookback::fixed::neg_rt")?,
+        "pricing::lookback::fixed::discount",
+    )?;
+    let dividend_discount = d_exp(
+        d_mul(-q, t_dec, "pricing::lookback::fixed::neg_qt")?,
+        "pricing::lookback::fixed::dividend_discount",
+    )?;
 
     if sigma == Positive::ZERO {
-        let discount = (-r * t).exp();
-        let forward = s * ((r - q) * t).exp();
-        let intrinsic = match option.option_style {
-            OptionStyle::Call => (forward - k).max(Positive::ZERO).to_dec() * discount,
-            OptionStyle::Put => (k - forward).max(Positive::ZERO).to_dec() * discount,
+        let forward = d_mul(
+            s.to_dec(),
+            d_exp(
+                d_mul(b, t_dec, "pricing::lookback::fixed::zero_vol::carry_t")?,
+                "pricing::lookback::fixed::zero_vol::growth",
+            )?,
+            "pricing::lookback::fixed::zero_vol::forward",
+        )?;
+        let payoff = match option.option_style {
+            OptionStyle::Call => d_sub(
+                forward,
+                k.to_dec(),
+                "pricing::lookback::fixed::zero_vol::call",
+            )?
+            .max(Decimal::ZERO),
+            OptionStyle::Put => d_sub(
+                k.to_dec(),
+                forward,
+                "pricing::lookback::fixed::zero_vol::put",
+            )?
+            .max(Decimal::ZERO),
         };
+        let intrinsic = d_mul(
+            payoff,
+            discount,
+            "pricing::lookback::fixed::zero_vol::discounted",
+        )?;
         return Ok(apply_side(intrinsic, option));
     }
 
-    let b = r - q;
-    let sigma_sq = sigma * sigma;
-    let t_dec = t.to_dec();
-    let sqrt_t = t_dec.sqrt().unwrap_or(Decimal::ZERO);
+    let sigma_dec = sigma.to_dec();
+    let sigma_sq = d_mul(sigma_dec, sigma_dec, "pricing::lookback::fixed::sigma_sq")?;
+    let sqrt_t = d_sqrt(t_dec, "pricing::lookback::fixed::sqrt_t")?;
+    let sigma_sqrt_t = d_mul(sigma_dec, sqrt_t, "pricing::lookback::fixed::sigma_sqrt_t")?;
+    let s_dec = s.to_dec();
+    // Lookback premium shared by both styles: the `λ` cut-off and the
+    // `S σ√T (N(λ) − ½) / 2` scaling of the running extremum.
+    let lookback_premium = |lambda: Decimal| -> Result<Decimal, PricingError> {
+        let n_lambda = big_n(lambda).unwrap_or(dec!(0.5));
+        Ok(d_mul(
+            d_mul(
+                d_mul(
+                    s_dec,
+                    sigma_sqrt_t,
+                    "pricing::lookback::fixed::premium_scale",
+                )?,
+                d_sub(n_lambda, dec!(0.5), "pricing::lookback::fixed::premium_cdf")?,
+                "pricing::lookback::fixed::premium_weighted",
+            )?,
+            dec!(0.5),
+            "pricing::lookback::fixed::premium",
+        )?)
+    };
+    let lambda = if b.abs() < dec!(1e-10) {
+        d_add(
+            dec!(1),
+            d_div(
+                d_mul(sigma_sq, t_dec, "pricing::lookback::fixed::flat_variance")?,
+                dec!(2),
+                "pricing::lookback::fixed::flat_half_variance",
+            )?,
+            "pricing::lookback::fixed::lambda_flat",
+        )?
+    } else {
+        d_div(
+            d_mul(
+                d_add(
+                    b,
+                    d_div(sigma_sq, dec!(2), "pricing::lookback::fixed::half_variance")?,
+                    "pricing::lookback::fixed::drift_rate",
+                )?,
+                t_dec,
+                "pricing::lookback::fixed::drift",
+            )?,
+            sigma_sqrt_t,
+            "pricing::lookback::fixed::lambda",
+        )?
+    };
 
     // For fixed strike lookback, we use a combination of standard BS
     // plus lookback premium
@@ -240,9 +527,6 @@ fn fixed_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
     let d2_val = d2(s, k, b, t, sigma)
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
-
-    let discount = (-r * t).exp();
-    let dividend_discount = (-q * t).exp();
 
     let price = match option.option_style {
         OptionStyle::Call => {
@@ -254,12 +538,20 @@ fn fixed_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
 
             // Standard BS call
             let s_leg = d_mul(
-                s.to_dec() * dividend_discount,
+                d_mul(
+                    s_dec,
+                    dividend_discount,
+                    "pricing::lookback::fixed::call::s_discounted",
+                )?,
                 n_d1,
                 "pricing::lookback::fixed::call::s_leg",
             )?;
             let k_leg = d_mul(
-                k.to_dec() * discount,
+                d_mul(
+                    k.to_dec(),
+                    discount,
+                    "pricing::lookback::fixed::call::k_discounted",
+                )?,
                 n_d2,
                 "pricing::lookback::fixed::call::k_leg",
             )?;
@@ -267,18 +559,9 @@ fn fixed_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
 
             // Lookback premium (value of being able to exercise at maximum)
             // For new contract from S, use simplified formula
-            let lambda = if b.abs() < dec!(1e-10) {
-                dec!(1) + sigma_sq * t_dec / dec!(2)
-            } else {
-                (b + sigma_sq / dec!(2)) * t_dec / (sigma.to_dec() * sqrt_t)
-            };
-            let n_lambda = big_n(lambda).unwrap_or(dec!(0.5));
-            let lookback_premium =
-                s.to_dec() * sigma.to_dec() * sqrt_t * (n_lambda - dec!(0.5)) * dec!(0.5);
-
             d_add(
                 bs_call,
-                lookback_premium,
+                lookback_premium(lambda)?,
                 "pricing::lookback::fixed::call::price",
             )?
             .max(Decimal::ZERO)
@@ -303,7 +586,7 @@ fn fixed_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
                 "pricing::lookback::fixed::put::k_leg",
             )?;
             let s_discounted = d_mul(
-                s.to_dec(),
+                s_dec,
                 dividend_discount,
                 "pricing::lookback::fixed::put::s_discounted",
             )?;
@@ -315,18 +598,9 @@ fn fixed_strike_lookback(option: &Options) -> Result<Decimal, PricingError> {
             let bs_put = d_sub(k_leg, s_leg, "pricing::lookback::fixed::put::bs")?;
 
             // Lookback premium (value of being able to exercise at minimum)
-            let lambda = if b.abs() < dec!(1e-10) {
-                dec!(1) + sigma_sq * t_dec / dec!(2)
-            } else {
-                (b + sigma_sq / dec!(2)) * t_dec / (sigma.to_dec() * sqrt_t)
-            };
-            let n_lambda = big_n(lambda).unwrap_or(dec!(0.5));
-            let lookback_premium =
-                s.to_dec() * sigma.to_dec() * sqrt_t * (n_lambda - dec!(0.5)) * dec!(0.5);
-
             d_add(
                 bs_put,
-                lookback_premium,
+                lookback_premium(lambda)?,
                 "pricing::lookback::fixed::put::price",
             )?
             .max(Decimal::ZERO)

--- a/src/pricing/monte_carlo.rs
+++ b/src/pricing/monte_carlo.rs
@@ -1,10 +1,10 @@
 use crate::Options;
 use crate::error::PricingError;
-use crate::model::decimal::{d_div, d_mul, d_sub, finite_decimal};
+use crate::model::decimal::{d_add, d_div, d_exp, d_mul, d_sub, d_sum_iter, finite_decimal};
 use crate::pricing::utils::wiener_increment;
 use num_traits::{FromPrimitive, ToPrimitive};
 use positive::Positive;
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::Decimal;
 use std::num::NonZeroUsize;
 use tracing::instrument;
 
@@ -60,12 +60,31 @@ pub fn monte_carlo_option_pricing(
     let dt = option.expiration_date.get_years()? / steps_raw as f64;
     let mut payoff_sum = 0.0;
 
+    let dt_dec = dt.to_dec();
+    let drift = d_mul(
+        option.risk_free_rate,
+        dt_dec,
+        "pricing::monte_carlo::gbm::drift",
+    )?;
     for _ in 0..simulations_raw {
         let mut st = option.underlying_price.to_dec();
         for _ in 0..steps_raw {
-            let w = wiener_increment(dt.to_dec())?;
-            st *=
-                Decimal::ONE + option.risk_free_rate * dt + option.implied_volatility.to_dec() * w;
+            let w = wiener_increment(dt_dec)?;
+            let diffusion = d_mul(
+                option.implied_volatility.to_dec(),
+                w,
+                "pricing::monte_carlo::gbm::diffusion",
+            )?;
+            let growth = d_add(
+                d_add(
+                    Decimal::ONE,
+                    drift,
+                    "pricing::monte_carlo::gbm::growth_drift",
+                )?,
+                diffusion,
+                "pricing::monte_carlo::gbm::growth",
+            )?;
+            st = d_mul(st, growth, "pricing::monte_carlo::gbm::step")?;
         }
         // Calculate the payoff for a call option
         let payoff_dec = d_sub(
@@ -175,18 +194,29 @@ pub fn price_option_monte_carlo(
     }
 
     // Calculate total discount factor (risk-free rate adjusted for dividends)
-    let effective_rate = option.risk_free_rate - option.dividend_yield;
-    let discount_factor = (-effective_rate * option.expiration_date.get_years()?).exp();
+    let effective_rate = d_sub(
+        option.risk_free_rate,
+        option.dividend_yield.to_dec(),
+        "pricing::monte_carlo::effective_rate",
+    )?;
+    let discount_factor = d_exp(
+        d_mul(
+            -effective_rate,
+            option.expiration_date.get_years()?.to_dec(),
+            "pricing::monte_carlo::discount_exponent",
+        )?,
+        "pricing::monte_carlo::discount_factor",
+    )?;
 
     // Calculate payoff for each final price and sum them
-    let total_payoff: Decimal = final_prices
-        .iter()
-        .map(|&final_price| {
+    let total_payoff: Decimal = d_sum_iter(
+        final_prices.iter().map(|&final_price| {
             option
                 .payoff_at_price(&final_price)
                 .unwrap_or(Decimal::ZERO)
-        })
-        .sum();
+        }),
+        "pricing::monte_carlo::total_payoff",
+    )?;
 
     // Average payoff discounted to present value. Both the mean and the
     // discounting are fused monetary flows, so they go through the checked

--- a/src/pricing/payoff.rs
+++ b/src/pricing/payoff.rs
@@ -162,32 +162,34 @@ impl PayoffInfo {
 /// - For a put option: Max(strike price - spot price, 0)
 #[inline]
 pub(crate) fn standard_payoff(info: &PayoffInfo) -> f64 {
-    trace!("standard_payoff - spot: {}", info.spot);
-    trace!("standard_payoff - info.strike: {}", info.strike);
-    trace!(
-        "standard_payoff - (info.spot - info.strike): {}",
-        info.spot - info.strike
-    );
-
     let spot: Decimal = info.spot.into();
     let strike: Decimal = info.strike.into();
+
+    // `Positive - Positive` aborts whenever the result would be negative, i.e.
+    // on every out-of-the-money call, so the moneyness is traced on the
+    // `Decimal` values. Both operands live in `[0, Decimal::MAX]`, which makes
+    // the difference always representable; the checked form keeps the raw
+    // operator out of the kernel.
+    let moneyness = spot.checked_sub(strike).unwrap_or(Decimal::ZERO);
+    trace!("standard_payoff - spot: {}", spot);
+    trace!("standard_payoff - info.strike: {}", strike);
+    trace!("standard_payoff - (info.spot - info.strike): {}", moneyness);
 
     // The result of `(spot - strike).max(ZERO)` is a non-negative finite Decimal whenever
     // the inputs are themselves finite (which Positive guarantees), so to_f64 is expected
     // to succeed. We log and fall back to 0.0 instead of panicking if conversion ever fails.
     let payoff = match info.style {
-        OptionStyle::Call => (spot - strike)
-            .max(Decimal::ZERO)
-            .to_f64()
-            .unwrap_or_else(|| {
-                warn!(
-                    spot = %spot,
-                    strike = %strike,
-                    "standard_payoff(Call): to_f64 returned None; defaulting to 0.0"
-                );
-                0.0
-            }),
-        OptionStyle::Put => (strike - spot)
+        OptionStyle::Call => moneyness.max(Decimal::ZERO).to_f64().unwrap_or_else(|| {
+            warn!(
+                spot = %spot,
+                strike = %strike,
+                "standard_payoff(Call): to_f64 returned None; defaulting to 0.0"
+            );
+            0.0
+        }),
+        OptionStyle::Put => strike
+            .checked_sub(spot)
+            .unwrap_or(Decimal::ZERO)
             .max(Decimal::ZERO)
             .to_f64()
             .unwrap_or_else(|| {

--- a/src/pricing/power.rs
+++ b/src/pricing/power.rs
@@ -22,6 +22,7 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
+use crate::model::decimal::{d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
 use positive::Positive;
 use rust_decimal::Decimal;
@@ -40,9 +41,13 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - The option type is not `Power`
-/// - The exponent is less than or equal to 0
+/// - [`PricingError::MethodError`] when the option type is not `Power`, when
+///   the exponent is not strictly positive, or when any `Decimal` ↔ `f64`
+///   boundary conversion fails (a non-finite `S^n`, forward, `d1` / `d2`, or
+///   discount factor produced by the `f64` kernel).
+/// - [`PricingError::Decimal`] when the final discounted legs leave the
+///   representable `Decimal` range.
+/// - `PricingError::ExpirationDate` when the expiration cannot be converted.
 pub fn power_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let exponent = match &option.option_type {
         OptionType::Power { exponent } => *exponent,
@@ -107,8 +112,12 @@ fn power_price(
             .ok_or_else(|| PricingError::other("Failed to compute S^n"))?;
 
         return match style {
-            OptionStyle::Call => Ok((s_power - k).max(dec!(0.0))),
-            OptionStyle::Put => Ok((k - s_power).max(dec!(0.0))),
+            OptionStyle::Call => {
+                Ok(d_sub(s_power, k, "pricing::power::intrinsic::call")?.max(dec!(0.0)))
+            }
+            OptionStyle::Put => {
+                Ok(d_sub(k, s_power, "pricing::power::intrinsic::put")?.max(dec!(0.0)))
+            }
         };
     }
 
@@ -158,8 +167,24 @@ fn power_price(
         .ok_or_else(|| PricingError::other("Failed to convert discount"))?;
 
     let price = match style {
-        OptionStyle::Call => discount_dec * (forward_dec * big_n(d1_dec)? - k * big_n(d2_dec)?),
-        OptionStyle::Put => discount_dec * (k * big_n(-d2_dec)? - forward_dec * big_n(-d1_dec)?),
+        OptionStyle::Call => d_mul(
+            discount_dec,
+            d_sub(
+                d_mul(forward_dec, big_n(d1_dec)?, "pricing::power::call::forward")?,
+                d_mul(k, big_n(d2_dec)?, "pricing::power::call::strike")?,
+                "pricing::power::call::intrinsic",
+            )?,
+            "pricing::power::call",
+        )?,
+        OptionStyle::Put => d_mul(
+            discount_dec,
+            d_sub(
+                d_mul(k, big_n(-d2_dec)?, "pricing::power::put::strike")?,
+                d_mul(forward_dec, big_n(-d1_dec)?, "pricing::power::put::forward")?,
+                "pricing::power::put::intrinsic",
+            )?,
+            "pricing::power::put",
+        )?,
     };
 
     Ok(price.max(dec!(0.0)))

--- a/src/pricing/quanto.rs
+++ b/src/pricing/quanto.rs
@@ -27,9 +27,9 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_sqrt, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
 use rust_decimal::Decimal;
-use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 
 /// Prices a Quanto option using the quanto-adjusted Black-Scholes formula.
@@ -44,10 +44,13 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - The option type is not `Quanto`
-/// - Required exotic parameters are missing
-/// - Correlation is outside the valid range [-1, 1]
+/// - [`PricingError::MethodError`] when the option type is not `Quanto`, when
+///   the required exotic parameters are missing, or when the correlation is
+///   outside `[-1, 1]`.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range: the quanto drift adjustment, the forward,
+///   the discount factor, `d1` / `d2`, or the converted price legs.
+/// - `PricingError::ExpirationDate` when the expiration cannot be converted.
 pub fn quanto_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let exchange_rate = match &option.option_type {
         OptionType::Quanto { exchange_rate } => exchange_rate.to_dec(),
@@ -84,10 +87,17 @@ pub fn quanto_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
 
     if t <= dec!(0.0) {
         let intrinsic = match option.option_style {
-            OptionStyle::Call => (s - k).max(dec!(0.0)),
-            OptionStyle::Put => (k - s).max(dec!(0.0)),
+            OptionStyle::Call => d_sub(s, k, "pricing::quanto::intrinsic::call")?.max(dec!(0.0)),
+            OptionStyle::Put => d_sub(k, s, "pricing::quanto::intrinsic::put")?.max(dec!(0.0)),
         };
-        return Ok(apply_side(intrinsic * exchange_rate, option));
+        return Ok(apply_side(
+            d_mul(
+                intrinsic,
+                exchange_rate,
+                "pricing::quanto::intrinsic::converted",
+            )?,
+            option,
+        ));
     }
 
     let price = quanto_price(
@@ -133,23 +143,95 @@ fn quanto_price(
     x: Decimal,
     style: &OptionStyle,
 ) -> Result<Decimal, PricingError> {
-    let quanto_adjustment = rho * sigma_s * sigma_fx;
-    let adjusted_drift = r_d - q - quanto_adjustment;
+    let quanto_adjustment = d_mul(
+        d_mul(rho, sigma_s, "pricing::quanto::rho_sigma_s")?,
+        sigma_fx,
+        "pricing::quanto::adjustment",
+    )?;
+    let adjusted_drift = d_sub(
+        d_sub(r_d, q, "pricing::quanto::carry")?,
+        quanto_adjustment,
+        "pricing::quanto::adjusted_drift",
+    )?;
 
-    let forward = s * (adjusted_drift * t).exp();
+    let forward = d_mul(
+        s,
+        d_exp(
+            d_mul(adjusted_drift, t, "pricing::quanto::drift_t")?,
+            "pricing::quanto::growth",
+        )?,
+        "pricing::quanto::forward",
+    )?;
 
-    let sqrt_t = t
-        .sqrt()
-        .ok_or_else(|| PricingError::other("Failed to compute sqrt(t)"))?;
+    let sqrt_t = d_sqrt(t, "pricing::quanto::sqrt_t")?;
+    let denominator = d_mul(sigma_s, sqrt_t, "pricing::quanto::denominator")?;
+    let discount = d_exp(
+        d_mul(-r_d, t, "pricing::quanto::neg_rt")?,
+        "pricing::quanto::discount",
+    )?;
 
-    let d1 = ((forward / k).ln() + (sigma_s * sigma_s / dec!(2.0)) * t) / (sigma_s * sqrt_t);
-    let d2 = d1 - sigma_s * sqrt_t;
+    // `K = 0`: the call is certain to be exercised, the put is worthless; a
+    // collapsed `σ√T` freezes the underlying at its forward. Both are the
+    // limits of the formula below, where the normal arguments diverge and the
+    // CDFs saturate.
+    let moneyness = if k.is_zero() {
+        None
+    } else {
+        Some(d_div(forward, k, "pricing::quanto::moneyness")?)
+    };
+    let (n_d1, n_d2, n_neg_d1, n_neg_d2) = match moneyness {
+        None => (dec!(1.0), dec!(1.0), dec!(0.0), dec!(0.0)),
+        Some(ratio) if ratio.is_zero() => (dec!(0.0), dec!(0.0), dec!(1.0), dec!(1.0)),
+        Some(ratio) if denominator.is_zero() => {
+            if ratio >= dec!(1.0) {
+                (dec!(1.0), dec!(1.0), dec!(0.0), dec!(0.0))
+            } else {
+                (dec!(0.0), dec!(0.0), dec!(1.0), dec!(1.0))
+            }
+        }
+        Some(ratio) => {
+            let d1 = d_div(
+                d_add(
+                    d_ln(ratio, "pricing::quanto::log_moneyness")?,
+                    d_mul(
+                        d_div(
+                            d_mul(sigma_s, sigma_s, "pricing::quanto::variance")?,
+                            dec!(2.0),
+                            "pricing::quanto::half_variance",
+                        )?,
+                        t,
+                        "pricing::quanto::variance_t",
+                    )?,
+                    "pricing::quanto::d1_numerator",
+                )?,
+                denominator,
+                "pricing::quanto::d1",
+            )?;
+            let d2 = d_sub(d1, denominator, "pricing::quanto::d2")?;
+            (big_n(d1)?, big_n(d2)?, big_n(-d1)?, big_n(-d2)?)
+        }
+    };
 
-    let discount = (-r_d * t).exp();
-
+    let converted_discount = d_mul(x, discount, "pricing::quanto::converted_discount")?;
     let price = match style {
-        OptionStyle::Call => x * discount * (forward * big_n(d1)? - k * big_n(d2)?),
-        OptionStyle::Put => x * discount * (k * big_n(-d2)? - forward * big_n(-d1)?),
+        OptionStyle::Call => d_mul(
+            converted_discount,
+            d_sub(
+                d_mul(forward, n_d1, "pricing::quanto::call::forward")?,
+                d_mul(k, n_d2, "pricing::quanto::call::strike")?,
+                "pricing::quanto::call::intrinsic",
+            )?,
+            "pricing::quanto::call",
+        )?,
+        OptionStyle::Put => d_mul(
+            converted_discount,
+            d_sub(
+                d_mul(k, n_neg_d2, "pricing::quanto::put::strike")?,
+                d_mul(forward, n_neg_d1, "pricing::quanto::put::forward")?,
+                "pricing::quanto::put::intrinsic",
+            )?,
+            "pricing::quanto::put",
+        )?,
     };
 
     Ok(price.max(dec!(0.0)))

--- a/src/pricing/rainbow.rs
+++ b/src/pricing/rainbow.rs
@@ -36,6 +36,7 @@
 
 use crate::Options;
 use crate::error::PricingError;
+use crate::model::decimal::{d_div, d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType, RainbowType, Side};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
@@ -57,10 +58,14 @@ use tracing::trace;
 ///
 /// # Errors
 ///
-/// Returns `PricingError` if:
-/// - The option type is not Rainbow
-/// - Required exotic parameters are missing
-/// - The correlation is outside [-1, 1]
+/// - [`PricingError::MethodError`] when the option type is not Rainbow, when
+///   `num_assets` is not 2, when the rainbow sub-type is an unsupported
+///   `#[non_exhaustive]` variant, when the required exotic parameters are
+///   missing, when the correlation is outside `[-1, 1]`, when the expiration
+///   cannot be converted, or when a `Decimal` ↔ `f64` boundary conversion in
+///   the Monte-Carlo kernel fails.
+/// - [`PricingError::Decimal`] when the intrinsic value at expiry or the
+///   discounted Monte-Carlo mean leaves the representable `Decimal` range.
 pub fn rainbow_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     match &option.option_type {
         OptionType::Rainbow {
@@ -161,7 +166,7 @@ fn price_call_on_max(
 ) -> Result<Decimal, PricingError> {
     if t <= dec!(0.0) {
         let max_s = s1.max(s2);
-        return Ok((max_s - k).max(dec!(0.0)));
+        return Ok(d_sub(max_s, k, "pricing::rainbow::call_on_max::intrinsic")?.max(dec!(0.0)));
     }
 
     let num_simulations = 10000;
@@ -181,8 +186,7 @@ fn price_call_on_max(
         true,
     )?;
 
-    let discount = (-r * t).exp();
-    Ok(discount * payoff_sum / Decimal::from(num_simulations))
+    discounted_mean(payoff_sum, r, t, num_simulations)
 }
 
 /// Prices a call option on the minimum of two assets using Monte Carlo simulation.
@@ -201,7 +205,7 @@ fn price_call_on_min(
 ) -> Result<Decimal, PricingError> {
     if t <= dec!(0.0) {
         let min_s = s1.min(s2);
-        return Ok((min_s - k).max(dec!(0.0)));
+        return Ok(d_sub(min_s, k, "pricing::rainbow::call_on_min::intrinsic")?.max(dec!(0.0)));
     }
 
     let num_simulations = 10000;
@@ -221,8 +225,28 @@ fn price_call_on_min(
         true,
     )?;
 
-    let discount = (-r * t).exp();
-    Ok(discount * payoff_sum / Decimal::from(num_simulations))
+    discounted_mean(payoff_sum, r, t, num_simulations)
+}
+
+/// Discounts the accumulated Monte-Carlo payoff to a present value.
+///
+/// Shared by the four rainbow kernels: `e^(-rT) · Σpayoff / N`.
+fn discounted_mean(
+    payoff_sum: Decimal,
+    r: Decimal,
+    t: Decimal,
+    num_simulations: usize,
+) -> Result<Decimal, PricingError> {
+    let discount = d_exp(
+        d_mul(-r, t, "pricing::rainbow::neg_rt")?,
+        "pricing::rainbow::discount",
+    )?;
+    let discounted = d_mul(discount, payoff_sum, "pricing::rainbow::discounted_sum")?;
+    Ok(d_div(
+        discounted,
+        Decimal::from(num_simulations),
+        "pricing::rainbow::mean",
+    )?)
 }
 
 /// Monte Carlo simulation for rainbow options.
@@ -354,7 +378,7 @@ fn price_put_on_max(
 ) -> Result<Decimal, PricingError> {
     if t <= dec!(0.0) {
         let max_s = s1.max(s2);
-        return Ok((k - max_s).max(dec!(0.0)));
+        return Ok(d_sub(k, max_s, "pricing::rainbow::put_on_max::intrinsic")?.max(dec!(0.0)));
     }
 
     let num_simulations = 10000;
@@ -374,8 +398,7 @@ fn price_put_on_max(
         false,
     )?;
 
-    let discount = (-r * t).exp();
-    Ok(discount * payoff_sum / Decimal::from(num_simulations))
+    discounted_mean(payoff_sum, r, t, num_simulations)
 }
 
 /// Prices a put option on the minimum of two assets using Monte Carlo simulation.
@@ -394,7 +417,7 @@ fn price_put_on_min(
 ) -> Result<Decimal, PricingError> {
     if t <= dec!(0.0) {
         let min_s = s1.min(s2);
-        return Ok((k - min_s).max(dec!(0.0)));
+        return Ok(d_sub(k, min_s, "pricing::rainbow::put_on_min::intrinsic")?.max(dec!(0.0)));
     }
 
     let num_simulations = 10000;
@@ -414,8 +437,7 @@ fn price_put_on_min(
         false,
     )?;
 
-    let discount = (-r * t).exp();
-    Ok(discount * payoff_sum / Decimal::from(num_simulations))
+    discounted_mean(payoff_sum, r, t, num_simulations)
 }
 
 fn apply_side(price: Decimal, option: &Options) -> Decimal {

--- a/src/pricing/spread.rs
+++ b/src/pricing/spread.rs
@@ -22,6 +22,7 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::greeks::big_n;
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_sqrt, d_sub};
 use crate::model::types::{OptionStyle, OptionType, Side};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
@@ -39,10 +40,14 @@ use rust_decimal_macros::dec;
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - The option type is not `Spread`
-/// - Required exotic parameters are missing
-/// - Correlation is outside the valid range [-1, 1]
+/// - [`PricingError::MethodError`] when the option type is not `Spread`, when
+///   the required exotic parameters are missing, when the correlation is
+///   outside `[-1, 1]`, when the Kirk adjusted strike `S2 + K` is
+///   non-positive, or when the combined variance is negative.
+/// - [`PricingError::Decimal`] when an intermediate step leaves the
+///   representable `Decimal` range: the adjusted strike, the combined
+///   variance, the present values, `d1` / `d2`, or the final legs.
+/// - `PricingError::ExpirationDate` when the expiration cannot be converted.
 pub fn spread_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let second_asset_price = match &option.option_type {
         OptionType::Spread { second_asset } => second_asset.to_dec(),
@@ -144,47 +149,141 @@ fn kirk_approximation(
     style: &OptionStyle,
 ) -> Result<Decimal, PricingError> {
     if t <= dec!(0.0) {
-        let spread = s1 - s2;
+        let spread = d_sub(s1, s2, "pricing::spread::kirk::intrinsic::spread")?;
         return match style {
-            OptionStyle::Call => Ok((spread - k).max(dec!(0.0))),
-            OptionStyle::Put => Ok((k - spread).max(dec!(0.0))),
+            OptionStyle::Call => {
+                Ok(d_sub(spread, k, "pricing::spread::kirk::intrinsic::call")?.max(dec!(0.0)))
+            }
+            OptionStyle::Put => {
+                Ok(d_sub(k, spread, "pricing::spread::kirk::intrinsic::put")?.max(dec!(0.0)))
+            }
         };
     }
 
-    let adjusted_strike = s2 + k;
+    let adjusted_strike = d_add(s2, k, "pricing::spread::kirk::adjusted_strike")?;
     if adjusted_strike <= dec!(0.0) {
         return Err(PricingError::other(
             "Adjusted strike (S2 + K) must be positive",
         ));
     }
 
-    let s2_ratio = s2 / adjusted_strike;
+    let s2_ratio = d_div(s2, adjusted_strike, "pricing::spread::kirk::s2_ratio")?;
 
-    let sigma_sq = sigma1 * sigma1 + s2_ratio * s2_ratio * sigma2 * sigma2
-        - dec!(2.0) * rho * sigma1 * sigma2 * s2_ratio;
+    let sigma_sq = d_sub(
+        d_add(
+            d_mul(sigma1, sigma1, "pricing::spread::kirk::var1")?,
+            d_mul(
+                d_mul(s2_ratio, s2_ratio, "pricing::spread::kirk::s2_ratio_sq")?,
+                d_mul(sigma2, sigma2, "pricing::spread::kirk::var2")?,
+                "pricing::spread::kirk::weighted_var2",
+            )?,
+            "pricing::spread::kirk::variance_sum",
+        )?,
+        d_mul(
+            d_mul(
+                d_mul(
+                    d_mul(dec!(2.0), rho, "pricing::spread::kirk::two_rho")?,
+                    sigma1,
+                    "pricing::spread::kirk::two_rho_sigma1",
+                )?,
+                sigma2,
+                "pricing::spread::kirk::two_rho_sigma1_sigma2",
+            )?,
+            s2_ratio,
+            "pricing::spread::kirk::covariance",
+        )?,
+        "pricing::spread::kirk::sigma_sq",
+    )?;
 
     let sigma = sigma_sq
         .sqrt()
         .ok_or_else(|| PricingError::other("Failed to compute adjusted volatility"))?;
 
-    let sqrt_t = t
-        .sqrt()
-        .ok_or_else(|| PricingError::other("Failed to compute sqrt(t)"))?;
+    let sqrt_t = d_sqrt(t, "pricing::spread::kirk::sqrt_t")?;
+    let denominator = d_mul(sigma, sqrt_t, "pricing::spread::kirk::denominator")?;
 
-    let d1 =
-        ((s1 / adjusted_strike).ln() + (r - q1 + sigma * sigma / dec!(2.0)) * t) / (sigma * sqrt_t);
-    let d2 = d1 - sigma * sqrt_t;
+    let s1_pv = d_mul(
+        s1,
+        d_exp(
+            d_mul(-q1, t, "pricing::spread::kirk::neg_q1t")?,
+            "pricing::spread::kirk::dividend_discount",
+        )?,
+        "pricing::spread::kirk::s1_pv",
+    )?;
+    let adjusted_strike_pv = d_mul(
+        adjusted_strike,
+        d_exp(
+            d_mul(-r, t, "pricing::spread::kirk::neg_rt")?,
+            "pricing::spread::kirk::discount",
+        )?,
+        "pricing::spread::kirk::adjusted_strike_pv",
+    )?;
 
-    let s1_pv = s1 * (-q1 * t).exp();
-    let adjusted_strike_pv = adjusted_strike * (-r * t).exp();
+    let ratio = d_div(s1, adjusted_strike, "pricing::spread::kirk::moneyness")?;
+
+    // `N(d1)`, `N(d2)`, `N(-d1)`, `N(-d2)`. A collapsed `σ√T` or a moneyness
+    // that underflowed below the representable scale drives the normal
+    // arguments to `±∞`, where the CDFs saturate: those are the limits of the
+    // formula, not substitutes for it.
+    let (n_d1, n_d2, n_neg_d1, n_neg_d2) = if denominator.is_zero() {
+        // σ√T → 0: the option is worth its discounted intrinsic, i.e. the
+        // step function at the forward.
+        if ratio >= dec!(1.0) {
+            (dec!(1.0), dec!(1.0), dec!(0.0), dec!(0.0))
+        } else {
+            (dec!(0.0), dec!(0.0), dec!(1.0), dec!(1.0))
+        }
+    } else if ratio.is_zero() {
+        (dec!(0.0), dec!(0.0), dec!(1.0), dec!(1.0))
+    } else {
+        let d1 = d_div(
+            d_add(
+                d_ln(ratio, "pricing::spread::kirk::log_moneyness")?,
+                d_mul(
+                    d_add(
+                        d_sub(r, q1, "pricing::spread::kirk::carry")?,
+                        d_div(
+                            d_mul(sigma, sigma, "pricing::spread::kirk::variance")?,
+                            dec!(2.0),
+                            "pricing::spread::kirk::half_variance",
+                        )?,
+                        "pricing::spread::kirk::drift_rate",
+                    )?,
+                    t,
+                    "pricing::spread::kirk::drift",
+                )?,
+                "pricing::spread::kirk::d1_numerator",
+            )?,
+            denominator,
+            "pricing::spread::kirk::d1",
+        )?;
+        let d2 = d_sub(d1, denominator, "pricing::spread::kirk::d2")?;
+        (big_n(d1)?, big_n(d2)?, big_n(-d1)?, big_n(-d2)?)
+    };
 
     match style {
         OptionStyle::Call => {
-            let call = s1_pv * big_n(d1)? - adjusted_strike_pv * big_n(d2)?;
+            let call = d_sub(
+                d_mul(s1_pv, n_d1, "pricing::spread::kirk::call::spot")?,
+                d_mul(
+                    adjusted_strike_pv,
+                    n_d2,
+                    "pricing::spread::kirk::call::strike",
+                )?,
+                "pricing::spread::kirk::call",
+            )?;
             Ok(call.max(dec!(0.0)))
         }
         OptionStyle::Put => {
-            let put = adjusted_strike_pv * big_n(-d2)? - s1_pv * big_n(-d1)?;
+            let put = d_sub(
+                d_mul(
+                    adjusted_strike_pv,
+                    n_neg_d2,
+                    "pricing::spread::kirk::put::strike",
+                )?,
+                d_mul(s1_pv, n_neg_d1, "pricing::spread::kirk::put::spot")?,
+                "pricing::spread::kirk::put",
+            )?;
             Ok(put.max(dec!(0.0)))
         }
     }
@@ -216,26 +315,96 @@ fn margrabe_formula(
     t: Decimal,
 ) -> Result<Decimal, PricingError> {
     if t <= dec!(0.0) {
-        return Ok((s1 - s2).max(dec!(0.0)));
+        return Ok(d_sub(s1, s2, "pricing::spread::margrabe::intrinsic")?.max(dec!(0.0)));
     }
 
-    let sigma_sq = sigma1 * sigma1 + sigma2 * sigma2 - dec!(2.0) * rho * sigma1 * sigma2;
+    let sigma_sq = d_sub(
+        d_add(
+            d_mul(sigma1, sigma1, "pricing::spread::margrabe::var1")?,
+            d_mul(sigma2, sigma2, "pricing::spread::margrabe::var2")?,
+            "pricing::spread::margrabe::variance_sum",
+        )?,
+        d_mul(
+            d_mul(
+                d_mul(dec!(2.0), rho, "pricing::spread::margrabe::two_rho")?,
+                sigma1,
+                "pricing::spread::margrabe::two_rho_sigma1",
+            )?,
+            sigma2,
+            "pricing::spread::margrabe::covariance",
+        )?,
+        "pricing::spread::margrabe::sigma_sq",
+    )?;
 
     let sigma = sigma_sq
         .sqrt()
         .ok_or_else(|| PricingError::other("Failed to compute combined volatility"))?;
 
-    let sqrt_t = t
-        .sqrt()
-        .ok_or_else(|| PricingError::other("Failed to compute sqrt(t)"))?;
+    let sqrt_t = d_sqrt(t, "pricing::spread::margrabe::sqrt_t")?;
+    let denominator = d_mul(sigma, sqrt_t, "pricing::spread::margrabe::denominator")?;
 
-    let d1 = ((s1 / s2).ln() + (q2 - q1 + sigma * sigma / dec!(2.0)) * t) / (sigma * sqrt_t);
-    let d2 = d1 - sigma * sqrt_t;
+    let s1_pv = d_mul(
+        s1,
+        d_exp(
+            d_mul(-q1, t, "pricing::spread::margrabe::neg_q1t")?,
+            "pricing::spread::margrabe::discount1",
+        )?,
+        "pricing::spread::margrabe::s1_pv",
+    )?;
+    let s2_pv = d_mul(
+        s2,
+        d_exp(
+            d_mul(-q2, t, "pricing::spread::margrabe::neg_q2t")?,
+            "pricing::spread::margrabe::discount2",
+        )?,
+        "pricing::spread::margrabe::s2_pv",
+    )?;
 
-    let s1_pv = s1 * (-q1 * t).exp();
-    let s2_pv = s2 * (-q2 * t).exp();
+    // Zero combined volatility, or a `σ√T` that underflowed below the
+    // representable scale: the exchange ratio is deterministic and the option
+    // is worth the difference of the two present values.
+    if denominator.is_zero() {
+        return Ok(d_sub(s1_pv, s2_pv, "pricing::spread::margrabe::deterministic")?.max(dec!(0.0)));
+    }
 
-    let price = s1_pv * big_n(d1)? - s2_pv * big_n(d2)?;
+    // `S2 = 0`: `N(d1) = N(d2) = 1` and the option collapses to `S1`'s
+    // present value; a ratio that rounds to zero is the mirror limit.
+    if s2.is_zero() {
+        return Ok(s1_pv.max(dec!(0.0)));
+    }
+    let ratio = d_div(s1, s2, "pricing::spread::margrabe::ratio")?;
+    if ratio.is_zero() {
+        return Ok(dec!(0.0));
+    }
+
+    let d1 = d_div(
+        d_add(
+            d_ln(ratio, "pricing::spread::margrabe::log_ratio")?,
+            d_mul(
+                d_add(
+                    d_sub(q2, q1, "pricing::spread::margrabe::carry")?,
+                    d_div(
+                        d_mul(sigma, sigma, "pricing::spread::margrabe::variance")?,
+                        dec!(2.0),
+                        "pricing::spread::margrabe::half_variance",
+                    )?,
+                    "pricing::spread::margrabe::drift_rate",
+                )?,
+                t,
+                "pricing::spread::margrabe::drift",
+            )?,
+            "pricing::spread::margrabe::d1_numerator",
+        )?,
+        denominator,
+        "pricing::spread::margrabe::d1",
+    )?;
+    let d2 = d_sub(d1, denominator, "pricing::spread::margrabe::d2")?;
+
+    let price = d_sub(
+        d_mul(s1_pv, big_n(d1)?, "pricing::spread::margrabe::leg1")?,
+        d_mul(s2_pv, big_n(d2)?, "pricing::spread::margrabe::leg2")?,
+        "pricing::spread::margrabe::price",
+    )?;
 
     Ok(price.max(dec!(0.0)))
 }

--- a/src/pricing/spread.rs
+++ b/src/pricing/spread.rs
@@ -226,9 +226,14 @@ fn kirk_approximation(
     // arguments to `±∞`, where the CDFs saturate: those are the limits of the
     // formula, not substitutes for it.
     let (n_d1, n_d2, n_neg_d1, n_neg_d2) = if denominator.is_zero() {
-        // σ√T → 0: the option is worth its discounted intrinsic, i.e. the
-        // step function at the forward.
-        if ratio >= dec!(1.0) {
+        // σ√T → 0: the option is worth its discounted intrinsic, i.e. the step
+        // function at the forward. The test has to compare the two present
+        // values, not the spot moneyness `S1 / (S2 + K)`: the carry `(r - q1)T`
+        // lives in the discounting, and dropping it flips the step whenever
+        // spot and forward straddle the adjusted strike. `sigma` is exactly
+        // zero at `rho = 1, sigma1 = w * sigma2`, so this branch is reachable
+        // from well-formed inputs.
+        if s1_pv >= adjusted_strike_pv {
             (dec!(1.0), dec!(1.0), dec!(0.0), dec!(0.0))
         } else {
             (dec!(0.0), dec!(0.0), dec!(1.0), dec!(1.0))
@@ -637,6 +642,118 @@ mod tests {
         assert!(
             price > dec!(0.0),
             "Spread option with negative correlation should have positive value"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests_kirk_zero_volatility {
+    use super::*;
+    use crate::ExpirationDate;
+    use crate::model::option::ExoticParams;
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+
+    /// Kirk's adjusted volatility is
+    /// `sigma^2 = (sigma1 - w*sigma2)^2 + 2*w*sigma1*sigma2*(1 - rho)` with
+    /// `w = S2 / (S2 + K)`, which is exactly zero at `rho = 1` and
+    /// `sigma1 = w * sigma2`. These are well-formed inputs, so the zero-vol
+    /// branch is reachable and its step test has to be right.
+    ///
+    /// `S2 = 100, K = 25` gives `w = 0.8` exactly, so `sigma1 = 0.2` against
+    /// `sigma2 = 0.25` collapses the adjusted volatility to exactly zero — the
+    /// weight has to divide exactly or the branch is never reached.
+    ///
+    /// Spot moneyness `S1 / (S2 + K) = 0.8` says out-of-the-money, but with
+    /// `r = 25%` and `q1 = 0` the present values say the opposite:
+    /// `S1*e^{-q1*T} = 100` against `(S2 + K)*e^{-r*T} = 125*e^{-0.25} = 97.35`.
+    fn zero_vol_spread(option_style: OptionStyle, risk_free_rate: Decimal) -> Options {
+        Options::new(
+            OptionType::Spread {
+                second_asset: Positive::HUNDRED,
+            },
+            Side::Long,
+            "TEST".to_string(),
+            pos_or_panic!(25.0),
+            ExpirationDate::Days(pos_or_panic!(365.0)),
+            pos_or_panic!(0.2),
+            Positive::ONE,
+            Positive::HUNDRED,
+            risk_free_rate,
+            option_style,
+            Positive::ZERO,
+            Some(ExoticParams {
+                spot_prices: None,
+                spot_min: None,
+                spot_max: None,
+                cliquet_local_cap: None,
+                cliquet_local_floor: None,
+                cliquet_global_cap: None,
+                cliquet_global_floor: None,
+                rainbow_second_asset_price: None,
+                rainbow_second_asset_volatility: None,
+                rainbow_second_asset_dividend: None,
+                rainbow_correlation: None,
+                spread_second_asset_volatility: Some(pos_or_panic!(0.25)),
+                spread_second_asset_dividend: Some(Positive::ZERO),
+                spread_correlation: Some(Decimal::ONE),
+                quanto_fx_volatility: None,
+                quanto_fx_correlation: None,
+                quanto_foreign_rate: None,
+                exchange_second_asset_volatility: None,
+                exchange_second_asset_dividend: None,
+                exchange_correlation: None,
+            }),
+        )
+    }
+
+    #[test]
+    fn test_zero_volatility_call_uses_present_values_not_spot_moneyness() {
+        let option = zero_vol_spread(OptionStyle::Call, dec!(0.25));
+        let price = match spread_black_scholes(&option) {
+            Ok(price) => price,
+            Err(e) => panic!("the spread should price: {e}"),
+        };
+
+        // The discounted intrinsic is `S1*e^{-q1*T} - (S2 + K)*e^{-r*T}`,
+        // about 2.65. Testing the spot moneyness instead returns zero here.
+        assert!(
+            price > dec!(2.5) && price < dec!(2.8),
+            "zero-vol call priced at {price}, expected the discounted intrinsic near 2.65"
+        );
+    }
+
+    #[test]
+    fn test_zero_volatility_put_is_worthless_when_the_call_is_in_the_money() {
+        let option = zero_vol_spread(OptionStyle::Put, dec!(0.25));
+        let price = match spread_black_scholes(&option) {
+            Ok(price) => price,
+            Err(e) => panic!("the spread should price: {e}"),
+        };
+        assert_eq!(price, Decimal::ZERO, "put priced at {price}");
+    }
+
+    #[test]
+    fn test_zero_volatility_step_flips_with_the_carry() {
+        // A negative rate pushes the adjusted strike's present value above the
+        // first asset's, so the same contract flips: the call is worthless and
+        // the put carries the intrinsic.
+        let call = zero_vol_spread(OptionStyle::Call, dec!(-0.10));
+        let put = zero_vol_spread(OptionStyle::Put, dec!(-0.10));
+
+        let call_price = match spread_black_scholes(&call) {
+            Ok(price) => price,
+            Err(e) => panic!("the call should price: {e}"),
+        };
+        let put_price = match spread_black_scholes(&put) {
+            Ok(price) => price,
+            Err(e) => panic!("the put should price: {e}"),
+        };
+
+        assert_eq!(call_price, Decimal::ZERO, "call priced at {call_price}");
+        assert!(
+            put_price > dec!(38.0),
+            "put priced at {put_price}, expected the discounted intrinsic near 38.1"
         );
     }
 }

--- a/src/pricing/spread.rs
+++ b/src/pricing/spread.rs
@@ -46,7 +46,8 @@ use rust_decimal_macros::dec;
 ///   non-positive, or when the combined variance is negative.
 /// - [`PricingError::Decimal`] when an intermediate step leaves the
 ///   representable `Decimal` range: the adjusted strike, the combined
-///   variance, the present values, `d1` / `d2`, or the final legs.
+///   variance, the present values, either logarithm of the log-moneyness,
+///   `d1` / `d2`, or the final legs.
 /// - `PricingError::ExpirationDate` when the expiration cannot be converted.
 pub fn spread_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
     let second_asset_price = match &option.option_type {
@@ -219,12 +220,9 @@ fn kirk_approximation(
         "pricing::spread::kirk::adjusted_strike_pv",
     )?;
 
-    let ratio = d_div(s1, adjusted_strike, "pricing::spread::kirk::moneyness")?;
-
-    // `N(d1)`, `N(d2)`, `N(-d1)`, `N(-d2)`. A collapsed `σ√T` or a moneyness
-    // that underflowed below the representable scale drives the normal
-    // arguments to `±∞`, where the CDFs saturate: those are the limits of the
-    // formula, not substitutes for it.
+    // `N(d1)`, `N(d2)`, `N(-d1)`, `N(-d2)`. A collapsed `σ√T` or a vanished `S1`
+    // drives the normal arguments to `±∞`, where the CDFs saturate: those are
+    // the limits of the formula, not substitutes for it.
     let (n_d1, n_d2, n_neg_d1, n_neg_d2) = if denominator.is_zero() {
         // σ√T → 0: the option is worth its discounted intrinsic, i.e. the step
         // function at the forward. The test has to compare the two present
@@ -238,12 +236,29 @@ fn kirk_approximation(
         } else {
             (dec!(0.0), dec!(0.0), dec!(1.0), dec!(1.0))
         }
-    } else if ratio.is_zero() {
+    } else if s1.is_zero() {
+        // `S1 = 0`: `ln(S1 / (S2 + K))` diverges to `-∞` and the CDFs saturate.
         (dec!(0.0), dec!(0.0), dec!(1.0), dec!(1.0))
     } else {
+        // Log-moneyness as `ln(S1) - ln(S2 + K)`, never as `ln(S1 / (S2 + K))`:
+        // the quotient underflows to zero below `1e-28` and drags the
+        // `(r - q1)T` carry down with it, so a tiny-but-nonzero `S1` against a
+        // discount factor that has wiped out the adjusted strike would price at
+        // zero instead of at `S1`'s present value. The difference of the two
+        // logarithms is exact where the quotient is not, and both logarithms
+        // exist: `S2 + K` was rejected above unless positive and `S1 = 0` is
+        // the branch just above.
+        let log_moneyness = d_sub(
+            d_ln(s1, "pricing::spread::kirk::log_s1")?,
+            d_ln(
+                adjusted_strike,
+                "pricing::spread::kirk::log_adjusted_strike",
+            )?,
+            "pricing::spread::kirk::log_moneyness",
+        )?;
         let d1 = d_div(
             d_add(
-                d_ln(ratio, "pricing::spread::kirk::log_moneyness")?,
+                log_moneyness,
                 d_mul(
                     d_add(
                         d_sub(r, q1, "pricing::spread::kirk::carry")?,
@@ -373,18 +388,30 @@ fn margrabe_formula(
     }
 
     // `S2 = 0`: `N(d1) = N(d2) = 1` and the option collapses to `S1`'s
-    // present value; a ratio that rounds to zero is the mirror limit.
+    // present value.
     if s2.is_zero() {
         return Ok(s1_pv.max(dec!(0.0)));
     }
-    let ratio = d_div(s1, s2, "pricing::spread::margrabe::ratio")?;
-    if ratio.is_zero() {
+    // `S1 = 0`: the payoff `max(S1 - S2, 0)` is identically zero.
+    if s1.is_zero() {
         return Ok(dec!(0.0));
     }
 
+    // Log-moneyness as `ln(S1) - ln(S2)`, never as `ln(S1 / S2)`: the quotient
+    // underflows to zero below `1e-28` and drags the `(q2 - q1)T` carry down
+    // with it, so a tiny-but-nonzero `S1` against a `q2` large enough to wipe
+    // out `S2`'s present value would price at zero instead of at `S1`'s present
+    // value. Both logarithms exist: the two spot branches above are the only
+    // non-positive inputs `d_ln` could see.
+    let log_ratio = d_sub(
+        d_ln(s1, "pricing::spread::margrabe::log_s1")?,
+        d_ln(s2, "pricing::spread::margrabe::log_s2")?,
+        "pricing::spread::margrabe::log_ratio",
+    )?;
+
     let d1 = d_div(
         d_add(
-            d_ln(ratio, "pricing::spread::margrabe::log_ratio")?,
+            log_ratio,
             d_mul(
                 d_add(
                     d_sub(q2, q1, "pricing::spread::margrabe::carry")?,
@@ -467,6 +494,111 @@ mod tests {
                 exchange_correlation: None,
             }),
         )
+    }
+
+    /// Margrabe leg (`K = 0`). `S1 / S2` rounds below the representable
+    /// `Decimal` scale, but a `q2` large enough to wipe out `S2`'s present
+    /// value offsets the log-moneyness through the `(q2 - q1)T` carry, so the
+    /// option is worth `S1`'s present value.
+    #[test]
+    fn test_margrabe_underflowing_ratio_with_offsetting_carry_prices_first_pv() {
+        let mut option = create_spread_option(Positive::ZERO, OptionStyle::Call);
+        option.underlying_price = Positive::new_decimal(Decimal::new(1, 27)).unwrap();
+        option.expiration_date = ExpirationDate::Days(pos_or_panic!(365.0));
+        option.dividend_yield = Positive::ZERO;
+        if let Some(ref mut params) = option.exotic_params {
+            params.spread_second_asset_volatility = Some(pos_or_panic!(0.2));
+            params.spread_second_asset_dividend = Some(pos_or_panic!(100.0));
+        }
+
+        let price = spread_black_scholes(&option).unwrap();
+
+        assert_eq!(
+            price,
+            Decimal::new(1, 27),
+            "vanished S2 present value should leave S1's present value, got {}",
+            price
+        );
+    }
+
+    /// Margrabe leg, mirror case: without the carry the same underflowing
+    /// ratio really does drive both CDFs to zero.
+    #[test]
+    fn test_margrabe_underflowing_ratio_without_carry_is_zero() {
+        let mut option = create_spread_option(Positive::ZERO, OptionStyle::Call);
+        option.underlying_price = Positive::new_decimal(Decimal::new(1, 27)).unwrap();
+        option.expiration_date = ExpirationDate::Days(pos_or_panic!(365.0));
+        option.dividend_yield = Positive::ZERO;
+        if let Some(ref mut params) = option.exotic_params {
+            params.spread_second_asset_volatility = Some(pos_or_panic!(0.2));
+        }
+
+        let price = spread_black_scholes(&option).unwrap();
+
+        assert_eq!(
+            price,
+            Decimal::ZERO,
+            "a ratio that vanishes in the limit should still price at zero, got {}",
+            price
+        );
+    }
+
+    /// Kirk leg (`K != 0`). `S1 / (S2 + K)` rounds below the representable
+    /// `Decimal` scale, but an `r` large enough to wipe out the adjusted
+    /// strike's present value offsets the log-moneyness through the
+    /// `(r - q1)T` carry, so the call is worth `S1`'s present value.
+    #[test]
+    fn test_kirk_underflowing_moneyness_with_offsetting_carry_prices_first_pv() {
+        let mut option = create_spread_option(pos_or_panic!(50.0), OptionStyle::Call);
+        option.option_type = OptionType::Spread {
+            second_asset: pos_or_panic!(50.0),
+        };
+        option.underlying_price = Positive::new_decimal(Decimal::new(1, 27)).unwrap();
+        option.expiration_date = ExpirationDate::Days(pos_or_panic!(365.0));
+        option.risk_free_rate = dec!(100.0);
+        option.dividend_yield = Positive::ZERO;
+        if let Some(ref mut params) = option.exotic_params {
+            params.spread_second_asset_volatility = Some(pos_or_panic!(0.2));
+        }
+
+        let price = spread_black_scholes(&option).unwrap();
+
+        assert_eq!(
+            price,
+            Decimal::new(1, 27),
+            "vanished adjusted-strike present value should leave S1's present value, got {}",
+            price
+        );
+    }
+
+    /// Kirk leg, mirror case: at `r = 0` the same underflowing moneyness is a
+    /// genuine limit, so the call is worthless and the put is the full
+    /// adjusted strike.
+    #[test]
+    fn test_kirk_underflowing_moneyness_without_carry_is_zero() {
+        let mut option = create_spread_option(pos_or_panic!(50.0), OptionStyle::Call);
+        option.option_type = OptionType::Spread {
+            second_asset: pos_or_panic!(50.0),
+        };
+        option.underlying_price = Positive::new_decimal(Decimal::new(1, 27)).unwrap();
+        option.expiration_date = ExpirationDate::Days(pos_or_panic!(365.0));
+        option.risk_free_rate = dec!(0.0);
+        option.dividend_yield = Positive::ZERO;
+        if let Some(ref mut params) = option.exotic_params {
+            params.spread_second_asset_volatility = Some(pos_or_panic!(0.2));
+        }
+
+        let call = spread_black_scholes(&option).unwrap();
+        assert_eq!(
+            call,
+            Decimal::ZERO,
+            "a moneyness that vanishes in the limit should still price at zero, got {}",
+            call
+        );
+
+        option.option_style = OptionStyle::Put;
+        let put = spread_black_scholes(&option).unwrap();
+        crate::assert_decimal_eq!(put, dec!(100.0), dec!(1e-20));
     }
 
     #[test]

--- a/src/pricing/telegraph.rs
+++ b/src/pricing/telegraph.rs
@@ -85,9 +85,12 @@
 use crate::Options;
 use crate::error::PricingError;
 use crate::error::decimal::DecimalError;
-use crate::model::decimal::{d_mul, finite_decimal};
+use crate::model::decimal::{
+    d_add, d_div, d_exp, d_mul, d_powd, d_sub, d_sum_iter, finite_decimal,
+};
 use crate::prelude::simulate_returns;
 use num_traits::{FromPrimitive, ToPrimitive};
+use positive::Positive;
 use rand::random;
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
@@ -160,15 +163,24 @@ impl TelegraphProcess {
         } else {
             self.lambda_up
         };
-        let lambda_dt = -lambda * dt;
-        // lambda_dt is non-positive (lambda, dt >= 0). For very-negative
-        // values exp(lambda_dt) underflows to 0; treat as a guaranteed
-        // flip (probability = 1). Otherwise use the standard Poisson
-        // transition: P(flip in dt) = 1 - exp(-lambda * dt).
-        let probability = if lambda_dt < dec!(-11.7) {
-            Decimal::ONE
-        } else {
-            Decimal::ONE - lambda_dt.exp()
+        // lambda_dt is non-positive for the physical case (lambda, dt >= 0).
+        // For very-negative values exp(lambda_dt) underflows to 0; treat as a
+        // guaranteed flip (probability = 1). Otherwise use the standard
+        // Poisson transition: P(flip in dt) = 1 - exp(-lambda * dt).
+        //
+        // The signature is infallible, so every unrepresentable intermediate
+        // degrades to the limit its sign implies rather than aborting: an
+        // exponent that overflows downward is a certain flip, one that
+        // overflows upward drives `1 - exp(..)` far below zero, i.e. no flip.
+        let probability = match (-lambda).checked_mul(dt) {
+            None if lambda.is_sign_negative() == dt.is_sign_negative() => Decimal::ONE,
+            None => Decimal::ZERO,
+            Some(lambda_dt) if lambda_dt < dec!(-11.7) => Decimal::ONE,
+            Some(lambda_dt) => match lambda_dt.checked_exp() {
+                Some(decay) => Decimal::ONE.checked_sub(decay).unwrap_or(Decimal::ZERO),
+                None if lambda_dt.is_sign_negative() => Decimal::ONE,
+                None => Decimal::ZERO,
+            },
         };
 
         // probability is mathematically in [0, 1] (Decimal::ONE or 1 - exp(neg)); to_f64 is
@@ -218,7 +230,10 @@ pub(crate) fn estimate_telegraph_parameters(
 ) -> Result<(Decimal, Decimal), DecimalError> {
     // Allow threshold to be zero - it's a valid threshold for classification
     // Returns are classified as +1 if > threshold, -1 if <= threshold
-    let mut current_state = if returns[0] > threshold {
+    let first = returns.first().ok_or_else(|| {
+        DecimalError::invalid_value(0.0, "returns must contain at least one observation")
+    })?;
+    let mut current_state = if *first > threshold {
         Decimal::ONE
     } else {
         Decimal::NEGATIVE_ONE
@@ -234,7 +249,11 @@ pub(crate) fn estimate_telegraph_parameters(
             Decimal::NEGATIVE_ONE
         };
         if new_state == current_state {
-            current_duration += Decimal::ONE;
+            current_duration = d_add(
+                current_duration,
+                Decimal::ONE,
+                "pricing::telegraph::estimate::duration",
+            )?;
         } else {
             if current_state == Decimal::ONE {
                 up_durations.push(current_duration);
@@ -269,8 +288,14 @@ pub(crate) fn estimate_telegraph_parameters(
         });
     }
 
-    let sum_down = down_durations.iter().sum::<Decimal>();
-    let sum_up = up_durations.iter().sum::<Decimal>();
+    let sum_down = d_sum_iter(
+        down_durations.iter().copied(),
+        "pricing::telegraph::estimate::sum_down",
+    )?;
+    let sum_up = d_sum_iter(
+        up_durations.iter().copied(),
+        "pricing::telegraph::estimate::sum_up",
+    )?;
 
     if sum_down == Decimal::ZERO {
         return Err(DecimalError::InvalidValue {
@@ -298,8 +323,24 @@ pub(crate) fn estimate_telegraph_parameters(
             "up_durations length not representable as Decimal",
         )
     })?;
-    let lambda_up = Decimal::ONE / sum_down * down_len;
-    let lambda_down = Decimal::ONE / sum_up * up_len;
+    let lambda_up = d_mul(
+        d_div(
+            Decimal::ONE,
+            sum_down,
+            "pricing::telegraph::estimate::inv_sum_down",
+        )?,
+        down_len,
+        "pricing::telegraph::estimate::lambda_up",
+    )?;
+    let lambda_down = d_mul(
+        d_div(
+            Decimal::ONE,
+            sum_up,
+            "pricing::telegraph::estimate::inv_sum_up",
+        )?,
+        up_len,
+        "pricing::telegraph::estimate::lambda_down",
+    )?;
     Ok((lambda_up, lambda_down))
 }
 
@@ -341,11 +382,15 @@ pub fn telegraph(
     lambda_down: Option<Decimal>,
 ) -> Result<Decimal, PricingError> {
     let no_steps_raw = no_steps.get();
-    let mut price = option.underlying_price;
+    let price = option.underlying_price;
     let no_steps_dec = Decimal::from_usize(no_steps_raw).ok_or_else(|| {
         PricingError::method_error("telegraph", &format!("invalid no_steps: {no_steps_raw}"))
     })?;
-    let dt = option.time_to_expiration()?.to_dec() / no_steps_dec;
+    let dt = d_div(
+        option.time_to_expiration()?.to_dec(),
+        no_steps_dec,
+        "pricing::telegraph::dt",
+    )?;
 
     let one_over_252 = finite_decimal(1.0 / 252.0)
         .ok_or_else(|| PricingError::non_finite("pricing::telegraph::one_over_252", 1.0 / 252.0))?;
@@ -374,29 +419,52 @@ pub fn telegraph(
 
     let tp = telegraph_process;
     let mut telegraph_process = tp.clone();
+    // Loop-invariant risk-neutral drift `r - σ²/2`.
+    let drift: Decimal = d_sub(
+        option.risk_free_rate,
+        d_mul(
+            dec!(0.5),
+            d_powd(
+                option.implied_volatility.to_dec(),
+                Decimal::TWO,
+                "pricing::telegraph::variance",
+            )?,
+            "pricing::telegraph::half_variance",
+        )?,
+        "pricing::telegraph::drift",
+    )?;
+    let drift_dt = d_mul(drift, dt, "pricing::telegraph::drift_dt")?;
+    let sqrt_dt = dt
+        .sqrt()
+        .ok_or_else(|| PricingError::method_error("telegraph", "non-finite dt sqrt"))?;
+    let sqrt_dt_f64 = sqrt_dt.to_f64().ok_or_else(|| {
+        PricingError::method_error("telegraph", "sqrt(dt) not representable as f64")
+    })?;
+    let mut price = price.to_dec();
     for _ in 0..no_steps_raw {
         let state = telegraph_process.next_state(dt);
-        let drift: Decimal = option.risk_free_rate - dec!(0.5) * option.implied_volatility.powi(2);
         let state_f64 = state as f64;
         let state_dec = finite_decimal(state_f64)
             .ok_or_else(|| PricingError::non_finite("pricing::telegraph::state_dec", state_f64))?;
-        let volatility: Decimal = option.implied_volatility.to_dec() * state_dec;
+        let volatility: Decimal = d_mul(
+            option.implied_volatility.to_dec(),
+            state_dec,
+            "pricing::telegraph::volatility",
+        )?;
 
-        let sqrt_dt = dt
-            .sqrt()
-            .ok_or_else(|| PricingError::method_error("telegraph", "non-finite dt sqrt"))?;
-        let sqrt_dt_f64 = sqrt_dt.to_f64().ok_or_else(|| {
-            PricingError::method_error("telegraph", "sqrt(dt) not representable as f64")
-        })?;
         let rh_f64 = sqrt_dt_f64 * random::<f64>();
         let rh = finite_decimal(rh_f64)
             .ok_or_else(|| PricingError::non_finite("pricing::telegraph::rh", rh_f64))?;
-        let lhs = drift * dt + volatility;
+        let lhs = d_add(drift_dt, volatility, "pricing::telegraph::exponent_scale")?;
 
-        let update = (lhs * rh).exp();
-        price *= update;
+        let update = d_exp(
+            d_mul(lhs, rh, "pricing::telegraph::exponent")?,
+            "pricing::telegraph::update",
+        )?;
+        price = d_mul(price, update, "pricing::telegraph::path")?;
     }
 
+    let price = Positive::new_decimal(price)?;
     let payoff = option.payoff_at_price(&price)?;
     // Build the discount exponent through a checked multiplication so
     // an overflow on `-risk_free_rate * time_to_expiration` is tagged
@@ -406,7 +474,7 @@ pub fn telegraph(
         option.time_to_expiration()?.to_dec(),
         "pricing::telegraph::discount_exponent",
     )?;
-    let discount = discount_exponent.exp();
+    let discount = d_exp(discount_exponent, "pricing::telegraph::discount")?;
     let result = d_mul(payoff, discount, "pricing::telegraph::price")?;
     Ok(result)
 }

--- a/src/pricing/utils.rs
+++ b/src/pricing/utils.rs
@@ -13,7 +13,7 @@ use crate::Options;
 use crate::error::PricingError;
 use crate::error::decimal::DecimalError;
 use crate::greeks::{big_n, d2};
-use crate::model::decimal::{d_add, d_mul, d_sub, finite_decimal};
+use crate::model::decimal::{d_add, d_div, d_exp, d_ln, d_mul, d_powd, d_sub, finite_decimal};
 use crate::model::types::Side;
 use crate::pricing::binomial_model::BinomialPricingParams;
 use crate::pricing::constants::{CLAMP_MAX, CLAMP_MIN};
@@ -59,13 +59,27 @@ pub fn simulate_returns(
         let u2 = random_decimal(rng)?;
 
         // Convert to normal distribution using Box-Muller transform
-        let r = (-Decimal::TWO * u1.ln()).sqrt().ok_or_else(|| {
+        let r = d_mul(
+            -Decimal::TWO,
+            d_ln(u1, "pricing::utils::box_muller::log_u1")?,
+            "pricing::utils::box_muller::radius_squared",
+        )?
+        .sqrt()
+        .ok_or_else(|| {
             DecimalError::arithmetic_error("sqrt", "non-finite operand in Box-Muller r")
         })?;
-        let theta = Decimal::TWO * Decimal::PI * u2;
+        let theta = d_mul(
+            d_mul(
+                Decimal::TWO,
+                Decimal::PI,
+                "pricing::utils::box_muller::two_pi",
+            )?,
+            u2,
+            "pricing::utils::box_muller::theta",
+        )?;
 
-        let x1 = r * theta.cos();
-        let x2 = r * theta.sin();
+        let x1 = d_mul(r, theta.cos(), "pricing::utils::box_muller::x1")?;
+        let x2 = d_mul(r, theta.sin(), "pricing::utils::box_muller::x2")?;
 
         Ok((x1, x2))
     }
@@ -78,11 +92,14 @@ pub fn simulate_returns(
     }
 
     // Adjust mean and standard deviation for the time step
-    let adjusted_mean = mean * time_step;
-    let adjusted_std = std_dev
-        * time_step.sqrt().ok_or_else(|| {
+    let adjusted_mean = d_mul(mean, time_step, "pricing::utils::simulate::adjusted_mean")?;
+    let adjusted_std = d_mul(
+        std_dev.to_dec(),
+        time_step.sqrt().ok_or_else(|| {
             DecimalError::arithmetic_error("sqrt", "invalid (negative or non-finite) time_step")
-        })?;
+        })?,
+        "pricing::utils::simulate::adjusted_std",
+    )?;
 
     // Special case: if std_dev is 0, return a vector of constant values
     if adjusted_std == Decimal::ZERO {
@@ -97,11 +114,19 @@ pub fn simulate_returns(
         let (n1, n2) = generate_normal_pair(&mut rng)?;
 
         // Scale the random numbers by mean and std_dev
-        let r1 = n1 * adjusted_std + adjusted_mean;
+        let r1 = d_add(
+            d_mul(n1, adjusted_std, "pricing::utils::simulate::scale_1")?,
+            adjusted_mean,
+            "pricing::utils::simulate::shift_1",
+        )?;
         returns.push(r1);
 
         if returns.len() < length {
-            let r2 = n2 * adjusted_std + adjusted_mean;
+            let r2 = d_add(
+                d_mul(n2, adjusted_std, "pricing::utils::simulate::scale_2")?,
+                adjusted_mean,
+                "pricing::utils::simulate::shift_2",
+            )?;
             returns.push(r2);
         }
     }
@@ -128,7 +153,14 @@ pub(crate) fn calculate_up_factor(
     let sqrt_dt = dt
         .sqrt()
         .ok_or_else(|| DecimalError::arithmetic_error("sqrt", "non-finite dt in up factor"))?;
-    Ok((sqrt_dt * volatility).exp())
+    d_exp(
+        d_mul(
+            sqrt_dt,
+            volatility.to_dec(),
+            "pricing::binomial::up_factor::exponent",
+        )?,
+        "pricing::binomial::up_factor",
+    )
 }
 
 /// Calculates the down factor for a given volatility and time step.
@@ -151,7 +183,18 @@ pub(crate) fn calculate_down_factor(
     let sqrt_dt = dt
         .sqrt()
         .ok_or_else(|| DecimalError::arithmetic_error("sqrt", "non-finite dt in down factor"))?;
-    Ok((dec!(-1.0) * sqrt_dt * volatility.to_dec()).exp())
+    d_exp(
+        d_mul(
+            d_mul(
+                dec!(-1.0),
+                sqrt_dt,
+                "pricing::binomial::down_factor::sqrt_dt",
+            )?,
+            volatility.to_dec(),
+            "pricing::binomial::down_factor::exponent",
+        )?,
+        "pricing::binomial::down_factor",
+    )
 }
 
 /// Calculates the probability using a given interest rate, time interval,
@@ -174,10 +217,34 @@ pub(crate) fn calculate_probability(
     down_factor: Decimal,
     up_factor: Decimal,
 ) -> Result<Decimal, DecimalError> {
-    Ok(
-        (((int_rate * dt).exp() - down_factor) / (up_factor - down_factor))
-            .clamp(CLAMP_MIN, CLAMP_MAX),
-    )
+    let spread = d_sub(
+        up_factor,
+        down_factor,
+        "pricing::binomial::probability::spread",
+    )?;
+    if spread.is_zero() {
+        // A lattice with no spread carries no risk-neutral probability: the
+        // callers detect the collapse and take the deterministic path instead
+        // of consuming a fabricated weight.
+        return Err(DecimalError::arithmetic_error(
+            "pricing::binomial::probability",
+            "up and down factors coincide, risk-neutral probability is undefined",
+        ));
+    }
+    let growth = d_exp(
+        d_mul(int_rate, dt, "pricing::binomial::probability::rate_dt")?,
+        "pricing::binomial::probability::growth",
+    )?;
+    Ok(d_div(
+        d_sub(
+            growth,
+            down_factor,
+            "pricing::binomial::probability::numerator",
+        )?,
+        spread,
+        "pricing::binomial::probability",
+    )?
+    .clamp(CLAMP_MIN, CLAMP_MAX))
 }
 
 /// Calculates the discount factor given an interest rate and time period.
@@ -197,7 +264,14 @@ pub(crate) fn calculate_discount_factor(
     int_rate: Decimal,
     dt: Decimal,
 ) -> Result<Decimal, DecimalError> {
-    Ok((-int_rate * dt).exp())
+    d_exp(
+        d_mul(
+            -int_rate,
+            dt,
+            "pricing::binomial::discount_factor::exponent",
+        )?,
+        "pricing::binomial::discount_factor",
+    )
 }
 
 /// Calculates the value of an option node in a binomial options pricing model.
@@ -224,12 +298,16 @@ pub(crate) fn option_node_value_wrapper(
     node: usize,
     discount_factor: Decimal,
 ) -> Result<Decimal, DecimalError> {
-    option_node_value(
-        probability,
-        next[0][node],
-        next[0][node + 1],
-        discount_factor,
-    )
+    let next_step = next
+        .first()
+        .ok_or_else(|| DecimalError::arithmetic_error("pricing::binomial::node", "missing step"))?;
+    let price_up = *next_step.get(node).ok_or_else(|| {
+        DecimalError::arithmetic_error("pricing::binomial::node", "missing up node")
+    })?;
+    let price_down = *next_step.get(node + 1).ok_or_else(|| {
+        DecimalError::arithmetic_error("pricing::binomial::node", "missing down node")
+    })?;
+    option_node_value(probability, price_up, price_down, discount_factor)
 }
 
 /// Calculates the value of an option node in a binomial tree model.
@@ -294,8 +372,36 @@ pub(crate) fn calculate_option_price(
     d: Decimal,
     i: usize,
 ) -> Result<Decimal, PricingError> {
+    // `i` is bounded by `no_steps` at every call site, but the subtraction is
+    // checked so a caller that walks past the last step reports instead of
+    // wrapping.
+    let down_steps = params.no_steps.get().checked_sub(i).ok_or_else(|| {
+        PricingError::method_error(
+            "calculate_option_price",
+            "step index exceeds the number of lattice steps",
+        )
+    })?;
+    let up_power = d_powd(
+        u,
+        Decimal::from(i as u64),
+        "pricing::binomial::option_price::up_power",
+    )?;
+    let down_power = d_powd(
+        d,
+        Decimal::from(down_steps as u64),
+        "pricing::binomial::option_price::down_power",
+    )?;
+    let spot = d_mul(
+        d_mul(
+            params.asset.to_dec(),
+            up_power,
+            "pricing::binomial::option_price::spot_up",
+        )?,
+        down_power,
+        "pricing::binomial::option_price::spot",
+    )?;
     let info = PayoffInfo {
-        spot: params.asset * u.powu(i as u64) * d.powi((params.no_steps.get() - i) as i64),
+        spot: Positive::new_decimal(spot)?,
         strike: params.strike,
         style: *params.option_style,
         side: *params.side,
@@ -340,8 +446,21 @@ pub(crate) fn calculate_option_price(
 pub(crate) fn calculate_discounted_payoff(
     params: BinomialPricingParams,
 ) -> Result<Decimal, PricingError> {
+    let growth = d_exp(
+        d_mul(
+            params.int_rate,
+            params.expiry.to_dec(),
+            "pricing::binomial::discounted_payoff::growth_exponent",
+        )?,
+        "pricing::binomial::discounted_payoff::growth",
+    )?;
+    let forward = d_mul(
+        params.asset.to_dec(),
+        growth,
+        "pricing::binomial::discounted_payoff::forward",
+    )?;
     let info = PayoffInfo {
-        spot: params.asset * (params.int_rate * params.expiry).exp(),
+        spot: Positive::new_decimal(forward)?,
         strike: params.strike,
         style: *params.option_style,
         side: *params.side,
@@ -363,7 +482,10 @@ pub(crate) fn calculate_discounted_payoff(
         params.expiry.to_dec(),
         "pricing::binomial::discounted_payoff::discount_exponent",
     )?;
-    let discount = discount_exponent.exp();
+    let discount = d_exp(
+        discount_exponent,
+        "pricing::binomial::discounted_payoff::discount",
+    )?;
     let discounted_payoff = d_mul(
         discount,
         payoff,
@@ -412,7 +534,11 @@ pub(crate) fn wiener_increment(dt: Decimal) -> Result<Decimal, PricingError> {
     let sqrt_dt = dt.sqrt().ok_or_else(|| {
         DecimalError::arithmetic_error("sqrt", "non-finite dt in wiener_increment")
     })?;
-    Ok(sample * sqrt_dt)
+    Ok(d_mul(
+        sample,
+        sqrt_dt,
+        "pricing::monte_carlo::wiener_increment::scaled",
+    )?)
 }
 
 /// Calculates the probability that the option will remain under the strike price.
@@ -445,7 +571,11 @@ pub fn probability_keep_under_strike(
     let d2_val = d2(
         option.underlying_price,
         strike_price,
-        option.risk_free_rate - option.dividend_yield.to_dec(), // carry b = r - q
+        d_sub(
+            option.risk_free_rate,
+            option.dividend_yield.to_dec(),
+            "pricing::utils::probability_keep_under_strike::carry",
+        )?, // carry b = r - q
         years,
         option.implied_volatility,
     )

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -5,5 +5,6 @@
 
 mod greeks_bounds_test;
 mod panic_freedom_test;
+mod pricing_panic_freedom_test;
 mod put_call_parity_test;
 mod quote_invariants_test;

--- a/tests/property/pricing_panic_freedom_test.rs
+++ b/tests/property/pricing_panic_freedom_test.rs
@@ -1,0 +1,395 @@
+//! Property-based tests for panic freedom across the exotic pricing kernels.
+//!
+//! The library is embedded in long-running services, where a panic kills the
+//! worker thread and takes the in-flight request with it. Every failure must
+//! therefore come back as a `Result`, including for inputs that are extreme
+//! but structurally valid.
+//!
+//! These tests drive every `src/pricing/` entry point over the edges of the
+//! `Decimal` domain — volatilities and strikes at the smallest representable
+//! scale, times to expiry and prices at the largest, rates far outside
+//! anything a market quotes — and over the exotic parameter surface:
+//! barriers at zero and at `Positive::MAX`, empty averaging windows, caps and
+//! floors at the `Decimal` extremes, correlations well outside `[-1, 1]`. The
+//! assertion is deliberately weak: whatever comes back, it must come back.
+
+use optionstratlib::model::ExpirationDate;
+use optionstratlib::model::Options;
+use optionstratlib::model::option::ExoticParams;
+use optionstratlib::model::types::{
+    AsianAveragingType, BarrierType, BinaryType, LookbackType, OptionStyle, OptionType,
+    RainbowType, Side,
+};
+use optionstratlib::pricing::{
+    BinomialPricingParams, asian_black_scholes, barone_adesi_whaley, barrier_black_scholes,
+    binary_black_scholes, chooser_black_scholes, cliquet_black_scholes, compound_black_scholes,
+    exchange_black_scholes, generate_binomial_tree, lookback_black_scholes,
+    monte_carlo_option_pricing, power_black_scholes, price_binomial, probability_keep_under_strike,
+    quanto_black_scholes, rainbow_black_scholes, simulate_returns, spread_black_scholes, telegraph,
+};
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::num::NonZeroUsize;
+use std::str::FromStr;
+
+/// The extremes that reach the arithmetic panics: the smallest representable
+/// `Decimal`, the largest, and the ordinary values in between.
+fn extreme_positive() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos("0.000000000000000000000000001")),
+        Just(pos("0.0000000000001")),
+        Just(pos("0.2")),
+        Just(pos("100")),
+        Just(pos("1000000")),
+        Just(Positive::MAX),
+    ]
+}
+
+/// Rates well outside anything quotable, in both directions.
+fn extreme_rate() -> impl Strategy<Value = Decimal> {
+    prop_oneof![
+        Just(Decimal::ZERO),
+        Just(dec!(0.05)),
+        Just(dec!(-0.05)),
+        Just(dec!(1000000)),
+        Just(dec!(-1000000)),
+        Just(Decimal::MAX),
+        Just(Decimal::MIN),
+    ]
+}
+
+fn pos(value: &str) -> Positive {
+    let decimal = Decimal::from_str(value).expect("literal is a valid Decimal");
+    Positive::new_decimal(decimal).expect("literal is non-negative")
+}
+
+fn option_style() -> impl Strategy<Value = OptionStyle> {
+    prop_oneof![Just(OptionStyle::Call), Just(OptionStyle::Put)]
+}
+
+fn side() -> impl Strategy<Value = Side> {
+    prop_oneof![Just(Side::Long), Just(Side::Short)]
+}
+
+/// Every exotic `OptionType`, including the shapes that have no financial
+/// meaning: a zero barrier, an empty reset schedule, a rainbow with the wrong
+/// number of assets, a zero exponent.
+fn exotic_option_type() -> impl Strategy<Value = OptionType> {
+    prop_oneof![
+        Just(OptionType::European),
+        Just(OptionType::American),
+        Just(OptionType::Bermuda {
+            exercise_dates: vec![]
+        }),
+        Just(OptionType::Asian {
+            averaging_type: AsianAveragingType::Geometric
+        }),
+        Just(OptionType::Asian {
+            averaging_type: AsianAveragingType::Arithmetic
+        }),
+        Just(OptionType::Barrier {
+            barrier_type: BarrierType::UpAndIn,
+            barrier_level: Positive::ZERO,
+            rebate: None
+        }),
+        Just(OptionType::Barrier {
+            barrier_type: BarrierType::UpAndOut,
+            barrier_level: pos("100"),
+            rebate: Some(Positive::MAX)
+        }),
+        Just(OptionType::Barrier {
+            barrier_type: BarrierType::DownAndIn,
+            barrier_level: Positive::MAX,
+            rebate: Some(Positive::ZERO)
+        }),
+        Just(OptionType::Barrier {
+            barrier_type: BarrierType::DownAndOut,
+            barrier_level: pos("0.000000000000000000000000001"),
+            rebate: None
+        }),
+        Just(OptionType::Binary {
+            binary_type: BinaryType::CashOrNothing
+        }),
+        Just(OptionType::Binary {
+            binary_type: BinaryType::AssetOrNothing
+        }),
+        Just(OptionType::Binary {
+            binary_type: BinaryType::Gap
+        }),
+        Just(OptionType::Lookback {
+            lookback_type: LookbackType::FixedStrike
+        }),
+        Just(OptionType::Lookback {
+            lookback_type: LookbackType::FloatingStrike
+        }),
+        Just(OptionType::Compound {
+            underlying_option: Box::new(OptionType::European)
+        }),
+        Just(OptionType::Chooser {
+            choice_date: Positive::ZERO
+        }),
+        Just(OptionType::Chooser {
+            choice_date: pos("15")
+        }),
+        Just(OptionType::Chooser {
+            choice_date: Positive::MAX
+        }),
+        Just(OptionType::Cliquet {
+            reset_dates: vec![]
+        }),
+        Just(OptionType::Cliquet {
+            reset_dates: vec![Positive::MAX, Positive::ZERO, pos("30")]
+        }),
+        Just(OptionType::Rainbow {
+            num_assets: 2,
+            rainbow_type: RainbowType::BestOf
+        }),
+        Just(OptionType::Rainbow {
+            num_assets: 0,
+            rainbow_type: RainbowType::WorstOf
+        }),
+        Just(OptionType::Spread {
+            second_asset: Positive::ZERO
+        }),
+        Just(OptionType::Spread {
+            second_asset: Positive::MAX
+        }),
+        Just(OptionType::Exchange {
+            second_asset: Positive::ZERO
+        }),
+        Just(OptionType::Exchange {
+            second_asset: pos("100")
+        }),
+        Just(OptionType::Quanto {
+            exchange_rate: Positive::ZERO
+        }),
+        Just(OptionType::Quanto {
+            exchange_rate: Positive::MAX
+        }),
+        Just(OptionType::Power {
+            exponent: Positive::ZERO
+        }),
+        Just(OptionType::Power { exponent: pos("2") }),
+        Just(OptionType::Power {
+            exponent: Positive::MAX
+        }),
+    ]
+}
+
+/// The `OptionType`s handed to the lattice and simulation engines: the three
+/// exercise styles they induct over, plus `Chooser` and `Power`, whose payoff
+/// arms are evaluated on every terminal node before an unsupported type is
+/// rejected.
+fn lattice_option_type() -> impl Strategy<Value = OptionType> {
+    prop_oneof![
+        Just(OptionType::European),
+        Just(OptionType::American),
+        Just(OptionType::Bermuda {
+            exercise_dates: vec![]
+        }),
+        Just(OptionType::Bermuda {
+            exercise_dates: vec![Positive::ZERO, pos("30"), Positive::MAX]
+        }),
+        Just(OptionType::Chooser {
+            choice_date: Positive::ZERO
+        }),
+        Just(OptionType::Chooser {
+            choice_date: pos("15")
+        }),
+        Just(OptionType::Power {
+            exponent: Positive::ZERO
+        }),
+        Just(OptionType::Power { exponent: pos("2") }),
+        Just(OptionType::Power {
+            exponent: Positive::MAX
+        }),
+    ]
+}
+
+/// The three shapes of `exotic_params` that reach the kernels: absent, all
+/// zero, and all at the `Decimal` / `Positive` extremes with correlations
+/// outside `[-1, 1]`.
+fn exotic_params() -> impl Strategy<Value = Option<ExoticParams>> {
+    prop_oneof![
+        Just(None),
+        Just(Some(ExoticParams {
+            spot_prices: Some(vec![]),
+            spot_min: Some(Decimal::ZERO),
+            spot_max: Some(Decimal::ZERO),
+            cliquet_local_cap: Some(Decimal::ZERO),
+            cliquet_local_floor: Some(Decimal::ZERO),
+            cliquet_global_cap: Some(Decimal::ZERO),
+            cliquet_global_floor: Some(Decimal::ZERO),
+            rainbow_second_asset_price: Some(Positive::ZERO),
+            rainbow_second_asset_volatility: Some(Positive::ZERO),
+            rainbow_second_asset_dividend: Some(Positive::ZERO),
+            rainbow_correlation: Some(Decimal::ZERO),
+            spread_second_asset_volatility: Some(Positive::ZERO),
+            spread_second_asset_dividend: Some(Positive::ZERO),
+            spread_correlation: Some(Decimal::ZERO),
+            quanto_fx_volatility: Some(Positive::ZERO),
+            quanto_fx_correlation: Some(Decimal::ZERO),
+            quanto_foreign_rate: Some(Decimal::ZERO),
+            exchange_second_asset_volatility: Some(Positive::ZERO),
+            exchange_second_asset_dividend: Some(Positive::ZERO),
+            exchange_correlation: Some(Decimal::ZERO),
+        })),
+        Just(Some(ExoticParams {
+            spot_prices: Some(vec![pos("100"), Positive::ZERO, Positive::MAX]),
+            spot_min: Some(Decimal::ZERO),
+            spot_max: Some(Decimal::MAX),
+            cliquet_local_cap: Some(Decimal::ZERO),
+            cliquet_local_floor: Some(Decimal::MIN),
+            cliquet_global_cap: Some(Decimal::MAX),
+            cliquet_global_floor: Some(Decimal::ZERO),
+            rainbow_second_asset_price: Some(Positive::MAX),
+            rainbow_second_asset_volatility: Some(Positive::ZERO),
+            rainbow_second_asset_dividend: Some(Positive::MAX),
+            rainbow_correlation: Some(dec!(5)),
+            spread_second_asset_volatility: Some(Positive::MAX),
+            spread_second_asset_dividend: Some(Positive::MAX),
+            spread_correlation: Some(dec!(-5)),
+            quanto_fx_volatility: Some(Positive::MAX),
+            quanto_fx_correlation: Some(dec!(9)),
+            quanto_foreign_rate: Some(Decimal::MAX),
+            exchange_second_asset_volatility: Some(Positive::ZERO),
+            exchange_second_asset_dividend: Some(Positive::MAX),
+            exchange_correlation: Some(dec!(-3)),
+        })),
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_option(
+    option_type: OptionType,
+    spot: Positive,
+    strike: Positive,
+    volatility: Positive,
+    days: Positive,
+    quantity: Positive,
+    dividend_yield: Positive,
+    rate: Decimal,
+    style: OptionStyle,
+    side: Side,
+    exotic: Option<ExoticParams>,
+) -> Options {
+    Options::new(
+        option_type,
+        side,
+        "TEST".to_string(),
+        strike,
+        ExpirationDate::Days(days),
+        volatility,
+        quantity,
+        spot,
+        rate,
+        style,
+        dividend_yield,
+        exotic,
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    /// Every exotic closed form returns for every combination of extremes,
+    /// whatever the `OptionType` it is handed: each one rejects the types it
+    /// does not model, so all twelve are driven with the same option.
+    #[test]
+    fn test_exotic_pricing_never_panics_on_extreme_inputs(
+        option_type in exotic_option_type(),
+        exotic in exotic_params(),
+        spot in extreme_positive(),
+        strike in extreme_positive(),
+        volatility in extreme_positive(),
+        days in extreme_positive(),
+        quantity in extreme_positive(),
+        dividend_yield in extreme_positive(),
+        rate in extreme_rate(),
+        style in option_style(),
+        side in side(),
+    ) {
+        let option = build_option(
+            option_type, spot, strike, volatility, days, quantity, dividend_yield, rate,
+            style, side, exotic,
+        );
+
+        let _ = asian_black_scholes(&option);
+        let _ = barrier_black_scholes(&option);
+        let _ = binary_black_scholes(&option);
+        let _ = lookback_black_scholes(&option);
+        let _ = compound_black_scholes(&option);
+        let _ = chooser_black_scholes(&option);
+        let _ = cliquet_black_scholes(&option);
+        let _ = rainbow_black_scholes(&option);
+        let _ = spread_black_scholes(&option);
+        let _ = quanto_black_scholes(&option);
+        let _ = exchange_black_scholes(&option);
+        let _ = power_black_scholes(&option);
+    }
+
+    /// The Barone-Adesi-Whaley approximation returns for every combination of
+    /// extremes, including the `r = 0` boundary where `1 - e^(-rT)` vanishes.
+    #[test]
+    fn test_barone_adesi_whaley_never_panics_on_extreme_inputs(
+        spot in extreme_positive(),
+        strike in extreme_positive(),
+        volatility in extreme_positive(),
+        years in extreme_positive(),
+        dividend_yield in extreme_positive(),
+        rate in extreme_rate(),
+        style in option_style(),
+    ) {
+        let _ = barone_adesi_whaley(
+            spot, strike, years, rate, dividend_yield, volatility, &style,
+        );
+    }
+
+    /// The lattice and simulation engines return for every combination of
+    /// extremes. They evaluate `OptionType::payoff` on every terminal node
+    /// before rejecting a type they cannot induct over, so they are driven on
+    /// the exercise styles they model plus `Chooser` and `Power`, whose payoff
+    /// arms used to abort on any out-of-the-money contract.
+    #[test]
+    fn test_numerical_engines_never_panic_on_extreme_inputs(
+        option_type in lattice_option_type(),
+        spot in extreme_positive(),
+        strike in extreme_positive(),
+        volatility in extreme_positive(),
+        days in extreme_positive(),
+        quantity in extreme_positive(),
+        dividend_yield in extreme_positive(),
+        rate in extreme_rate(),
+        style in option_style(),
+        side in side(),
+    ) {
+        let option = build_option(
+            option_type.clone(), spot, strike, volatility, days, quantity, dividend_yield,
+            rate, style, side, None,
+        );
+        let steps = NonZeroUsize::new(8).expect("literal is non-zero");
+        let simulations = NonZeroUsize::new(4).expect("literal is non-zero");
+        let params = BinomialPricingParams {
+            asset: spot,
+            volatility,
+            int_rate: rate,
+            strike,
+            expiry: days,
+            no_steps: steps,
+            option_type: &option_type,
+            option_style: &style,
+            side: &side,
+        };
+
+        let _ = price_binomial(params.clone());
+        let _ = generate_binomial_tree(&params);
+        let _ = monte_carlo_option_pricing(&option, steps, simulations);
+        let _ = telegraph(&option, steps, Some(dec!(0.5)), Some(dec!(0.3)));
+        let _ = telegraph(&option, steps, None, None);
+        let _ = probability_keep_under_strike(option, Some(strike));
+        let _ = simulate_returns(rate, volatility, 8, days.to_dec());
+    }
+}


### PR DESCRIPTION
## Summary

A probe over the public pricing surface — every entry point wrapped in
`catch_unwind`, driven across the extremes of the `Decimal` domain and over the
whole `OptionType` matrix — found **129 distinct panic sites** in
`src/pricing/`. They are the same class #441 fixed in the Black-Scholes core:
`rust_decimal` and `positive` abort on the operator path, so `Exp overflowed`,
`Pow overflowed`, `Unable to calculate ln for zero`, `Division by zero` and the
`Positive` invariant panics were all reachable from ordinary-looking inputs.

The single most reachable site fired 216,000 times in one probe run: a barrier
option with a zero barrier level divides by it. The most embarrassing one is
not an extreme input at all — an out-of-the-money chooser at `S = 100`,
`K = 110` aborted, and so did a power put whose `S^n` exceeds the strike.

The probe is now clean over **31,365,504 calls**, including a pass with a
`TRACE` subscriber installed.

## Changes

Every panicking site now goes through the checked helpers in
`src/model/decimal.rs`. Where a formula has a defined limit, the limit is
returned rather than an error:

- **`american.rs`** — `4M/K` with `K = 1 - e^(-rT)` is a 0/0 at `r = 0`, which
  is an ordinary input, so **every zero-rate American option aborted**.
  Replaced by its limit `8/(sigma^2 T)`.
- **`asian.rs`** — a non-positive Turnbull-Wakeman `M1`, or a matched variance
  that collapses, falls into the `sigma -> 0` branch the function already had.
- **`chooser.rs`** — a collapsed diffusion saturates the CDFs by the sign of
  the numerator; a genuine 0/0 returns a typed error rather than a guess.
- **`exchange.rs`, `spread.rs`, `quanto.rs`** — a zero second asset or strike,
  and a moneyness that rounds below the representable scale, take the same
  infinity limits.
- **`barrier.rs`, `binary.rs`, `cliquet.rs`, `compound.rs`, `lookback.rs`,
  `power.rs`, `rainbow.rs`** — discounts, reflection powers, moment matching
  and the intrinsics rebuilt on `d_exp` / `d_ln` / `d_powd` / `d_div` /
  `d_mul` / `d_sub`.
- **`binomial_model.rs`, `monte_carlo.rs`, `telegraph.rs`, `utils.rs`** — the
  lattice and simulation engines, including the indexing: `prices[i]` became
  `.get()` / `.get_mut()` with a typed error, an unchecked `.sum()` over the
  Monte-Carlo payoffs became `d_sum_iter`, and the reset loop in `cliquet`
  moved from `[i-1]` / `[i]` to `windows(2)`.

Domain rejects were added only where an input has no financial meaning: a zero
underlying, strike or barrier level in `barrier.rs`, and a non-positive
underlying or strike in the BAW helper.

### The root cause outside `src/pricing/`

`OptionType::payoff` aborted for an out-of-the-money chooser and for a power
put whose `S^n` exceeds the strike, and it reached the lattice, the telegraph
and the Monte-Carlo engines through their payoff evaluation. Both arms now form
the intrinsic on `Decimal` and floor it, which is the same arithmetic
`Positive::sub` was doing internally — every in-the-money price is
bit-identical, only the aborting path changed. The alternative, rejecting those
types at the engine entry, would have turned a currently-correct
exotic-at-expiry price into an unsupported-type error, so it was not taken.

## Technical decisions

The mathematical limits are listed above and each is the limit of the formula
the function already implements, not a substitute for it. The one place the
sweep refused to guess — the chooser's genuine 0/0, where both the diffusion
and the log-moneyness collapse — returns a typed `MethodError`.

`telegraph.rs::next_state` returns `i8` and could not become fallible without a
public change, so an unrepresentable `lambda * dt` degrades to the limit its
sign implies, mirroring the `to_f64`-failure degradation the function already
had.

Left alone deliberately: the `f64` Gauss-Legendre kernels in `compound.rs`,
`power.rs` and `rainbow.rs`. `f64` arithmetic does not panic, the indices are
provably in range on fixed-size arrays, and every `f64 -> Decimal` boundary
already produces a typed error for a non-finite value. Rewriting them risks
numeric drift for no panic-freedom gain.

## Public API impact

None. Every pricing entry point already returned `Result<_, PricingError>`.
`intrinsic_value` in `asian.rs` became fallible, but it is a private helper.

## Testing

- [x] Unit tests added or updated — 7 new in `src/model/types.rs::tests_payoff`
      covering both payoff arms at, above and below the money
- [x] Integration tests added or updated
- [x] Reference regression test added — the existing reference and parity tests
      pass **unedited**, which is the bar for a sweep that must not move a price
- [ ] Criterion benchmark added/updated
- [x] `make pre-push` equivalents run locally and clean

`tests/property/pricing_panic_freedom_test.rs` is the repeatable form of the
probe: three properties at 512 cases each, driving all twelve exotic entry
points over 31 `OptionType` shapes (zero barrier, empty reset schedule, rainbow
with zero assets, zero exponent, `Positive::MAX` choice date), three
`exotic_params` shapes, and the extreme numeric domain; plus the BAW `r = 0`
boundary and the lattice and simulation engines.

Suite on the rebased branch: **3913 lib, 423 integration, 20 property, 207 doc
— 0 failures**, with `cargo fmt --all --check`, `cargo clippy --all-targets
--all-features --workspace -- -D warnings` and `make scan-banned` clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic only — no `saturating_*` / `wrapping_*` in financial math
- [x] `rust_decimal::Decimal` at public monetary boundaries
- [x] Module boundaries respected
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging
- [x] `README.tpl` updated if public surface changed — not applicable

## Stack

- Base branch: `main` (#441 and #443 are merged)
- Stack: #441 → #443 → **#444 (this)** → 442b → 442c → 442d → 442e
- Part of the sweep opened in #442; the remaining module groups are `curves/`
  and `surfaces/`, `chains/` and `simulation/`, `strategies/`, and the
  close-out that extends `make scan-banned` to the math operators.

Closes #444
