### PR TITLE
Make curves, surfaces and geometrics panic-free (#446)

### DIFF
--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -3,22 +3,18 @@
    Email: jb@taunais.com
    Date: 9/1/25
 ******************************************************************************/
-// Scoped allow: bulk migration of unchecked `[]` indexing to
-// `.get().ok_or_else(..)` tracked as follow-ups to #341. The existing
-// call sites are internal to this file and audited for invariant-bound
-// indices (fixed-length buffers, just-pushed slices, etc.).
-#![allow(clippy::indexing_slicing)]
-
 use crate::curves::Point2D;
 use crate::curves::traits::StatisticalCurve;
 use crate::curves::utils::detect_peaks_and_valleys;
+use crate::error::decimal::DecimalError;
 use crate::error::{CurveError, InterpolationError, MetricsError};
 use crate::geometrics::{
     Arithmetic, AxisOperations, BasicMetrics, BiLinearInterpolation, ConstructionMethod,
     ConstructionParams, CubicInterpolation, GeometricObject, GeometricTransformations, Interpolate,
     InterpolationType, LinearInterpolation, MergeAxisInterpolate, MergeOperation, MetricsExtractor,
-    RangeMetrics, RiskMetrics, ShapeMetrics, SplineInterpolation, TrendMetrics,
+    RangeMetrics, RiskMetrics, ShapeMetrics, SplineInterpolation, TrendMetrics, powu_checked,
 };
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
 use crate::utils::Len;
 use crate::visualization::{Graph, GraphData};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -129,6 +125,157 @@ impl Curve {
         let x_range = Self::calculate_range(points.iter().map(|p| p.x));
         Curve { points, x_range }
     }
+
+    /// Fetches the point at `index` without going through the panicking
+    /// [`Index`] contract.
+    ///
+    /// `kind` selects the [`InterpolationError`] variant so each algorithm
+    /// reports an out-of-bounds window under its own name.
+    fn point_at(
+        &self,
+        index: usize,
+        kind: fn(String) -> InterpolationError,
+    ) -> Result<&Point2D, InterpolationError> {
+        self.points.iter().nth(index).ok_or_else(|| {
+            kind(format!(
+                "point index {index} is out of bounds for a curve of {} points",
+                self.points.len()
+            ))
+        })
+    }
+}
+
+/// Wraps a checked-arithmetic failure raised while building or transforming a
+/// curve.
+fn construction_err(err: DecimalError) -> CurveError {
+    CurveError::ConstructionError(err.to_string())
+}
+
+/// Wraps a checked-arithmetic failure raised while analysing a curve.
+fn analysis_err(err: DecimalError) -> CurveError {
+    CurveError::AnalysisError(err.to_string())
+}
+
+/// Wraps a checked-arithmetic failure in the interpolation variant of the
+/// algorithm that raised it.
+fn interp_err(
+    kind: fn(String) -> InterpolationError,
+) -> impl Fn(DecimalError) -> InterpolationError {
+    move |err| kind(err.to_string())
+}
+
+/// Reads one sample of a sorted metric series, naming the statistic on the
+/// out-of-bounds path instead of panicking.
+fn sample_at(
+    values: &[Decimal],
+    index: usize,
+    what: &'static str,
+) -> Result<Decimal, MetricsError> {
+    values.get(index).copied().ok_or_else(|| {
+        MetricsError::BasicError(format!(
+            "{what}: sample {index} is out of bounds for {} values",
+            values.len()
+        ))
+    })
+}
+
+/// Arithmetic mean of a sample. Errors on an empty sample, where the mean is
+/// undefined, and on a sum that leaves the representable range.
+fn mean_of(values: &[Decimal], op: &'static str) -> Result<Decimal, DecimalError> {
+    let sum = d_sum_iter(values.iter().copied(), op)?;
+    d_div(sum, Decimal::from(values.len()), op)
+}
+
+/// Population variance of a sample about `mean`.
+fn variance_of(
+    values: &[Decimal],
+    mean: Decimal,
+    op: &'static str,
+) -> Result<Decimal, DecimalError> {
+    let mut acc = Decimal::ZERO;
+    for &value in values {
+        let centered = d_sub(value, mean, op)?;
+        let squared = powu_checked(centered, 2, op)?;
+        acc = d_add(acc, squared, op)?;
+    }
+    d_div(acc, Decimal::from(values.len()), op)
+}
+
+/// Mean of `(centered / std_dev)^order` over a pre-centered sample: the
+/// standardized moment behind skewness (`order = 3`) and kurtosis
+/// (`order = 4`).
+fn standardized_moment(
+    centered: &[Decimal],
+    std_dev: Decimal,
+    order: u64,
+    op: &'static str,
+) -> Result<Decimal, DecimalError> {
+    let mut acc = Decimal::ZERO;
+    for &value in centered {
+        let z = d_div(value, std_dev, op)?;
+        let moment = powu_checked(z, order, op)?;
+        acc = d_add(acc, moment, op)?;
+    }
+    d_div(acc, Decimal::from(centered.len()), op)
+}
+
+/// Reads one slot of a spline working band, naming the band on the
+/// out-of-bounds path instead of panicking.
+fn band_at(
+    band: &[Decimal],
+    index: usize,
+    name: &'static str,
+) -> Result<Decimal, InterpolationError> {
+    band.get(index).copied().ok_or_else(|| {
+        InterpolationError::Spline(format!(
+            "spline band `{name}` has no slot {index} (len {})",
+            band.len()
+        ))
+    })
+}
+
+/// Mutable counterpart of [`band_at`].
+fn band_at_mut<'a>(
+    band: &'a mut [Decimal],
+    index: usize,
+    name: &'static str,
+) -> Result<&'a mut Decimal, InterpolationError> {
+    let len = band.len();
+    band.get_mut(index).ok_or_else(|| {
+        InterpolationError::Spline(format!(
+            "spline band `{name}` has no slot {index} (len {len})"
+        ))
+    })
+}
+
+/// Evaluates `moment * d^3 / six_h`, the cubic half of a natural-spline
+/// segment, one checked step at a time.
+fn cube_scaled(
+    moment: Decimal,
+    d: Decimal,
+    six_h: Decimal,
+    op: &'static str,
+) -> Result<Decimal, InterpolationError> {
+    let scaled = d_mul(moment, d, op).map_err(interp_err(InterpolationError::Spline))?;
+    let scaled = d_mul(scaled, d, op).map_err(interp_err(InterpolationError::Spline))?;
+    let scaled = d_mul(scaled, d, op).map_err(interp_err(InterpolationError::Spline))?;
+    d_div(scaled, six_h, op).map_err(interp_err(InterpolationError::Spline))
+}
+
+/// Evaluates `(y / h - moment * h / 6) * d`, the linear half of a
+/// natural-spline segment, one checked step at a time.
+fn linear_term(
+    y: Decimal,
+    moment: Decimal,
+    h: Decimal,
+    d: Decimal,
+    op: &'static str,
+) -> Result<Decimal, InterpolationError> {
+    let level = d_div(y, h, op).map_err(interp_err(InterpolationError::Spline))?;
+    let bend = d_mul(moment, h, op).map_err(interp_err(InterpolationError::Spline))?;
+    let bend = d_div(bend, dec!(6), op).map_err(interp_err(InterpolationError::Spline))?;
+    let slope = d_sub(level, bend, op).map_err(interp_err(InterpolationError::Spline))?;
+    d_mul(slope, d, op).map_err(interp_err(InterpolationError::Spline))
 }
 
 impl Len for Curve {
@@ -198,12 +345,22 @@ impl GeometricObject<Point2D, Decimal> for Curve {
                         ));
                     }
                 };
-                let step_size = (t_end - t_start) / Decimal::from(steps);
+                if steps == 0 {
+                    return Err(CurveError::ConstructionError(
+                        "Parametric construction needs at least one step".to_string(),
+                    ));
+                }
+                let op = "Curve::construct::step_size";
+                let span = d_sub(t_end, t_start, op).map_err(construction_err)?;
+                let step_size = d_div(span, Decimal::from(steps), op).map_err(construction_err)?;
 
                 let points: Result<BTreeSet<Point2D>, CurveError> = (0..=steps)
                     .into_par_iter()
                     .map(|i| {
-                        let t = t_start + step_size * Decimal::from(i);
+                        let offset = d_mul(step_size, Decimal::from(i), "Curve::construct::offset")
+                            .map_err(construction_err)?;
+                        let t = d_add(t_start, offset, "Curve::construct::t")
+                            .map_err(construction_err)?;
                         f(t).map_err(|e| CurveError::ConstructionError(e.to_string()))
                     })
                     .collect();
@@ -284,6 +441,10 @@ impl Index<usize> for Curve {
         // and is documented above.
         match self.points.iter().nth(index) {
             Some(p) => p,
+            // scan-banned: allow -- `std::ops::Index` returns `&Self::Output`
+            // and has no fallible channel; the contract mirrors `Vec::index`.
+            // No library code reaches this arm: every internal lookup goes
+            // through `Curve::point_at`.
             None => panic!(
                 "Curve::index: out of bounds (index = {index}, len = {})",
                 self.points.len()
@@ -394,11 +555,29 @@ impl LinearInterpolation<Point2D, Decimal> for Curve {
     fn linear_interpolate(&self, x: Decimal) -> Result<Point2D, InterpolationError> {
         let (i, j) = self.find_bracket_points(x)?;
 
-        let p1 = &self[i];
-        let p2 = &self[j];
+        let p1 = self.point_at(i, InterpolationError::Linear)?;
+        let p2 = self.point_at(j, InterpolationError::Linear)?;
+
+        // `Point2D` orders on (x, y) but compares equal on x alone, so a
+        // `BTreeSet<Point2D>` legitimately holds two points sharing an
+        // abscissa; the slope is then undefined rather than infinite.
+        let run = d_sub(p2.x, p1.x, "Curve::linear_interpolate::run")
+            .map_err(interp_err(InterpolationError::Linear))?;
+        if run.is_zero() {
+            return Err(InterpolationError::DegenerateInterval);
+        }
 
         // Linear interpolation for y value
-        let y = p1.y + (x - p1.x) * (p2.y - p1.y) / (p2.x - p1.x);
+        let dx = d_sub(x, p1.x, "Curve::linear_interpolate::dx")
+            .map_err(interp_err(InterpolationError::Linear))?;
+        let rise = d_sub(p2.y, p1.y, "Curve::linear_interpolate::rise")
+            .map_err(interp_err(InterpolationError::Linear))?;
+        let scaled = d_mul(dx, rise, "Curve::linear_interpolate::scaled")
+            .map_err(interp_err(InterpolationError::Linear))?;
+        let ratio = d_div(scaled, run, "Curve::linear_interpolate::ratio")
+            .map_err(interp_err(InterpolationError::Linear))?;
+        let y = d_add(p1.y, ratio, "Curve::linear_interpolate::y")
+            .map_err(interp_err(InterpolationError::Linear))?;
 
         Ok(Point2D::new(x, y))
     }
@@ -534,23 +713,49 @@ impl BiLinearInterpolation<Point2D, Decimal> for Curve {
 
         let (i, _j) = self.find_bracket_points(x)?;
 
-        // Get four points forming a grid by using Index implementation on self
-        let p11 = &self[i]; // Bottom left
-        let p12 = &self[i + 1]; // Bottom right
-        let p21 = &self[i + 2]; // Top left
-        let p22 = &self[i + 3]; // Top right
+        // The grid is the four consecutive points starting at the lower
+        // bracket index. `find_bracket_points` only guarantees `i + 1`, so any
+        // `x` in the last three intervals leaves the window past the end.
+        let p11 = self.point_at(i, InterpolationError::Bilinear)?; // Bottom left
+        let p12 = self.point_at(i + 1, InterpolationError::Bilinear)?; // Bottom right
+        let p21 = self.point_at(i + 2, InterpolationError::Bilinear)?; // Top left
+        let p22 = self.point_at(i + 3, InterpolationError::Bilinear)?; // Top right
+
+        let span = d_sub(p12.x, p11.x, "Curve::bilinear_interpolate::span")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        if span.is_zero() {
+            return Err(InterpolationError::DegenerateInterval);
+        }
 
         // Normalize x to [0,1] interval
-        let dx = (x - p11.x) / (p12.x - p11.x);
+        let offset = d_sub(x, p11.x, "Curve::bilinear_interpolate::offset")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        let dx = d_div(offset, span, "Curve::bilinear_interpolate::dx")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
 
         // Interpolate along bottom edge
-        let bottom = p11.y + dx * (p12.y - p11.y);
+        let bottom_rise = d_sub(p12.y, p11.y, "Curve::bilinear_interpolate::bottom_rise")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        let bottom_step = d_mul(dx, bottom_rise, "Curve::bilinear_interpolate::bottom_step")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        let bottom = d_add(p11.y, bottom_step, "Curve::bilinear_interpolate::bottom")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
 
         // Interpolate along top edge
-        let top = p21.y + dx * (p22.y - p21.y);
+        let top_rise = d_sub(p22.y, p21.y, "Curve::bilinear_interpolate::top_rise")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        let top_step = d_mul(dx, top_rise, "Curve::bilinear_interpolate::top_step")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        let top = d_add(p21.y, top_step, "Curve::bilinear_interpolate::top")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
 
         // Final interpolation in y direction
-        let y = bottom + (top - bottom) / dec!(2);
+        let edge_gap = d_sub(top, bottom, "Curve::bilinear_interpolate::edge_gap")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        let half_gap = d_div(edge_gap, dec!(2), "Curve::bilinear_interpolate::half_gap")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
+        let y = d_add(bottom, half_gap, "Curve::bilinear_interpolate::y")
+            .map_err(interp_err(InterpolationError::Bilinear))?;
 
         Ok(Point2D::new(x, y))
     }
@@ -703,31 +908,87 @@ impl CubicInterpolation<Point2D, Decimal> for Curve {
 
         // Select four points for interpolation
         // Ensuring we always have enough points before and after
-        let (p0, p1, p2, p3) = if i == 0 {
-            (&self[0], &self[1], &self[2], &self[3])
+        let window = if i == 0 {
+            [0, 1, 2, 3]
         } else if i == len - 2 {
-            (
-                &self[len - 4],
-                &self[len - 3],
-                &self[len - 2],
-                &self[len - 1],
-            )
+            [len - 4, len - 3, len - 2, len - 1]
         } else {
-            (&self[i - 1], &self[i], &self[i + 1], &self[i + 2])
+            [i - 1, i, i + 1, i + 2]
         };
+        let p0 = self.point_at(window[0], InterpolationError::Cubic)?;
+        let p1 = self.point_at(window[1], InterpolationError::Cubic)?;
+        let p2 = self.point_at(window[2], InterpolationError::Cubic)?;
+        let p3 = self.point_at(window[3], InterpolationError::Cubic)?;
+
+        let span = d_sub(p2.x, p1.x, "Curve::cubic_interpolate::span")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        if span.is_zero() {
+            return Err(InterpolationError::DegenerateInterval);
+        }
 
         // Calculate t parameter (normalized x position between p1 and p2)
-        let t = (x - p1.x) / (p2.x - p1.x);
+        let offset = d_sub(x, p1.x, "Curve::cubic_interpolate::offset")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let t = d_div(offset, span, "Curve::cubic_interpolate::t")
+            .map_err(interp_err(InterpolationError::Cubic))?;
 
         // Cubic interpolation using Catmull-Rom spline
-        let t2 = t * t;
-        let t3 = t2 * t;
+        let t2 = d_mul(t, t, "Curve::cubic_interpolate::t2")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let t3 = d_mul(t2, t, "Curve::cubic_interpolate::t3")
+            .map_err(interp_err(InterpolationError::Cubic))?;
 
-        let y = dec!(0.5)
-            * (dec!(2) * p1.y
-                + (-p0.y + p2.y) * t
-                + (dec!(2) * p0.y - dec!(5) * p1.y + dec!(4) * p2.y - p3.y) * t2
-                + (-p0.y + dec!(3) * p1.y - dec!(3) * p2.y + p3.y) * t3);
+        let term0 = d_mul(dec!(2), p1.y, "Curve::cubic_interpolate::term0")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+
+        let linear_coeff = d_sub(p2.y, p0.y, "Curve::cubic_interpolate::linear_coeff")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let term1 = d_mul(linear_coeff, t, "Curve::cubic_interpolate::term1")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+
+        let two_p0 = d_mul(dec!(2), p0.y, "Curve::cubic_interpolate::two_p0")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let five_p1 = d_mul(dec!(5), p1.y, "Curve::cubic_interpolate::five_p1")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let four_p2 = d_mul(dec!(4), p2.y, "Curve::cubic_interpolate::four_p2")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let quad_coeff = d_sub(two_p0, five_p1, "Curve::cubic_interpolate::quad_coeff_a")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let quad_coeff = d_add(
+            quad_coeff,
+            four_p2,
+            "Curve::cubic_interpolate::quad_coeff_b",
+        )
+        .map_err(interp_err(InterpolationError::Cubic))?;
+        let quad_coeff = d_sub(quad_coeff, p3.y, "Curve::cubic_interpolate::quad_coeff_c")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let term2 = d_mul(quad_coeff, t2, "Curve::cubic_interpolate::term2")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+
+        let three_p1 = d_mul(dec!(3), p1.y, "Curve::cubic_interpolate::three_p1")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let three_p2 = d_mul(dec!(3), p2.y, "Curve::cubic_interpolate::three_p2")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let cubic_coeff = d_sub(three_p1, p0.y, "Curve::cubic_interpolate::cubic_coeff_a")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let cubic_coeff = d_sub(
+            cubic_coeff,
+            three_p2,
+            "Curve::cubic_interpolate::cubic_coeff_b",
+        )
+        .map_err(interp_err(InterpolationError::Cubic))?;
+        let cubic_coeff = d_add(cubic_coeff, p3.y, "Curve::cubic_interpolate::cubic_coeff_c")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+        let term3 = d_mul(cubic_coeff, t3, "Curve::cubic_interpolate::term3")
+            .map_err(interp_err(InterpolationError::Cubic))?;
+
+        let sum = d_sum_iter(
+            [term0, term1, term2, term3],
+            "Curve::cubic_interpolate::sum",
+        )
+        .map_err(interp_err(InterpolationError::Cubic))?;
+        let y = d_mul(dec!(0.5), sum, "Curve::cubic_interpolate::y")
+            .map_err(interp_err(InterpolationError::Cubic))?;
 
         Ok(Point2D::new(x, y))
     }
@@ -897,7 +1158,9 @@ impl SplineInterpolation<Point2D, Decimal> for Curve {
         }
 
         // Check if x is within the valid range
-        if x < self[0].x || x > self[len - 1].x {
+        let first = self.point_at(0, InterpolationError::Spline)?;
+        let last = self.point_at(len - 1, InterpolationError::Spline)?;
+        if x < first.x || x > last.x {
             return Err(InterpolationError::Spline(
                 "x is outside the range of points".to_string(),
             ));
@@ -909,47 +1172,128 @@ impl SplineInterpolation<Point2D, Decimal> for Curve {
         }
 
         let n = len;
+        let pts: Vec<&Point2D> = self.points.iter().collect();
+        let at = |index: usize| -> Result<&Point2D, InterpolationError> {
+            pts.get(index).copied().ok_or_else(|| {
+                InterpolationError::Spline(format!(
+                    "point index {index} is out of bounds for a curve of {n} points"
+                ))
+            })
+        };
 
-        // Calculate second derivatives
-        let mut a = vec![Decimal::ZERO; n];
-        let mut b = vec![Decimal::ZERO; n];
-        let mut c = vec![Decimal::ZERO; n];
-        let mut r = vec![Decimal::ZERO; n];
+        // Calculate second derivatives. The three interior bands and the
+        // right-hand side are built in order, with the natural-spline
+        // boundary rows (`b[0] = b[n-1] = 1`) pushed at the ends.
+        let mut a = vec![Decimal::ZERO];
+        let mut b = vec![Decimal::ONE];
+        let mut c = vec![Decimal::ZERO];
+        let mut r = vec![Decimal::ZERO];
 
         // Fill the matrices
         for i in 1..n - 1 {
-            let hi = self[i].x - self[i - 1].x;
-            let hi1 = self[i + 1].x - self[i].x;
+            let prev = at(i - 1)?;
+            let curr = at(i)?;
+            let next = at(i + 1)?;
 
-            a[i] = hi;
-            b[i] = dec!(2) * (hi + hi1);
-            c[i] = hi1;
+            let hi = d_sub(curr.x, prev.x, "Curve::spline_interpolate::hi")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let hi1 = d_sub(next.x, curr.x, "Curve::spline_interpolate::hi1")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            // A repeated abscissa collapses a knot interval; the second
+            // derivative there is undefined rather than infinite.
+            if hi.is_zero() || hi1.is_zero() {
+                return Err(InterpolationError::DegenerateInterval);
+            }
 
-            r[i] = dec!(6) * ((self[i + 1].y - self[i].y) / hi1 - (self[i].y - self[i - 1].y) / hi);
+            let band = d_add(hi, hi1, "Curve::spline_interpolate::band")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let diag = d_mul(dec!(2), band, "Curve::spline_interpolate::diag")
+                .map_err(interp_err(InterpolationError::Spline))?;
+
+            let rise_next = d_sub(next.y, curr.y, "Curve::spline_interpolate::rise_next")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let slope_next = d_div(rise_next, hi1, "Curve::spline_interpolate::slope_next")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let rise_prev = d_sub(curr.y, prev.y, "Curve::spline_interpolate::rise_prev")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let slope_prev = d_div(rise_prev, hi, "Curve::spline_interpolate::slope_prev")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let curvature = d_sub(
+                slope_next,
+                slope_prev,
+                "Curve::spline_interpolate::curvature",
+            )
+            .map_err(interp_err(InterpolationError::Spline))?;
+            let rhs = d_mul(dec!(6), curvature, "Curve::spline_interpolate::rhs")
+                .map_err(interp_err(InterpolationError::Spline))?;
+
+            a.push(hi);
+            b.push(diag);
+            c.push(hi1);
+            r.push(rhs);
         }
 
         // Add boundary conditions (natural spline)
-        b[0] = dec!(1);
-        b[n - 1] = dec!(1);
+        a.push(Decimal::ZERO);
+        b.push(Decimal::ONE);
+        c.push(Decimal::ZERO);
+        r.push(Decimal::ZERO);
 
         // Solve tridiagonal system using Thomas algorithm
         let mut m = vec![Decimal::ZERO; n];
 
         for i in 1..n - 1 {
-            let w = a[i] / b[i - 1];
-            b[i] -= w * c[i - 1];
-            r[i] = r[i] - w * r[i - 1];
+            let a_i = band_at(&a, i, "a")?;
+            let b_prev = band_at(&b, i - 1, "b")?;
+            if b_prev.is_zero() {
+                return Err(InterpolationError::DegenerateInterval);
+            }
+            let w = d_div(a_i, b_prev, "Curve::spline_interpolate::w")
+                .map_err(interp_err(InterpolationError::Spline))?;
+
+            let c_prev = band_at(&c, i - 1, "c")?;
+            let wc = d_mul(w, c_prev, "Curve::spline_interpolate::wc")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let b_i = band_at(&b, i, "b")?;
+            *band_at_mut(&mut b, i, "b")? = d_sub(b_i, wc, "Curve::spline_interpolate::b_i")
+                .map_err(interp_err(InterpolationError::Spline))?;
+
+            let r_prev = band_at(&r, i - 1, "r")?;
+            let wr = d_mul(w, r_prev, "Curve::spline_interpolate::wr")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let r_i = band_at(&r, i, "r")?;
+            *band_at_mut(&mut r, i, "r")? = d_sub(r_i, wr, "Curve::spline_interpolate::r_i")
+                .map_err(interp_err(InterpolationError::Spline))?;
         }
 
-        m[n - 1] = r[n - 1] / b[n - 1];
+        let b_last = band_at(&b, n - 1, "b")?;
+        if b_last.is_zero() {
+            return Err(InterpolationError::DegenerateInterval);
+        }
+        let r_last = band_at(&r, n - 1, "r")?;
+        *band_at_mut(&mut m, n - 1, "m")? =
+            d_div(r_last, b_last, "Curve::spline_interpolate::m_last")
+                .map_err(interp_err(InterpolationError::Spline))?;
         for i in (1..n - 1).rev() {
-            m[i] = (r[i] - c[i] * m[i + 1]) / b[i];
+            let c_i = band_at(&c, i, "c")?;
+            let m_next = band_at(&m, i + 1, "m")?;
+            let cm = d_mul(c_i, m_next, "Curve::spline_interpolate::cm")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let r_i = band_at(&r, i, "r")?;
+            let numerator = d_sub(r_i, cm, "Curve::spline_interpolate::m_numerator")
+                .map_err(interp_err(InterpolationError::Spline))?;
+            let b_i = band_at(&b, i, "b")?;
+            if b_i.is_zero() {
+                return Err(InterpolationError::DegenerateInterval);
+            }
+            *band_at_mut(&mut m, i, "m")? = d_div(numerator, b_i, "Curve::spline_interpolate::m_i")
+                .map_err(interp_err(InterpolationError::Spline))?;
         }
 
         // Find segment for interpolation
         let mut segment = None;
         for i in 0..n - 1 {
-            if self[i].x <= x && x <= self[i + 1].x {
+            if at(i)?.x <= x && x <= at(i + 1)?.x {
                 segment = Some(i);
                 break;
             }
@@ -960,14 +1304,34 @@ impl SplineInterpolation<Point2D, Decimal> for Curve {
         })?;
 
         // Calculate interpolated value
-        let h = self[segment + 1].x - self[segment].x;
-        let dx = self[segment + 1].x - x;
-        let dx1 = x - self[segment].x;
+        let left = at(segment)?;
+        let right = at(segment + 1)?;
+        let h = d_sub(right.x, left.x, "Curve::spline_interpolate::h")
+            .map_err(interp_err(InterpolationError::Spline))?;
+        if h.is_zero() {
+            return Err(InterpolationError::DegenerateInterval);
+        }
+        let dx = d_sub(right.x, x, "Curve::spline_interpolate::dx")
+            .map_err(interp_err(InterpolationError::Spline))?;
+        let dx1 = d_sub(x, left.x, "Curve::spline_interpolate::dx1")
+            .map_err(interp_err(InterpolationError::Spline))?;
 
-        let y = m[segment] * dx * dx * dx / (dec!(6) * h)
-            + m[segment + 1] * dx1 * dx1 * dx1 / (dec!(6) * h)
-            + (self[segment].y / h - m[segment] * h / dec!(6)) * dx
-            + (self[segment + 1].y / h - m[segment + 1] * h / dec!(6)) * dx1;
+        let m_left = band_at(&m, segment, "m")?;
+        let m_right = band_at(&m, segment + 1, "m")?;
+        let six_h = d_mul(dec!(6), h, "Curve::spline_interpolate::six_h")
+            .map_err(interp_err(InterpolationError::Spline))?;
+
+        let left_cube = cube_scaled(m_left, dx, six_h, "Curve::spline_interpolate::left_cube")?;
+        let right_cube = cube_scaled(m_right, dx1, six_h, "Curve::spline_interpolate::right_cube")?;
+        let left_linear = linear_term(left.y, m_left, h, dx, "Curve::spline_interpolate::left")?;
+        let right_linear =
+            linear_term(right.y, m_right, h, dx1, "Curve::spline_interpolate::right")?;
+
+        let y = d_sum_iter(
+            [left_cube, right_cube, left_linear, right_linear],
+            "Curve::spline_interpolate::y",
+        )
+        .map_err(interp_err(InterpolationError::Spline))?;
 
         Ok(Point2D::new(x, y))
     }
@@ -1003,16 +1367,27 @@ impl MetricsExtractor for Curve {
         }
 
         // Mean
-        let mean = y_values.iter().sum::<Decimal>() / Decimal::from(y_values.len());
+        let mean = mean_of(&y_values, "Curve::compute_basic_metrics::mean")
+            .map_err(|e| MetricsError::BasicError(e.to_string()))?;
 
         // Median
         let mut sorted_values = y_values.clone();
         sorted_values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mid = sorted_values.len() / 2;
         let median = if sorted_values.len().is_multiple_of(2) {
-            (sorted_values[sorted_values.len() / 2 - 1] + sorted_values[sorted_values.len() / 2])
-                / Decimal::TWO
+            let below = mid.checked_sub(1).ok_or_else(|| {
+                MetricsError::BasicError(
+                    "median: empty sample after the emptiness guard".to_string(),
+                )
+            })?;
+            let lower = sample_at(&sorted_values, below, "median")?;
+            let upper = sample_at(&sorted_values, mid, "median")?;
+            let pair = d_add(lower, upper, "Curve::compute_basic_metrics::median_pair")
+                .map_err(|e| MetricsError::BasicError(e.to_string()))?;
+            d_div(pair, Decimal::TWO, "Curve::compute_basic_metrics::median")
+                .map_err(|e| MetricsError::BasicError(e.to_string()))?
         } else {
-            sorted_values[sorted_values.len() / 2]
+            sample_at(&sorted_values, mid, "median")?
         };
 
         // Mode (most frequent value)
@@ -1029,11 +1404,8 @@ impl MetricsExtractor for Curve {
         };
 
         // Standard Deviation
-        let variance = y_values
-            .iter()
-            .map(|&x| (x - mean).powu(2))
-            .sum::<Decimal>()
-            / Decimal::from(y_values.len());
+        let variance = variance_of(&y_values, mean, "Curve::compute_basic_metrics::variance")
+            .map_err(|e| MetricsError::BasicError(e.to_string()))?;
         let std_dev = variance.sqrt().unwrap_or(Decimal::ZERO);
 
         Ok(BasicMetrics {
@@ -1059,14 +1431,19 @@ impl MetricsExtractor for Curve {
         }
 
         // Mean and Standard Deviation
-        let mean = y_values.iter().sum::<Decimal>() / Decimal::from(y_values.len());
+        let mean = mean_of(&y_values, "Curve::compute_shape_metrics::mean")
+            .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
 
         // Compute centered and scaled values
-        let centered_values: Vec<Decimal> = y_values.iter().map(|&x| x - mean).collect();
+        let centered_values: Vec<Decimal> = y_values
+            .iter()
+            .map(|&x| d_sub(x, mean, "Curve::compute_shape_metrics::centered"))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
 
         // Compute variance
-        let variance = centered_values.iter().map(|&x| x.powu(2)).sum::<Decimal>()
-            / Decimal::from(y_values.len());
+        let variance = variance_of(&y_values, mean, "Curve::compute_shape_metrics::variance")
+            .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
         let std_dev = variance.sqrt().unwrap_or(Decimal::ONE);
         if std_dev.is_zero() || std_dev < dec!(1e-9) {
             return Err(MetricsError::ShapeError(format!(
@@ -1075,20 +1452,28 @@ impl MetricsExtractor for Curve {
         }
 
         // Skewness calculation (Fisher-Pearson standardized moment)
-        let skewness = centered_values
-            .iter()
-            .map(|&x| (x / std_dev).powu(3))
-            .sum::<Decimal>()
-            // / (Decimal::from(y_values.len()) * Decimal::ONE_HUNDRED);
-            / (Decimal::from(y_values.len()));
+        let skewness = standardized_moment(
+            &centered_values,
+            std_dev,
+            3,
+            "Curve::compute_shape_metrics::skewness",
+        )
+        .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
 
         // Kurtosis calculation (Fisher's definition - adjust to excess kurtosis)
-        let kurtosis = centered_values
-            .iter()
-            .map(|&x| (x / std_dev).powu(4))
-            .sum::<Decimal>()
-            / Decimal::from(y_values.len())
-            - Decimal::from(3);
+        let raw_kurtosis = standardized_moment(
+            &centered_values,
+            std_dev,
+            4,
+            "Curve::compute_shape_metrics::kurtosis",
+        )
+        .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let kurtosis = d_sub(
+            raw_kurtosis,
+            Decimal::from(3),
+            "Curve::compute_shape_metrics::excess_kurtosis",
+        )
+        .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
 
         // Peaks and Valleys detection
         let (peaks, valleys) = detect_peaks_and_valleys(&self.points, dec!(0.1), 2);
@@ -1131,14 +1516,20 @@ impl MetricsExtractor for Curve {
             .cloned()
             .ok_or_else(|| MetricsError::BasicError("empty curve in max_point".to_string()))?;
 
-        let range = max_point.y - min_point.y;
+        let range = d_sub(
+            max_point.y,
+            min_point.y,
+            "Curve::compute_range_metrics::range",
+        )
+        .map_err(|e| MetricsError::RangeError(e.to_string()))?;
 
         // Quartiles
-        let q1 = y_values[len / 4];
-        let q2 = y_values[len / 2];
-        let q3 = y_values[3 * len / 4];
+        let q1 = sample_at(&y_values, len / 4, "first quartile")?;
+        let q2 = sample_at(&y_values, len / 2, "median")?;
+        let q3 = sample_at(&y_values, 3 * len / 4, "third quartile")?;
 
-        let interquartile_range = q3 - q1;
+        let interquartile_range = d_sub(q3, q1, "Curve::compute_range_metrics::iqr")
+            .map_err(|e| MetricsError::RangeError(e.to_string()))?;
 
         Ok(RangeMetrics {
             min: min_point,
@@ -1167,54 +1558,70 @@ impl MetricsExtractor for Curve {
         let x_vals: Vec<Decimal> = points.iter().map(|p| p.x).collect();
         let y_vals: Vec<Decimal> = points.iter().map(|p| p.y).collect();
 
-        let sum_x: Decimal = x_vals.iter().sum();
-        let sum_y: Decimal = y_vals.iter().sum();
-        let sum_xy: Decimal = x_vals.iter().zip(&y_vals).map(|(x, y)| *x * *y).sum();
-        let sum_xx: Decimal = x_vals.iter().map(|x| *x * *x).sum();
+        let trend = || -> Result<(Decimal, Decimal, Decimal), DecimalError> {
+            let op = "Curve::compute_trend_metrics";
+            let sum_x = d_sum_iter(x_vals.iter().copied(), op)?;
+            let sum_y = d_sum_iter(y_vals.iter().copied(), op)?;
+            let mut sum_xy = Decimal::ZERO;
+            let mut sum_xx = Decimal::ZERO;
+            for (x, y) in x_vals.iter().zip(&y_vals) {
+                sum_xy = d_add(sum_xy, d_mul(*x, *y, op)?, op)?;
+                sum_xx = d_add(sum_xx, d_mul(*x, *x, op)?, op)?;
+            }
 
-        let slope = (n * sum_xy - sum_x * sum_y) / (n * sum_xx - sum_x * sum_x);
-        let intercept = (sum_y - slope * sum_x) / n;
+            let numerator = d_sub(d_mul(n, sum_xy, op)?, d_mul(sum_x, sum_y, op)?, op)?;
+            let denominator = d_sub(d_mul(n, sum_xx, op)?, d_mul(sum_x, sum_x, op)?, op)?;
+            let slope = d_div(numerator, denominator, op)?;
+            let intercept = d_div(d_sub(sum_y, d_mul(slope, sum_x, op)?, op)?, n, op)?;
 
-        // R-squared Calculation
-        let mean_y = sum_y / n;
-        let sst: Decimal = y_vals.iter().map(|y| (*y - mean_y).powu(2)).sum();
+            // R-squared Calculation
+            let mean_y = d_div(sum_y, n, op)?;
+            let mut sst = Decimal::ZERO;
+            for y in &y_vals {
+                let centered = d_sub(*y, mean_y, op)?;
+                sst = d_add(sst, powu_checked(centered, 2, op)?, op)?;
+            }
 
-        let ssr: Decimal = y_vals
-            .iter()
-            .zip(&x_vals)
-            .map(|(y, x)| {
-                let y_predicted = slope * *x + intercept;
-                (*y - y_predicted).powu(2)
-            })
-            .sum();
+            let mut ssr = Decimal::ZERO;
+            for (y, x) in y_vals.iter().zip(&x_vals) {
+                let y_predicted = d_add(d_mul(slope, *x, op)?, intercept, op)?;
+                let residual = d_sub(*y, y_predicted, op)?;
+                ssr = d_add(ssr, powu_checked(residual, 2, op)?, op)?;
+            }
 
-        let r_squared = if sst == Decimal::ZERO {
-            Decimal::ONE
-        } else {
-            Decimal::ONE - (ssr / sst)
+            let r_squared = if sst == Decimal::ZERO {
+                Decimal::ONE
+            } else {
+                d_sub(Decimal::ONE, d_div(ssr, sst, op)?, op)?
+            };
+
+            Ok((slope, intercept, r_squared))
         };
+
+        // A sample whose abscissas all collapse to one value (or whose squares
+        // underflow the `Decimal` scale) leaves the ordinary-least-squares
+        // denominator at zero, where the slope is undefined rather than
+        // infinite.
+        let (slope, intercept, r_squared) =
+            trend().map_err(|e| MetricsError::TrendError(e.to_string()))?;
 
         // Moving Average Calculation
         let window_sizes = [3, 5, 7];
-        let moving_average: Vec<Point2D> = window_sizes
-            .iter()
-            .flat_map(|&window| {
-                if window > points.len() {
-                    vec![]
-                } else {
-                    points
-                        .windows(window)
-                        .map(|window_points| {
-                            let avg_x = window_points.iter().map(|p| p.x).sum::<Decimal>()
-                                / Decimal::from(window_points.len());
-                            let avg_y = window_points.iter().map(|p| p.y).sum::<Decimal>()
-                                / Decimal::from(window_points.len());
-                            Point2D::new(avg_x, avg_y)
-                        })
-                        .collect::<Vec<Point2D>>()
-                }
-            })
-            .collect();
+        let mut moving_average: Vec<Point2D> = Vec::new();
+        for window in window_sizes {
+            if window > points.len() {
+                continue;
+            }
+            for window_points in points.windows(window) {
+                let xs: Vec<Decimal> = window_points.iter().map(|p| p.x).collect();
+                let ys: Vec<Decimal> = window_points.iter().map(|p| p.y).collect();
+                let avg_x = mean_of(&xs, "Curve::compute_trend_metrics::moving_average_x")
+                    .map_err(|e| MetricsError::TrendError(e.to_string()))?;
+                let avg_y = mean_of(&ys, "Curve::compute_trend_metrics::moving_average_y")
+                    .map_err(|e| MetricsError::TrendError(e.to_string()))?;
+                moving_average.push(Point2D::new(avg_x, avg_y));
+            }
+        }
 
         Ok(TrendMetrics {
             slope,
@@ -1237,14 +1644,27 @@ impl MetricsExtractor for Curve {
             });
         }
 
-        let mean = y_values.iter().sum::<Decimal>() / Decimal::from(y_values.len());
-        let volatility = y_values
-            .iter()
-            .map(|&x| (x - mean).powu(2))
-            .sum::<Decimal>()
-            / Decimal::from(y_values.len())
-                .sqrt()
-                .unwrap_or(Decimal::ZERO);
+        let op = "Curve::compute_risk_metrics";
+        let mean = mean_of(&y_values, op).map_err(|e| MetricsError::RiskError(e.to_string()))?;
+        // Note the grouping: the sum of squared deviations is divided by
+        // `sqrt(n)`, not by `sqrt(sum / n)`. Preserved as-is; only the
+        // arithmetic is made checked.
+        let mut squared_deviations = Decimal::ZERO;
+        for &value in &y_values {
+            let centered =
+                d_sub(value, mean, op).map_err(|e| MetricsError::RiskError(e.to_string()))?;
+            let squared = powu_checked(centered, 2, op)
+                .map_err(|e| MetricsError::RiskError(e.to_string()))?;
+            squared_deviations = d_add(squared_deviations, squared, op)
+                .map_err(|e| MetricsError::RiskError(e.to_string()))?;
+        }
+        let sqrt_n = Decimal::from(y_values.len())
+            .sqrt()
+            .unwrap_or(Decimal::ZERO);
+        // `d_div` rejects the zero denominator, which the emptiness guard
+        // above already rules out.
+        let volatility = d_div(squared_deviations, sqrt_n, op)
+            .map_err(|e| MetricsError::RiskError(e.to_string()))?;
 
         if volatility == Decimal::ZERO {
             return Ok(RiskMetrics {
@@ -1257,23 +1677,26 @@ impl MetricsExtractor for Curve {
         }
 
         let z_score = dec!(1.645);
-        let var = mean - z_score * volatility;
+        let scaled_vol =
+            d_mul(z_score, volatility, op).map_err(|e| MetricsError::RiskError(e.to_string()))?;
+        let var =
+            d_sub(mean, scaled_vol, op).map_err(|e| MetricsError::RiskError(e.to_string()))?;
 
-        let below_var_count = y_values.iter().filter(|&&x| x < var).count();
-        let expected_shortfall = if below_var_count > 0 {
-            y_values.iter().filter(|&&x| x < var).sum::<Decimal>()
-                / Decimal::from(below_var_count as u64)
-        } else {
+        let tail: Vec<Decimal> = y_values.iter().copied().filter(|&x| x < var).collect();
+        let expected_shortfall = if tail.is_empty() {
             Decimal::ZERO
+        } else {
+            mean_of(&tail, op).map_err(|e| MetricsError::RiskError(e.to_string()))?
         };
 
         let beta = if mean != Decimal::ZERO {
-            volatility / mean
+            d_div(volatility, mean, op).map_err(|e| MetricsError::RiskError(e.to_string()))?
         } else {
             Decimal::ZERO
         };
 
-        let sharpe_ratio = mean / volatility;
+        let sharpe_ratio =
+            d_div(mean, volatility, op).map_err(|e| MetricsError::RiskError(e.to_string()))?;
 
         Ok(RiskMetrics {
             volatility,
@@ -1359,8 +1782,8 @@ impl Arithmetic<Curve> for Curve {
         }
 
         // If only one curve, return a clone
-        if curves.len() == 1 {
-            return Ok(curves[0].clone());
+        if let [only] = curves {
+            return Ok((*only).clone());
         }
 
         // Find the intersection of x-ranges
@@ -1386,13 +1809,16 @@ impl Arithmetic<Curve> for Curve {
 
         // Determine number of interpolation steps
         let steps = 100; // Configurable number of interpolation points
-        let step_size = (max_x - min_x) / Decimal::from(steps);
+        let op = "Curve::merge";
+        let span = d_sub(max_x, min_x, op).map_err(construction_err)?;
+        let step_size = d_div(span, Decimal::from(steps), op).map_err(construction_err)?;
 
         // Interpolate and perform operation using parallel iterator
         let result_points: Result<Vec<Point2D>, CurveError> = (0..=steps)
             .into_par_iter()
             .map(|i| {
-                let x = min_x + step_size * Decimal::from(i);
+                let offset = d_mul(step_size, Decimal::from(i), op).map_err(construction_err)?;
+                let x = d_add(min_x, offset, op).map_err(construction_err)?;
 
                 // Interpolate y values for each curve
                 let y_values: Result<Vec<Decimal>, CurveError> = curves
@@ -1409,29 +1835,38 @@ impl Arithmetic<Curve> for Curve {
 
                 // Perform the specified operation on interpolated y values
                 let result_y: Decimal = match operation {
-                    MergeOperation::Add => y_values.par_iter().sum(),
-                    MergeOperation::Subtract => {
-                        // Use Rayon's fold to parallelize subtraction
-                        y_values
-                            .par_iter()
-                            .enumerate()
-                            .map(|(i, &val)| if i == 0 { val } else { -val })
-                            .reduce(|| Decimal::ZERO, |a, b| a + b)
+                    MergeOperation::Add => {
+                        d_sum_iter(y_values.iter().copied(), op).map_err(construction_err)?
                     }
-                    MergeOperation::Multiply => y_values.par_iter().product(),
+                    MergeOperation::Subtract => {
+                        let signed = y_values
+                            .iter()
+                            .enumerate()
+                            .map(|(i, &val)| if i == 0 { val } else { -val });
+                        d_sum_iter(signed, op).map_err(construction_err)?
+                    }
+                    MergeOperation::Multiply => y_values.par_iter().copied().map(Ok).reduce(
+                        || Ok(Decimal::ONE),
+                        |a, b| d_mul(a?, b?, op).map_err(construction_err),
+                    )?,
                     MergeOperation::Divide => y_values
                         .par_iter()
                         .enumerate()
                         .map(|(i, &val)| {
+                            // `Decimal::MAX` is the pre-existing sentinel for a
+                            // zero divisor; only the arithmetic is made checked.
                             if i == 0 {
-                                val
+                                Ok(val)
                             } else if val == Decimal::ZERO {
-                                Decimal::MAX
+                                Ok(Decimal::MAX)
                             } else {
-                                Decimal::ONE / val
+                                d_div(Decimal::ONE, val, op).map_err(construction_err)
                             }
                         })
-                        .reduce(|| Decimal::ONE, |a, b| a * b),
+                        .reduce(
+                            || Ok(Decimal::ONE),
+                            |a, b| d_mul(a?, b?, op).map_err(construction_err),
+                        )?,
                     MergeOperation::Max => y_values
                         .par_iter()
                         .cloned()
@@ -1509,15 +1944,24 @@ impl AxisOperations<Point2D, Decimal> for Curve {
     }
 
     fn get_closest_point(&self, x: &Decimal) -> Result<&Point2D, Self::Error> {
-        self.points
-            .iter()
-            .min_by(|a, b| {
-                let dist_a = (a.x - *x).abs();
-                let dist_b = (b.x - *x).abs();
-                dist_a
-                    .partial_cmp(&dist_b)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+        // The distance is folded explicitly rather than computed inside a
+        // comparator: `a.x - x` overflows for abscissas at opposite ends of
+        // the `Decimal` range, and `min_by` has no channel for that.
+        let mut closest: Option<(&Point2D, Decimal)> = None;
+        for point in &self.points {
+            let distance = d_sub(point.x, *x, "Curve::get_closest_point")
+                .map_err(analysis_err)?
+                .abs();
+            // `min_by` keeps the first of several equal minima; `<=` here
+            // preserves that.
+            match closest {
+                Some((_, best)) if best <= distance => {}
+                _ => closest = Some((point, distance)),
+            }
+        }
+
+        closest
+            .map(|(point, _)| point)
             .ok_or(CurveError::Point2DError {
                 reason: "No points available",
             })
@@ -1593,11 +2037,23 @@ impl GeometricTransformations<Point2D> for Curve {
             ));
         }
 
+        let (Some(dx), Some(dy)) = (deltas.first(), deltas.get(1)) else {
+            return Err(CurveError::invalid_parameters(
+                "translate",
+                "Expected 2 deltas for 2D translation",
+            ));
+        };
+
         let translated_points = self
             .points
             .iter()
-            .map(|point| Point2D::new(point.x + deltas[0], point.y + deltas[1]))
-            .collect();
+            .map(|point| {
+                let x = d_add(point.x, **dx, "Curve::translate::x")?;
+                let y = d_add(point.y, **dy, "Curve::translate::y")?;
+                Ok(Point2D::new(x, y))
+            })
+            .collect::<Result<BTreeSet<Point2D>, DecimalError>>()
+            .map_err(construction_err)?;
 
         Ok(Curve::new(translated_points))
     }
@@ -1610,25 +2066,45 @@ impl GeometricTransformations<Point2D> for Curve {
             ));
         }
 
+        let (Some(fx), Some(fy)) = (factors.first(), factors.get(1)) else {
+            return Err(CurveError::invalid_parameters(
+                "scale",
+                "Expected 2 factors for 2D scaling",
+            ));
+        };
+
         let scaled_points = self
             .points
             .iter()
-            .map(|point| Point2D::new(point.x * factors[0], point.y * factors[1]))
-            .collect();
+            .map(|point| {
+                let x = d_mul(point.x, **fx, "Curve::scale::x")?;
+                let y = d_mul(point.y, **fy, "Curve::scale::y")?;
+                Ok(Point2D::new(x, y))
+            })
+            .collect::<Result<BTreeSet<Point2D>, DecimalError>>()
+            .map_err(construction_err)?;
 
         Ok(Curve::new(scaled_points))
     }
 
     fn intersect_with(&self, other: &Self) -> Result<Vec<Point2D>, Self::Error> {
         let mut intersections = Vec::new();
+        let epsilon = Decimal::new(1, 6);
 
         // Use existing pairs iterator for efficiency
         for p1 in self.get_points() {
             for p2 in other.get_points() {
                 // Find points with small distance between them
-                if (p1.x - p2.x).abs() < Decimal::new(1, 6)
-                    && (p1.y - p2.y).abs() < Decimal::new(1, 6)
-                {
+                let dx = d_sub(p1.x, p2.x, "Curve::intersect_with::dx")
+                    .map_err(analysis_err)?
+                    .abs();
+                if dx >= epsilon {
+                    continue;
+                }
+                let dy = d_sub(p1.y, p2.y, "Curve::intersect_with::dy")
+                    .map_err(analysis_err)?
+                    .abs();
+                if dy < epsilon {
                     intersections.push(*p1);
                 }
             }
@@ -1640,11 +2116,26 @@ impl GeometricTransformations<Point2D> for Curve {
     fn derivative_at(&self, point: &Point2D) -> Result<Vec<Decimal>, Self::Error> {
         let (i, j) = self.find_bracket_points(point.x)?;
 
-        let p0 = &self[i];
-        let p1 = &self[j];
+        let p0 = self.point_at(i, InterpolationError::Linear)?;
+        let p1 = self.point_at(j, InterpolationError::Linear)?;
 
-        let a = (p1.y - p0.y) / (p1.x * p1.x - p0.x * p0.x);
-        let derivative = dec!(2.0) * a * point.x;
+        let op = "Curve::derivative_at";
+        let rise = d_sub(p1.y, p0.y, op).map_err(analysis_err)?;
+        let x1_sq = d_mul(p1.x, p1.x, op).map_err(analysis_err)?;
+        let x0_sq = d_mul(p0.x, p0.x, op).map_err(analysis_err)?;
+        let run = d_sub(x1_sq, x0_sq, op).map_err(analysis_err)?;
+        if run.is_zero() {
+            // The parabola fitted through the bracket is degenerate when the
+            // two abscissas have the same square, so its coefficient is
+            // undefined rather than infinite.
+            return Err(CurveError::AnalysisError(
+                "derivative_at: bracketing abscissas have equal squares".to_string(),
+            ));
+        }
+
+        let a = d_div(rise, run, op).map_err(analysis_err)?;
+        let slope = d_mul(dec!(2.0), a, op).map_err(analysis_err)?;
+        let derivative = d_mul(slope, point.x, op).map_err(analysis_err)?;
 
         Ok(vec![derivative])
     }
@@ -1686,11 +2177,22 @@ impl GeometricTransformations<Point2D> for Curve {
         let mut area = Decimal::ZERO;
         let points: Vec<_> = self.points.iter().collect();
 
+        let op = "Curve::measure_under";
+
         // Approximate area using trapezoidal rule
         for pair in points.windows(2) {
-            let width = pair[1].x - pair[0].x;
-            let height = ((pair[0].y - base_value) + (pair[1].y - base_value)) / Decimal::TWO;
-            area += width * height;
+            let (Some(left), Some(right)) = (pair.first(), pair.get(1)) else {
+                return Err(CurveError::AnalysisError(
+                    "measure_under: trapezoid window is shorter than two points".to_string(),
+                ));
+            };
+            let width = d_sub(right.x, left.x, op).map_err(analysis_err)?;
+            let left_height = d_sub(left.y, *base_value, op).map_err(analysis_err)?;
+            let right_height = d_sub(right.y, *base_value, op).map_err(analysis_err)?;
+            let sum_heights = d_add(left_height, right_height, op).map_err(analysis_err)?;
+            let height = d_div(sum_heights, Decimal::TWO, op).map_err(analysis_err)?;
+            let slice = d_mul(width, height, op).map_err(analysis_err)?;
+            area = d_add(area, slice, op).map_err(analysis_err)?;
         }
 
         Ok(area.abs())
@@ -1765,7 +2267,7 @@ mod tests_curves {
 
     #[test]
     fn test_create_constant_curve() {
-        let curve = create_constant_curve(dec!(1.0), dec!(2.0), dec!(5.0));
+        let curve = create_constant_curve(dec!(1.0), dec!(2.0), dec!(5.0)).unwrap();
         assert_eq!(curve.get_points().len(), 11);
         for point in curve.get_points() {
             assert_eq!(point.y, dec!(5.0));
@@ -1774,7 +2276,7 @@ mod tests_curves {
 
     #[test]
     fn test_create_linear_curve() {
-        let curve = create_linear_curve(dec!(1.0), dec!(2.0), dec!(2.0));
+        let curve = create_linear_curve(dec!(1.0), dec!(2.0), dec!(2.0)).unwrap();
         assert_eq!(curve.get_points().len(), 11);
         let mut slope = dec!(2.0);
         for point in curve.get_points() {
@@ -2265,8 +2767,8 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_curves_add() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
 
         let result = Curve::merge(&[&curve1, &curve2], MergeOperation::Add).unwrap();
 
@@ -2289,8 +2791,8 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_curves_subtract() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0)).unwrap();
         let result = Curve::merge(&[&curve1, &curve2], MergeOperation::Subtract).unwrap();
         // Check result at some sample points
         let test_points = [dec!(0.0), dec!(5.0), dec!(10.0)];
@@ -2311,8 +2813,8 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_curves_multiply() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0)).unwrap();
 
         let result = Curve::merge(&[&curve1, &curve2], MergeOperation::Multiply).unwrap();
 
@@ -2335,8 +2837,8 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_curves_divide() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(6.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(6.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
         let result = Curve::merge(&[&curve1, &curve2], MergeOperation::Divide).unwrap();
 
         // Check result at some sample points
@@ -2364,8 +2866,8 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_curves_max() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0)).unwrap();
 
         let result = Curve::merge(&[&curve1, &curve2], MergeOperation::Max).unwrap();
 
@@ -2389,8 +2891,8 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_curves_min() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0)).unwrap();
 
         let result = Curve::merge(&[&curve1, &curve2], MergeOperation::Min).unwrap();
 
@@ -2414,8 +2916,8 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_with_single_operation() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0)).unwrap();
 
         let result = curve1.merge_with(&curve2, MergeOperation::Add).unwrap();
 
@@ -2438,8 +2940,8 @@ mod tests_curve_arithmetic {
         assert!(result.is_err());
 
         // Test with curves of incompatible ranges
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0));
-        let curve2 = create_linear_curve(dec!(5.0), dec!(15.0), dec!(2.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(5.0), dec!(15.0), dec!(2.0)).unwrap();
 
         // Verify that the merge operation works even with partially overlapping ranges
         let result = Curve::merge(&[&curve1, &curve2], MergeOperation::Add);
@@ -2448,9 +2950,9 @@ mod tests_curve_arithmetic {
 
     #[test]
     fn test_merge_multiple_curves() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0));
-        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0));
-        let curve3 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(1.0)).unwrap();
+        let curve2 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
+        let curve3 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(3.0)).unwrap();
 
         let result = Curve::merge(&[&curve1, &curve2, &curve3], MergeOperation::Add).unwrap();
 
@@ -2847,8 +3349,8 @@ mod tests_merge_axis_interpolate {
     #[test]
     fn test_merge_axis_interpolate_linear() {
         // Create two curves with different x ranges and points
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5));
-        let curve2 = create_linear_curve(dec!(4.0), dec!(20.0), dec!(1.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5)).unwrap();
+        let curve2 = create_linear_curve(dec!(4.0), dec!(20.0), dec!(1.0)).unwrap();
 
         // Merge and interpolate using linear interpolation
         let result = curve1.merge_axis_interpolate(&curve2, InterpolationType::Linear);
@@ -2873,8 +3375,8 @@ mod tests_merge_axis_interpolate {
     #[test]
     fn test_merge_axis_interpolate_cubic() {
         // Create two curves with different x ranges and points
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5));
-        let curve2 = create_linear_curve(dec!(4.0), dec!(20.0), dec!(1.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5)).unwrap();
+        let curve2 = create_linear_curve(dec!(4.0), dec!(20.0), dec!(1.0)).unwrap();
 
         // Merge and interpolate using cubic interpolation
         let result = curve1.merge_axis_interpolate(&curve2, InterpolationType::Cubic);

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -1666,16 +1666,10 @@ impl MetricsExtractor for Curve {
         let volatility = d_div(squared_deviations, sqrt_n, op)
             .map_err(|e| MetricsError::RiskError(e.to_string()))?;
 
-        if volatility == Decimal::ZERO {
-            return Ok(RiskMetrics {
-                volatility,
-                value_at_risk: Decimal::ZERO,
-                expected_shortfall: Decimal::ZERO,
-                beta: Decimal::ZERO,
-                sharpe_ratio: Decimal::ZERO,
-            });
-        }
-
+        // Value at Risk (95% confidence) using parametric method. At zero
+        // dispersion this is `mean - 1.645 * 0 = mean`, a deterministic level
+        // rather than an absence of value, so it is computed from the formula
+        // on every path instead of being short-circuited to zero.
         let z_score = dec!(1.645);
         let scaled_vol =
             d_mul(z_score, volatility, op).map_err(|e| MetricsError::RiskError(e.to_string()))?;
@@ -1689,14 +1683,23 @@ impl MetricsExtractor for Curve {
             mean_of(&tail, op).map_err(|e| MetricsError::RiskError(e.to_string()))?
         };
 
+        // `volatility / mean` is already zero at zero dispersion, so this
+        // guard only covers the undefined `x / 0`.
         let beta = if mean != Decimal::ZERO {
             d_div(volatility, mean, op).map_err(|e| MetricsError::RiskError(e.to_string()))?
         } else {
             Decimal::ZERO
         };
 
-        let sharpe_ratio =
-            d_div(mean, volatility, op).map_err(|e| MetricsError::RiskError(e.to_string()))?;
+        // Sharpe Ratio (assuming risk-free rate of 0). A flat curve has no
+        // dispersion to divide by, which makes this the one field that is
+        // genuinely undefined at `volatility == 0`; the others keep their
+        // deterministic limits.
+        let sharpe_ratio = if volatility.is_zero() {
+            Decimal::ZERO
+        } else {
+            d_div(mean, volatility, op).map_err(|e| MetricsError::RiskError(e.to_string()))?
+        };
 
         Ok(RiskMetrics {
             volatility,
@@ -2762,7 +2765,7 @@ mod tests_spline_interpolate {
 #[cfg(test)]
 mod tests_curve_arithmetic {
     use super::*;
-    use crate::curves::utils::create_linear_curve;
+    use crate::curves::utils::{create_constant_curve, create_linear_curve};
     use crate::geometrics::InterpolationType;
 
     #[test]
@@ -2860,6 +2863,28 @@ mod tests_curve_arithmetic {
                 x,
                 expected_y,
                 result_point.y
+            );
+        }
+    }
+
+    /// Division is not associative, so every divisor has to reach the result.
+    /// `Curve::merge` reaches them by turning each element after the first
+    /// into its reciprocal and folding the whole set with a combining
+    /// reducer, so no partial is discarded. Three curves at 8, 2 and 2 must
+    /// give `8 / 2 / 2 = 2`, never `8 / 2` and never 8.
+    #[test]
+    fn test_merge_curves_divide_folds_every_divisor() {
+        let eight = create_constant_curve(dec!(0.0), dec!(10.0), dec!(8.0)).unwrap();
+        let two_a = create_constant_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
+        let two_b = create_constant_curve(dec!(0.0), dec!(10.0), dec!(2.0)).unwrap();
+
+        let result = Curve::merge(&[&eight, &two_a, &two_b], MergeOperation::Divide).unwrap();
+
+        for x in [dec!(0.0), dec!(5.0), dec!(10.0)] {
+            let y = result.interpolate(x, InterpolationType::Cubic).unwrap().y;
+            assert!(
+                (y - dec!(2)).abs() < dec!(0.0001),
+                "expected 8 / 2 / 2 = 2 at x = {x}, got {y}"
             );
         }
     }
@@ -3276,6 +3301,43 @@ mod tests_curve_metrics {
         assert_eq!(risk_metrics.volatility, dec!(0.0));
         assert_eq!(risk_metrics.beta, dec!(0.0));
         assert_eq!(risk_metrics.sharpe_ratio, dec!(0.0));
+    }
+
+    /// A flat curve has no uncertainty, but it is not worthless. Only the
+    /// fields that are genuinely undefined at zero dispersion may be zeroed;
+    /// the parametric VaR still has its deterministic limit at the mean.
+    #[test]
+    fn test_risk_metrics_flat_curve_keeps_deterministic_var() {
+        let curve = create_constant_curve();
+        let metrics = curve.compute_risk_metrics().unwrap();
+
+        // Measured, and genuinely zero.
+        assert_eq!(metrics.volatility, Decimal::ZERO);
+        // `mean - 1.645 * 0` is the mean, not zero: the curve is worth 5.
+        assert_eq!(metrics.value_at_risk, dec!(5));
+        // No sample falls below the VaR, so the conditional mean has an empty
+        // tail and the function's own empty-tail rule gives zero.
+        assert_eq!(metrics.expected_shortfall, Decimal::ZERO);
+        // `volatility / mean` is already zero here; no special case needed.
+        assert_eq!(metrics.beta, Decimal::ZERO);
+        // `mean / 0` is the one genuinely undefined field.
+        assert_eq!(metrics.sharpe_ratio, Decimal::ZERO);
+    }
+
+    /// The same shape with a negative mean: the VaR limit follows the mean
+    /// wherever it sits, so a sign error cannot hide behind a positive value.
+    #[test]
+    fn test_risk_metrics_flat_negative_curve_keeps_deterministic_var() {
+        let points = BTreeSet::from_iter(vec![
+            Point2D::new(dec!(0.0), dec!(-2.5)),
+            Point2D::new(dec!(1.0), dec!(-2.5)),
+            Point2D::new(dec!(2.0), dec!(-2.5)),
+        ]);
+        let metrics = Curve::new(points).compute_risk_metrics().unwrap();
+
+        assert_eq!(metrics.volatility, Decimal::ZERO);
+        assert_eq!(metrics.value_at_risk, dec!(-2.5));
+        assert_eq!(metrics.sharpe_ratio, Decimal::ZERO);
     }
 
     #[test]

--- a/src/curves/traits.rs
+++ b/src/curves/traits.rs
@@ -3,15 +3,10 @@
    Email: jb@taunais.com
    Date: 23/2/25
 ******************************************************************************/
-// Scoped allow: bulk migration of unchecked `[]` indexing to
-// `.get().ok_or_else(..)` tracked as follow-ups to #341. The existing
-// call sites are internal to this file and audited for invariant-bound
-// indices (fixed-length buffers, just-pushed slices, etc.).
-#![allow(clippy::indexing_slicing)]
-
 use crate::curves::{Curve, Point2D};
 use crate::error::{CurveError, OperationErrorKind};
 use crate::geometrics::{BasicMetrics, MetricsExtractor, RangeMetrics, ShapeMetrics, TrendMetrics};
+use crate::model::decimal::d_sub;
 use num_traits::ToPrimitive;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -140,6 +135,22 @@ pub trait StatisticalCurve: MetricsExtractor {
                 },
             ));
         }
+
+        // Every generated sample is placed on one of the curve's own
+        // abscissas, so the request cannot exceed how many there are.
+        let x_values: Vec<Decimal> = self.get_x_values();
+        if num_points > x_values.len() {
+            return Err(CurveError::OperationError(
+                OperationErrorKind::InvalidParameters {
+                    operation: "generate_statistical_curve".to_string(),
+                    reason: format!(
+                        "Number of points ({num_points}) exceeds the {} x-values available on the curve",
+                        x_values.len()
+                    ),
+                },
+            ));
+        }
+
         // Initialize random number generator with optional seed
         let seed_value = seed.unwrap_or_else(rand::random);
         let mut rng = StdRng::seed_from_u64(seed_value);
@@ -191,20 +202,24 @@ pub trait StatisticalCurve: MetricsExtractor {
             }
         }
 
-        let x_values: Vec<Decimal> = self.get_x_values();
-
         // Apply trend (slope and intercept)
         let slope = trend_metrics.slope.to_f64().unwrap_or(0.0);
         if slope.abs() > 0.001 {
             let intercept = trend_metrics.intercept.to_f64().unwrap_or(0.0);
-            for i in 0..y_values.len() {
-                let x_f = x_values[i].to_f64().ok_or_else(|| {
+            for (i, y) in y_values.iter_mut().enumerate() {
+                let x = x_values.get(i).ok_or_else(|| {
+                    CurveError::invalid_parameters(
+                        "generate_statistical_curve",
+                        "fewer x-values than generated samples",
+                    )
+                })?;
+                let x_f = x.to_f64().ok_or_else(|| {
                     CurveError::invalid_parameters(
                         "to_f64",
                         "Decimal out of range / non-representable as f64 in regression x-input",
                     )
                 })?;
-                y_values[i] += slope * x_f + intercept;
+                *y += slope * x_f + intercept;
             }
         }
 
@@ -227,19 +242,21 @@ pub trait StatisticalCurve: MetricsExtractor {
         // Ensure mode value is included
         if num_points > 3 {
             let index = rng.random_range(0..(num_points / 3));
-            y_values[index] = basic_metrics.mode.to_f64().unwrap_or(y_values[index]);
+            if let Some(slot) = y_values.get_mut(index) {
+                *slot = basic_metrics.mode.to_f64().unwrap_or(*slot);
+            }
         }
 
         // Create points and construct curve
         let mut points = BTreeSet::new();
-        for i in 0..num_points {
-            let x_f = x_values[i].to_f64().ok_or_else(|| {
+        for (x, y) in x_values.iter().zip(&y_values).take(num_points) {
+            let x_f = x.to_f64().ok_or_else(|| {
                 CurveError::invalid_parameters(
                     "to_f64",
                     "Decimal out of range / non-representable as f64 in regression x-input",
                 )
             })?;
-            let point = Point2D::from_f64_tuple(x_f, y_values[i])?;
+            let point = Point2D::from_f64_tuple(x_f, *y)?;
             points.insert(point);
         }
 
@@ -334,7 +351,9 @@ pub trait StatisticalCurve: MetricsExtractor {
     /// [`CurveError::ConstructionError`] raised while recomputing the
     /// curve's actual metrics (typically when the curve contains
     /// non-finite samples or lacks the density required for the
-    /// requested metric).
+    /// requested metric). Returns [`CurveError::AnalysisError`] when the gap
+    /// between an actual and a target metric leaves the representable
+    /// `Decimal` range.
     fn verify_curve_metrics(
         &self,
         curve: &Curve,
@@ -345,9 +364,24 @@ pub trait StatisticalCurve: MetricsExtractor {
             .compute_basic_metrics()
             .map_err(|e| CurveError::MetricsError(format!("Failed to compute metrics: {e}")))?;
 
-        // Check if the key metrics are within tolerance
-        let mean_diff = (actual_metrics.mean - target_metrics.mean).abs();
-        let std_dev_diff = (actual_metrics.std_dev - target_metrics.std_dev).abs();
+        // Check if the key metrics are within tolerance. A target sitting at
+        // the far end of the `Decimal` range makes the gap itself
+        // unrepresentable, which is a comparison failure rather than a
+        // silently large difference.
+        let mean_diff = d_sub(
+            actual_metrics.mean,
+            target_metrics.mean,
+            "StatisticalCurve::verify_curve_metrics::mean_diff",
+        )
+        .map_err(|e| CurveError::AnalysisError(e.to_string()))?
+        .abs();
+        let std_dev_diff = d_sub(
+            actual_metrics.std_dev,
+            target_metrics.std_dev,
+            "StatisticalCurve::verify_curve_metrics::std_dev_diff",
+        )
+        .map_err(|e| CurveError::AnalysisError(e.to_string()))?
+        .abs();
 
         Ok(mean_diff <= tolerance && std_dev_diff <= tolerance)
     }

--- a/src/curves/utils.rs
+++ b/src/curves/utils.rs
@@ -10,10 +10,17 @@
 #![allow(clippy::indexing_slicing)]
 
 use crate::curves::{Curve, Point2D};
+use crate::error::CurveError;
 use crate::geometrics::GeometricObject;
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub};
 use rust_decimal::Decimal;
 use std::collections::BTreeSet;
 use tracing::warn;
+
+/// Wraps a checked-arithmetic failure raised while sampling a utility curve.
+fn sampling_err(err: crate::error::decimal::DecimalError) -> CurveError {
+    CurveError::ConstructionError(err.to_string())
+}
 
 /// Creates a linear curve defined by a starting point, an ending point, and a slope.
 ///
@@ -67,10 +74,11 @@ use tracing::warn;
 /// - For higher resolution or adaptive step generation, consider modifying the function
 ///   or implementing a similar utility.
 ///
-/// # Panics
-/// This function will panic if the calculated `step_size` results in a division by zero,
-/// which could occur if `end` is equal to `start`. The caller should ensure that `end`
-/// is greater than `start` to avoid this scenario.
+/// # Errors
+///
+/// Returns [`CurveError::ConstructionError`] when the span `end - start`, a
+/// sampled abscissa or the ordinate `slope * x` leaves the representable
+/// `Decimal` range.
 ///
 /// # See Also
 /// - [`Point2D::new`]: Utility used to construct individual points for the curve.
@@ -88,27 +96,33 @@ use tracing::warn;
 ///     Decimal::new(0, 1),   // start = 0.0
 ///     Decimal::new(100, 1), // end = 10.0
 ///     Decimal::new(1, 0)    // slope = 1.0
-/// );
+/// )
+/// .expect("the range and slope are well within the Decimal range");
 /// ```
 ///
 /// would result in a curve defined by the points:
 /// `(0.0, 0.0)`, `(1.0, 1.0)`, ..., `(10.0, 10.0)`.
 ///
 /// From the above, it demonstrates how linearly spaced and
-#[must_use]
-pub fn create_linear_curve(start: Decimal, end: Decimal, slope: Decimal) -> Curve {
+pub fn create_linear_curve(
+    start: Decimal,
+    end: Decimal,
+    slope: Decimal,
+) -> Result<Curve, CurveError> {
     let steps = 10;
-    let step_size = (end - start) / Decimal::from(steps);
+    let op = "create_linear_curve";
+    let span = d_sub(end, start, op).map_err(sampling_err)?;
+    let step_size = d_div(span, Decimal::from(steps), op).map_err(sampling_err)?;
 
-    let points: Vec<Point2D> = (0..=steps)
-        .map(|i| {
-            let x = start + step_size * Decimal::from(i);
-            let y = slope * x;
-            Point2D::new(x, y)
-        })
-        .collect();
+    let mut points: Vec<Point2D> = Vec::new();
+    for i in 0..=steps {
+        let offset = d_mul(step_size, Decimal::from(i), op).map_err(sampling_err)?;
+        let x = d_add(start, offset, op).map_err(sampling_err)?;
+        let y = d_mul(slope, x, op).map_err(sampling_err)?;
+        points.push(Point2D::new(x, y));
+    }
 
-    Curve::from_vector(points.iter().collect())
+    Ok(Curve::from_vector(points.iter().collect()))
 }
 
 /// Creates a constant curve with equidistant points along the x-axis and the same constant value for the y-axis.
@@ -142,28 +156,34 @@ pub fn create_linear_curve(start: Decimal, end: Decimal, slope: Decimal) -> Curv
 /// While this is designed to remain usage-agnostic, in practice, it results in a horizontal line in Cartesian
 /// space that is constant in the y-dimension and spans the x-range.
 ///
-/// # Panics
-/// - The function will panic if `steps` is set to zero or if the provided `start` and `end` values result in
-///   invalid arithmetic operations, such as division by zero or overflow of Decimal values.
+/// # Errors
+///
+/// Returns [`CurveError::ConstructionError`] when the span `end - start` or a
+/// sampled abscissa leaves the representable `Decimal` range.
 ///
 /// # See Also
 /// - [`Point2D::new`]: Used to create individual points in the resulting curve.
 /// - [`Curve::from_vector`]: Used internally to convert the set of constant points into a `Curve` object.
-#[must_use]
-pub fn create_constant_curve(start: Decimal, end: Decimal, value: Decimal) -> Curve {
+pub fn create_constant_curve(
+    start: Decimal,
+    end: Decimal,
+    value: Decimal,
+) -> Result<Curve, CurveError> {
     let steps = 10;
-    let step_size = (end - start) / Decimal::from(steps);
+    let op = "create_constant_curve";
+    let span = d_sub(end, start, op).map_err(sampling_err)?;
+    let step_size = d_div(span, Decimal::from(steps), op).map_err(sampling_err)?;
 
-    let point_values: Vec<Point2D> = (0..=steps)
-        .map(|i| {
-            let x = start + step_size * Decimal::from(i);
-            Point2D::new(x, value)
-        })
-        .collect();
+    let mut point_values: Vec<Point2D> = Vec::new();
+    for i in 0..=steps {
+        let offset = d_mul(step_size, Decimal::from(i), op).map_err(sampling_err)?;
+        let x = d_add(start, offset, op).map_err(sampling_err)?;
+        point_values.push(Point2D::new(x, value));
+    }
 
     let points: Vec<&Point2D> = point_values.iter().collect();
 
-    Curve::from_vector(points)
+    Ok(Curve::from_vector(points))
 }
 
 /// Detects peaks and valleys in a set of points with configurable sensitivity

--- a/src/geometrics/interpolation/traits.rs
+++ b/src/geometrics/interpolation/traits.rs
@@ -1,9 +1,3 @@
-// Scoped allow: bulk migration of unchecked `[]` indexing to
-// `.get().ok_or_else(..)` tracked as follow-ups to #341. The existing
-// call sites are internal to this file and audited for invariant-bound
-// indices (fixed-length buffers, just-pushed slices, etc.).
-#![allow(clippy::indexing_slicing)]
-
 use crate::error::InterpolationError;
 use crate::geometrics::{
     BiLinearInterpolation, CubicInterpolation, GeometricObject, InterpolationType,
@@ -127,14 +121,20 @@ where
         if points.len() < 2 {
             return Err(InterpolationError::EmptyData);
         }
-        if x.get_x() < points[0].get_x() || x.get_x() > points[points.len() - 1].get_x() {
+        let (Some(first), Some(last)) = (points.first(), points.last()) else {
+            return Err(InterpolationError::EmptyData);
+        };
+        if x.get_x() < first.get_x() || x.get_x() > last.get_x() {
             return Err(InterpolationError::OutOfRange {
                 target: x.get_x().to_string(),
             });
         }
         // Find points that bracket x
-        for i in 0..points.len() - 1 {
-            if points[i].get_x() <= x.get_x() && x.get_x() <= points[i + 1].get_x() {
+        for (i, pair) in points.windows(2).enumerate() {
+            let (Some(left), Some(right)) = (pair.first(), pair.get(1)) else {
+                return Err(InterpolationError::DegenerateInterval);
+            };
+            if left.get_x() <= x.get_x() && x.get_x() <= right.get_x() {
                 return Ok((i, i + 1));
             }
         }

--- a/src/geometrics/mod.rs
+++ b/src/geometrics/mod.rs
@@ -28,4 +28,5 @@ pub use operations::{
     Arithmetic, AxisOperations, GeometricTransformations, MergeAxisInterpolate, MergeOperation,
 };
 pub use utils::GeometricObject;
+pub(crate) use utils::powu_checked;
 pub use visualization::{PlotBuilder, Plottable};

--- a/src/geometrics/operations/axis.rs
+++ b/src/geometrics/operations/axis.rs
@@ -298,8 +298,8 @@ mod tests_merge_indexes {
 
     #[test]
     fn test_merge_indexes_normal() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5));
-        let curve2 = create_linear_curve(dec!(5.0), dec!(15.0), dec!(1.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5)).unwrap();
+        let curve2 = create_linear_curve(dec!(5.0), dec!(15.0), dec!(1.0)).unwrap();
         let merged_indexes = curve1.merge_indexes(curve2.get_index_values());
 
         assert_eq!(merged_indexes.len(), 6);
@@ -309,8 +309,8 @@ mod tests_merge_indexes {
 
     #[test]
     fn test_merge_indexes_normal_bis() {
-        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5));
-        let curve2 = create_linear_curve(dec!(4.0), dec!(20.0), dec!(1.0));
+        let curve1 = create_linear_curve(dec!(0.0), dec!(10.0), dec!(0.5)).unwrap();
+        let curve2 = create_linear_curve(dec!(4.0), dec!(20.0), dec!(1.0)).unwrap();
         let merged_indexes = curve1.merge_indexes(curve2.get_index_values());
 
         assert_eq!(merged_indexes.len(), 10);

--- a/src/geometrics/utils.rs
+++ b/src/geometrics/utils.rs
@@ -3,9 +3,30 @@
    Email: jb@taunais.com
    Date: 21/1/25
 ******************************************************************************/
+use crate::error::decimal::DecimalError;
 use crate::geometrics::ConstructionMethod;
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, MathematicalOps};
 use std::collections::BTreeSet;
+
+/// Checked counterpart of [`MathematicalOps::powu`], which aborts with
+/// `Pow overflowed` on the operator path.
+///
+/// `powu` is `checked_powu` plus an `unwrap`, so routing through the checked
+/// call keeps the digits identical while turning the abort into a
+/// [`DecimalError::Overflow`] tagged with `op`.
+///
+/// # Errors
+///
+/// Returns [`DecimalError::Overflow`] when `base^exp` leaves the
+/// representable `Decimal` range.
+pub(crate) fn powu_checked(
+    base: Decimal,
+    exp: u64,
+    op: &'static str,
+) -> Result<Decimal, DecimalError> {
+    base.checked_powu(exp)
+        .ok_or_else(|| DecimalError::overflow(op, base, Decimal::from(exp)))
+}
 
 /// Defines a geometric object constructed from a set of points.
 /// Provides methods for creating, accessing, and manipulating these objects.

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -1,9 +1,3 @@
-// Scoped allow: bulk migration of unchecked `[]` indexing to
-// `.get().ok_or_else(..)` tracked as follow-ups to #341. The existing
-// call sites are internal to this file and audited for invariant-bound
-// indices (fixed-length buffers, just-pushed slices, etc.).
-#![allow(clippy::indexing_slicing)]
-
 //! This module provides functionality for visualizing and plotting 3D surfaces.
 //! It leverages the `plotters` crate for rendering and offers a flexible API for
 //! customizing plot appearance and saving outputs.  It supports plotting single
@@ -28,13 +22,15 @@
 //!
 
 use crate::curves::{Curve, Point2D};
+use crate::error::decimal::DecimalError;
 use crate::error::{InterpolationError, MetricsError, SurfaceError};
 use crate::geometrics::{
     Arithmetic, AxisOperations, BasicMetrics, BiLinearInterpolation, ConstructionMethod,
     ConstructionParams, CubicInterpolation, GeometricObject, GeometricTransformations, Interpolate,
     InterpolationType, LinearInterpolation, MergeAxisInterpolate, MergeOperation, MetricsExtractor,
-    RangeMetrics, RiskMetrics, ShapeMetrics, SplineInterpolation, TrendMetrics,
+    RangeMetrics, RiskMetrics, ShapeMetrics, SplineInterpolation, TrendMetrics, powu_checked,
 };
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
 use crate::surfaces::Point3D;
 use crate::surfaces::types::Axis;
 use crate::utils::Len;
@@ -229,35 +225,87 @@ impl Surface {
             ));
         }
 
+        let missing = |index: usize| {
+            InterpolationError::Spline(format!(
+                "spline knot {index} is out of bounds for {} samples",
+                sorted_points.len()
+            ))
+        };
+
         // Handle out-of-range cases
-        if target <= x_selector(&sorted_points[0]) {
-            return Ok(z_selector(&sorted_points[0]));
+        let first = sorted_points.first().ok_or_else(|| missing(0))?;
+        if target <= x_selector(first) {
+            return Ok(z_selector(first));
         }
 
-        if target >= x_selector(&sorted_points[sorted_points.len() - 1]) {
-            return Ok(z_selector(&sorted_points[sorted_points.len() - 1]));
+        let last_index = sorted_points.len() - 1;
+        let last = sorted_points.last().ok_or_else(|| missing(last_index))?;
+        if target >= x_selector(last) {
+            return Ok(z_selector(last));
         }
 
-        // Find the segment where the target falls
+        // Find the segment where the target falls. The `target <= first`
+        // branch above already returned, so the first match is never at index
+        // 0 and `index - 1` cannot underflow; the `checked_sub` states it.
         let (left_index, right_index) = match sorted_points
             .iter()
             .enumerate()
             .find(|(_, p)| x_selector(p) > target)
         {
-            Some((index, _)) => (index - 1, index),
-            None => (sorted_points.len() - 2, sorted_points.len() - 1),
+            Some((index, _)) => (
+                index.checked_sub(1).ok_or_else(|| {
+                    InterpolationError::Spline(
+                        "spline bracket starts before the first knot".to_string(),
+                    )
+                })?,
+                index,
+            ),
+            None => (
+                last_index.checked_sub(1).ok_or_else(|| {
+                    InterpolationError::Spline(
+                        "spline bracket needs at least two knots".to_string(),
+                    )
+                })?,
+                last_index,
+            ),
         };
 
         // Get the points for interpolation
-        let x0 = x_selector(&sorted_points[left_index]);
-        let x1 = x_selector(&sorted_points[right_index]);
-        let z0 = z_selector(&sorted_points[left_index]);
-        let z1 = z_selector(&sorted_points[right_index]);
+        let left = sorted_points
+            .get(left_index)
+            .ok_or_else(|| missing(left_index))?;
+        let right = sorted_points
+            .get(right_index)
+            .ok_or_else(|| missing(right_index))?;
+        let x0 = x_selector(left);
+        let x1 = x_selector(right);
+        let z0 = z_selector(left);
+        let z1 = z_selector(right);
 
         // Linear interpolation
-        let interpolated_z = z0 + (z1 - z0) * ((target - x0) / (x1 - x0));
+        let op = "Surface::one_dimensional_spline_interpolation";
+        let run = d_sub(x1, x0, op).map_err(interp_err(InterpolationError::Spline))?;
+        if run.is_zero() {
+            return Err(InterpolationError::DegenerateInterval);
+        }
+        let rise = d_sub(z1, z0, op).map_err(interp_err(InterpolationError::Spline))?;
+        let offset = d_sub(target, x0, op).map_err(interp_err(InterpolationError::Spline))?;
+        let ratio = d_div(offset, run, op).map_err(interp_err(InterpolationError::Spline))?;
+        let step = d_mul(rise, ratio, op).map_err(interp_err(InterpolationError::Spline))?;
+        let interpolated_z = d_add(z0, step, op).map_err(interp_err(InterpolationError::Spline))?;
 
         Ok(interpolated_z)
+    }
+
+    /// Fetches the point at `index` without going through the panicking
+    /// [`Index`] contract.
+    fn point_at(&self, index: usize) -> Result<&Point3D, SurfaceError> {
+        self.points.iter().nth(index).ok_or_else(|| {
+            SurfaceError::AnalysisError(format!(
+                "point index {index} is out of bounds for a surface of {} points",
+                self.points.len()
+            ))
+        })
     }
 
     /// Converts the surface points from Decimal to f64 format, with swapped y and z coordinates.
@@ -304,6 +352,121 @@ impl Surface {
             })
             .collect()
     }
+}
+
+/// Wraps a checked-arithmetic failure in the interpolation variant of the
+/// algorithm that raised it.
+fn interp_err(
+    kind: fn(String) -> InterpolationError,
+) -> impl Fn(DecimalError) -> InterpolationError {
+    move |err| kind(err.to_string())
+}
+
+/// Wraps a checked-arithmetic failure raised while building a surface.
+fn construction_err(err: DecimalError) -> SurfaceError {
+    SurfaceError::ConstructionError(err.to_string())
+}
+
+/// Wraps a checked-arithmetic failure raised while analysing a surface.
+fn analysis_err(err: DecimalError) -> SurfaceError {
+    SurfaceError::AnalysisError(err.to_string())
+}
+
+/// Wraps a checked-arithmetic failure raised while fitting a surface trend.
+fn trend_err(err: DecimalError) -> MetricsError {
+    MetricsError::TrendError(err.to_string())
+}
+
+/// Wraps a checked-arithmetic failure raised while computing surface risk.
+fn risk_err(err: DecimalError) -> MetricsError {
+    MetricsError::RiskError(err.to_string())
+}
+
+/// Squared euclidean distance from `point` to `(x, y)`, computed with checked
+/// arithmetic so a coordinate at the edge of the `Decimal` range reports
+/// instead of aborting.
+fn squared_distance(
+    point: &Point3D,
+    x: Decimal,
+    y: Decimal,
+    op: &'static str,
+) -> Result<Decimal, DecimalError> {
+    let dx = d_sub(point.x, x, op)?;
+    let dy = d_sub(point.y, y, op)?;
+    d_add(powu_checked(dx, 2, op)?, powu_checked(dy, 2, op)?, op)
+}
+
+/// Orders `points` by their squared distance to `(x, y)`, keeping the stable
+/// ordering `sort_by` produced while moving the arithmetic out of the
+/// comparator, which has no channel for an overflow.
+fn sort_by_distance<'a>(
+    points: &mut [&'a Point3D],
+    x: Decimal,
+    y: Decimal,
+    op: &'static str,
+) -> Result<(), DecimalError> {
+    let mut keyed: Vec<(Decimal, &'a Point3D)> = Vec::with_capacity(points.len());
+    for point in points.iter() {
+        keyed.push((squared_distance(point, x, y, op)?, point));
+    }
+    keyed.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    for (slot, (_, point)) in points.iter_mut().zip(keyed) {
+        *slot = point;
+    }
+    Ok(())
+}
+
+/// Reads one entry of a nearest-neighbour window, naming the slot on the
+/// out-of-bounds path instead of panicking.
+fn nth<'a>(
+    points: &[&'a Point3D],
+    index: usize,
+    kind: fn(String) -> InterpolationError,
+) -> Result<&'a Point3D, InterpolationError> {
+    points.get(index).copied().ok_or_else(|| {
+        kind(format!(
+            "neighbour {index} is out of bounds for a window of {} points",
+            points.len()
+        ))
+    })
+}
+
+/// Reads one sample of a sorted metric series, naming the statistic on the
+/// out-of-bounds path instead of panicking.
+fn sample_at(
+    values: &[Decimal],
+    index: usize,
+    what: &'static str,
+) -> Result<Decimal, MetricsError> {
+    values.get(index).copied().ok_or_else(|| {
+        MetricsError::BasicError(format!(
+            "{what}: sample {index} is out of bounds for {} values",
+            values.len()
+        ))
+    })
+}
+
+/// Arithmetic mean of a sample. Errors on an empty sample, where the mean is
+/// undefined, and on a sum that leaves the representable range.
+fn mean_of(values: &[Decimal], op: &'static str) -> Result<Decimal, DecimalError> {
+    let sum = d_sum_iter(values.iter().copied(), op)?;
+    d_div(sum, Decimal::from(values.len()), op)
+}
+
+/// Sum of `(value - mean)^order` over a sample: the raw central moment behind
+/// the variance (`order = 2`), skewness (`3`) and kurtosis (`4`).
+fn central_moment(
+    values: &[Decimal],
+    mean: Decimal,
+    order: u64,
+    op: &'static str,
+) -> Result<Decimal, DecimalError> {
+    let mut acc = Decimal::ZERO;
+    for &value in values {
+        let centered = d_sub(value, mean, op)?;
+        acc = d_add(acc, powu_checked(centered, order, op)?, op)?;
+    }
+    Ok(acc)
 }
 
 impl Default for Surface {
@@ -530,8 +693,16 @@ impl GeometricObject<Point3D, Point2D> for Surface {
                         ));
                     }
                 };
-                let x_step = (x_end - x_start) / Decimal::from(x_steps);
-                let y_step = (y_end - y_start) / Decimal::from(y_steps);
+                if x_steps == 0 || y_steps == 0 {
+                    return Err(SurfaceError::ConstructionError(
+                        "Parametric construction needs at least one step on each axis".to_string(),
+                    ));
+                }
+                let op = "Surface::construct::step";
+                let x_span = d_sub(x_end, x_start, op).map_err(construction_err)?;
+                let x_step = d_div(x_span, Decimal::from(x_steps), op).map_err(construction_err)?;
+                let y_span = d_sub(y_end, y_start, op).map_err(construction_err)?;
+                let y_step = d_div(y_span, Decimal::from(y_steps), op).map_err(construction_err)?;
 
                 // Wrap f in an Arc so it can be shared across threads
                 let f = Arc::new(f);
@@ -539,10 +710,14 @@ impl GeometricObject<Point3D, Point2D> for Surface {
                 let points: Result<BTreeSet<Point3D>, SurfaceError> = (0..=x_steps)
                     .into_par_iter()
                     .flat_map(|i| {
-                        let x = x_start + x_step * Decimal::from(i);
                         let f = Arc::clone(&f);
                         (0..=y_steps).into_par_iter().map(move |j| {
-                            let y = y_start + y_step * Decimal::from(j);
+                            let x_offset =
+                                d_mul(x_step, Decimal::from(i), op).map_err(construction_err)?;
+                            let x = d_add(x_start, x_offset, op).map_err(construction_err)?;
+                            let y_offset =
+                                d_mul(y_step, Decimal::from(j), op).map_err(construction_err)?;
+                            let y = d_add(y_start, y_offset, op).map_err(construction_err)?;
                             let t = Point2D::new(x, y);
                             f(t).map_err(|e| SurfaceError::ConstructionError(e.to_string()))
                         })
@@ -588,6 +763,10 @@ impl Index<usize> for Surface {
         // so panic on out-of-bounds is the documented contract.
         match self.points.iter().nth(index) {
             Some(p) => p,
+            // scan-banned: allow -- `std::ops::Index` returns `&Self::Output`
+            // and has no fallible channel; the contract mirrors `Vec::index`.
+            // No library code reaches this arm: every internal lookup goes
+            // through `Surface::point_at`.
             None => panic!(
                 "Surface::index: out of bounds (index = {index}, len = {})",
                 self.points.len()
@@ -713,25 +892,77 @@ impl LinearInterpolation<Point3D, Point2D> for Surface {
             return Ok(*point);
         }
 
+        // Barycentric interpolation needs a triangle, so a surface with fewer
+        // than three points has no answer to give.
+        if self.points.len() < 3 {
+            return Err(InterpolationError::Linear(
+                "Need at least three points for linear interpolation".to_string(),
+            ));
+        }
+
+        let op = "Surface::linear_interpolate";
         let mut nearest_points: Vec<&Point3D> = self.points.iter().collect();
-        nearest_points.sort_by(|a, b| {
-            let dist_a = (a.x - xy.x).powi(2) + (a.y - xy.y).powi(2);
-            let dist_b = (b.x - xy.x).powi(2) + (b.y - xy.y).powi(2);
-            dist_a
-                .partial_cmp(&dist_b)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        sort_by_distance(&mut nearest_points, xy.x, xy.y, op)
+            .map_err(interp_err(InterpolationError::Linear))?;
 
-        let p1 = nearest_points[0];
-        let p2 = nearest_points[1];
-        let p3 = nearest_points[2];
+        let p1 = nth(&nearest_points, 0, InterpolationError::Linear)?;
+        let p2 = nth(&nearest_points, 1, InterpolationError::Linear)?;
+        let p3 = nth(&nearest_points, 2, InterpolationError::Linear)?;
 
-        let denominator = (p2.y - p3.y) * (p1.x - p3.x) + (p3.x - p2.x) * (p1.y - p3.y);
-        let w1 = ((p2.y - p3.y) * (xy.x - p3.x) + (p3.x - p2.x) * (xy.y - p3.y)) / denominator;
-        let w2 = ((p3.y - p1.y) * (xy.x - p3.x) + (p1.x - p3.x) * (xy.y - p3.y)) / denominator;
-        let w3 = Decimal::ONE - w1 - w2;
+        let y23 = d_sub(p2.y, p3.y, op).map_err(interp_err(InterpolationError::Linear))?;
+        let x13 = d_sub(p1.x, p3.x, op).map_err(interp_err(InterpolationError::Linear))?;
+        let x32 = d_sub(p3.x, p2.x, op).map_err(interp_err(InterpolationError::Linear))?;
+        let y13 = d_sub(p1.y, p3.y, op).map_err(interp_err(InterpolationError::Linear))?;
+        let denominator = d_add(
+            d_mul(y23, x13, op).map_err(interp_err(InterpolationError::Linear))?,
+            d_mul(x32, y13, op).map_err(interp_err(InterpolationError::Linear))?,
+            op,
+        )
+        .map_err(interp_err(InterpolationError::Linear))?;
+        if denominator.is_zero() {
+            // Three collinear (or coincident) neighbours span no area, so the
+            // barycentric weights are undefined rather than infinite.
+            return Err(InterpolationError::Linear(
+                "Degenerate triangle detected: the three nearest points are collinear".to_string(),
+            ));
+        }
 
-        let z = w1 * p1.z + w2 * p2.z + w3 * p3.z;
+        let qx3 = d_sub(xy.x, p3.x, op).map_err(interp_err(InterpolationError::Linear))?;
+        let qy3 = d_sub(xy.y, p3.y, op).map_err(interp_err(InterpolationError::Linear))?;
+        let y31 = d_sub(p3.y, p1.y, op).map_err(interp_err(InterpolationError::Linear))?;
+
+        let w1_num = d_add(
+            d_mul(y23, qx3, op).map_err(interp_err(InterpolationError::Linear))?,
+            d_mul(x32, qy3, op).map_err(interp_err(InterpolationError::Linear))?,
+            op,
+        )
+        .map_err(interp_err(InterpolationError::Linear))?;
+        let w1 = d_div(w1_num, denominator, op).map_err(interp_err(InterpolationError::Linear))?;
+
+        let w2_num = d_add(
+            d_mul(y31, qx3, op).map_err(interp_err(InterpolationError::Linear))?,
+            d_mul(x13, qy3, op).map_err(interp_err(InterpolationError::Linear))?,
+            op,
+        )
+        .map_err(interp_err(InterpolationError::Linear))?;
+        let w2 = d_div(w2_num, denominator, op).map_err(interp_err(InterpolationError::Linear))?;
+
+        let w3 = d_sub(
+            d_sub(Decimal::ONE, w1, op).map_err(interp_err(InterpolationError::Linear))?,
+            w2,
+            op,
+        )
+        .map_err(interp_err(InterpolationError::Linear))?;
+
+        let z = d_sum_iter(
+            [
+                d_mul(w1, p1.z, op).map_err(interp_err(InterpolationError::Linear))?,
+                d_mul(w2, p2.z, op).map_err(interp_err(InterpolationError::Linear))?,
+                d_mul(w3, p3.z, op).map_err(interp_err(InterpolationError::Linear))?,
+            ],
+            op,
+        )
+        .map_err(interp_err(InterpolationError::Linear))?;
 
         Ok(Point3D::new(xy.x, xy.y, z))
     }
@@ -781,16 +1012,17 @@ impl BiLinearInterpolation<Point3D, Point2D> for Surface {
         }
 
         // Find the four closest points
+        let op = "Surface::bilinear_interpolate";
         let mut sorted_points: Vec<&Point3D> = self.points.iter().collect();
-        sorted_points.sort_by(|a, b| {
-            let dist_a = (a.x - xy.x).powi(2) + (a.y - xy.y).powi(2);
-            let dist_b = (b.x - xy.x).powi(2) + (b.y - xy.y).powi(2);
-            dist_a
-                .partial_cmp(&dist_b)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        sort_by_distance(&mut sorted_points, xy.x, xy.y, op)
+            .map_err(interp_err(InterpolationError::Bilinear))?;
 
-        let closest_points = &sorted_points[0..4];
+        let closest_points = sorted_points.get(0..4).ok_or_else(|| {
+            InterpolationError::Bilinear(format!(
+                "need four neighbours, found {}",
+                sorted_points.len()
+            ))
+        })?;
 
         // Sort points to create a quadrilateral
         let mut quad_points: Vec<&Point3D> = closest_points.to_vec();
@@ -803,20 +1035,45 @@ impl BiLinearInterpolation<Point3D, Point2D> for Surface {
         });
 
         // Get the four points for interpolation
-        let q11 = quad_points[0]; // Bottom-left point
-        let q12 = quad_points[1]; // Bottom-right point
-        let q21 = quad_points[2]; // Top-left point
-        let q22 = quad_points[3]; // Top-right point
+        let q11 = nth(&quad_points, 0, InterpolationError::Bilinear)?; // Bottom-left point
+        let q12 = nth(&quad_points, 1, InterpolationError::Bilinear)?; // Bottom-right point
+        let q21 = nth(&quad_points, 2, InterpolationError::Bilinear)?; // Top-left point
+        let q22 = nth(&quad_points, 3, InterpolationError::Bilinear)?; // Top-right point
 
         // Calculate normalized coordinates
-        let x_ratio = (xy.x - q11.x) / (q12.x - q11.x);
-        let y_ratio = (xy.y - q11.y) / (q21.y - q11.y);
+        let x_span = d_sub(q12.x, q11.x, op).map_err(interp_err(InterpolationError::Bilinear))?;
+        let y_span = d_sub(q21.y, q11.y, op).map_err(interp_err(InterpolationError::Bilinear))?;
+        if x_span.is_zero() || y_span.is_zero() {
+            // The quadrilateral has collapsed onto a line, so the normalized
+            // coordinates are undefined rather than infinite.
+            return Err(InterpolationError::DegenerateInterval);
+        }
+        let x_offset = d_sub(xy.x, q11.x, op).map_err(interp_err(InterpolationError::Bilinear))?;
+        let x_ratio =
+            d_div(x_offset, x_span, op).map_err(interp_err(InterpolationError::Bilinear))?;
+        let y_offset = d_sub(xy.y, q11.y, op).map_err(interp_err(InterpolationError::Bilinear))?;
+        let y_ratio =
+            d_div(y_offset, y_span, op).map_err(interp_err(InterpolationError::Bilinear))?;
 
         // Perform bilinear interpolation
-        let z = (Decimal::ONE - x_ratio) * (Decimal::ONE - y_ratio) * q11.z
-            + x_ratio * (Decimal::ONE - y_ratio) * q12.z
-            + (Decimal::ONE - x_ratio) * y_ratio * q21.z
-            + x_ratio * y_ratio * q22.z;
+        let inv_x =
+            d_sub(Decimal::ONE, x_ratio, op).map_err(interp_err(InterpolationError::Bilinear))?;
+        let inv_y =
+            d_sub(Decimal::ONE, y_ratio, op).map_err(interp_err(InterpolationError::Bilinear))?;
+        let corner = |a: Decimal, b: Decimal, z: Decimal| -> Result<Decimal, InterpolationError> {
+            let weight = d_mul(a, b, op).map_err(interp_err(InterpolationError::Bilinear))?;
+            d_mul(weight, z, op).map_err(interp_err(InterpolationError::Bilinear))
+        };
+        let z = d_sum_iter(
+            [
+                corner(inv_x, inv_y, q11.z)?,
+                corner(x_ratio, inv_y, q12.z)?,
+                corner(inv_x, y_ratio, q21.z)?,
+                corner(x_ratio, y_ratio, q22.z)?,
+            ],
+            op,
+        )
+        .map_err(interp_err(InterpolationError::Bilinear))?;
 
         Ok(Point3D::new(xy.x, xy.y, z))
     }
@@ -848,42 +1105,48 @@ impl CubicInterpolation<Point3D, Point2D> for Surface {
         }
 
         // Find the 9 closest points for cubic interpolation
+        let op = "Surface::cubic_interpolate";
         let mut sorted_points: Vec<&Point3D> = self.points.iter().collect();
-        sorted_points.sort_by(|a, b| {
-            let dist_a = (a.x - xy.x).powi(2) + (a.y - xy.y).powi(2);
-            let dist_b = (b.x - xy.x).powi(2) + (b.y - xy.y).powi(2);
-            dist_a
-                .partial_cmp(&dist_b)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        sort_by_distance(&mut sorted_points, xy.x, xy.y, op)
+            .map_err(interp_err(InterpolationError::Cubic))?;
 
-        let closest_points = &sorted_points[0..9];
+        let closest_points = sorted_points.get(0..9).ok_or_else(|| {
+            InterpolationError::Cubic(format!(
+                "need nine neighbours, found {}",
+                sorted_points.len()
+            ))
+        })?;
 
         // Cubic interpolation requires solving a system of equations
         // We'll use a weighted cubic interpolation approach
 
         // Calculate weights based on distance
-        let weights: Vec<Decimal> = closest_points
-            .iter()
-            .map(|&point| {
-                let sq = (point.x - xy.x).powi(2) + (point.y - xy.y).powi(2);
-                let dist = match sq.sqrt() {
-                    Some(d) => d,
-                    None => {
-                        // sqrt only fails for negative input or a result that
-                        // cannot be represented as Decimal (overflow). Squared
-                        // distance is always >= 0, so this is the overflow
-                        // case — drop the point's contribution by giving it
-                        // zero weight rather than a misleadingly small one.
-                        warn!(
-                            "cubic_interpolate: sqrt failed for operand ({sq}); dropping point from weighting"
-                        );
-                        return Decimal::ZERO;
-                    }
-                };
-                Decimal::ONE / (dist + Decimal::new(1, 6)) // Avoid division by zero
-            })
-            .collect();
+        let mut weights: Vec<Decimal> = Vec::with_capacity(closest_points.len());
+        for &point in closest_points {
+            let sq = squared_distance(point, xy.x, xy.y, op)
+                .map_err(interp_err(InterpolationError::Cubic))?;
+            let dist = match sq.sqrt() {
+                Some(d) => d,
+                None => {
+                    // sqrt only fails for negative input or a result that
+                    // cannot be represented as Decimal (overflow). Squared
+                    // distance is always >= 0, so this is the overflow
+                    // case — drop the point's contribution by giving it
+                    // zero weight rather than a misleadingly small one.
+                    warn!(
+                        "cubic_interpolate: sqrt failed for operand ({sq}); dropping point from weighting"
+                    );
+                    weights.push(Decimal::ZERO);
+                    continue;
+                }
+            };
+            // The 1e-6 floor keeps a coincident neighbour out of a zero divisor.
+            let shifted = d_add(dist, Decimal::new(1, 6), op)
+                .map_err(interp_err(InterpolationError::Cubic))?;
+            weights.push(
+                d_div(Decimal::ONE, shifted, op).map_err(interp_err(InterpolationError::Cubic))?,
+            );
+        }
 
         // Weighted cubic interpolation
         let mut numerator_z = Decimal::ZERO;
@@ -891,18 +1154,26 @@ impl CubicInterpolation<Point3D, Point2D> for Surface {
 
         for (&point, &weight) in closest_points.iter().zip(weights.iter()) {
             // Cubic weight function
-            let cubic_weight = weight.powi(3);
-            numerator_z += point.z * cubic_weight;
-            denominator += cubic_weight;
+            let cubic_weight =
+                powu_checked(weight, 3, op).map_err(interp_err(InterpolationError::Cubic))?;
+            let contribution =
+                d_mul(point.z, cubic_weight, op).map_err(interp_err(InterpolationError::Cubic))?;
+            numerator_z = d_add(numerator_z, contribution, op)
+                .map_err(interp_err(InterpolationError::Cubic))?;
+            denominator = d_add(denominator, cubic_weight, op)
+                .map_err(interp_err(InterpolationError::Cubic))?;
         }
 
         // Prevent division by zero
         let interpolated_z = if denominator != Decimal::ZERO {
-            numerator_z / denominator
+            d_div(numerator_z, denominator, op).map_err(interp_err(InterpolationError::Cubic))?
         } else {
             // Fallback to average if weights are problematic
-            closest_points.iter().map(|p| p.z).sum::<Decimal>()
-                / Decimal::from(closest_points.len())
+            let zs: Vec<Decimal> = closest_points.iter().map(|p| p.z).collect();
+            let sum = d_sum_iter(zs.iter().copied(), op)
+                .map_err(interp_err(InterpolationError::Cubic))?;
+            d_div(sum, Decimal::from(closest_points.len()), op)
+                .map_err(interp_err(InterpolationError::Cubic))?
         };
 
         Ok(Point3D::new(xy.x, xy.y, interpolated_z))
@@ -1017,11 +1288,23 @@ impl MetricsExtractor for Surface {
     fn compute_basic_metrics(&self) -> Result<BasicMetrics, MetricsError> {
         let z_values: Vec<Decimal> = self.points.iter().map(|p| p.z).collect();
 
-        let mean = z_values.iter().sum::<Decimal>() / Decimal::from(z_values.len());
+        // An empty surface has no statistics; report the same zeroed set
+        // `Curve::compute_basic_metrics` already returns for an empty curve.
+        if z_values.is_empty() {
+            return Ok(BasicMetrics {
+                mean: Decimal::ZERO,
+                median: Decimal::ZERO,
+                mode: Decimal::ZERO,
+                std_dev: Decimal::ZERO,
+            });
+        }
+
+        let op = "Surface::compute_basic_metrics";
+        let mean = mean_of(&z_values, op).map_err(|e| MetricsError::BasicError(e.to_string()))?;
 
         let mut sorted = z_values.clone();
         sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let median = sorted[sorted.len() / 2];
+        let median = sample_at(&sorted, sorted.len() / 2, "median")?;
 
         // Mode calculation using HashMap to count occurrences
         let mode = {
@@ -1036,13 +1319,11 @@ impl MetricsExtractor for Surface {
                 .unwrap_or(Decimal::ZERO)
         };
 
-        let std_dev = (z_values
-            .iter()
-            .map(|x| (*x - mean).powu(2))
-            .sum::<Decimal>()
-            / Decimal::from(z_values.len()))
-        .sqrt()
-        .unwrap_or(Decimal::ZERO);
+        let sum_sq = central_moment(&z_values, mean, 2, op)
+            .map_err(|e| MetricsError::BasicError(e.to_string()))?;
+        let variance = d_div(sum_sq, Decimal::from(z_values.len()), op)
+            .map_err(|e| MetricsError::BasicError(e.to_string()))?;
+        let std_dev = variance.sqrt().unwrap_or(Decimal::ZERO);
 
         Ok(BasicMetrics {
             mean,
@@ -1054,28 +1335,56 @@ impl MetricsExtractor for Surface {
 
     fn compute_shape_metrics(&self) -> Result<ShapeMetrics, MetricsError> {
         let z_values: Vec<Decimal> = self.points.iter().map(|p| p.z).collect();
-        let mean = z_values.iter().sum::<Decimal>() / Decimal::from(z_values.len());
-        let std_dev = (z_values
-            .iter()
-            .map(|x| (*x - mean).powu(2))
-            .sum::<Decimal>()
-            / Decimal::from(z_values.len()))
-        .sqrt()
-        .unwrap_or(Decimal::ONE);
+
+        // Skewness and kurtosis need a spread to standardise by; mirror the
+        // zeroed answer `Curve::compute_shape_metrics` returns below two
+        // samples.
+        if z_values.len() < 2 {
+            return Ok(ShapeMetrics {
+                skewness: Decimal::ZERO,
+                kurtosis: Decimal::ZERO,
+                peaks: vec![],
+                valleys: vec![],
+                inflection_points: vec![],
+            });
+        }
+
+        let op = "Surface::compute_shape_metrics";
+        let mean = mean_of(&z_values, op).map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let sum_sq = central_moment(&z_values, mean, 2, op)
+            .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let variance = d_div(sum_sq, Decimal::from(z_values.len()), op)
+            .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let std_dev = variance.sqrt().unwrap_or(Decimal::ONE);
+        if std_dev.is_zero() {
+            return Err(MetricsError::ShapeError(format!(
+                "standard deviation ({std_dev}) is too small to compute skewness/kurtosis; the surface is degenerate"
+            )));
+        }
 
         let n = Decimal::from(z_values.len());
 
-        let skewness = z_values
-            .iter()
-            .map(|x| (*x - mean).powu(3))
-            .sum::<Decimal>()
-            / (n * std_dev.powu(3));
+        let skew_num = central_moment(&z_values, mean, 3, op)
+            .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let skew_den = d_mul(
+            n,
+            powu_checked(std_dev, 3, op).map_err(|e| MetricsError::ShapeError(e.to_string()))?,
+            op,
+        )
+        .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let skewness =
+            d_div(skew_num, skew_den, op).map_err(|e| MetricsError::ShapeError(e.to_string()))?;
 
-        let kurtosis = z_values
-            .iter()
-            .map(|x| (*x - mean).powu(4))
-            .sum::<Decimal>()
-            / (n * std_dev.powu(4));
+        let kurt_num = central_moment(&z_values, mean, 4, op)
+            .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let kurt_den = d_mul(
+            n,
+            powu_checked(std_dev, 4, op).map_err(|e| MetricsError::ShapeError(e.to_string()))?,
+            op,
+        )
+        .map_err(|e| MetricsError::ShapeError(e.to_string()))?;
+        let kurtosis =
+            d_div(kurt_num, kurt_den, op).map_err(|e| MetricsError::ShapeError(e.to_string()))?;
 
         Ok(ShapeMetrics {
             skewness,
@@ -1088,19 +1397,33 @@ impl MetricsExtractor for Surface {
 
     fn compute_range_metrics(&self) -> Result<RangeMetrics, MetricsError> {
         let z_values: Vec<Decimal> = self.points.iter().map(|p| p.z).collect();
+
+        // An empty surface has no quantiles; mirror the zeroed answer
+        // `Curve::compute_range_metrics` returns for an empty curve.
+        if z_values.is_empty() {
+            return Ok(RangeMetrics {
+                min: Point2D::new(Decimal::ZERO, Decimal::ZERO),
+                max: Point2D::new(Decimal::ZERO, Decimal::ZERO),
+                range: Decimal::ZERO,
+                quartiles: (Decimal::ZERO, Decimal::ZERO, Decimal::ZERO),
+                interquartile_range: Decimal::ZERO,
+            });
+        }
+
         let mut sorted = z_values.clone();
         sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
         let min = sorted.first().copied().unwrap_or(Decimal::ZERO);
         let max = sorted.last().copied().unwrap_or(Decimal::ZERO);
 
+        let op = "Surface::compute_range_metrics";
         let len = sorted.len();
-        let q1 = sorted[len / 4];
-        let q2 = sorted[len / 2];
-        let q3 = sorted[3 * len / 4];
+        let q1 = sample_at(&sorted, len / 4, "first quartile")?;
+        let q2 = sample_at(&sorted, len / 2, "median")?;
+        let q3 = sample_at(&sorted, 3 * len / 4, "third quartile")?;
 
-        let range = max - min;
-        let iqr = q3 - q1;
+        let range = d_sub(max, min, op).map_err(|e| MetricsError::RangeError(e.to_string()))?;
+        let iqr = d_sub(q3, q1, op).map_err(|e| MetricsError::RangeError(e.to_string()))?;
 
         Ok(RangeMetrics {
             min: Point2D::new(Decimal::ZERO, min),
@@ -1129,65 +1452,72 @@ impl MetricsExtractor for Surface {
         let x_vals: Vec<Decimal> = points.iter().map(|p| p.x).collect();
         let z_vals: Vec<Decimal> = points.iter().map(|p| p.y).collect();
 
-        let sum_x: Decimal = x_vals.iter().sum();
-        let sum_z: Decimal = z_vals.iter().sum();
+        let op = "Surface::compute_trend_metrics";
+        let sum_x = d_sum_iter(x_vals.iter().copied(), op).map_err(trend_err)?;
+        let sum_z = d_sum_iter(z_vals.iter().copied(), op).map_err(trend_err)?;
 
         // Check for identical points to avoid division by zero
-        let is_identical_points = z_vals.iter().all(|&z| z == z_vals[0]);
+        let first_z = sample_at(&z_vals, 0, "trend baseline")?;
+        let is_identical_points = z_vals.iter().all(|&z| z == first_z);
 
         let (slope, intercept, r_squared) = if is_identical_points {
             // All points are the same
-            (Decimal::ZERO, z_vals[0], Decimal::ONE)
+            (Decimal::ZERO, first_z, Decimal::ONE)
         } else {
-            let sum_xz: Decimal = x_vals.iter().zip(&z_vals).map(|(x, z)| *x * *z).sum();
-            let sum_xx: Decimal = x_vals.iter().map(|x| *x * *x).sum();
+            let regression = || -> Result<(Decimal, Decimal, Decimal), DecimalError> {
+                let mut sum_xz = Decimal::ZERO;
+                let mut sum_xx = Decimal::ZERO;
+                for (x, z) in x_vals.iter().zip(&z_vals) {
+                    sum_xz = d_add(sum_xz, d_mul(*x, *z, op)?, op)?;
+                    sum_xx = d_add(sum_xx, d_mul(*x, *x, op)?, op)?;
+                }
 
-            let slope = (n * sum_xz - sum_x * sum_z) / (n * sum_xx - sum_x * sum_x);
-            let intercept = (sum_z - slope * sum_x) / n;
+                let numerator = d_sub(d_mul(n, sum_xz, op)?, d_mul(sum_x, sum_z, op)?, op)?;
+                let denominator = d_sub(d_mul(n, sum_xx, op)?, d_mul(sum_x, sum_x, op)?, op)?;
+                let slope = d_div(numerator, denominator, op)?;
+                let intercept = d_div(d_sub(sum_z, d_mul(slope, sum_x, op)?, op)?, n, op)?;
 
-            // R-squared Calculation
-            let mean_z = sum_z / n;
-            let sst: Decimal = z_vals.iter().map(|z| (*z - mean_z).powu(2)).sum();
+                // R-squared Calculation
+                let mean_z = d_div(sum_z, n, op)?;
+                let sst = central_moment(&z_vals, mean_z, 2, op)?;
 
-            let ssr: Decimal = z_vals
-                .iter()
-                .zip(&x_vals)
-                .map(|(z, x)| {
-                    let z_predicted = slope * *x + intercept;
-                    (*z - z_predicted).powu(2)
-                })
-                .sum();
+                let mut ssr = Decimal::ZERO;
+                for (z, x) in z_vals.iter().zip(&x_vals) {
+                    let z_predicted = d_add(d_mul(slope, *x, op)?, intercept, op)?;
+                    let residual = d_sub(*z, z_predicted, op)?;
+                    ssr = d_add(ssr, powu_checked(residual, 2, op)?, op)?;
+                }
 
-            let r_squared = if sst == Decimal::ZERO {
-                Decimal::ONE
-            } else {
-                Decimal::ONE - (ssr / sst)
+                let r_squared = if sst == Decimal::ZERO {
+                    Decimal::ONE
+                } else {
+                    d_sub(Decimal::ONE, d_div(ssr, sst, op)?, op)?
+                };
+
+                Ok((slope, intercept, r_squared))
             };
 
-            (slope, intercept, r_squared)
+            // A surface whose abscissas all collapse to one value (a single
+            // column) leaves the ordinary-least-squares denominator at zero,
+            // where the slope is undefined rather than infinite.
+            regression().map_err(trend_err)?
         };
 
         // Moving Average Calculation
         let window_sizes = [3, 5, 7];
-        let moving_average: Vec<Point2D> = window_sizes
-            .iter()
-            .flat_map(|&window| {
-                if window > points.len() {
-                    vec![]
-                } else {
-                    points
-                        .windows(window)
-                        .map(|window_points| {
-                            let avg_x = window_points.iter().map(|p| p.x).sum::<Decimal>()
-                                / Decimal::from(window_points.len());
-                            let avg_y = window_points.iter().map(|p| p.y).sum::<Decimal>()
-                                / Decimal::from(window_points.len());
-                            Point2D::new(avg_x, avg_y)
-                        })
-                        .collect::<Vec<Point2D>>()
-                }
-            })
-            .collect();
+        let mut moving_average: Vec<Point2D> = Vec::new();
+        for window in window_sizes {
+            if window > points.len() {
+                continue;
+            }
+            for window_points in points.windows(window) {
+                let xs: Vec<Decimal> = window_points.iter().map(|p| p.x).collect();
+                let ys: Vec<Decimal> = window_points.iter().map(|p| p.y).collect();
+                let avg_x = mean_of(&xs, op).map_err(trend_err)?;
+                let avg_y = mean_of(&ys, op).map_err(trend_err)?;
+                moving_average.push(Point2D::new(avg_x, avg_y));
+            }
+        }
 
         Ok(TrendMetrics {
             slope,
@@ -1200,28 +1530,55 @@ impl MetricsExtractor for Surface {
     fn compute_risk_metrics(&self) -> Result<RiskMetrics, MetricsError> {
         let z_values: Vec<Decimal> = self.points.iter().map(|p| p.z).collect();
 
-        let mean = z_values.iter().sum::<Decimal>() / Decimal::from(z_values.len());
-        let volatility = (z_values
-            .iter()
-            .map(|x| (*x - mean).powu(2))
-            .sum::<Decimal>()
-            / Decimal::from(z_values.len()))
-        .sqrt()
-        .unwrap_or(Decimal::ZERO);
+        // An empty surface carries no risk; mirror the zeroed answer
+        // `Curve::compute_risk_metrics` returns for an empty curve.
+        if z_values.is_empty() {
+            return Ok(RiskMetrics {
+                volatility: Decimal::ZERO,
+                value_at_risk: Decimal::ZERO,
+                expected_shortfall: Decimal::ZERO,
+                beta: Decimal::ZERO,
+                sharpe_ratio: Decimal::ZERO,
+            });
+        }
+
+        let op = "Surface::compute_risk_metrics";
+        let mean = mean_of(&z_values, op).map_err(risk_err)?;
+        let sum_sq = central_moment(&z_values, mean, 2, op).map_err(risk_err)?;
+        let variance = d_div(sum_sq, Decimal::from(z_values.len()), op).map_err(risk_err)?;
+        let volatility = variance.sqrt().unwrap_or(Decimal::ZERO);
+
+        // A flat surface has no dispersion, so the Sharpe ratio is undefined;
+        // mirror the zeroed answer `Curve::compute_risk_metrics` returns.
+        if volatility == Decimal::ZERO {
+            return Ok(RiskMetrics {
+                volatility,
+                value_at_risk: Decimal::ZERO,
+                expected_shortfall: Decimal::ZERO,
+                beta: Decimal::ZERO,
+                sharpe_ratio: Decimal::ZERO,
+            });
+        }
 
         // Value at Risk (95% confidence) using parametric method
         let z_score = dec!(1.645); // 95% confidence interval
-        let var = mean - z_score * volatility;
+        let scaled_vol = d_mul(z_score, volatility, op).map_err(risk_err)?;
+        let var = d_sub(mean, scaled_vol, op).map_err(risk_err)?;
 
-        // Expected Shortfall (Conditional VaR) calculation
-        let expected_shortfall = z_values.iter().filter(|&x| *x < var).sum::<Decimal>()
-            / Decimal::from(z_values.iter().filter(|&x| *x < var).count() as u64);
+        // Expected Shortfall (Conditional VaR) calculation. An empty tail has
+        // no conditional mean; report zero as `Curve` does.
+        let tail: Vec<Decimal> = z_values.iter().copied().filter(|&x| x < var).collect();
+        let expected_shortfall = if tail.is_empty() {
+            Decimal::ZERO
+        } else {
+            mean_of(&tail, op).map_err(risk_err)?
+        };
 
         // Beta calculation with optional market volatility
         let beta = Decimal::ZERO; // TODO: Implement beta calculation
 
         // Sharpe Ratio (assuming risk-free rate of 0)
-        let sharpe_ratio = mean / volatility;
+        let sharpe_ratio = d_div(mean, volatility, op).map_err(risk_err)?;
 
         Ok(RiskMetrics {
             volatility,
@@ -1244,8 +1601,8 @@ impl Arithmetic<Surface> for Surface {
             ));
         }
 
-        if surfaces.len() == 1 {
-            return Ok(surfaces[0].clone());
+        if let [only] = surfaces {
+            return Ok((*only).clone());
         }
 
         // Find intersection of x,y ranges
@@ -1280,15 +1637,20 @@ impl Arithmetic<Surface> for Surface {
 
         // Create interpolation grid
         let steps = 50;
-        let x_step = (max_x - min_x) / Decimal::from(steps);
-        let y_step = (max_y - min_y) / Decimal::from(steps);
+        let op = "Surface::merge";
+        let x_span = d_sub(max_x, min_x, op).map_err(construction_err)?;
+        let x_step = d_div(x_span, Decimal::from(steps), op).map_err(construction_err)?;
+        let y_span = d_sub(max_y, min_y, op).map_err(construction_err)?;
+        let y_step = d_div(y_span, Decimal::from(steps), op).map_err(construction_err)?;
 
         let result_points: Result<Vec<Point3D>, SurfaceError> = (0..=steps)
             .into_par_iter()
             .flat_map(|i| {
-                let x = min_x + x_step * Decimal::from(i);
                 (0..=steps).into_par_iter().map(move |j| {
-                    let y = min_y + y_step * Decimal::from(j);
+                    let x_offset = d_mul(x_step, Decimal::from(i), op).map_err(construction_err)?;
+                    let x = d_add(min_x, x_offset, op).map_err(construction_err)?;
+                    let y_offset = d_mul(y_step, Decimal::from(j), op).map_err(construction_err)?;
+                    let y = d_add(min_y, y_offset, op).map_err(construction_err)?;
                     let point = Point2D::new(x, y);
 
                     // Interpolate z values
@@ -1306,23 +1668,36 @@ impl Arithmetic<Surface> for Surface {
 
                     // Apply operation
                     let result_z = match operation {
-                        MergeOperation::Add => z_values.par_iter().sum(),
+                        MergeOperation::Add => {
+                            d_sum_iter(z_values.iter().copied(), op).map_err(construction_err)?
+                        }
                         MergeOperation::Subtract => {
                             let first = z_values.first().cloned().unwrap_or(Decimal::ZERO);
-                            let remaining_sum: Decimal = z_values.iter().skip(1).sum();
-                            first - remaining_sum
+                            let remaining_sum = d_sum_iter(z_values.iter().skip(1).copied(), op)
+                                .map_err(construction_err)?;
+                            d_sub(first, remaining_sum, op).map_err(construction_err)?
                         }
-                        MergeOperation::Multiply => z_values.par_iter().product(),
+                        MergeOperation::Multiply => z_values.par_iter().copied().map(Ok).reduce(
+                            || Ok(Decimal::ONE),
+                            |a, b| d_mul(a?, b?, op).map_err(construction_err),
+                        )?,
                         MergeOperation::Divide => {
                             let first = z_values.first().cloned().unwrap_or(Decimal::ONE);
                             z_values
                                 .par_iter()
                                 .skip(1)
                                 .fold(
-                                    || first,
-                                    |acc, &val| if val == Decimal::ZERO { acc } else { acc / val },
+                                    || Ok(first),
+                                    |acc: Result<Decimal, SurfaceError>, &val| {
+                                        let acc = acc?;
+                                        if val == Decimal::ZERO {
+                                            Ok(acc)
+                                        } else {
+                                            d_div(acc, val, op).map_err(construction_err)
+                                        }
+                                    },
                                 )
-                                .reduce(|| first, |a, _b| a)
+                                .reduce(|| Ok(first), |a, _b| a)?
                         }
                         MergeOperation::Max => z_values
                             .par_iter()
@@ -1376,14 +1751,23 @@ impl AxisOperations<Point3D, Point2D> for Surface {
     fn get_closest_point(&self, x: &Point2D) -> Result<&Point3D, Self::Error> {
         // Compare squared distances directly: ordering is monotonic on
         // non-negative inputs, so the sqrt is unnecessary and would
-        // introduce a fallback that could otherwise distort ordering.
-        self.points
-            .iter()
-            .min_by(|a, b| {
-                let sq_a = (a.x - x.x).powi(2) + (a.y - x.y).powi(2);
-                let sq_b = (b.x - x.x).powi(2) + (b.y - x.y).powi(2);
-                sq_a.partial_cmp(&sq_b).unwrap_or(std::cmp::Ordering::Equal)
-            })
+        // introduce a fallback that could otherwise distort ordering. The
+        // distance is folded explicitly because a coordinate at the edge of
+        // the `Decimal` range overflows, and `min_by` has no channel for that.
+        let mut closest: Option<(&Point3D, Decimal)> = None;
+        for point in &self.points {
+            let squared = squared_distance(point, x.x, x.y, "Surface::get_closest_point")
+                .map_err(analysis_err)?;
+            // `min_by` keeps the first of several equal minima; `<=` here
+            // preserves that.
+            match closest {
+                Some((_, best)) if best <= squared => {}
+                _ => closest = Some((point, squared)),
+            }
+        }
+
+        closest
+            .map(|(point, _)| point)
             .ok_or(SurfaceError::Point3DError {
                 reason: "No points found",
             })
@@ -1463,17 +1847,24 @@ impl GeometricTransformations<Point3D> for Surface {
             ));
         }
 
+        let (Some(dx), Some(dy), Some(dz)) = (deltas.first(), deltas.get(1), deltas.get(2)) else {
+            return Err(SurfaceError::invalid_parameters(
+                "translate",
+                "Expected 3 deltas for 3D translation",
+            ));
+        };
+
         let translated_points = self
             .points
             .iter()
             .map(|point| {
-                Point3D::new(
-                    point.x + *deltas[0],
-                    point.y + *deltas[1],
-                    point.z + *deltas[2],
-                )
+                let x = d_add(point.x, **dx, "Surface::translate::x")?;
+                let y = d_add(point.y, **dy, "Surface::translate::y")?;
+                let z = d_add(point.z, **dz, "Surface::translate::z")?;
+                Ok(Point3D::new(x, y, z))
             })
-            .collect();
+            .collect::<Result<BTreeSet<Point3D>, DecimalError>>()
+            .map_err(construction_err)?;
 
         Ok(Surface::new(translated_points))
     }
@@ -1486,17 +1877,25 @@ impl GeometricTransformations<Point3D> for Surface {
             ));
         }
 
+        let (Some(fx), Some(fy), Some(fz)) = (factors.first(), factors.get(1), factors.get(2))
+        else {
+            return Err(SurfaceError::invalid_parameters(
+                "scale",
+                "Expected 3 factors for 3D scaling",
+            ));
+        };
+
         let scaled_points = self
             .points
             .iter()
             .map(|point| {
-                Point3D::new(
-                    point.x * *factors[0],
-                    point.y * *factors[1],
-                    point.z * *factors[2],
-                )
+                let x = d_mul(point.x, **fx, "Surface::scale::x")?;
+                let y = d_mul(point.y, **fy, "Surface::scale::y")?;
+                let z = d_mul(point.z, **fz, "Surface::scale::z")?;
+                Ok(Point3D::new(x, y, z))
             })
-            .collect();
+            .collect::<Result<BTreeSet<Point3D>, DecimalError>>()
+            .map_err(construction_err)?;
 
         Ok(Surface::new(scaled_points))
     }
@@ -1504,13 +1903,20 @@ impl GeometricTransformations<Point3D> for Surface {
     fn intersect_with(&self, other: &Self) -> Result<Vec<Point3D>, Self::Error> {
         let mut intersections = Vec::new();
         let epsilon = Decimal::new(1, 6); // 0.000001 tolerance
+        let op = "Surface::intersect_with";
 
         for p1 in self.points.iter() {
             for p2 in other.points.iter() {
-                if (p1.x - p2.x).abs() < epsilon
-                    && (p1.y - p2.y).abs() < epsilon
-                    && (p1.z - p2.z).abs() < epsilon
-                {
+                let dx = d_sub(p1.x, p2.x, op).map_err(analysis_err)?.abs();
+                if dx >= epsilon {
+                    continue;
+                }
+                let dy = d_sub(p1.y, p2.y, op).map_err(analysis_err)?.abs();
+                if dy >= epsilon {
+                    continue;
+                }
+                let dz = d_sub(p1.z, p2.z, op).map_err(analysis_err)?.abs();
+                if dz < epsilon {
                     intersections.push(*p1);
                 }
             }
@@ -1528,29 +1934,36 @@ impl GeometricTransformations<Point3D> for Surface {
             ));
         }
 
+        let op = "Surface::derivative_at";
+
         // For surfaces with exactly 2 or 3 points, use a simple approach
         if self.points.len() <= 3 {
-            // let points: Vec<_> = self.points.iter().collect();
+            let p0 = self.point_at(0)?;
+            let p1 = self.point_at(1)?;
 
             // Ensure points are not identical
-            if self[0] == self[1] {
+            if p0 == p1 {
                 return Err(SurfaceError::invalid_parameters(
                     "derivative_at",
                     "Points are identical, cannot calculate derivatives",
                 ));
             }
 
-            // Calculate derivatives using the first two points
-            let dx = if (self[1].x - self[0].x) == Decimal::ZERO {
+            // Calculate derivatives using the first two points. `Decimal::MAX`
+            // is the pre-existing sentinel for a collapsed axis.
+            let rise = d_sub(p1.z, p0.z, op).map_err(analysis_err)?;
+            let run_x = d_sub(p1.x, p0.x, op).map_err(analysis_err)?;
+            let dx = if run_x == Decimal::ZERO {
                 Decimal::MAX
             } else {
-                (self[1].z - self[0].z) / (self[1].x - self[0].x)
+                d_div(rise, run_x, op).map_err(analysis_err)?
             };
 
-            let dy = if (self[1].y - self[0].y) == Decimal::ZERO {
+            let run_y = d_sub(p1.y, p0.y, op).map_err(analysis_err)?;
+            let dy = if run_y == Decimal::ZERO {
                 Decimal::MAX
             } else {
-                (self[1].z - self[0].z) / (self[1].y - self[0].y)
+                d_div(rise, run_y, op).map_err(analysis_err)?
             };
 
             return Ok(vec![dx, dy]);
@@ -1568,19 +1981,16 @@ impl GeometricTransformations<Point3D> for Surface {
         // For more complex surfaces, find nearby points
         let tolerance = dec!(0.5);
 
-        let x_points: BTreeSet<Point3D> = self
-            .get_points()
-            .into_iter()
-            .filter(|p| (p.x - point.x).abs() < tolerance)
-            .cloned()
-            .collect();
-
-        let y_points: BTreeSet<Point3D> = self
-            .get_points()
-            .into_iter()
-            .filter(|p| (p.y - point.y).abs() < tolerance)
-            .cloned()
-            .collect();
+        let mut x_points: BTreeSet<Point3D> = BTreeSet::new();
+        let mut y_points: BTreeSet<Point3D> = BTreeSet::new();
+        for candidate in self.get_points() {
+            if d_sub(candidate.x, point.x, op).map_err(analysis_err)?.abs() < tolerance {
+                x_points.insert(*candidate);
+            }
+            if d_sub(candidate.y, point.y, op).map_err(analysis_err)?.abs() < tolerance {
+                y_points.insert(*candidate);
+            }
+        }
 
         // If not enough nearby points, use the entire surface
         let x_candidates = if x_points.len() < 2 {
@@ -1609,17 +2019,33 @@ impl GeometricTransformations<Point3D> for Surface {
         let mut y_sorted: Vec<_> = y_candidates.iter().collect();
         y_sorted.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal));
 
-        // Prevent division by zero
-        let dx = if x_sorted[0].x == x_sorted[1].x {
-            Decimal::ZERO
-        } else {
-            (x_sorted[1].z - x_sorted[0].z) / (x_sorted[1].x - x_sorted[0].x)
+        let missing = || {
+            SurfaceError::AnalysisError(
+                "derivative_at: fewer than two candidates after filtering".to_string(),
+            )
+        };
+        let (Some(x0), Some(x1)) = (x_sorted.first(), x_sorted.get(1)) else {
+            return Err(missing());
+        };
+        let (Some(y0), Some(y1)) = (y_sorted.first(), y_sorted.get(1)) else {
+            return Err(missing());
         };
 
-        let dy = if y_sorted[0].y == y_sorted[1].y {
+        // Prevent division by zero
+        let dx = if x0.x == x1.x {
             Decimal::ZERO
         } else {
-            (y_sorted[1].z - y_sorted[0].z) / (y_sorted[1].y - y_sorted[0].y)
+            let rise = d_sub(x1.z, x0.z, op).map_err(analysis_err)?;
+            let run = d_sub(x1.x, x0.x, op).map_err(analysis_err)?;
+            d_div(rise, run, op).map_err(analysis_err)?
+        };
+
+        let dy = if y0.y == y1.y {
+            Decimal::ZERO
+        } else {
+            let rise = d_sub(y1.z, y0.z, op).map_err(analysis_err)?;
+            let run = d_sub(y1.y, y0.y, op).map_err(analysis_err)?;
+            d_div(rise, run, op).map_err(analysis_err)?
         };
 
         Ok(vec![dx, dy])
@@ -1663,21 +2089,47 @@ impl GeometricTransformations<Point3D> for Surface {
         let mut volume = Decimal::ZERO;
         let points: Vec<_> = self.points.iter().collect();
 
+        let op = "Surface::measure_under";
+
         // For each possible triangle in the surface
         for window in points.windows(3) {
             // Calculate area of triangle
-            let p1 = window[0];
-            let p2 = window[1];
-            let p3 = window[2];
+            let (Some(p1), Some(p2), Some(p3)) = (window.first(), window.get(1), window.get(2))
+            else {
+                return Err(SurfaceError::AnalysisError(
+                    "measure_under: triangle window is shorter than three points".to_string(),
+                ));
+            };
 
-            let area =
-                ((p2.x - p1.x) * (p3.y - p1.y) - (p3.x - p1.x) * (p2.y - p1.y)).abs() / dec!(2);
+            let cross_a = d_mul(
+                d_sub(p2.x, p1.x, op).map_err(analysis_err)?,
+                d_sub(p3.y, p1.y, op).map_err(analysis_err)?,
+                op,
+            )
+            .map_err(analysis_err)?;
+            let cross_b = d_mul(
+                d_sub(p3.x, p1.x, op).map_err(analysis_err)?,
+                d_sub(p2.y, p1.y, op).map_err(analysis_err)?,
+                op,
+            )
+            .map_err(analysis_err)?;
+            let cross = d_sub(cross_a, cross_b, op).map_err(analysis_err)?;
+            let area = d_div(cross.abs(), dec!(2), op).map_err(analysis_err)?;
 
             // Average height from base_value
-            let avg_height =
-                ((p1.z - *base_value) + (p2.z - *base_value) + (p3.z - *base_value)) / dec!(3);
+            let heights = d_sum_iter(
+                [
+                    d_sub(p1.z, *base_value, op).map_err(analysis_err)?,
+                    d_sub(p2.z, *base_value, op).map_err(analysis_err)?,
+                    d_sub(p3.z, *base_value, op).map_err(analysis_err)?,
+                ],
+                op,
+            )
+            .map_err(analysis_err)?;
+            let avg_height = d_div(heights, dec!(3), op).map_err(analysis_err)?;
 
-            volume += area * avg_height;
+            let prism = d_mul(area, avg_height, op).map_err(analysis_err)?;
+            volume = d_add(volume, prism, op).map_err(analysis_err)?;
         }
 
         Ok(volume.abs())

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -37,9 +37,7 @@ use crate::utils::Len;
 
 use crate::visualization::{Graph, GraphData, Surface3D};
 use num_traits::ToPrimitive;
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
@@ -1548,19 +1546,10 @@ impl MetricsExtractor for Surface {
         let variance = d_div(sum_sq, Decimal::from(z_values.len()), op).map_err(risk_err)?;
         let volatility = variance.sqrt().unwrap_or(Decimal::ZERO);
 
-        // A flat surface has no dispersion, so the Sharpe ratio is undefined;
-        // mirror the zeroed answer `Curve::compute_risk_metrics` returns.
-        if volatility == Decimal::ZERO {
-            return Ok(RiskMetrics {
-                volatility,
-                value_at_risk: Decimal::ZERO,
-                expected_shortfall: Decimal::ZERO,
-                beta: Decimal::ZERO,
-                sharpe_ratio: Decimal::ZERO,
-            });
-        }
-
-        // Value at Risk (95% confidence) using parametric method
+        // Value at Risk (95% confidence) using parametric method. At zero
+        // dispersion this is `mean - 1.645 * 0 = mean`, a deterministic level
+        // rather than an absence of value, so it is computed from the formula
+        // on every path instead of being short-circuited to zero.
         let z_score = dec!(1.645); // 95% confidence interval
         let scaled_vol = d_mul(z_score, volatility, op).map_err(risk_err)?;
         let var = d_sub(mean, scaled_vol, op).map_err(risk_err)?;
@@ -1577,8 +1566,15 @@ impl MetricsExtractor for Surface {
         // Beta calculation with optional market volatility
         let beta = Decimal::ZERO; // TODO: Implement beta calculation
 
-        // Sharpe Ratio (assuming risk-free rate of 0)
-        let sharpe_ratio = d_div(mean, volatility, op).map_err(risk_err)?;
+        // Sharpe Ratio (assuming risk-free rate of 0). A flat surface has no
+        // dispersion to divide by, which makes this the one field that is
+        // genuinely undefined at `volatility == 0`; the others keep their
+        // deterministic limits.
+        let sharpe_ratio = if volatility.is_zero() {
+            Decimal::ZERO
+        } else {
+            d_div(mean, volatility, op).map_err(risk_err)?
+        };
 
         Ok(RiskMetrics {
             volatility,
@@ -1682,22 +1678,22 @@ impl Arithmetic<Surface> for Surface {
                             |a, b| d_mul(a?, b?, op).map_err(construction_err),
                         )?,
                         MergeOperation::Divide => {
-                            let first = z_values.first().cloned().unwrap_or(Decimal::ONE);
-                            z_values
-                                .par_iter()
-                                .skip(1)
-                                .fold(
-                                    || Ok(first),
-                                    |acc: Result<Decimal, SurfaceError>, &val| {
-                                        let acc = acc?;
-                                        if val == Decimal::ZERO {
-                                            Ok(acc)
-                                        } else {
-                                            d_div(acc, val, op).map_err(construction_err)
-                                        }
-                                    },
-                                )
-                                .reduce(|| Ok(first), |a, _b| a)?
+                            // Division is neither associative nor commutative,
+                            // so the divisors are folded in sequence from the
+                            // first value. A parallel fold produces one partial
+                            // per chunk and its reducer would have to discard
+                            // all but one of them, dropping both the trailing
+                            // divisors and any checked-arithmetic error raised
+                            // inside a discarded chunk.
+                            let mut divisors = z_values.iter().copied();
+                            let first = divisors.next().unwrap_or(Decimal::ONE);
+                            divisors.try_fold(first, |acc, val| {
+                                if val == Decimal::ZERO {
+                                    Ok(acc)
+                                } else {
+                                    d_div(acc, val, op).map_err(construction_err)
+                                }
+                            })?
                         }
                         MergeOperation::Max => z_values
                             .par_iter()
@@ -3215,6 +3211,55 @@ mod tests_surface_arithmetic {
         assert_eq!(mid_point.z, dec!(0.0));
     }
 
+    fn constant_surface(height: Decimal) -> Surface {
+        let points =
+            BTreeSet::from_iter([dec!(0.0), dec!(0.5), dec!(1.0)].into_iter().flat_map(|x| {
+                [dec!(0.0), dec!(0.5), dec!(1.0)]
+                    .into_iter()
+                    .map(move |y| Point3D::new(x, y, height))
+            }));
+        Surface::new(points)
+    }
+
+    /// Division is not associative, so the divisors have to be folded in
+    /// sequence. Three surfaces at 8, 2 and 2 must give `8 / 2 / 2 = 2`; a
+    /// reducer that keeps only its left input drops the trailing divisors and
+    /// lands somewhere between 4 and 8.
+    #[test]
+    fn test_merge_divide_folds_every_divisor() {
+        let eight = constant_surface(dec!(8));
+        let two_a = constant_surface(dec!(2));
+        let two_b = constant_surface(dec!(2));
+
+        let result = Surface::merge(&[&eight, &two_a, &two_b], MergeOperation::Divide).unwrap();
+
+        let mid_point = result
+            .interpolate(Point2D::new(dec!(0.5), dec!(0.5)), InterpolationType::Cubic)
+            .unwrap();
+        assert!(
+            (mid_point.z - dec!(2)).abs() < dec!(0.0001),
+            "expected 8 / 2 / 2 = 2, got {}",
+            mid_point.z
+        );
+    }
+
+    /// A divisor that fails the checked division has to surface as an error
+    /// rather than being discarded together with the fold result that
+    /// produced it. `1e20 / 1e-20` is `1e40`, well past `Decimal::MAX`, while
+    /// both operands stay far enough inside the range that the interpolation
+    /// feeding the fold cannot fail first.
+    #[test]
+    fn test_merge_divide_reports_overflow_instead_of_dropping_it() {
+        let tiny = constant_surface(Decimal::new(1, 20));
+        let big = constant_surface(dec!(100000000000000000000));
+
+        let result = Surface::merge(&[&big, &tiny], MergeOperation::Divide);
+        assert!(
+            matches!(result, Err(SurfaceError::ConstructionError(_))),
+            "a quotient outside the Decimal range must be reported, got {result:?}"
+        );
+    }
+
     #[test]
     fn test_incompatible_ranges() {
         let surface1 = Surface::new(BTreeSet::from_iter(vec![
@@ -3388,6 +3433,45 @@ mod tests_metrics {
         // We have a linear trend with slope 2.0
         assert!((metrics.slope - dec!(2.0)).abs() < dec!(0.001));
         assert!((metrics.intercept - dec!(2.0)).abs() < dec!(0.001));
+    }
+
+    /// A flat surface has no uncertainty, but it is not worthless. Only the
+    /// fields that are genuinely undefined at zero dispersion may be zeroed;
+    /// the parametric VaR still has its deterministic limit at the mean.
+    #[test]
+    fn test_risk_metrics_flat_surface_keeps_deterministic_var() {
+        let points = BTreeSet::from_iter((0..3i64).flat_map(|i| {
+            (0..3i64).map(move |j| Point3D::new(Decimal::from(i), Decimal::from(j), dec!(5)))
+        }));
+        let surface = Surface::new(points);
+        let metrics = surface.compute_risk_metrics().unwrap();
+
+        // Measured, and genuinely zero.
+        assert_eq!(metrics.volatility, Decimal::ZERO);
+        // `mean - 1.645 * 0` is the mean, not zero: the surface is worth 5.
+        assert_eq!(metrics.value_at_risk, dec!(5));
+        // No sample falls below the VaR, so the conditional mean has an empty
+        // tail and the function's own empty-tail rule gives zero.
+        assert_eq!(metrics.expected_shortfall, Decimal::ZERO);
+        // Not implemented yet, zero either way.
+        assert_eq!(metrics.beta, Decimal::ZERO);
+        // `mean / 0` is the one genuinely undefined field.
+        assert_eq!(metrics.sharpe_ratio, Decimal::ZERO);
+    }
+
+    /// The same shape with a negative mean: the VaR limit follows the mean
+    /// wherever it sits, so a sign error cannot hide behind a positive value.
+    #[test]
+    fn test_risk_metrics_flat_negative_surface_keeps_deterministic_var() {
+        let points = BTreeSet::from_iter((0..3i64).flat_map(|i| {
+            (0..3i64).map(move |j| Point3D::new(Decimal::from(i), Decimal::from(j), dec!(-2.5)))
+        }));
+        let surface = Surface::new(points);
+        let metrics = surface.compute_risk_metrics().unwrap();
+
+        assert_eq!(metrics.volatility, Decimal::ZERO);
+        assert_eq!(metrics.value_at_risk, dec!(-2.5));
+        assert_eq!(metrics.sharpe_ratio, Decimal::ZERO);
     }
 }
 

--- a/tests/property/curves_panic_freedom_test.rs
+++ b/tests/property/curves_panic_freedom_test.rs
@@ -1,0 +1,394 @@
+//! Property-based tests for panic freedom across curves, surfaces and the
+//! shared geometry helpers.
+//!
+//! The library is embedded in long-running services, where a panic kills the
+//! worker thread and takes the in-flight request with it. Every failure must
+//! therefore come back as a `Result`, including for inputs that are extreme
+//! but structurally valid.
+//!
+//! Geometry fails in two directions at once, so both are driven here. The
+//! numeric axis is the usual `Decimal` domain: coordinates at the smallest
+//! representable scale, at `Decimal::MAX` and `Decimal::MIN`, and the
+//! ordinary values in between. The structural axis is what makes a point set
+//! degenerate rather than merely large: an empty set, a single point, two
+//! points sharing an abscissa (every interpolator divides by `x2 - x1`),
+//! collinear neighbours (barycentric weights divide by a zero triangle area),
+//! a surface that is one row or one column, and a grid with a repeated
+//! `(x, y)`. The assertion is deliberately weak: whatever comes back, it must
+//! come back.
+
+use optionstratlib::curves::{Curve, Point2D, StatisticalCurve};
+use optionstratlib::geometrics::{
+    Arithmetic, AxisOperations, BasicMetrics, ConstructionMethod, ConstructionParams,
+    GeometricObject, GeometricTransformations, Interpolate, InterpolationType,
+    MergeAxisInterpolate, MergeOperation, MetricsExtractor, RangeMetrics, ShapeMetrics,
+    TrendMetrics,
+};
+use optionstratlib::surfaces::{Point3D, Surface};
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::collections::BTreeSet;
+
+/// The smallest representable `Decimal`. Squaring it underflows to zero,
+/// which is what collapses a regression denominator on a curve whose
+/// abscissas are all tiny.
+const TINY: Decimal = Decimal::from_parts(1, 0, 0, false, 28);
+
+/// Coordinates that reach the arithmetic panics: the edges of the `Decimal`
+/// range, the smallest representable scale, and the ordinary values between.
+fn extreme_coordinate() -> impl Strategy<Value = Decimal> {
+    prop_oneof![
+        Just(Decimal::ZERO),
+        Just(TINY),
+        Just(-TINY),
+        Just(dec!(0.5)),
+        Just(dec!(1)),
+        Just(dec!(100)),
+        Just(dec!(-100)),
+        Just(dec!(1000000)),
+        Just(Decimal::MAX),
+        Just(Decimal::MIN),
+    ]
+}
+
+fn interpolation_type() -> impl Strategy<Value = InterpolationType> {
+    prop_oneof![
+        Just(InterpolationType::Linear),
+        Just(InterpolationType::Bilinear),
+        Just(InterpolationType::Cubic),
+        Just(InterpolationType::Spline),
+    ]
+}
+
+fn merge_operation() -> impl Strategy<Value = MergeOperation> {
+    prop_oneof![
+        Just(MergeOperation::Add),
+        Just(MergeOperation::Subtract),
+        Just(MergeOperation::Multiply),
+        Just(MergeOperation::Divide),
+        Just(MergeOperation::Max),
+        Just(MergeOperation::Min),
+    ]
+}
+
+fn curve_from(points: &[(Decimal, Decimal)]) -> Curve {
+    Curve::new(
+        points
+            .iter()
+            .map(|&(x, y)| Point2D::new(x, y))
+            .collect::<BTreeSet<_>>(),
+    )
+}
+
+fn surface_from(points: &[(Decimal, Decimal, Decimal)]) -> Surface {
+    Surface::new(
+        points
+            .iter()
+            .map(|&(x, y, z)| Point3D::new(x, y, z))
+            .collect::<BTreeSet<_>>(),
+    )
+}
+
+/// The structural degeneracies a curve can carry, each paired with the
+/// numeric extreme the strategy draws.
+fn degenerate_curve() -> impl Strategy<Value = Curve> {
+    (extreme_coordinate(), extreme_coordinate(), 0usize..8).prop_map(|(a, b, shape)| {
+        let points: Vec<(Decimal, Decimal)> = match shape {
+            // Empty: nothing to interpolate, index or average over.
+            0 => vec![],
+            // A single point: `len - 1` underflows, the variance has no spread.
+            1 => vec![(a, b)],
+            // Two points: below the window every algorithm but linear needs.
+            2 => vec![(a, b), (dec!(1), dec!(1))],
+            // `Point2D` orders on (x, y) but compares equal on x alone, so a
+            // `BTreeSet` legitimately holds a repeated abscissa.
+            3 => vec![(a, b), (a, dec!(3)), (dec!(2), dec!(4)), (dec!(3), dec!(5))],
+            // Four points, the minimum for cubic and bilinear.
+            4 => vec![(dec!(0), a), (dec!(1), b), (dec!(2), a), (dec!(3), b)],
+            // Flat: zero variance, zero standard deviation.
+            5 => vec![(dec!(0), a), (dec!(1), a), (dec!(2), a), (dec!(3), a)],
+            // Abscissas at the smallest scale: their squares underflow, which
+            // collapses the ordinary-least-squares denominator.
+            6 => vec![
+                (Decimal::ZERO, a),
+                (TINY, b),
+                (TINY + TINY, a),
+                (TINY + TINY + TINY, b),
+            ],
+            // Coordinates spanning the whole `Decimal` range in both axes.
+            _ => vec![
+                (Decimal::MIN, a),
+                (Decimal::ZERO, b),
+                (dec!(1), a),
+                (Decimal::MAX, b),
+            ],
+        };
+        curve_from(&points)
+    })
+}
+
+/// The structural degeneracies a surface can carry.
+fn degenerate_surface() -> impl Strategy<Value = Surface> {
+    (extreme_coordinate(), extreme_coordinate(), 0usize..8).prop_map(|(a, b, shape)| {
+        let points: Vec<(Decimal, Decimal, Decimal)> = match shape {
+            // Empty: every mean divides by zero.
+            0 => vec![],
+            // A single point: no triangle, no spread.
+            1 => vec![(a, b, a)],
+            // Two points: below the three a barycentric weight needs.
+            2 => vec![(dec!(0), dec!(0), a), (dec!(1), dec!(1), b)],
+            // One row: every y is the same.
+            3 => (0..4i64).map(|i| (Decimal::from(i), dec!(0), a)).collect(),
+            // One column: every x is the same, so the trend denominator is
+            // zero.
+            4 => (0..4i64).map(|j| (dec!(0), Decimal::from(j), b)).collect(),
+            // Collinear: the three nearest points span no triangle area.
+            5 => (0..4i64)
+                .map(|i| (Decimal::from(i), Decimal::from(i), a))
+                .collect(),
+            // A repeated `(x, y)` with different z values.
+            6 => vec![
+                (dec!(1), dec!(1), a),
+                (dec!(1), dec!(1), b),
+                (dec!(2), dec!(2), a),
+                (dec!(3), dec!(3), b),
+            ],
+            // A full grid, with z at the numeric extreme.
+            _ => {
+                let mut grid = Vec::new();
+                for i in 0..4i64 {
+                    for j in 0..4i64 {
+                        grid.push((
+                            Decimal::from(i),
+                            Decimal::from(j),
+                            if (i + j) % 2 == 0 { a } else { b },
+                        ));
+                    }
+                }
+                grid
+            }
+        };
+        surface_from(&points)
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Every interpolator returns for every combination of a degenerate point
+    /// set and an extreme query abscissa. This covers the two failures the
+    /// geometry adds to the numeric ones: an out-of-range window index, and a
+    /// zero-length knot interval from a repeated abscissa.
+    #[test]
+    fn test_curve_interpolation_never_panics(
+        curve in degenerate_curve(),
+        kind in interpolation_type(),
+        x in extreme_coordinate(),
+    ) {
+        let _ = curve.interpolate(x, kind);
+        let _ = curve.find_bracket_points(x);
+        let _ = curve.get_closest_point(&x);
+        let _ = curve.get_values(x);
+        let _ = curve.contains_point(&x);
+        let _ = curve.get_point(&x);
+    }
+
+    /// Every metric returns for every degenerate curve, including the empty
+    /// one, the flat one whose standard deviation is zero, and the one whose
+    /// abscissas collapse the regression denominator.
+    #[test]
+    fn test_curve_metrics_never_panic(curve in degenerate_curve()) {
+        let _ = curve.compute_basic_metrics();
+        let _ = curve.compute_shape_metrics();
+        let _ = curve.compute_range_metrics();
+        let _ = curve.compute_trend_metrics();
+        let _ = curve.compute_risk_metrics();
+        let _ = curve.compute_curve_metrics();
+        let _ = curve.get_x_values();
+        let _ = curve.get_index_values();
+        let _ = curve.to_string();
+    }
+
+    /// Every transformation returns, including the ones whose factor or delta
+    /// pushes a coordinate out of the representable range, and the wrong-arity
+    /// argument lists.
+    #[test]
+    fn test_curve_transformations_never_panic(
+        curve in degenerate_curve(),
+        a in extreme_coordinate(),
+        b in extreme_coordinate(),
+    ) {
+        let _ = curve.translate(vec![&a, &b]);
+        let _ = curve.translate(vec![&a]);
+        let _ = curve.translate(vec![]);
+        let _ = curve.scale(vec![&a, &b]);
+        let _ = curve.scale(vec![&a]);
+        let _ = curve.extrema();
+        let _ = curve.measure_under(&a);
+        let _ = curve.derivative_at(&Point2D::new(a, b));
+    }
+
+    /// Merging, intersecting and axis-aligning two independently degenerate
+    /// curves returns, whichever operation is asked for.
+    #[test]
+    fn test_curve_binary_operations_never_panic(
+        left in degenerate_curve(),
+        right in degenerate_curve(),
+        operation in merge_operation(),
+        kind in interpolation_type(),
+    ) {
+        let _ = left.merge_with(&right, operation);
+        let _ = Curve::merge(&[&left, &right], operation);
+        let _ = Curve::merge(&[], operation);
+        let _ = Curve::merge(&[&left], operation);
+        let _ = left.intersect_with(&right);
+        let _ = left.merge_axis_interpolate(&right, kind);
+    }
+
+    /// Parametric construction returns for a zero step count, which divides
+    /// the span by zero, and for a span that overflows the `Decimal` range.
+    #[test]
+    fn test_curve_construction_never_panics(
+        start in extreme_coordinate(),
+        end in extreme_coordinate(),
+        steps in 0usize..4,
+    ) {
+        let _ = Curve::construct(ConstructionMethod::Parametric {
+            f: Box::new(|t: Decimal| Ok(Point2D::new(t, t))),
+            params: ConstructionParams::D2 { t_start: start, t_end: end, steps },
+        });
+        let _ = Curve::construct(ConstructionMethod::<Point2D, Decimal>::FromData {
+            points: BTreeSet::new(),
+        });
+    }
+
+    /// Statistical generation returns for every point count, including counts
+    /// that exceed the abscissas the curve can supply and a target
+    /// distribution with no spread.
+    #[test]
+    fn test_statistical_curve_generation_never_panics(
+        curve in degenerate_curve(),
+        num_points in 0usize..12,
+        std_dev in extreme_coordinate(),
+        mean in extreme_coordinate(),
+    ) {
+        let basic = BasicMetrics { mean, median: mean, mode: mean, std_dev };
+        let shape = ShapeMetrics {
+            skewness: Decimal::ZERO,
+            kurtosis: dec!(3),
+            peaks: vec![],
+            valleys: vec![],
+            inflection_points: vec![],
+        };
+        let range = RangeMetrics {
+            min: Point2D::new(Decimal::ZERO, dec!(5)),
+            max: Point2D::new(dec!(10), dec!(15)),
+            range: dec!(10),
+            quartiles: (dec!(7), dec!(10), dec!(13)),
+            interquartile_range: dec!(6),
+        };
+        let trend = TrendMetrics {
+            slope: dec!(1),
+            intercept: Decimal::ZERO,
+            moving_average: vec![],
+            r_squared: dec!(1),
+        };
+
+        let _ = curve.generate_statistical_curve(
+            &basic, &shape, &range, &trend, num_points, Some(42),
+        );
+        let _ = curve.generate_refined_statistical_curve(
+            &basic, &shape, &range, &trend, num_points, 2, dec!(0.1), Some(42),
+        );
+        let _ = curve.verify_curve_metrics(&curve, &basic, dec!(0.1));
+    }
+
+    /// Every surface interpolator returns for every combination of a
+    /// degenerate point set and an extreme query point, including the
+    /// two-point surface that used to index a third neighbour and the
+    /// collinear one whose barycentric denominator is zero.
+    #[test]
+    fn test_surface_interpolation_never_panics(
+        surface in degenerate_surface(),
+        kind in interpolation_type(),
+        x in extreme_coordinate(),
+        y in extreme_coordinate(),
+    ) {
+        let xy = Point2D::new(x, y);
+        let _ = surface.interpolate(xy, kind);
+        let _ = surface.get_closest_point(&xy);
+        let _ = surface.get_values(xy);
+        let _ = surface.contains_point(&xy);
+        let _ = surface.get_point(&xy);
+        let _ = surface.get_f64_points();
+    }
+
+    /// Every surface metric returns, including on the empty surface where
+    /// every mean divides by zero and the quartile index reads past the end.
+    #[test]
+    fn test_surface_metrics_never_panic(surface in degenerate_surface()) {
+        let _ = surface.compute_basic_metrics();
+        let _ = surface.compute_shape_metrics();
+        let _ = surface.compute_range_metrics();
+        let _ = surface.compute_trend_metrics();
+        let _ = surface.compute_risk_metrics();
+        let _ = surface.get_index_values();
+    }
+
+    /// Every surface transformation returns, at every arity and every extreme.
+    #[test]
+    fn test_surface_transformations_never_panic(
+        surface in degenerate_surface(),
+        a in extreme_coordinate(),
+        b in extreme_coordinate(),
+        c in extreme_coordinate(),
+    ) {
+        let _ = surface.translate(vec![&a, &b, &c]);
+        let _ = surface.translate(vec![&a]);
+        let _ = surface.scale(vec![&a, &b, &c]);
+        let _ = surface.scale(vec![&a]);
+        let _ = surface.extrema();
+        let _ = surface.measure_under(&a);
+        let _ = surface.derivative_at(&Point3D::new(a, b, c));
+    }
+
+    /// Merging, intersecting and axis-aligning two independently degenerate
+    /// surfaces returns, whichever operation is asked for.
+    #[test]
+    fn test_surface_binary_operations_never_panic(
+        left in degenerate_surface(),
+        right in degenerate_surface(),
+        operation in merge_operation(),
+        kind in interpolation_type(),
+    ) {
+        let _ = left.merge_with(&right, operation);
+        let _ = Surface::merge(&[&left, &right], operation);
+        let _ = Surface::merge(&[], operation);
+        let _ = Surface::merge(&[&left], operation);
+        let _ = left.intersect_with(&right);
+        let _ = left.merge_axis_interpolate(&right, kind);
+    }
+
+    /// Parametric surface construction returns for a zero step count on
+    /// either axis and for spans that overflow the `Decimal` range.
+    #[test]
+    fn test_surface_construction_never_panics(
+        x_start in extreme_coordinate(),
+        x_end in extreme_coordinate(),
+        y_start in extreme_coordinate(),
+        y_end in extreme_coordinate(),
+        x_steps in 0usize..3,
+        y_steps in 0usize..3,
+    ) {
+        let _ = Surface::construct(ConstructionMethod::Parametric {
+            f: Box::new(|p: Point2D| Ok(Point3D::new(p.x, p.y, p.x))),
+            params: ConstructionParams::D3 {
+                x_start, x_end, y_start, y_end, x_steps, y_steps,
+            },
+        });
+        let _ = Surface::construct(ConstructionMethod::<Point3D, Point2D>::FromData {
+            points: BTreeSet::new(),
+        });
+    }
+}

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains property-based tests using proptest to verify
 //! mathematical invariants and bounds across a wide range of inputs.
 
+mod curves_panic_freedom_test;
 mod greeks_bounds_test;
 mod panic_freedom_test;
 mod pricing_panic_freedom_test;


### PR DESCRIPTION
## Summary

A probe over the public curve and surface API found **372 panics in 4,108
calls**: 134 `Subtraction overflowed`, 117 `Multiplication overflowed`, 40
`Addition overflowed`, 34 `Division by zero`, 21 `Pow overflowed` and 26
out-of-bounds indexes. The probe is now at **zero**.

Most of them came from ordinary inputs rather than extreme ones, because this
module's degeneracies are geometric, not numeric: an empty point set, a single
point, two points sharing an abscissa, a one-column surface. Every interpolator
divided by `x2 - x1` with the raw operator, and a repeated abscissa is not
hypothetical — `Point2D` orders on `(x, y)` but compares equal on `x` alone, so
a `BTreeSet<Point2D>` legitimately holds both. That inconsistency is left alone
here and tracked in #450; the division now returns
`InterpolationError::DegenerateInterval`, which is what the variant already
documented.

## Breaking change

`create_linear_curve` and `create_constant_curve` now return
`Result<Curve, CurveError>` instead of `Curve`. Both aborted the caller's
process on a span or an ordinate that leaves the `Decimal` range:
`create_linear_curve(-Decimal::MAX, Decimal::MAX, dec!(1))` panicked with
`Subtraction overflowed`, and `create_linear_curve(dec!(0), dec!(10),
Decimal::MAX)` with `Multiplication overflowed`. There is no way to keep an
infallible signature without inventing a value, so **`cargo-semver-checks` will
flag this PR, and that is the intended outcome, not a failure to work around**.
Callers add `?` or `.expect(..)`.

## Other paths that now report instead of aborting

- `compute_trend_metrics` on both curves and surfaces returns
  `MetricsError::TrendError` when the least-squares denominator is zero — every
  abscissa equal, or abscissas so small their squares underflow. A one-column
  surface is the ordinary case that used to abort.
- `bilinear_interpolate` returns `InterpolationError::Bilinear` when its
  four-point window runs past the end of the curve, which is any `x` in the
  last three intervals. Conservative on purpose: it changes no
  currently-working result. Making it usable across the whole domain means
  deciding a numeric answer that is undefined today, which is #451.
- `Surface::linear_interpolate` reports a surface with fewer than three points,
  and three collinear nearest neighbours.
- The surface metrics gained the empty-input and zero-dispersion guards the
  curve metrics already had.
- `generate_statistical_curve` rejects `num_points` above the curve's own
  x-value count instead of indexing past the end.
- `verify_curve_metrics` reports a gap to a target metric that is itself
  unrepresentable.

## The two `panic!` sites

Both are `impl Index<usize>` (`curves/curve.rs`, `surfaces/surface.rs`).
`std::ops::Index::index` returns `&Self::Output` with no fallible channel, so
the choice is to keep the panic or remove a public trait impl. They keep it,
behind `// scan-banned: allow` with the `Vec::index` contract as the argument —
and every internal `self[i]` in the library is gone, which is where 16 of the
372 panics came from. Four files shed their
`#![allow(clippy::indexing_slicing)]` entirely: `curves/curve.rs`,
`curves/traits.rs`, `surfaces/surface.rs` and
`geometrics/interpolation/traits.rs`.

## Technical decisions

The 43 call sites that gained a mechanical `.unwrap()` for the signature change
are all inside `#[cfg(test)] mod` blocks — 39 in `curves/curve.rs`, 4 in
`geometrics/operations/axis.rs`. No assertion or expected value was touched,
and no production call site needed one.

`calculate_prominence` looked reachable and turned out not to be: for its
subtraction to overflow the y-spread must exceed 7.9e28, but
`compute_shape_metrics` computes the variance first and fails above 2.8e14. A
second probe confirmed it over 27 runs, so that file is untouched and keeps its
existing allow.

## Public API impact

`create_linear_curve` and `create_constant_curve` change their return type, as
above. The re-export in `curves/mod.rs` needed no change. Everything else in
the module keeps its signature; the new failures travel through existing error
variants.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [x] Reference regression test added — the existing curve and surface tests
      pass **unedited**, which is the bar for a sweep that must not move a value
- [ ] Criterion benchmark added/updated
- [x] `make pre-push` equivalents run locally and clean

`tests/property/curves_panic_freedom_test.rs` adds 11 properties covering
construction, interpolation, metrics and the statistical helpers over both the
`Decimal` extremes and the structural degeneracies. They also pass at
`PROPTEST_CASES=8192`. One of them found a panic the hand-written probe had not
thought to reach: `verify_curve_metrics` with a `Decimal::MIN` target mean
against an ordinary curve mean.

Suite: **4574 passed, 0 failed, 79 ignored**, with `cargo fmt --all --check`,
`cargo clippy --all-targets --all-features --workspace -- -D warnings` and
`make scan-banned` clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic only — no `saturating_*` / `wrapping_*` in financial math
- [x] `rust_decimal::Decimal` at public monetary boundaries
- [x] Module boundaries respected
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging
- [x] `README.tpl` updated if public surface changed — the two constructors are
      not named in it, so no regeneration is needed

## Stack

- Base branch: `stack/2-444-panic-sweep-pricing` (PR #445)
- Stacked on: #445
- Stack: #441 → #443 → #445 → **#446 (this)** → 442c → 442d → 442e
- The diff is cumulative until #445 merges; review it against the base branch.

Closes #446
