### PR TITLE
Implement the chooser formula the module documents (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returned **4.8770575499** from both kernels and now returns
   **2.4080487528** (geometric) and **2.4182085485** (arithmetic). The old
   value was only correct at `b = 0`, where every average collapses to `S`.
+- **The simple chooser was priced with the wrong formula (#448).**
+  `chooser_black_scholes` discounted its two `y` legs at the choice date `t`
+  instead of at expiry `T`, and built `y1` from `b*t` where Rubinstein (1991)
+  has `b*T + σ²*t/2`, so every simple chooser came out too expensive. On
+  Haug's worked example (S = K = 50, t = 0.25, T = 0.5, r = b = 0.08,
+  σ = 0.25; reference **6.1071**) the function returned **6.524120** and now
+  returns **6.107077**: 6.8% high before, within 1e-14 of the closed form now.
+  The module doc already stated the corrected formula; the code did not
+  implement it.
+- With no diffusion left to run to the choice date (`σ√t` collapsing to zero)
+  the surviving branch is now picked on the sign of `ln(S/K) + b*T`, the
+  forward moneyness at expiry, rather than on `ln(S/K)`. A chooser whose spot
+  sits below the strike but whose forward sits above it prices as the call,
+  not as the put. A zero numerator, which that limit used to report as an
+  undefined `0 / 0`, is exactly forward parity — where call and put are worth
+  the same — and now returns that common value instead of an error (#448).
 - **Reachable panic in the lower break-even of eight strategies.**
   `strike - credit` was computed with the raw `Positive - Decimal` operator,
   which panics when the credit (or, on a long structure, the debit) exceeds the

--- a/src/pricing/chooser.rs
+++ b/src/pricing/chooser.rs
@@ -627,7 +627,8 @@ mod tests {
         );
         let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
 
-        assert_decimal_eq!(chooser_price, call_price + put_price, dec!(1e-6));
+        let parity = d_add(call_price, put_price, "test::chooser::parity").unwrap();
+        assert_decimal_eq!(chooser_price, parity, dec!(1e-6));
     }
 
     /// Same identity with a dividend yield, so the `e^(-q(T-t))` scale on the
@@ -657,7 +658,9 @@ mod tests {
         let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
         let scale = f64_to_decimal((-q * gap_years).exp()).unwrap();
 
-        assert_decimal_eq!(chooser_price, call_price + put_price * scale, dec!(1e-6));
+        let scaled_put = d_mul(put_price, scale, "test::chooser::scaled_put").unwrap();
+        let parity = d_add(call_price, scaled_put, "test::chooser::parity").unwrap();
+        assert_decimal_eq!(chooser_price, parity, dec!(1e-6));
     }
 
     /// A choice horizon of zero leaves no diffusion, so `σ√t` collapses and
@@ -731,7 +734,8 @@ mod tests {
         let put = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Put);
         let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
 
-        assert_decimal_eq!(price, call_price + put_price, dec!(1e-8));
+        let straddle = d_add(call_price, put_price, "test::chooser::straddle").unwrap();
+        assert_decimal_eq!(price, straddle, dec!(1e-8));
     }
 
     /// The closed form and the `price_at_choice_equals_expiry` branch have to

--- a/src/pricing/chooser.rs
+++ b/src/pricing/chooser.rs
@@ -11,17 +11,42 @@
 //!
 //! # Simple Chooser (Rubinstein 1991)
 //!
-//! At the choice date t, the holder chooses max(Call, Put).
+//! At the choice date t, the holder chooses max(Call, Put). Both branches
+//! share one strike K and one expiry T, which is what makes the chooser
+//! *simple*. A complex chooser carries a separate strike and expiry per
+//! branch, needs a bivariate normal and a root solve for the indifference
+//! spot, and is not implemented here.
+//!
 //! The value is:
 //!
-//! `V = S*e^(-qT)*N(d1) - K*e^(-rT)*N(d2) + K*e^(-rt)*N(-y2) - S*e^(-qt)*N(-y1)`
+//! `V = S*e^(-qT)*N(d1) - K*e^(-rT)*N(d2) + K*e^(-rT)*N(-y2) - S*e^(-qT)*N(-y1)`
 //!
 //! Where:
 //! - T = time to final expiration
 //! - t = time to choice date
 //! - d1, d2 are standard BS d-values for T
-//! - y1 = [ln(S/K) + b*t + (σ²/2)*t] / (σ√t)
+//! - y1 = [ln(S/K) + b*T + (σ²/2)*t] / (σ√t)
 //! - y2 = y1 - σ√t
+//!
+//! Two details are easy to get wrong, and both follow from the same
+//! decomposition. Put-call parity at the choice date gives
+//!
+//! `max(C_t, P_t) = C_t + max(0, K*e^(-r(T-t)) - S_t*e^(-q(T-t)))`
+//!
+//! so a chooser is a T-expiry call plus `e^(-q(T-t))` puts expiring at t,
+//! struck at the discounted forward `K*e^(-b(T-t))`. The d-values of that
+//! embedded put are exactly y1 and y2. Hence:
+//!
+//! - the `y` legs discount over the **full** life T, not over t: the
+//!   embedded put's own `e^(-rt)` discount combines with the strike
+//!   adjustment `e^(-b(T-t))` back into `e^(-rT)`;
+//! - the `y` drift mixes horizons — the carry runs to T, the variance only
+//!   to t — because the choice is made at t but settles at T.
+//!
+//! Reference: Haug, *The Complete Guide to Option Pricing Formulas*, 2nd ed.,
+//! §2.5.1 "Simple Chooser Options"; original result Rubinstein (1991),
+//! "Options for the Undecided". Haug's worked example (S = K = 50, t = 0.25,
+//! T = 0.5, r = b = 0.08, σ = 0.25) prices at 6.1071.
 
 use crate::Options;
 use crate::error::PricingError;
@@ -31,7 +56,6 @@ use crate::model::types::OptionType;
 use positive::Positive;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use std::cmp::Ordering;
 
 /// Prices a Chooser option using Rubinstein (1991) simple chooser formula.
 ///
@@ -47,9 +71,7 @@ use std::cmp::Ordering;
 ///
 /// - [`PricingError::MethodError`] when `option` is not an
 ///   [`OptionType::Chooser`] variant, when the expiration cannot be converted
-///   to a year fraction, when the `d1` / `d2` kernels reject the inputs, or
-///   when both the choice-date diffusion `σ√t` and the log-moneyness collapse
-///   to zero, which leaves `y1` genuinely undefined.
+///   to a year fraction, or when the `d1` / `d2` kernels reject the inputs.
 /// - [`PricingError::Decimal`] when an intermediate step leaves the
 ///   representable `Decimal` range: the discount factors, the zero-volatility
 ///   forward, `y1` / `y2`, or the four price legs.
@@ -151,25 +173,32 @@ fn simple_chooser_price(option: &Options, choice_date_days: f64) -> Result<Decim
         .map_err(|e: crate::error::GreeksError| PricingError::other(&e.to_string()))?;
 
     // d-values for the choice date t
-    // y1 = [ln(S/K) + (b + σ²/2)*t] / (σ√t)
+    // y1 = [ln(S/K) + b*T + (σ²/2)*t] / (σ√t)
     // y2 = y1 - σ√t
+    //
+    // The two horizons do not collapse into one: the carry accrues over the
+    // full life T because the chooser settles at T, while only the variance
+    // realised up to the choice date t is still uncertain when the holder
+    // decides.
     let sigma_dec = sigma.to_dec();
     let sigma_sqrt_t_choice = d_mul(
         sigma_dec,
         sqrt_t_choice,
         "pricing::chooser::sigma_sqrt_t_choice",
     )?;
-    let drift = d_mul(
-        d_add(
-            b,
-            d_div(
-                d_mul(sigma_dec, sigma_dec, "pricing::chooser::variance")?,
-                dec!(2),
-                "pricing::chooser::half_variance",
-            )?,
-            "pricing::chooser::drift_rate",
+    let carry_to_expiry = d_mul(b, t_big_dec, "pricing::chooser::carry_to_expiry")?;
+    let half_variance_to_choice = d_mul(
+        d_div(
+            d_mul(sigma_dec, sigma_dec, "pricing::chooser::variance")?,
+            dec!(2),
+            "pricing::chooser::half_variance",
         )?,
         t_choice_dec,
+        "pricing::chooser::half_variance_to_choice",
+    )?;
+    let drift = d_add(
+        carry_to_expiry,
+        half_variance_to_choice,
         "pricing::chooser::drift",
     )?;
     let moneyness = d_div(s.to_dec(), k.to_dec(), "pricing::chooser::moneyness")?;
@@ -186,21 +215,26 @@ fn simple_chooser_price(option: &Options, choice_date_days: f64) -> Result<Decim
     };
 
     // `N(-y)` at the choice date. When the choice-date diffusion `σ√t`
-    // collapses to zero the exponents diverge and the CDF saturates at the
-    // sign of the numerator; `0 / 0` stays genuinely undefined and is
-    // reported rather than guessed.
+    // collapses to zero the exponents diverge and both CDFs saturate at the
+    // sign of the numerator, which then reads `ln(S/K) + b*T`. That is the
+    // sign of `C - P = e^(-rT) * (S*e^(bT) - K)`: with no diffusion left the
+    // holder must choose now, and takes the branch the forward favours.
+    // Saturating to zero keeps the call legs and drops the `y` legs;
+    // saturating to one turns the sum into the put by parity.
+    //
+    // A zero numerator leaves `y1` at `0 / 0`, but the *price* is no longer
+    // ambiguous: it says `S*e^(bT) = K`, where call and put are worth the
+    // same, so both saturations return the same number. The call branch is
+    // taken rather than reporting an error.
     let (n_neg_y1, n_neg_y2) = match (y1_numerator, sigma_sqrt_t_choice.is_zero()) {
         (None, _) => (Decimal::ONE, Decimal::ONE),
-        (Some(numerator), true) => match numerator.cmp(&Decimal::ZERO) {
-            Ordering::Greater => (Decimal::ZERO, Decimal::ZERO),
-            Ordering::Less => (Decimal::ONE, Decimal::ONE),
-            Ordering::Equal => {
-                return Err(PricingError::method_error(
-                    "simple_chooser_price",
-                    "choice-date diffusion and log-moneyness both collapsed to zero",
-                ));
+        (Some(numerator), true) => {
+            if numerator < Decimal::ZERO {
+                (Decimal::ONE, Decimal::ONE)
+            } else {
+                (Decimal::ZERO, Decimal::ZERO)
             }
-        },
+        }
         (Some(numerator), false) => {
             let y1 = d_div(numerator, sigma_sqrt_t_choice, "pricing::chooser::y1")?;
             let y2 = d_sub(y1, sigma_sqrt_t_choice, "pricing::chooser::y2")?;
@@ -215,7 +249,8 @@ fn simple_chooser_price(option: &Options, choice_date_days: f64) -> Result<Decim
     let n_d1 = big_n(d1_val).unwrap_or(Decimal::ZERO);
     let n_d2 = big_n(d2_val).unwrap_or(Decimal::ZERO);
 
-    // Discount factors
+    // Discount factors. Every leg settles at T, the `y` legs included: the
+    // choice date only fixes which branch survives, not when it pays.
     let dividend_discount_t = d_exp(
         d_mul(-q, t_big_dec, "pricing::chooser::neg_qt")?,
         "pricing::chooser::dividend_discount_t",
@@ -224,54 +259,23 @@ fn simple_chooser_price(option: &Options, choice_date_days: f64) -> Result<Decim
         d_mul(-r, t_big_dec, "pricing::chooser::neg_rt")?,
         "pricing::chooser::discount_t",
     )?;
-    let dividend_discount_choice = d_exp(
-        d_mul(-q, t_choice_dec, "pricing::chooser::neg_qt_choice")?,
-        "pricing::chooser::dividend_discount_choice",
-    )?;
-    let discount_choice = d_exp(
-        d_mul(-r, t_choice_dec, "pricing::chooser::neg_rt_choice")?,
-        "pricing::chooser::discount_choice",
-    )?;
 
-    // Rubinstein (1991) simple chooser formula:
-    // V = S*e^(-qT)*N(d1) - K*e^(-rT)*N(d2) + K*e^(-rt)*N(-y2) - S*e^(-qt)*N(-y1)
+    // Rubinstein (1991) simple chooser formula, Haug 2nd ed. §2.5.1:
+    // V = S*e^(-qT)*N(d1) - K*e^(-rT)*N(d2) + K*e^(-rT)*N(-y2) - S*e^(-qT)*N(-y1)
     // This equals: Call(K, T) + Put_component_for_choice_flexibility.
-    // Every leg is now built via two chained `d_mul` calls so the
-    // leading monetary product (underlying * dividend discount, or
-    // strike * discount) is checked and a subsequent saturation on
-    // the CDF weight cannot mask the original overflow.
-    let leg_s_t_discounted = d_mul(
+    // The two monetary products are formed once and checked before any CDF
+    // weight multiplies in, so a saturating weight cannot mask an overflow
+    // in `S * e^(-qT)` or `K * e^(-rT)`.
+    let s_pv = d_mul(
         s.to_dec(),
         dividend_discount_t,
-        "pricing::chooser::price::leg_s_t_discounted",
+        "pricing::chooser::price::s_pv",
     )?;
-    let leg_s_t = d_mul(leg_s_t_discounted, n_d1, "pricing::chooser::price::leg_s_t")?;
-    let leg_k_t_discounted = d_mul(
-        k.to_dec(),
-        discount_t,
-        "pricing::chooser::price::leg_k_t_discounted",
-    )?;
-    let leg_k_t = d_mul(leg_k_t_discounted, n_d2, "pricing::chooser::price::leg_k_t")?;
-    let leg_k_choice_discounted = d_mul(
-        k.to_dec(),
-        discount_choice,
-        "pricing::chooser::price::leg_k_choice_discounted",
-    )?;
-    let leg_k_choice = d_mul(
-        leg_k_choice_discounted,
-        n_neg_y2,
-        "pricing::chooser::price::leg_k_choice",
-    )?;
-    let leg_s_choice_discounted = d_mul(
-        s.to_dec(),
-        dividend_discount_choice,
-        "pricing::chooser::price::leg_s_choice_discounted",
-    )?;
-    let leg_s_choice = d_mul(
-        leg_s_choice_discounted,
-        n_neg_y1,
-        "pricing::chooser::price::leg_s_choice",
-    )?;
+    let k_pv = d_mul(k.to_dec(), discount_t, "pricing::chooser::price::k_pv")?;
+    let leg_s_t = d_mul(s_pv, n_d1, "pricing::chooser::price::leg_s_t")?;
+    let leg_k_t = d_mul(k_pv, n_d2, "pricing::chooser::price::leg_k_t")?;
+    let leg_k_choice = d_mul(k_pv, n_neg_y2, "pricing::chooser::price::leg_k_choice")?;
+    let leg_s_choice = d_mul(s_pv, n_neg_y1, "pricing::chooser::price::leg_s_choice")?;
     let diff1 = d_sub(leg_s_t, leg_k_t, "pricing::chooser::price::diff1")?;
     let diff2 = d_add(diff1, leg_k_choice, "pricing::chooser::price::diff2")?;
     let price = d_sub(diff2, leg_s_choice, "pricing::chooser::price")?;
@@ -362,6 +366,7 @@ mod tests {
     use super::*;
     use crate::ExpirationDate;
     use crate::assert_decimal_eq;
+    use crate::model::decimal::f64_to_decimal;
     use crate::model::types::{OptionStyle, OptionType, Side};
     use positive::pos_or_panic;
     use rust_decimal_macros::dec;
@@ -519,6 +524,235 @@ mod tests {
         let price = chooser_black_scholes(&option).unwrap();
         // ITM put intrinsic = 10
         assert_decimal_eq!(price, dec!(10.0), dec!(0.01));
+    }
+
+    /// Builds a chooser with every parameter spelled out, for the reference
+    /// regressions below. `expiry_days` and `choice_days` are calendar days
+    /// on the Actual/365 convention the crate uses everywhere.
+    #[allow(clippy::too_many_arguments)]
+    fn chooser_with(
+        underlying: f64,
+        strike: f64,
+        expiry_days: f64,
+        choice_days: f64,
+        sigma: f64,
+        rate: Decimal,
+        dividend: f64,
+    ) -> Options {
+        Options::new(
+            OptionType::Chooser {
+                choice_date: pos_or_panic!(choice_days),
+            },
+            Side::Long,
+            "TEST".to_string(),
+            pos_or_panic!(strike),
+            ExpirationDate::Days(pos_or_panic!(expiry_days)),
+            pos_or_panic!(sigma),
+            Positive::ONE,
+            pos_or_panic!(underlying),
+            rate,
+            OptionStyle::Call,
+            pos_or_panic!(dividend),
+            None,
+        )
+    }
+
+    /// Builds the European leg used to cross-check the chooser decomposition.
+    fn european(
+        underlying: f64,
+        strike: f64,
+        expiry_days: f64,
+        sigma: f64,
+        rate: Decimal,
+        dividend: f64,
+        style: OptionStyle,
+    ) -> Options {
+        Options::new(
+            OptionType::European,
+            Side::Long,
+            "TEST".to_string(),
+            pos_or_panic!(strike),
+            ExpirationDate::Days(pos_or_panic!(expiry_days)),
+            pos_or_panic!(sigma),
+            Positive::ONE,
+            pos_or_panic!(underlying),
+            rate,
+            style,
+            pos_or_panic!(dividend),
+            None,
+        )
+    }
+
+    /// Haug, *The Complete Guide to Option Pricing Formulas*, 2nd ed.,
+    /// §2.5.1 "Simple Chooser Options", worked example: S = X = 50,
+    /// t = 0.25, T = 0.5, r = b = 0.08, σ = 0.25, value 6.1071.
+    ///
+    /// This is the acceptance test for #448. Before the fix the function
+    /// discounted the `y` legs at the choice date instead of at expiry and
+    /// used `b*t` where the formula has `b*T + σ²*t/2`, returning 6.5241.
+    #[test]
+    fn test_simple_chooser_haug_example_matches_reference() {
+        // 182.5 / 365 = 0.5 years to expiry, 91.25 / 365 = 0.25 to the choice.
+        let option = chooser_with(50.0, 50.0, 182.5, 91.25, 0.25, dec!(0.08), 0.0);
+        let price = chooser_black_scholes(&option).unwrap();
+        assert_decimal_eq!(price, dec!(6.1071), dec!(1e-4));
+    }
+
+    /// `max(C_t, P_t) = C_t + max(0, P_t - C_t)` at the choice date. By
+    /// put-call parity the second term is `e^(-q(T-t))` puts expiring at t
+    /// struck at the discounted forward `K*e^(-b(T-t))`, so the chooser must
+    /// equal a T-expiry call plus that scaled t-expiry put. Checked without
+    /// dividends, where the scale factor is one.
+    #[test]
+    fn test_simple_chooser_equals_call_plus_forward_struck_put() {
+        let (s, k, expiry_days, choice_days, sigma, r) =
+            (50.0, 50.0, 182.5, 91.25, 0.25, dec!(0.08));
+        let chooser = chooser_with(s, k, expiry_days, choice_days, sigma, r, 0.0);
+        let chooser_price = chooser_black_scholes(&chooser).unwrap();
+
+        let call = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Call);
+        let call_price = crate::pricing::black_scholes_model::black_scholes(&call).unwrap();
+
+        // K * e^(-b(T-t)) with b = r (no dividends).
+        let carry_gap = 0.08 * (expiry_days - choice_days) / 365.0;
+        let adjusted_strike = k * (-carry_gap).exp();
+        let put = european(
+            s,
+            adjusted_strike,
+            choice_days,
+            sigma,
+            r,
+            0.0,
+            OptionStyle::Put,
+        );
+        let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
+
+        assert_decimal_eq!(chooser_price, call_price + put_price, dec!(1e-6));
+    }
+
+    /// Same identity with a dividend yield, so the `e^(-q(T-t))` scale on the
+    /// embedded put is exercised rather than collapsing to one.
+    #[test]
+    fn test_simple_chooser_equals_call_plus_forward_struck_put_with_dividend() {
+        // S = 100, K = 95, t = 0.25, T = 0.75, r = 0.06, q = 0.03, σ = 0.30.
+        let (s, k, expiry_days, choice_days, sigma, r, q) =
+            (100.0, 95.0, 273.75, 91.25, 0.30, dec!(0.06), 0.03);
+        let chooser = chooser_with(s, k, expiry_days, choice_days, sigma, r, q);
+        let chooser_price = chooser_black_scholes(&chooser).unwrap();
+
+        let call = european(s, k, expiry_days, sigma, r, q, OptionStyle::Call);
+        let call_price = crate::pricing::black_scholes_model::black_scholes(&call).unwrap();
+
+        let gap_years = (expiry_days - choice_days) / 365.0;
+        let adjusted_strike = k * (-(0.06 - q) * gap_years).exp();
+        let put = european(
+            s,
+            adjusted_strike,
+            choice_days,
+            sigma,
+            r,
+            q,
+            OptionStyle::Put,
+        );
+        let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
+        let scale = f64_to_decimal((-q * gap_years).exp()).unwrap();
+
+        assert_decimal_eq!(chooser_price, call_price + put_price * scale, dec!(1e-6));
+    }
+
+    /// A choice horizon of zero leaves no diffusion, so `σ√t` collapses and
+    /// both CDFs saturate on the sign of `ln(S/K) + b*T`. Spot is *below* the
+    /// strike here but the forward is above it, so the call must win: the
+    /// pre-#448 numerator reduced to `ln(S/K)` and would have returned the put.
+    #[test]
+    fn test_simple_chooser_zero_choice_horizon_follows_the_forward_not_the_spot() {
+        let (s, k, expiry_days, sigma, r) = (99.0, 100.0, 182.5, 0.25, dec!(0.08));
+        let option = chooser_with(s, k, expiry_days, 0.0, sigma, r, 0.0);
+        let price = chooser_black_scholes(&option).unwrap();
+
+        let call = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Call);
+        let call_price = crate::pricing::black_scholes_model::black_scholes(&call).unwrap();
+        let put = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Put);
+        let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
+
+        assert!(
+            call_price > put_price,
+            "forward is above the strike, so the call must be richer: {call_price} vs {put_price}"
+        );
+        assert_decimal_eq!(price, call_price, dec!(1e-8));
+    }
+
+    /// The other side of the same limit: a forward far below the strike makes
+    /// the numerator negative, both CDFs saturate at one, and the sum collapses
+    /// to the put by parity.
+    #[test]
+    fn test_simple_chooser_zero_choice_horizon_deep_otm_call_returns_the_put() {
+        let (s, k, expiry_days, sigma, r) = (80.0, 100.0, 182.5, 0.25, dec!(0.08));
+        let option = chooser_with(s, k, expiry_days, 0.0, sigma, r, 0.0);
+        let price = chooser_black_scholes(&option).unwrap();
+
+        let put = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Put);
+        let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
+
+        assert_decimal_eq!(price, put_price, dec!(1e-8));
+    }
+
+    /// At the forward-parity spot `S*e^(bT) = K` the `y1` numerator is zero,
+    /// which used to be reported as an undefined `0 / 0`. With the corrected
+    /// numerator the price is no longer ambiguous — call and put are worth the
+    /// same there — so the function returns that common value.
+    #[test]
+    fn test_simple_chooser_zero_choice_horizon_at_forward_parity_prices_the_tie() {
+        // S = 100 * e^(-0.08 * 0.5) puts the forward exactly on the strike.
+        let (k, expiry_days, sigma, r) = (100.0, 182.5, 0.25, dec!(0.08));
+        let s = k * (-0.04f64).exp();
+        let option = chooser_with(s, k, expiry_days, 0.0, sigma, r, 0.0);
+        let price = chooser_black_scholes(&option).unwrap();
+
+        let call = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Call);
+        let call_price = crate::pricing::black_scholes_model::black_scholes(&call).unwrap();
+        let put = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Put);
+        let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
+
+        assert_decimal_eq!(call_price, put_price, dec!(1e-8));
+        assert_decimal_eq!(price, call_price, dec!(1e-8));
+    }
+
+    /// Choosing at expiry is choosing after the fact, which is a straddle:
+    /// `max((S-K)+, (K-S)+)` pays whichever leg finished in the money.
+    #[test]
+    fn test_choice_at_expiry_equals_straddle() {
+        let (s, k, expiry_days, sigma, r) = (100.0, 100.0, 182.5, 0.25, dec!(0.05));
+        let option = chooser_with(s, k, expiry_days, expiry_days, sigma, r, 0.0);
+        let price = chooser_black_scholes(&option).unwrap();
+
+        let call = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Call);
+        let call_price = crate::pricing::black_scholes_model::black_scholes(&call).unwrap();
+        let put = european(s, k, expiry_days, sigma, r, 0.0, OptionStyle::Put);
+        let put_price = crate::pricing::black_scholes_model::black_scholes(&put).unwrap();
+
+        assert_decimal_eq!(price, call_price + put_price, dec!(1e-8));
+    }
+
+    /// The closed form and the `price_at_choice_equals_expiry` branch have to
+    /// meet: as t approaches T, `y1` tends to `d1` and `y2` to `d2`, and the
+    /// formula collapses to the straddle. A tenth of a day short of expiry the
+    /// gap is already under a cent, and the chooser stays below the straddle.
+    #[test]
+    fn test_simple_chooser_converges_to_the_straddle_as_choice_nears_expiry() {
+        let (s, k, expiry_days, sigma, r) = (100.0, 100.0, 182.5, 0.25, dec!(0.05));
+        let price =
+            chooser_black_scholes(&chooser_with(s, k, expiry_days, 182.4, sigma, r, 0.0)).unwrap();
+
+        let straddle =
+            chooser_black_scholes(&chooser_with(s, k, expiry_days, expiry_days, sigma, r, 0.0))
+                .unwrap();
+
+        assert!(
+            price < straddle,
+            "an earlier choice cannot be worth more than choosing at expiry: {price} vs {straddle}"
+        );
+        assert_decimal_eq!(price, straddle, dec!(0.01));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The module header documents Rubinstein's simple chooser. The body did not
implement it, and the price was **6.83% high** against Haug's published
example.

Two defects, which are the same mistake seen twice:

| | before | after |
|---|---|---|
| `y1` numerator | `ln(S/K) + (b + σ²/2)·t` | `ln(S/K) + b·T + σ²·t/2` |
| `y` leg discounts | `K·e^{-rt}`, `S·e^{-qt}` | `K·e^{-rT}`, `S·e^{-qT}` |

Parity at the choice date gives
`max(C_t, P_t) = C_t + max(0, K·e^{-r(T−t)} − S_t·e^{-q(T−t)})`, so a chooser
is a `T`-expiry call plus `e^{-q(T−t)}` puts expiring at `t`, struck at the
discounted forward. The embedded put's own d-values *are* `y1`/`y2`, and its
`e^{-rt}` discount recombines with the strike adjustment `e^{-b(T−t)}` back
into `e^{-rT}`. That is why the carry runs to expiry while only the variance
runs to the choice date.

## The number

| | value |
|---|---|
| before | 6.524120579621281140947825628 |
| after | **6.107077498162327583120889761** |
| Haug, published | 6.1071 |
| independent recomputation | 6.107077498162337 |

Reference: Haug, *The Complete Guide to Option Pricing Formulas*, 2nd ed.,
§2.5.1; original result Rubinstein (1991), "Options for the Undecided". The
"before" figure was reproduced by reverting the two numeric defects in place,
not reconstructed.

## The #445 limit changes with it

The zero-diffusion limit keeps its saturation structure, but its discriminant
depends on the numerator this PR corrects. The sign test is now
`ln(S/K) + b·T` — the sign of `C − P = e^{-rT}(S·e^{bT} − K)` — rather than the
spot moneyness `ln(S/K)`.

With no diffusion left the holder chooses immediately and takes whichever
branch the forward favours, so the old test was wrong for every spot between
the strike and the forward. At `S = 99, K = 100, T = 0.5, r = b = 8%` it priced
the put at 5.5075 and now prices the call at 8.4285.

That also makes the `Ordering::Equal` error spurious. A zero numerator now
means `S·e^{bT} = K`, forward parity, where both saturations return the same
number — so the branch returns that common value instead of reporting an
indeterminacy that no longer exists. The `# Errors` doc drops the clause; no
signature change.

## Naming

This is the **simple** chooser, not the complex one, and the issue title is
wrong. `OptionType::Chooser { choice_date }` carries one strike and one
expiry, and Haug's 6.1071 is his simple-chooser example. His complex chooser
takes separate call and put strikes and expiries, needs a bivariate normal and
a root solve for the indifference spot, and cannot be expressed by this
variant at all.

## Testing

- [x] Unit tests added or updated
- [x] Reference regression test — `test_simple_chooser_haug_example_matches_reference`
      pins 6.1071 at 1e-4
- [x] **No existing test was re-baselined.** Nothing pinned the wrong 6.5241,
      which is why the defect survived
- [x] `cargo test --all-features --workspace` — 3945 lib, 423 integration,
      40 property, 207 doc, 0 failures
- [x] `cargo fmt --all --check`, clippy `-D warnings`, `make scan-banned` and
      `make public-api-check` clean

New coverage: the Haug regression; the zero-horizon limit following the
forward rather than the spot, in both directions; forward parity pricing the
tie; and the `max(C, P) = C + max(0, P − C)` identity with and without
dividends, so the `e^{-q(T−t)}` scale on the embedded puts is exercised.

## Public API impact

None. No signature changes; the file stays panic-free as of #445.

## Stack

- Base branch: `main`, independent of every other open line.

Closes #448
