### PR TITLE
Make the point types agree with themselves (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `S = 110`, `K = 100` is unchanged at `14.877057549928595`, since a call on
   a non-dividend-paying forward is never exercised early while `r > 0`; flip
   the rate to `r = −5%` and it moves from `4.872890362397602` to `10`.
+- **`Point2D` and `Point3D` compare, order and hash on all their coordinates**
+  (#450). Both types broke the `Ord` contract, which requires `a == b` exactly
+  when `a.cmp(&b)` is `Ordering::Equal`: `Point2D` compared equal on `x` alone
+  while ordering on `(x, y)`, and `Point3D` compared equal on `(x, y)` while
+  ordering on `(x, y, z)`. Two points could be equal *and* strictly ordered.
+  `PartialEq` now reads every coordinate on both types, and `Point3D` gains a
+  `Hash` impl (it had none). Ordering is unchanged.
+- **A surface no longer loses half its grid when its axes are merged.**
+  `Surface` indexes itself by `Point2D` through `AxisOperations<Point3D,
+  Point2D>`, and `merge_indexes` deduplicates those indices in a `HashSet`.
+  With `Point2D` hashing on `x` alone, every column of the grid collapsed onto
+  a single cell: merging a 2x2 surface with itself produced **two** indices
+  instead of four, and `merge_axis_interpolate` then worked from the truncated
+  axis. It now keeps all of them. Anything asserting the narrow result will
+  see more indices, and more interpolated points, than before.
+- **A `BTreeSet` of points no longer depends on how it was built.**
+  `BTreeSet::from_iter` (and therefore `collect`) sorts and then deduplicates
+  adjacent elements with `PartialEq`, while `insert` deduplicates with `Ord`.
+  While those two disagreed, the same points produced different sets by
+  different routes: four `Point3D` stacked on one xy-coordinate collected to a
+  set of **one** and inserted to a set of **four**. Collecting now keeps every
+  distinct point, so `Surface::get_curve` returns the whole projection — an
+  `n`-by-`m` grid yields up to `n * m` points where it used to yield `n`,
+  having silently dropped all but the greatest ordinate per abscissa. Curves
+  collected from an option chain are unaffected, their abscissae being unique
+  strikes.
+- `Surface::bilinear_interpolate` now reports `"Invalid quadrilateral"` for
+  points stacked on one xy-coordinate. That check existed but was unreachable:
+  the collapse above reduced such a set to a single point first, so the
+  `"Need at least four points"` guard answered instead.
+- Membership probes against `Point2D` / `Point3D` are now exact. Code doing
+  `points.contains(&probe)`, `points.iter().any(|p| p == &probe)` or
+  `HashSet`/`BTreeSet` lookups used to match any point sharing the probe's
+  leading coordinates; it now matches only the point itself. Nothing in the
+  crate relied on the loose behaviour except `merge_indexes` above, but a
+  downstream caller might.
 - **`OptionData::apply_spread` widens a thin quote instead of withdrawing it**
   (#439). A contract whose mid sat below one full spread used to lose `bid`,
   `ask` **and** `middle`. Both sides are now quoted around the mid — `mid ±

--- a/public-api/optionstratlib.txt
+++ b/public-api/optionstratlib.txt
@@ -9516,6 +9516,8 @@ impl core::convert::From<&optionstratlib::surfaces::Point3D> for optionstratlib:
 pub fn optionstratlib::surfaces::Point3D::from(&optionstratlib::surfaces::Point3D) -> Self
 impl core::fmt::Display for optionstratlib::surfaces::Point3D
 pub fn optionstratlib::surfaces::Point3D::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for optionstratlib::surfaces::Point3D
+pub fn optionstratlib::surfaces::Point3D::hash<H: core::hash::Hasher>(&self, &mut H)
 impl optionstratlib::geometrics::AxisOperations<optionstratlib::surfaces::Point3D, optionstratlib::curves::Point2D> for optionstratlib::surfaces::Surface
 pub type optionstratlib::surfaces::Surface::Error = optionstratlib::error::SurfaceError
 pub fn optionstratlib::surfaces::Surface::contains_point(&self, &optionstratlib::curves::Point2D) -> bool
@@ -26152,6 +26154,8 @@ impl core::convert::From<&optionstratlib::surfaces::Point3D> for optionstratlib:
 pub fn optionstratlib::surfaces::Point3D::from(&optionstratlib::surfaces::Point3D) -> Self
 impl core::fmt::Display for optionstratlib::surfaces::Point3D
 pub fn optionstratlib::surfaces::Point3D::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for optionstratlib::surfaces::Point3D
+pub fn optionstratlib::surfaces::Point3D::hash<H: core::hash::Hasher>(&self, &mut H)
 impl optionstratlib::geometrics::AxisOperations<optionstratlib::surfaces::Point3D, optionstratlib::curves::Point2D> for optionstratlib::surfaces::Surface
 pub type optionstratlib::surfaces::Surface::Error = optionstratlib::error::SurfaceError
 pub fn optionstratlib::surfaces::Surface::contains_point(&self, &optionstratlib::curves::Point2D) -> bool

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -120,6 +120,19 @@ impl Curve {
     ///
     /// - [`Point2D`]: The type of points used to define the curve.
     /// - [`crate::curves::Curve::calculate_range`]: Computes the x-range of a set of points.
+    /// # Duplicate abscissae
+    ///
+    /// [`Point2D`] orders on the full `(x, y)` pair, so `points` may hold
+    /// several ordinates for one abscissa and `new` stores them all. Most of
+    /// the crate treats a curve as single-valued in `x` —
+    /// [`Curve::get_point`] returns the first match, [`Curve::merge`]
+    /// resamples onto one shared x-grid — and the interpolators reject a
+    /// repeated abscissa with [`InterpolationError::DegenerateInterval`],
+    /// since the slope over a zero-width interval is undefined.
+    ///
+    /// Whether such a curve should be rejected, normalized or supported is
+    /// unresolved: [`crate::surfaces::Surface::get_curve`] produces one
+    /// legitimately, by projecting a grid. See issue #466.
     #[must_use]
     pub fn new(points: BTreeSet<Point2D>) -> Self {
         let x_range = Self::calculate_range(points.iter().map(|p| p.x));

--- a/src/curves/types.rs
+++ b/src/curves/types.rs
@@ -79,7 +79,10 @@ impl Display for Point2D {
 /// onto one cell whenever those indices pass through a `HashSet`.
 ///
 /// The "one ordinate per abscissa" rule is a property of a *curve*, not of a
-/// point; [`crate::curves::Curve`] enforces it at construction.
+/// point, and it is a container-level invariant that nothing currently
+/// enforces: [`crate::curves::Curve::new`] stores a repeated abscissa
+/// unchanged, and whether such a curve should be rejected, normalized or
+/// supported is deferred to issue #466.
 impl PartialEq for Point2D {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y

--- a/src/curves/types.rs
+++ b/src/curves/types.rs
@@ -66,9 +66,23 @@ impl Display for Point2D {
     }
 }
 
+/// Two points are equal when both coordinates are equal.
+///
+/// `PartialEq`, `Ord` and `Hash` all read the full `(x, y)` pair, so
+/// `a == b` holds exactly when `a.cmp(&b)` is [`Ordering::Equal`], and equal
+/// points hash alike. `Ord` requires that agreement.
+///
+/// Comparing on `x` alone would also break `Point2D` in its second role: it
+/// is the *index* type of a surface (`AxisOperations<Point3D, Point2D>`),
+/// where it names a coordinate in the xy-plane and `z` is the dependent
+/// value. An x-only `Eq`/`Hash` collapses every column of a surface grid
+/// onto one cell whenever those indices pass through a `HashSet`.
+///
+/// The "one ordinate per abscissa" rule is a property of a *curve*, not of a
+/// point; [`crate::curves::Curve`] enforces it at construction.
 impl PartialEq for Point2D {
     fn eq(&self, other: &Self) -> bool {
-        self.x == other.x
+        self.x == other.x && self.y == other.y
     }
 }
 
@@ -76,8 +90,11 @@ impl Eq for Point2D {}
 
 impl Hash for Point2D {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.x.mantissa().hash(state);
-        self.x.scale().hash(state);
+        // Delegate to `Decimal`'s own `Hash`, which normalizes first. Hashing
+        // the raw mantissa and scale would give `dec!(1.0)` and `dec!(1.00)`
+        // different hashes even though they compare equal.
+        self.x.hash(state);
+        self.y.hash(state);
     }
 }
 
@@ -87,6 +104,8 @@ impl PartialOrd for Point2D {
     }
 }
 
+/// Orders on `(x, y)`, lexicographically: the same pair [`PartialEq`] reads,
+/// so `cmp` returns [`Ordering::Equal`] exactly when the points are equal.
 impl Ord for Point2D {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.x.cmp(&other.x) {
@@ -313,6 +332,15 @@ mod tests {
         }
     }
 
+    /// Equality reads both coordinates.
+    ///
+    /// This test used to assert `p1 == p3` and `p1 == p4` — that points
+    /// sharing an abscissa were equal whatever their ordinate. That is the
+    /// contract this type no longer has: `test_comparison_operators` below
+    /// asserts `p1 < p3` on the very same two values, and `Ord` requires
+    /// `a == b` exactly when `a.cmp(&b)` is `Equal`. Only one of the two
+    /// could survive, and the ordering is the one the rest of the crate
+    /// relies on (`BTreeSet<Point2D>`, and `Point2D` as a surface index).
     #[test]
     fn test_equal() {
         let p1 = Point2D::from_f64_tuple(1.0, 2.0).unwrap();
@@ -320,10 +348,47 @@ mod tests {
         let p3 = Point2D::from_f64_tuple(1.0, 3.0).unwrap();
         let p4 = Point2D::from_f64_tuple(1.0, 4.0).unwrap();
         let p5 = Point2D::from_f64_tuple(2.0, 2.0).unwrap();
+
+        // Both coordinates equal.
         assert_eq!(p1, p2);
-        assert_eq!(p1, p3);
-        assert_eq!(p1, p4);
+        // Same abscissa, different ordinate: distinct points.
+        assert_ne!(p1, p3);
+        assert_ne!(p1, p4);
+        // Different abscissa.
         assert_ne!(p1, p5);
+    }
+
+    /// `Eq` and `Ord` agree, which is what `Ord` requires of an implementor.
+    #[test]
+    fn test_eq_agrees_with_ord() {
+        let p1 = Point2D::from_f64_tuple(1.0, 2.0).unwrap();
+        let p2 = Point2D::from_f64_tuple(1.0, 2.0).unwrap();
+        let p3 = Point2D::from_f64_tuple(1.0, 3.0).unwrap();
+
+        assert_eq!(p1.cmp(&p2), Ordering::Equal);
+        assert_eq!(p1 == p2, p1.cmp(&p2) == Ordering::Equal);
+        assert_eq!(p1 == p3, p1.cmp(&p3) == Ordering::Equal);
+    }
+
+    /// `Hash` agrees with `Eq`, including across `Decimal` scales: `1.0` and
+    /// `1.00` compare equal, so they must hash alike. The previous
+    /// implementation hashed the raw mantissa and scale and failed this.
+    #[test]
+    fn test_hash_agrees_with_eq() {
+        use std::collections::HashSet;
+
+        let p1 = Point2D::new(dec!(1.0), dec!(2.0));
+        let scaled = Point2D::new(dec!(1.00), dec!(2.000));
+        let other_y = Point2D::new(dec!(1.0), dec!(3.0));
+
+        assert_eq!(p1, scaled);
+        assert_ne!(p1, other_y);
+
+        let set: HashSet<Point2D> = [p1, scaled, other_y].into_iter().collect();
+        // `p1` and `scaled` are one entry; `other_y` is a second.
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&p1));
+        assert!(set.contains(&other_y));
     }
 }
 
@@ -599,6 +664,12 @@ mod tests_edge_cases {
         assert!(debug_str.contains("-2.25"));
     }
 
+    /// Ordering is lexicographic on `(x, y)`.
+    ///
+    /// The `p1 < p3` block below is unchanged, but it used to contradict
+    /// `test_equal`, which asserted `p1 == p3` on the same two values: a
+    /// point could be both equal to and less than another. `PartialEq` now
+    /// reads `y` as well, so the two tests agree.
     #[test]
     fn test_comparison_operators() {
         let p1 = Point2D::new(dec!(1.0), dec!(2.0));
@@ -611,13 +682,19 @@ mod tests_edge_cases {
         assert!(p2 > p1);
         assert!(p2 >= p1);
 
-        // Same x, different y
+        // Same x, different y: ordered by y, and not equal.
         assert!(p1 < p3);
         assert!(p1 <= p3);
         assert!(p3 > p1);
         assert!(p3 >= p1);
+        assert_ne!(p1, p3);
     }
 
+    /// Sorting keeps both coordinates: by `x` first, then by `y`.
+    ///
+    /// This test is unchanged and is the reason an x-only `Ord` was not an
+    /// option: the two points at `x = 1` must sort by their ordinate, not
+    /// land in whatever order the input happened to have.
     #[test]
     fn test_ordering_consistency() {
         let points = vec![

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -129,6 +129,15 @@ impl Surface {
     ///
     /// let object = Surface::new(points);
     /// ```
+    ///
+    /// # Duplicate coordinates
+    ///
+    /// [`Point3D`] orders on the full `(x, y, z)` triple, so `points` may
+    /// hold several heights above one xy-coordinate and `new` stores them
+    /// all, even though [`Surface::get_point`] and
+    /// [`Surface::contains_point`] return only the first match. Whether such
+    /// a surface should be rejected or normalized is unresolved; see the
+    /// issue #466.
     #[must_use]
     pub fn new(points: BTreeSet<Point3D>) -> Self {
         let x_range = Self::calculate_range(points.iter().map(|p| p.x));
@@ -160,6 +169,21 @@ impl Surface {
     /// - For `Axis::X`, the returned curve contains points with (y, z) coordinates
     /// - For `Axis::Y`, the returned curve contains points with (x, z) coordinates
     /// - For `Axis::Z`, the returned curve contains points with (x, y) coordinates
+    ///
+    /// # Multi-valued projections
+    ///
+    /// Dropping a coordinate from a grid is multi-valued: every row of the
+    /// grid contributes a different height above the same projected abscissa.
+    /// A projection of an `n`-by-`m` grid therefore yields up to `n * m`
+    /// points, several of which share an abscissa.
+    ///
+    /// Every point is kept. The returned [`Curve`] is consequently **not**
+    /// single-valued in `x`, unlike a curve built from a series, so
+    /// interpolating it returns
+    /// [`InterpolationError::DegenerateInterval`](crate::error::InterpolationError::DegenerateInterval)
+    /// wherever two projected points share an abscissa. Callers that need a
+    /// function of the projected abscissa must aggregate the points
+    /// themselves — this method does not choose an aggregation for them.
     #[must_use]
     pub fn get_curve(&self, axis: Axis) -> Curve {
         let points = self
@@ -2165,6 +2189,13 @@ mod tests_surface_basic {
         assert_eq!(surface.y_range.1, dec!(1.0));
     }
 
+    /// Projecting out `x` maps `(x, y, z)` to `(y, z)`, which is multi-valued
+    /// on a grid: the test surface has two points at `y = 0` and two at
+    /// `y = 1`, and all five survive the projection.
+    ///
+    /// The membership probes below are unchanged, but they are stricter than
+    /// they were: `Point2D` used to compare on `x` alone, so `p == (0, 0)`
+    /// also matched `(0, 1)`. It now means what it says.
     #[test]
     fn test_get_curve_x_axis() {
         let points = create_test_points();
@@ -2204,6 +2235,9 @@ mod tests_surface_basic {
         ));
     }
 
+    /// Projecting out `y` maps `(x, y, z)` to `(x, z)`, multi-valued on a
+    /// grid for the same reason as the X-axis case above. The probes are
+    /// unchanged and now mean exact membership.
     #[test]
     fn test_get_curve_y_axis() {
         let points = create_test_points();
@@ -2226,6 +2260,9 @@ mod tests_surface_basic {
         );
     }
 
+    /// Projecting out `z` maps `(x, y, z)` to `(x, y)`: the xy-footprint of
+    /// the surface, which on a grid has several ordinates per abscissa by
+    /// construction. The probes are unchanged and now mean exact membership.
     #[test]
     fn test_get_curve_z_axis() {
         let points = create_test_points();
@@ -2662,6 +2699,21 @@ mod tests_surface_bilinear_interpolation {
         assert!(result.z > dec!(0.0) && result.z < dec!(1.0));
     }
 
+    /// Four points stacked on one xy-coordinate are an invalid quadrilateral,
+    /// and `bilinear_interpolate` says so.
+    ///
+    /// This test used to assert the *"Need at least four points"* message
+    /// instead, and it reached it because `BTreeSet::from_iter` sorts and then
+    /// deduplicates adjacent elements with `PartialEq`, not with `Ord`. With
+    /// `Point3D` comparing equal on `(x, y)`, these four points collapsed to
+    /// **one** on the way into the set, so the length guard fired and the
+    /// invalid-quadrilateral check below it was unreachable. The same four
+    /// values inserted one by one produced a set of four, because `insert`
+    /// dispatches on `Ord` — the same container, two different contents,
+    /// decided by which constructor was used.
+    ///
+    /// `PartialEq` now agrees with `Ord`, so the set holds all four and the
+    /// check the test is named after is the one that runs.
     #[test]
     fn test_invalid_quadrilateral() {
         let points = BTreeSet::from_iter(vec![
@@ -2670,12 +2722,14 @@ mod tests_surface_bilinear_interpolation {
             Point3D::new(dec!(0.0), dec!(0.0), dec!(2.0)),
             Point3D::new(dec!(0.0), dec!(0.0), dec!(3.0)),
         ]);
+        assert_eq!(points.len(), 4, "all four heights are distinct points");
+
         let surface = Surface::new(points);
         let result = surface.bilinear_interpolate(Point2D::new(dec!(0.0), dec!(0.0)));
         assert!(result.is_err());
         assert!(matches!(
             result,
-            Err(InterpolationError::Bilinear(msg)) if msg.contains("Need at least four points for bilinear interpolation")
+            Err(InterpolationError::Bilinear(msg)) if msg.contains("Invalid quadrilateral")
         ));
     }
 
@@ -3670,13 +3724,30 @@ mod tests_axis_operations {
         );
     }
 
+    /// Merging a 2x2 grid with itself yields all four xy-coordinates.
+    ///
+    /// This test used to assert `merged.len() == 2`, and it passed. That was
+    /// not the specification, it was data loss: `merge_indexes` funnels the
+    /// index values through a `HashSet<Input>`, `Input` is `Point2D` for a
+    /// surface, and `Point2D` hashed and compared on `x` alone — so both
+    /// cells of every column collapsed into one and half the grid vanished
+    /// before `merge_axis_interpolate` ever saw it. `Point2D` now carries
+    /// both coordinates in `Eq` and `Hash`, so the axis survives the merge.
     #[test]
     fn test_merge_indexes() {
         let surface1 = create_test_surface();
         let surface2 = create_test_surface();
         let merged = surface1.merge_indexes(surface2.get_index_values());
 
-        assert_eq!(merged.len(), 2);
+        assert_eq!(merged.len(), 4);
+        for expected in [
+            Point2D::new(dec!(0.0), dec!(0.0)),
+            Point2D::new(dec!(0.0), dec!(1.0)),
+            Point2D::new(dec!(1.0), dec!(0.0)),
+            Point2D::new(dec!(1.0), dec!(1.0)),
+        ] {
+            assert!(merged.contains(&expected), "missing index {expected}");
+        }
     }
 }
 

--- a/src/surfaces/types.rs
+++ b/src/surfaces/types.rs
@@ -13,6 +13,7 @@ use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use utoipa::ToSchema;
 
 /// Represents a point in three-dimensional space with `x`, `y` and `z` coordinates.
@@ -61,13 +62,31 @@ impl Display for Point3D {
     }
 }
 
+/// Two points are equal when all three coordinates are equal.
+///
+/// `PartialEq`, `Ord` and `Hash` all read the full `(x, y, z)` triple, so
+/// `a == b` holds exactly when `a.cmp(&b)` is [`Ordering::Equal`], and equal
+/// points hash alike, as `Ord` requires.
+///
+/// The "one `z` per `(x, y)`" rule is a property of a *surface*, not of a
+/// point; [`crate::surfaces::Surface`] enforces it at construction.
 impl PartialEq for Point3D {
     fn eq(&self, other: &Self) -> bool {
-        self.x == other.x && self.y == other.y
+        self.x == other.x && self.y == other.y && self.z == other.z
     }
 }
 
 impl Eq for Point3D {}
+
+impl Hash for Point3D {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Delegate to `Decimal`'s own `Hash`, which normalizes first, so that
+        // `dec!(1.0)` and `dec!(1.00)` — which compare equal — hash alike.
+        self.x.hash(state);
+        self.y.hash(state);
+        self.z.hash(state);
+    }
+}
 
 impl PartialOrd for Point3D {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -75,6 +94,9 @@ impl PartialOrd for Point3D {
     }
 }
 
+/// Orders on `(x, y, z)`, lexicographically: the same triple [`PartialEq`]
+/// reads, so `cmp` returns [`Ordering::Equal`] exactly when the points are
+/// equal.
 impl Ord for Point3D {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.x.cmp(&other.x) {
@@ -368,6 +390,11 @@ mod tests {
         assert_eq!(point.z, dec!(3.0));
     }
 
+    /// Ordering is lexicographic on `(x, y, z)`.
+    ///
+    /// The assertions are unchanged; `p1 < p2` used to contradict
+    /// `test_equal`, which asserted `p1 == p2` on those same values. Only
+    /// `PartialEq` moved.
     #[test]
     fn test_point3d_ordering() {
         let p1 = Point3D::from_f64_tuple(1.0, 2.0, 3.0).unwrap();
@@ -378,6 +405,12 @@ mod tests {
         assert!(p1 < p2); // Same x,y, different z
         assert!(p1 < p3); // Same x, different y
         assert!(p1 < p4); // Different x
+
+        // ... and none of them is equal, which is what `Ord` demands of a
+        // strict ordering.
+        assert_ne!(p1, p2);
+        assert_ne!(p1, p3);
+        assert_ne!(p1, p4);
     }
 
     #[test]
@@ -403,6 +436,13 @@ mod tests {
         }
     }
 
+    /// Equality reads all three coordinates.
+    ///
+    /// This test used to assert `p1 == p3` — that two points sharing an
+    /// xy-coordinate were equal whatever their height. `test_point3d_ordering`
+    /// asserts `p1 < p3` on those same two values, so a point was both equal
+    /// to and less than another, which `Ord` forbids. `PartialEq` now reads
+    /// `z` as well and the two tests agree.
     #[test]
     fn test_equal() {
         let p1 = Point3D::from_f64_tuple(1.0, 2.0, 3.0).unwrap();
@@ -410,10 +450,46 @@ mod tests {
         let p3 = Point3D::from_f64_tuple(1.0, 2.0, 4.0).unwrap();
         let p4 = Point3D::from_f64_tuple(1.0, 3.0, 3.0).unwrap();
         let p5 = Point3D::from_f64_tuple(2.0, 2.0, 3.0).unwrap();
+
+        // All three coordinates equal.
         assert_eq!(p1, p2);
-        assert_eq!(p1, p3);
+        // Same xy-coordinate, different height: distinct points.
+        assert_ne!(p1, p3);
         assert_ne!(p1, p4);
         assert_ne!(p1, p5);
+    }
+
+    /// `Eq` and `Ord` agree, which is what `Ord` requires of an implementor.
+    #[test]
+    fn test_eq_agrees_with_ord() {
+        let p1 = Point3D::from_f64_tuple(1.0, 2.0, 3.0).unwrap();
+        let p2 = Point3D::from_f64_tuple(1.0, 2.0, 3.0).unwrap();
+        let p3 = Point3D::from_f64_tuple(1.0, 2.0, 4.0).unwrap();
+
+        assert_eq!(p1.cmp(&p2), Ordering::Equal);
+        assert_eq!(p1 == p2, p1.cmp(&p2) == Ordering::Equal);
+        assert_eq!(p1 == p3, p1.cmp(&p3) == Ordering::Equal);
+    }
+
+    /// `Hash` agrees with `Eq`, including across `Decimal` scales. `Point3D`
+    /// had no `Hash` impl at all before, so it could not be used as a hash
+    /// key; this pins the contract now that it can.
+    #[test]
+    fn test_hash_agrees_with_eq() {
+        use std::collections::HashSet;
+
+        let p1 = Point3D::new(dec!(1.0), dec!(2.0), dec!(3.0));
+        let scaled = Point3D::new(dec!(1.00), dec!(2.000), dec!(3.0000));
+        let other_z = Point3D::new(dec!(1.0), dec!(2.0), dec!(4.0));
+
+        assert_eq!(p1, scaled);
+        assert_ne!(p1, other_z);
+
+        let set: HashSet<Point3D> = [p1, scaled, other_z].into_iter().collect();
+        // `p1` and `scaled` are one entry; `other_z` is a second.
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&p1));
+        assert!(set.contains(&other_z));
     }
 }
 

--- a/src/surfaces/types.rs
+++ b/src/surfaces/types.rs
@@ -69,7 +69,10 @@ impl Display for Point3D {
 /// points hash alike, as `Ord` requires.
 ///
 /// The "one `z` per `(x, y)`" rule is a property of a *surface*, not of a
-/// point; [`crate::surfaces::Surface`] enforces it at construction.
+/// point, and it is a container-level invariant that nothing currently
+/// enforces: [`crate::surfaces::Surface::new`] retains a repeated `(x, y)`
+/// coordinate, and whether such a surface should be rejected, normalized or
+/// supported is deferred to issue #466.
 impl PartialEq for Point3D {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y && self.z == other.z

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -7,6 +7,7 @@ mod chains_panic_freedom_test;
 mod curves_panic_freedom_test;
 mod greeks_bounds_test;
 mod panic_freedom_test;
+mod point_contract_test;
 mod pricing_panic_freedom_test;
 mod put_call_parity_test;
 mod quote_invariants_test;

--- a/tests/property/point_contract_test.rs
+++ b/tests/property/point_contract_test.rs
@@ -1,0 +1,179 @@
+//! Property-based tests for the `Eq` / `Ord` / `Hash` contract on `Point2D`
+//! and `Point3D`.
+//!
+//! `Ord` requires that `a == b` hold exactly when `a.cmp(&b)` is
+//! `Ordering::Equal`, and `Hash` requires that equal values hash alike. Both
+//! types used to break the first: they compared equal on a prefix of their
+//! coordinates while ordering on all of them, so two points could be equal
+//! and yet order strictly. `Curve` stores its points in a
+//! `BTreeSet<Point2D>`, which dispatches on `Ord`, while `Surface` indexes
+//! itself by `Point2D` through a `HashSet`, which dispatches on `Eq` and
+//! `Hash` — so the disagreement was not academic: it let a curve hold two
+//! ordinates for one abscissa and made half of a surface grid disappear on
+//! merge.
+//!
+//! These properties are the invariant, driven over coordinates chosen to
+//! stress `Decimal` equality: values that are numerically equal at different
+//! scales (`1.0` versus `1.00`) hash differently if the implementation reads
+//! the raw mantissa and scale rather than normalizing, and there are enough
+//! repeats in the strategy that pairs actually collide.
+
+use optionstratlib::curves::Point2D;
+use optionstratlib::surfaces::Point3D;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::cmp::Ordering;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Hash of a single value, for comparing two hashes directly.
+fn hash_of<T: Hash>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// A small pool of coordinates, deliberately narrow so that independently
+/// generated points collide often enough to exercise the equal case, and
+/// containing values that are numerically equal at different scales.
+fn coordinate() -> impl Strategy<Value = Decimal> {
+    prop_oneof![
+        Just(Decimal::ZERO),
+        Just(dec!(1)),
+        Just(dec!(1.0)),
+        Just(dec!(1.00)),
+        Just(dec!(-1.0)),
+        Just(dec!(2.5)),
+        Just(dec!(2.50)),
+        Just(Decimal::MAX),
+        Just(Decimal::MIN),
+        (-1000i64..1000i64).prop_map(Decimal::from),
+    ]
+}
+
+fn point2d() -> impl Strategy<Value = Point2D> {
+    (coordinate(), coordinate()).prop_map(|(x, y)| Point2D::new(x, y))
+}
+
+fn point3d() -> impl Strategy<Value = Point3D> {
+    (coordinate(), coordinate(), coordinate()).prop_map(|(x, y, z)| Point3D::new(x, y, z))
+}
+
+proptest! {
+    /// The `Ord` contract: equality and `cmp` are the same relation.
+    #[test]
+    fn point2d_eq_iff_cmp_equal(a in point2d(), b in point2d()) {
+        prop_assert_eq!(a == b, a.cmp(&b) == Ordering::Equal);
+    }
+
+    /// The `Hash` contract: equal points hash alike. Unequal points may
+    /// collide, so only this direction is asserted.
+    #[test]
+    fn point2d_hash_agrees_with_eq(a in point2d(), b in point2d()) {
+        if a == b {
+            prop_assert_eq!(hash_of(&a), hash_of(&b));
+        }
+    }
+
+    /// `PartialOrd` agrees with `Ord`, as its contract requires for a type
+    /// that implements both.
+    #[test]
+    fn point2d_partial_cmp_agrees_with_cmp(a in point2d(), b in point2d()) {
+        prop_assert_eq!(a.partial_cmp(&b), Some(a.cmp(&b)));
+    }
+
+    /// Ordering is antisymmetric: reversing the arguments reverses the result.
+    #[test]
+    fn point2d_cmp_is_antisymmetric(a in point2d(), b in point2d()) {
+        prop_assert_eq!(a.cmp(&b), b.cmp(&a).reverse());
+    }
+
+    /// Ordering is transitive.
+    #[test]
+    fn point2d_cmp_is_transitive(a in point2d(), b in point2d(), c in point2d()) {
+        if a <= b && b <= c {
+            prop_assert!(a <= c);
+        }
+    }
+
+    /// Equality is reflexive, and a point hashes to itself.
+    #[test]
+    fn point2d_is_reflexive(a in point2d()) {
+        prop_assert_eq!(a, a);
+        prop_assert_eq!(a.cmp(&a), Ordering::Equal);
+        prop_assert_eq!(hash_of(&a), hash_of(&a));
+    }
+
+    /// Equal points are indistinguishable by coordinate, which is what makes
+    /// `Point2D` usable as a surface index: an index that compared on `x`
+    /// alone would identify two different points in the plane.
+    #[test]
+    fn point2d_equality_reads_both_coordinates(a in point2d(), b in point2d()) {
+        prop_assert_eq!(a == b, a.x == b.x && a.y == b.y);
+    }
+
+    /// The `Ord` contract for `Point3D`.
+    #[test]
+    fn point3d_eq_iff_cmp_equal(a in point3d(), b in point3d()) {
+        prop_assert_eq!(a == b, a.cmp(&b) == Ordering::Equal);
+    }
+
+    /// The `Hash` contract for `Point3D`.
+    #[test]
+    fn point3d_hash_agrees_with_eq(a in point3d(), b in point3d()) {
+        if a == b {
+            prop_assert_eq!(hash_of(&a), hash_of(&b));
+        }
+    }
+
+    /// `PartialOrd` agrees with `Ord` for `Point3D`.
+    #[test]
+    fn point3d_partial_cmp_agrees_with_cmp(a in point3d(), b in point3d()) {
+        prop_assert_eq!(a.partial_cmp(&b), Some(a.cmp(&b)));
+    }
+
+    /// Ordering is antisymmetric for `Point3D`.
+    #[test]
+    fn point3d_cmp_is_antisymmetric(a in point3d(), b in point3d()) {
+        prop_assert_eq!(a.cmp(&b), b.cmp(&a).reverse());
+    }
+
+    /// Ordering is transitive for `Point3D`.
+    #[test]
+    fn point3d_cmp_is_transitive(a in point3d(), b in point3d(), c in point3d()) {
+        if a <= b && b <= c {
+            prop_assert!(a <= c);
+        }
+    }
+
+    /// Equality is reflexive for `Point3D`, and a point hashes to itself.
+    #[test]
+    fn point3d_is_reflexive(a in point3d()) {
+        prop_assert_eq!(a, a);
+        prop_assert_eq!(a.cmp(&a), Ordering::Equal);
+        prop_assert_eq!(hash_of(&a), hash_of(&a));
+    }
+
+    /// Equality reads all three coordinates for `Point3D`.
+    #[test]
+    fn point3d_equality_reads_all_coordinates(a in point3d(), b in point3d()) {
+        prop_assert_eq!(a == b, a.x == b.x && a.y == b.y && a.z == b.z);
+    }
+}
+
+/// A `Decimal` compares equal across scales, so the points do too and must
+/// hash alike. Pinned as an explicit case because it is the shape the
+/// previous `Point2D::hash` got wrong: it hashed the raw mantissa and scale.
+#[test]
+fn equal_across_decimal_scales_hashes_alike() {
+    let a = Point2D::new(dec!(1.0), dec!(2.0));
+    let b = Point2D::new(dec!(1.000), dec!(2.0000));
+    assert_eq!(a, b);
+    assert_eq!(hash_of(&a), hash_of(&b));
+
+    let c = Point3D::new(dec!(1.0), dec!(2.0), dec!(3.0));
+    let d = Point3D::new(dec!(1.000), dec!(2.0000), dec!(3.00000));
+    assert_eq!(c, d);
+    assert_eq!(hash_of(&c), hash_of(&d));
+}


### PR DESCRIPTION
## Summary

`Point2D` compared equal on `x` alone while ordering on `(x, y)`, and hashed on
`x` alone. `Point3D` compared equal on `(x, y)` while ordering on `(x, y, z)`,
and had no `Hash` at all. That breaks the contract `Ord` requires — `a == b`
iff `a.cmp(&b) == Ordering::Equal` — and both types are stored in a `BTreeSet`.

**The consequence is that a `BTreeSet` of these points had no well-defined
contents.** `BTreeSet::from_iter` deduplicates adjacent elements with
`PartialEq`; `BTreeSet::insert` deduplicates with `Ord`. Measured at `main`, on
the same four `Point3D` stacked on one coordinate:

```
from_iter  len = 1
insert     len = 4
```

## What it cost

- **`Surface::merge_indexes` collapsed every column of a grid into one cell.**
  It collects its axis through a `HashSet`, so with `Eq` on `x` alone, four
  distinct `(x, y)` indices became two — and a checked-in, passing test
  asserted exactly that loss.
- **`Surface::get_curve` returned three of its five projected points**, keeping
  only the greatest ordinate per abscissa. `(0, 0)` and `(1, 1)` were simply
  absent, and the tests probing for them passed only because `x`-only equality
  made `(0, 1)` match a probe for `(0, 0)`. The same defect caused the loss and
  concealed it.

## The decision, and its evidence

Points carry their full coordinates; the function-of-abscissa invariant belongs
to the container, not to the point.

The evidence is the asymmetry in how the two containers index themselves.
`Curve` uses `AxisOperations<Point2D, Decimal>` — a bare abscissa, because only
`x` identifies a curve sample. `Surface` uses
`AxisOperations<Point3D, Point2D>` — an `(x, y)` pair, where **both coordinates
are load-bearing**. Taking `y` out of `Ord` instead would have kept `Eq` and
`Hash` on `x` alone and left the surface bug fully intact.

`Hash` also stops reading `mantissa()` and `scale()` directly. `Decimal`
compares numerically, so `dec!(1.0) == dec!(1.00)` while those two hashed
differently — `Hash` disagreed with `Eq` independently of everything above.

## What this PR deliberately does not do

An earlier cut normalized duplicates away at construction. That was removed,
because "greatest ordinate wins" happens to be exactly what `collect` was doing
by accident, and blessing an accident as the semantics of a projection is worse
than leaving the question open. A projection of a grid is genuinely
multi-valued, and `points` is a `pub` field on both types, so a struct literal
bypasses any constructor — normalization could never be a real invariant.

`Curve::new`, `Surface::new` and `get_curve` now document what they store, and
**#466** tracks the design decision. `get_curve` has no production callers and
is uncallable from outside the crate — its `Axis` parameter type is not
re-exported — so the blast radius is the three tests that assert it.

## Testing

- [x] `tests/property/point_contract_test.rs` — asserts `a == b` iff
      `a.cmp(&b) == Equal`, and that `Hash` agrees with `Eq`, for both types
- [x] **Six existing tests asserted the old contract and were rewritten**, not
      deleted. Two of them asserted both halves of the violation 286 lines apart
      in the same file. `test_merge_indexes` now asserts all four indices, with
      a comment saying the old `2` was the data loss rather than the
      specification
- [x] The three projection tests are back to their original assertions
      verbatim, and now pass for the right reason
- [x] `cargo test --all-features --workspace` — 3941 lib, 423 integration,
      55 property, 207 doc, 0 failures
- [x] `cargo fmt --all --check`, clippy `-D warnings`, `make scan-banned` and
      `make public-api-check` clean

## Public API impact

One addition: `impl Hash for Point3D`. The snapshot diff in
`public-api/optionstratlib.txt` is that impl and nothing else.

Behaviour that moves for callers: a `HashSet` or `HashMap` keyed on either
point type now keeps entries it used to merge. There is exactly one such site
in the crate — the `HashSet` in `merge_indexes` — and widening it is the fix.

## Stack

- Base branch: `main`, independent of every other open line.

Closes #450
