### PR TITLE
Take the Asian moments from the integral, not a shortcut (#454, #447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every arithmetic Asian option with `r = q` was mispriced** (#454). The
+  Turnbull-Wakeman second moment short-circuited its removable `b = 0`
+  singularity to `M2 = S² e^{σ² T}`, which is `E[S_T²]`: the second moment of
+  the *terminal* price, not of its average. The `b → 0` limit of the double
+  integral the function actually implements is
+  `M2 = (2 S² / (σ² T²)) [ (e^{σ² T} − 1) / σ² − T ]`. The stand-in handed the
+  moment matching `σ_adj = σ` where the average carries `σ_adj ≈ σ / √3`, so
+  the price came out far too high and the branch was discontinuous: a one-year
+  ATM call on `S = K = 100`, `σ = 20%`, `r = q = 4%` returned
+  **7.6532330880**, against `4.4308752837` and `4.4308753262` for a carry a
+  billionth either side. It now returns **4.4308753052**, which agrees with
+  quadrature on the defining integral to `3e-10` and with both neighbours to
+  `2.2e-8`. A forward-priced or fully-carried underlying is an ordinary
+  contract, so every pinned `r = q` Asian value moves.
+- **A zero-volatility Asian option priced off the terminal forward instead of
+  the average** (#454). Both kernels short-circuited `σ = 0` to
+  `(S e^{bT} − K)⁺ e^{−rT}`, but a deterministic path still has to be
+  averaged: the geometric mean of `S e^{b t}` over the window is `S e^{bT/2}`
+  and the arithmetic mean is `S (e^{bT} − 1) / (bT)`, which are also the
+  `σ → 0` limits of the Kemna-Vorst and Turnbull-Wakeman formulas the branches
+  stand in for. A one-year ATM call on `S = K = 100`, `r = 5%`, `q = 0`
+  returned **4.8770575499** from both kernels and now returns
+  **2.4080487528** (geometric) and **2.4182085485** (arithmetic). The old
+  value was only correct at `b = 0`, where every average collapses to `S`.
 - **Reachable panic in the lower break-even of eight strategies.**
   `strike - credit` was computed with the raw `Positive - Decimal` operator,
   which panics when the credit (or, on a long structure, the debit) exceeds the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `2.2e-8`. A forward-priced or fully-carried underlying is an ordinary
   contract, so every pinned `r = q` Asian value moves.
 - **A zero-volatility Asian option priced off the terminal forward instead of
-  the average** (#454). Both kernels short-circuited `σ = 0` to
+  the average** (#447). Both kernels short-circuited `σ = 0` to
   `(S e^{bT} − K)⁺ e^{−rT}`, but a deterministic path still has to be
   averaged: the geometric mean of `S e^{b t}` over the window is `S e^{bT/2}`
   and the arithmetic mean is `S (e^{bT} − 1) / (bT)`, which are also the

--- a/src/pricing/asian.rs
+++ b/src/pricing/asian.rs
@@ -51,9 +51,9 @@ use rust_decimal_macros::dec;
 /// - [`PricingError::Decimal`] when an intermediate step leaves the
 ///   representable `Decimal` range: the discount factor, the forward, either
 ///   Turnbull-Wakeman moment, the moment-matched variance, or the final
-///   Black legs. The two removable singularities of the Turnbull-Wakeman
-///   second moment, `b = -σ²` and `b = -σ²/2`, are evaluated at their limits
-///   and never raise.
+///   Black legs. The three removable singularities of the Turnbull-Wakeman
+///   second moment, `b = 0`, `b = -σ²` and `b = -σ²/2`, are evaluated at
+///   their limits and never raise.
 /// - [`PricingError::Positive`] when the `σ / √3` geometric adjustment is not
 ///   representable as a `Positive`.
 pub fn asian_black_scholes(option: &Options) -> Result<Decimal, PricingError> {
@@ -98,32 +98,36 @@ fn geometric_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     }
 
     if sigma == Positive::ZERO {
-        // Deterministic case: the average of a driftless-variance path is the
-        // forward itself, so the option collapses to a discounted intrinsic.
+        // Deterministic path, but the payoff is still on an *average*. The
+        // geometric mean of `S e^{b t}` over the window is
+        //
+        //     exp((1 / T) ∫₀^T (ln S + b t) dt) = S e^{b T / 2},
+        //
+        // the forward carried for half the window, not the terminal forward
+        // `S e^{b T}`. That is also the `σ → 0` value of the Kemna-Vorst legs
+        // below, whose adjusted carry `b_adj = (b - σ² / 6) / 2` tends to
+        // `b / 2` while `σ_adj = σ / √3` tends to zero. The two agree at
+        // `b = 0`, where both collapse to `S`, and differ for every other
+        // carry.
         let t_dec = t.to_dec();
         let discount = d_exp(
             d_mul(-r, t_dec, "pricing::asian::geometric::det::neg_rt")?,
             "pricing::asian::geometric::det::discount",
         )?;
         let carry = d_sub(r, q, "pricing::asian::geometric::det::carry")?;
-        let forward = d_mul(
+        let average = d_mul(
             s.to_dec(),
             d_exp(
-                d_mul(carry, t_dec, "pricing::asian::geometric::det::carry_t")?,
+                d_div(
+                    d_mul(carry, t_dec, "pricing::asian::geometric::det::carry_t")?,
+                    dec!(2),
+                    "pricing::asian::geometric::det::half_carry_t",
+                )?,
                 "pricing::asian::geometric::det::growth",
             )?,
-            "pricing::asian::geometric::det::forward",
+            "pricing::asian::geometric::det::average",
         )?;
-        let intrinsic = match option.option_style {
-            OptionStyle::Call => {
-                d_sub(forward, k.to_dec(), "pricing::asian::geometric::det::call")?
-                    .max(Decimal::ZERO)
-            }
-            OptionStyle::Put => d_sub(k.to_dec(), forward, "pricing::asian::geometric::det::put")?
-                .max(Decimal::ZERO),
-        };
-        let price = d_mul(intrinsic, discount, "pricing::asian::geometric::det::price")?;
-        return Ok(apply_side(price, option));
+        return deterministic_price(average, k.to_dec(), discount, option);
     }
 
     // Geometric average adjustments (Kemna-Vorst)
@@ -236,16 +240,14 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     )?;
 
     if sigma == Positive::ZERO {
+        // Same correction as in the geometric kernel: a deterministic path is
+        // still averaged. The arithmetic mean of `S e^{b t}` over the window
+        // is `M1`, which carries no σ at all, so it is both the `σ → 0` value
+        // of the moment matching below and the answer here. The terminal
+        // forward `S e^{b T}` overstates it for every `b > 0`.
         let carry = d_sub(r, q, "pricing::asian::arithmetic::det::carry")?;
-        let forward = d_mul(
-            s.to_dec(),
-            d_exp(
-                d_mul(carry, t_dec, "pricing::asian::arithmetic::det::carry_t")?,
-                "pricing::asian::arithmetic::det::growth",
-            )?,
-            "pricing::asian::arithmetic::det::forward",
-        )?;
-        return deterministic_price(forward, k.to_dec(), discount, option);
+        let average = arithmetic_average_forward(s.to_dec(), carry, t_dec)?;
+        return deterministic_price(average, k.to_dec(), discount, option);
     }
 
     // Turnbull-Wakeman approximation
@@ -263,24 +265,9 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     )?;
     let b_plus_var = d_add(b, sigma_sq, "pricing::asian::arithmetic::b_plus_var")?;
 
-    // First moment of arithmetic average (M1)
-    let m1 = if b.abs() < dec!(1e-10) {
-        s_dec
-    } else {
-        d_mul(
-            s_dec,
-            d_div(
-                d_sub(
-                    d_exp(bt, "pricing::asian::arithmetic::m1::exp_bt")?,
-                    dec!(1),
-                    "pricing::asian::arithmetic::m1::numerator",
-                )?,
-                bt,
-                "pricing::asian::arithmetic::m1::ratio",
-            )?,
-            "pricing::asian::arithmetic::m1",
-        )?
-    };
+    // First moment of the arithmetic average (M1), including its own
+    // removable singularity at `b = 0`.
+    let m1 = arithmetic_average_forward(s_dec, b, t_dec)?;
 
     // Second moment of arithmetic average (M2).
     //
@@ -291,22 +278,82 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     //     M2 = (2 S² / T²) ∫₀^T e^{b u} ∫₀^u e^{a t} dt du
     //        = (2 S² / (a T²)) [ (e^{c T} - 1) / c - (e^{b T} - 1) / b ],
     //
-    // which is the closed form expanded in the `else` branch below. Two of its
-    // three denominators are removable: at `a = 0` (`b = -σ²`) and at `c = 0`
-    // (`b = -σ²/2`) the vanishing factor is cancelled by a bracket that
-    // vanishes with it, and M2 stays finite. Both limits below were taken by
-    // going back to the integral and evaluating the degenerate exponential
-    // directly instead of dividing by its rate — `∫₀^u e^{0·t} dt = u` for
-    // `a = 0`, `∫₀^T e^{0·u} du = T` for `c = 0` — which is the same value as
+    // which is the closed form expanded in the `else` branch below. All three
+    // of its denominators are removable: at `b = 0` (`r = q`), at `a = 0`
+    // (`b = -σ²`) and at `c = 0` (`b = -σ²/2`) the vanishing factor is
+    // cancelled by a bracket that vanishes with it, and M2 stays finite. Every
+    // limit below was taken by going back to the integral and evaluating the
+    // degenerate exponential directly instead of dividing by its rate —
+    // `∫₀^T e^{0·u} du = T` for `b = 0`, `∫₀^u e^{0·t} dt = u` for `a = 0`,
+    // `∫₀^T e^{0·u} du = T` again for `c = 0` — which is the same value as
     // differentiating the bracket at the zero. They are exact, not
-    // approximations. `r = 0, q = 4%, σ = 20%, T = 1` lands exactly on `a = 0`
-    // and is an ordinary contract, so neither boundary may raise.
+    // approximations. `r = q` lands on `b = 0` and `r = 0, q = 4%, σ = 20%,
+    // T = 1` lands exactly on `a = 0`; both are ordinary contracts, so no
+    // boundary may raise.
     let m2 = if b.abs() < dec!(1e-10) {
-        let term = d_exp(
-            d_mul(sigma_sq, t_dec, "pricing::asian::arithmetic::m2::var_t")?,
-            "pricing::asian::arithmetic::m2::exp_var_t",
-        )?;
-        d_mul(s_sq, term, "pricing::asian::arithmetic::m2::driftless")?
+        // `b → 0`, i.e. `r = q`. The outer growth term degenerates to
+        // `∫₀^T e^{0·u} du` and the inner rate to `a = σ²`, so
+        //
+        //     M2 = (2 S² / T²) ∫₀^T ∫₀^u e^{σ² t} dt du
+        //        = (2 S² / T²) ∫₀^T (e^{σ² u} - 1) / σ² du
+        //        = (2 S² / (σ² T²)) [ (e^{σ² T} - 1) / σ² - T ],
+        //
+        // the second integration having used `∫₀^T e^{σ² u} du =
+        // (e^{σ² T} - 1) / σ²` and `∫₀^T du = T`. The general form tends to
+        // the same value: `a, c → σ²` and `(e^{b T} - 1) / b → T`.
+        //
+        // This is *not* `S² e^{σ² T}`, which is `E[S_T²]` — the second moment
+        // of the terminal price rather than of its average. At `σ = 20%,
+        // T = 1` they are `1.01347 S²` against `1.04081 S²`, and the moment
+        // matching turns that gap into `σ_adj = σ` instead of the correct
+        // `σ_adj ≈ σ / √3`. `r = q` is a forward-priced or fully-carried
+        // underlying, so this branch has to be the limit and not a stand-in.
+        if sigma_sq.is_zero() {
+            // σ² underflowed `Decimal`'s 28-digit scale (σ < 1e-14). The
+            // bracket above is `σ² T² / 2 + O(σ⁴)`, so the nested `σ² → 0`
+            // limit of the whole expression is exactly `S²`, and there is no
+            // need to divide by the variance that vanished.
+            s_sq
+        } else {
+            let exp_var_t = d_exp(
+                d_mul(
+                    sigma_sq,
+                    t_dec,
+                    "pricing::asian::arithmetic::m2::b_limit::var_t",
+                )?,
+                "pricing::asian::arithmetic::m2::b_limit::exp_var_t",
+            )?;
+            let bracket = d_sub(
+                d_div(
+                    d_sub(
+                        exp_var_t,
+                        dec!(1),
+                        "pricing::asian::arithmetic::m2::b_limit::exp_var_t_less_one",
+                    )?,
+                    sigma_sq,
+                    "pricing::asian::arithmetic::m2::b_limit::first",
+                )?,
+                t_dec,
+                "pricing::asian::arithmetic::m2::b_limit::bracket",
+            )?;
+            d_mul(
+                d_div(
+                    d_mul(
+                        dec!(2),
+                        s_sq,
+                        "pricing::asian::arithmetic::m2::b_limit::two_s_sq",
+                    )?,
+                    d_mul(
+                        sigma_sq,
+                        t_sq,
+                        "pricing::asian::arithmetic::m2::b_limit::denominator",
+                    )?,
+                    "pricing::asian::arithmetic::m2::b_limit::scale",
+                )?,
+                bracket,
+                "pricing::asian::arithmetic::m2::b_limit",
+            )?
+        }
     } else if b_plus_var.abs() < dec!(1e-10) {
         // `a → 0`, i.e. `b = -σ²`. The inner integral degenerates to
         // `∫₀^u dt = u`, leaving
@@ -547,6 +594,42 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     Ok(apply_side(price, option))
 }
 
+/// Arithmetic average of the deterministic carry path, `S (e^{bT} - 1) / (bT)`.
+///
+/// This is the Turnbull-Wakeman first moment `M1`. It carries no volatility:
+/// the mean of `S e^{b t}` over `[0, T]` is the same whether or not the path
+/// fluctuates around it, so the expression doubles as the `σ → 0` value of
+/// the arithmetic average.
+///
+/// The `b → 0` singularity is removable and the limit is `S` itself:
+/// `(e^{bT} - 1) / (bT) = 1 + bT/2 + (bT)²/6 + … → 1`. The same `1e-10`
+/// threshold as the second moment selects it, so the two moments switch to
+/// their limits together.
+///
+/// # Errors
+///
+/// Returns [`PricingError::Decimal`] when `e^{bT}` or the product with `S`
+/// leaves the representable `Decimal` range.
+fn arithmetic_average_forward(s: Decimal, b: Decimal, t: Decimal) -> Result<Decimal, PricingError> {
+    if b.abs() < dec!(1e-10) {
+        return Ok(s);
+    }
+    let bt = d_mul(b, t, "pricing::asian::average_forward::bt")?;
+    Ok(d_mul(
+        s,
+        d_div(
+            d_sub(
+                d_exp(bt, "pricing::asian::average_forward::exp_bt")?,
+                dec!(1),
+                "pricing::asian::average_forward::numerator",
+            )?,
+            bt,
+            "pricing::asian::average_forward::ratio",
+        )?,
+        "pricing::asian::average_forward",
+    )?)
+}
+
 /// Discounted intrinsic on a known average, i.e. the `σ → 0` limit of the
 /// Black formula used by both Asian kernels.
 fn deterministic_price(
@@ -730,6 +813,160 @@ mod tests {
             at,
             above
         );
+    }
+
+    /// `S = K = 100`, `T = 1`, `σ = 20%`, `q = 4%`, so the Turnbull-Wakeman
+    /// carry is `b = r - 4%` and the risk-free rate alone selects the
+    /// boundary: `r = 4%` puts `b` on zero. That is a fully-carried
+    /// underlying, i.e. a forward-priced contract, not an edge case.
+    fn create_zero_carry_option(risk_free_rate: Decimal) -> Options {
+        Options::new(
+            OptionType::Asian {
+                averaging_type: AsianAveragingType::Arithmetic,
+            },
+            Side::Long,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(365.0)),
+            Positive::new_decimal(dec!(0.2)).unwrap(),
+            Positive::ONE,
+            Positive::HUNDRED,
+            risk_free_rate,
+            OptionStyle::Call,
+            Positive::new_decimal(dec!(0.04)).unwrap(),
+            None,
+        )
+    }
+
+    /// `S = K = 100`, `T = 1`, `r = 5%`, `q = 0`: a carried underlying on a
+    /// deterministic path, whose payoff is still struck against an *average*.
+    fn create_deterministic_option(
+        averaging_type: AsianAveragingType,
+        implied_volatility: Positive,
+    ) -> Options {
+        Options::new(
+            OptionType::Asian { averaging_type },
+            Side::Long,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(365.0)),
+            implied_volatility,
+            Positive::ONE,
+            Positive::HUNDRED,
+            dec!(0.05),
+            OptionStyle::Call,
+            Positive::ZERO,
+            None,
+        )
+    }
+
+    /// `b = 0` zeroes the outer rate of the Turnbull-Wakeman second moment.
+    /// Removable like the other two, and the limit is emphatically not
+    /// `S² e^{σ² T}`: quadrature on the defining double integral gives
+    /// `M2 = 1.0134677405 S²`, which prices at `4.4308753050`.
+    #[test]
+    fn test_arithmetic_asian_zero_carry_prices_the_average() {
+        let option = create_zero_carry_option(dec!(0.04));
+        let price = asian_black_scholes(&option).unwrap();
+
+        assert_decimal_eq!(price, dec!(4.4308753050), dec!(1e-6));
+
+        // The matched volatility has to land just above the geometric-average
+        // volatility `σ / √3`, so the two prices must sit close together. The
+        // terminal second moment would have matched the spot `σ = 20%`
+        // instead and priced this contract at `7.6532`, more than `3.3` above
+        // the geometric leg.
+        let mut geometric = option.clone();
+        geometric.option_type = OptionType::Asian {
+            averaging_type: AsianAveragingType::Geometric,
+        };
+        let geometric_price = asian_black_scholes(&geometric).unwrap();
+        assert_decimal_eq!(geometric_price, dec!(4.2581167661), dec!(1e-6));
+        assert!(
+            geometric_price < price && price < geometric_price + dec!(0.25),
+            "arithmetic {} must sit just above geometric {}",
+            price,
+            geometric_price
+        );
+    }
+
+    /// The limit branch has to agree with the general formula evaluated a hair
+    /// off the boundary, otherwise it is merely a value and not the limit.
+    ///
+    /// The tolerance is `1e-7`. A `1e-9` shift in `r` moves the price by about
+    /// `2.1e-8` through the genuine `dP/dr ≈ 21` sensitivity, and the general
+    /// branch holds its precision at `|b| = 1e-9` despite the cancellation
+    /// between its two terms — the two neighbours below straddle the limit and
+    /// are only `4.3e-8` apart from each other. `1e-7` therefore clears the
+    /// real sensitivity while the terminal-moment stand-in would miss by `3.2`.
+    #[test]
+    fn test_arithmetic_asian_zero_carry_boundary_is_continuous() {
+        let at = asian_black_scholes(&create_zero_carry_option(dec!(0.04))).unwrap();
+        let below = asian_black_scholes(&create_zero_carry_option(dec!(0.039999999))).unwrap();
+        let above = asian_black_scholes(&create_zero_carry_option(dec!(0.040000001))).unwrap();
+
+        assert_decimal_eq!(at, below, dec!(1e-7));
+        assert_decimal_eq!(at, above, dec!(1e-7));
+        assert!(
+            below < at && at < above,
+            "the price must stay monotone in r across the boundary: {} {} {}",
+            below,
+            at,
+            above
+        );
+    }
+
+    /// A volatility under `1e-14` squares to zero at `Decimal`'s scale, which
+    /// would make the vanishing-carry branch divide by the variance it just
+    /// lost. The nested `σ² → 0` limit is `M2 = S²`, matching `M1²`, so the
+    /// matched variance is zero and the contract prices as the discounted
+    /// intrinsic on the average — `b = 0`, so that average is `S` itself.
+    #[test]
+    fn test_arithmetic_asian_zero_carry_underflowed_volatility_prices() {
+        let mut option = create_zero_carry_option(dec!(0.04));
+        option.underlying_price = pos_or_panic!(110.0);
+        option.implied_volatility = Positive::new_decimal(dec!(1e-15)).unwrap();
+
+        let price = asian_black_scholes(&option).unwrap();
+
+        // (110 - 100) e^{-0.04}.
+        assert_decimal_eq!(price, dec!(9.6078943915), dec!(1e-9));
+    }
+
+    /// A deterministic path is still averaged: the geometric mean of
+    /// `S e^{b t}` over `[0, T]` is `S e^{bT/2}`, not the terminal forward
+    /// `S e^{bT}`. `(100 e^{0.025} - 100) e^{-0.05} = 2.4080487528`.
+    #[test]
+    fn test_geometric_asian_zero_volatility_averages_the_path() {
+        let option = create_deterministic_option(AsianAveragingType::Geometric, Positive::ZERO);
+        let price = asian_black_scholes(&option).unwrap();
+
+        assert_decimal_eq!(price, dec!(2.4080487528), dec!(1e-9));
+
+        // And it is the `σ → 0` limit of the Kemna-Vorst legs rather than a
+        // separate convention: at `σ = 1e-6` the closed form is already there.
+        let near = create_deterministic_option(
+            AsianAveragingType::Geometric,
+            Positive::new_decimal(dec!(1e-6)).unwrap(),
+        );
+        assert_decimal_eq!(price, asian_black_scholes(&near).unwrap(), dec!(1e-9));
+    }
+
+    /// Same for the arithmetic kernel, where the average of the deterministic
+    /// path is `M1 = S (e^{bT} - 1) / (bT)`.
+    /// `(102.5421927520 - 100) e^{-0.05} = 2.4182085485`.
+    #[test]
+    fn test_arithmetic_asian_zero_volatility_averages_the_path() {
+        let option = create_deterministic_option(AsianAveragingType::Arithmetic, Positive::ZERO);
+        let price = asian_black_scholes(&option).unwrap();
+
+        assert_decimal_eq!(price, dec!(2.4182085485), dec!(1e-9));
+
+        let near = create_deterministic_option(
+            AsianAveragingType::Arithmetic,
+            Positive::new_decimal(dec!(1e-6)).unwrap(),
+        );
+        assert_decimal_eq!(price, asian_black_scholes(&near).unwrap(), dec!(1e-9));
     }
 
     #[test]

--- a/src/pricing/asian.rs
+++ b/src/pricing/asian.rs
@@ -308,32 +308,48 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
         // matching turns that gap into `σ_adj = σ` instead of the correct
         // `σ_adj ≈ σ / √3`. `r = q` is a forward-priced or fully-carried
         // underlying, so this branch has to be the limit and not a stand-in.
-        if sigma_sq.is_zero() {
-            // σ² underflowed `Decimal`'s 28-digit scale (σ < 1e-14). The
-            // bracket above is `σ² T² / 2 + O(σ⁴)`, so the nested `σ² → 0`
-            // limit of the whole expression is exactly `S²`, and there is no
-            // need to divide by the variance that vanished.
-            s_sq
+        //
+        // Collecting the whole expression on `x = σ² T` gives the form
+        // evaluated below,
+        //
+        //     M2 = 2 S² (e^x - 1 - x) / x² = S² (1 + x/3 + x²/12 + …),
+        //
+        // one division shorter and, since `e^x - 1 - x` is an exact `Decimal`
+        // subtraction, carrying every digit `e^x` had.
+        let x = d_mul(
+            sigma_sq,
+            t_dec,
+            "pricing::asian::arithmetic::m2::b_limit::var_t",
+        )?;
+        if x < dec!(1e-6) {
+            // `e^x` is stored to 28 decimal places, so the `x² / 2` that
+            // leads `e^x - 1 - x` sinks below that floor as `x` shrinks and
+            // the closed form loses it: at `x = 1e-14` it valued a worthless
+            // contract at 31, and below `x ≈ 1e-13` the `2 S² / x²` scale
+            // leaves `Decimal` altogether. The two-term series truncates at
+            // `x² / 12`, a relative `x / 4 ≤ 2.5e-7` on the matched variance,
+            // against the closed form's `6e-28 / x³`; they cross at
+            // `x ≈ 2e-7`, so below `1e-6` the series is the better of the
+            // two. It also absorbs `σ² = 0` (σ under `1e-14` underflows the
+            // scale), where `M2 = S²` exactly and there is nothing to divide
+            // by.
+            d_mul(
+                s_sq,
+                d_add(
+                    Decimal::ONE,
+                    d_div(x, dec!(3), "pricing::asian::arithmetic::m2::b_limit::third")?,
+                    "pricing::asian::arithmetic::m2::b_limit::series",
+                )?,
+                "pricing::asian::arithmetic::m2::b_limit::small_variance",
+            )?
         } else {
-            let exp_var_t = d_exp(
-                d_mul(
-                    sigma_sq,
-                    t_dec,
-                    "pricing::asian::arithmetic::m2::b_limit::var_t",
-                )?,
-                "pricing::asian::arithmetic::m2::b_limit::exp_var_t",
-            )?;
             let bracket = d_sub(
-                d_div(
-                    d_sub(
-                        exp_var_t,
-                        dec!(1),
-                        "pricing::asian::arithmetic::m2::b_limit::exp_var_t_less_one",
-                    )?,
-                    sigma_sq,
-                    "pricing::asian::arithmetic::m2::b_limit::first",
+                d_sub(
+                    d_exp(x, "pricing::asian::arithmetic::m2::b_limit::exp_x")?,
+                    Decimal::ONE,
+                    "pricing::asian::arithmetic::m2::b_limit::exp_x_less_one",
                 )?,
-                t_dec,
+                x,
                 "pricing::asian::arithmetic::m2::b_limit::bracket",
             )?;
             d_mul(
@@ -343,11 +359,7 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
                         s_sq,
                         "pricing::asian::arithmetic::m2::b_limit::two_s_sq",
                     )?,
-                    d_mul(
-                        sigma_sq,
-                        t_sq,
-                        "pricing::asian::arithmetic::m2::b_limit::denominator",
-                    )?,
+                    d_mul(x, x, "pricing::asian::arithmetic::m2::b_limit::x_sq")?,
                     "pricing::asian::arithmetic::m2::b_limit::scale",
                 )?,
                 bracket,
@@ -931,6 +943,50 @@ mod tests {
 
         // (110 - 100) e^{-0.04}.
         assert_decimal_eq!(price, dec!(9.6078943915), dec!(1e-9));
+    }
+
+    /// Below `x = σ² T = 1e-6` the vanishing-carry branch sums the series
+    /// instead of evaluating `e^x - 1 - x`, whose leading `x² / 2` would sink
+    /// under `Decimal`'s 28-decimal floor. The two have to meet at the
+    /// threshold: `σ = 0.001` puts `x` exactly on `1e-6`, so the neighbours
+    /// below and above are priced by different formulas. The tolerance is
+    /// `1e-7`; the genuine `dP/dσ ≈ 22.13` accounts for `2.2e-8` of each
+    /// measured gap and the formulas themselves differ by `2.8e-9`.
+    #[test]
+    fn test_arithmetic_asian_zero_carry_small_variance_series_matches_closed_form() {
+        let mut option = create_zero_carry_option(dec!(0.04));
+
+        option.implied_volatility = Positive::new_decimal(dec!(0.000999999)).unwrap();
+        let series = asian_black_scholes(&option).unwrap();
+        option.implied_volatility = Positive::new_decimal(dec!(0.001)).unwrap();
+        let at = asian_black_scholes(&option).unwrap();
+        option.implied_volatility = Positive::new_decimal(dec!(0.001000001)).unwrap();
+        let closed_form = asian_black_scholes(&option).unwrap();
+
+        assert_decimal_eq!(series, at, dec!(1e-7));
+        assert_decimal_eq!(closed_form, at, dec!(1e-7));
+        assert!(
+            series < at && at < closed_form,
+            "the price must stay monotone in σ across the threshold: {} {} {}",
+            series,
+            at,
+            closed_form
+        );
+    }
+
+    /// A near-zero volatility must leave a near-zero price. The closed form
+    /// cannot deliver that on its own: at `σ = 1e-7` (`x = 1e-14`) it loses
+    /// the whole `x² / 2` to rounding and prices this worthless contract at
+    /// `31`. The series keeps the matched volatility at `σ / √3`, so the
+    /// price stays the Black value `e^{-0.04} · 100 · (2 N(σ_adj / 2) - 1)`.
+    #[test]
+    fn test_arithmetic_asian_zero_carry_tiny_volatility_stays_proportional() {
+        let mut option = create_zero_carry_option(dec!(0.04));
+        option.implied_volatility = Positive::new_decimal(dec!(1e-7)).unwrap();
+
+        let price = asian_black_scholes(&option).unwrap();
+
+        assert_decimal_eq!(price, dec!(0.0000022129811), dec!(1e-11));
     }
 
     /// A deterministic path is still averaged: the geometric mean of


### PR DESCRIPTION
## Summary

Three branches of the Asian pricing short-circuited to an expression that is
not the limit of the formula they short-circuit. This closes both #454 (the
driftless second moment) and #447 (the zero-volatility forward), because they
land on the same lines and splitting them would have meant rebasing one onto
the other for no reviewer benefit.

**The driftless second moment used `M2 = S² e^{σ²T}`.** The `b → 0` limit of
the integral the function actually implements,

```
E[A²] = (2 S² / T²) ∫₀^T e^{bu} ∫₀^u e^{at} dt du
```

is `(2 S² / (σ²T²)) · [ (e^{σ²T} − 1)/σ² − T ]`, derived the same way #445
derived the other two removable boundaries: evaluate the degenerate exponential
rather than divide by its vanishing rate.

The gap is not cosmetic. At `σ = 20%`, `T = 1` the old branch handed the moment
matching `σ_adj = 0.20` where the correct value is `0.11566` — **it was pricing
an arithmetic Asian at full spot volatility**. Every contract with `r = q` was
affected, which is a forward-priced or fully-carried underlying, not an edge
case.

**The zero-volatility short-circuits had the same shape of error in a different
variable.** Both returned the terminal forward `S e^{bT}`. The arithmetic
average of a deterministic path is `M1`; the geometric average is `S e^{bT/2}`.
The geometric branch disagreed with its own Kemna-Vorst legs everywhere except
exactly at `b = 0` — the cleanest evidence available that it was wrong rather
than a different convention.

## Prices moved

| contract | before | after |
|---|---|---|
| `S=K=100, T=1, σ=20%, r=q=4%` | 7.6532330880 | **4.4308753052** |
| `S=K=100, T=0.5, σ=25%, r=q=5%` | 6.8693005996 | **3.9746021865** |
| `σ=0, S=K=100, T=1, r=5%, q=0` geometric | 4.8770575499 | **2.4080487528** |
| same, arithmetic | 4.8770575499 | **2.4182085485** |

Every "before" figure was measured from the crate at `HEAD`, not reconstructed.
Both entries are in `CHANGELOG.md` under `[Unreleased]`.

## What is unchanged, and why that is structural

`M1`'s own driftless branch is correct: `(e^{bT} − 1)/(bT) → 1`, so `M1 → S`.
It is unchanged in value, and is now extracted into a shared
`arithmetic_average_forward` helper so the zero-volatility branch reuses the
expression instead of duplicating a guard.

The Kemna-Vorst legs have no defect: `b` enters only through
`b_adj = (b − σ²/6)/2`, which is linear, so `b = 0` is an ordinary point and
the function is analytic there.

**The general `else` branch is untouched.** Prices away from these boundaries
are therefore unchanged by construction rather than by testing, and the
existing reference tests pass unedited.

For `σ < 1e-14` the variance underflows `Decimal`'s scale; the bracket is
`σ²T²/2 + O(σ⁴)`, so the nested limit is exactly `S²` and the branch returns
it rather than dividing by the variance that vanished.

## Verification

Three independent ways, because a limit that is only exercised is not proven:

1. **Series limit of the closed form** — `(e^{bT} − 1)/b → T`, `a, c → σ²`
   gives the same expression, and the `else` branch was confirmed to be
   algebraically the reference bracket, so it is the right thing to take the
   limit of.
2. **Quadrature on the double integral** (40 digits): `M2 = 1.0134677405 S²`
   at `σ = 20%, T = 1`, price `4.4308753049687568`. The crate now returns
   `4.4308753052434734` — agreement to **2.7e-10**. This is the check that does
   not assume the closed form is right.
3. **Continuity against the general branch either side of the boundary**:

| shift in `r` | gap after | gap before |
|---|---|---|
| −1e-9 | 2.152e-8 | 3.2224 |
| +1e-9 | 2.097e-8 | 3.2224 |
| −1e-10 | 2.400e-9 | 3.2224 |
| +1e-10 | 1.850e-9 | 3.2224 |

The stated tolerance is `1e-7`, which clears the genuine `dP/dr ≈ 21`
sensitivity with room. The test also asserts monotonicity in `r` across the
boundary.

## Testing

- [x] Unit tests added or updated
- [x] Reference regression test — the existing Asian reference tests pass
      **unedited**; no assertion was changed
- [x] `cargo test --all-features --workspace` — 3942 lib, 423 integration,
      40 property, 207 doc, 0 failures
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features
      --workspace -- -D warnings`, `make scan-banned` and `make
      public-api-check` clean

## Public API impact

None. No signature changes; the new helper is private.

## Stack

- Base branch: `main`
- Independent of #460 (the `strategies/` sweep), which touches no pricing file.

Closes #454
Closes #447
