### PR TITLE
Make the composition layer panic-free (#460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Two `ProtectivePut` methods are now fallible, which is a breaking change**
+  (#460). `total_fees` returns `Result<Positive, PositiveError>` instead of
+  `Positive`, and `protection_level` returns
+  `Result<Decimal, StrategyError>` instead of `Decimal`. Both aborted the
+  process on inputs a caller can supply: the fee sum used the raw `Positive +
+  Positive`, which panics for a fee at `Positive::MAX`, and `protection_level`
+  divided by the spot cost basis with the raw operator, which a zero
+  underlying price turns into a panic. Adding `try_` twins instead would have
+  left the panicking methods in place, which is the opposite of what this
+  sweep is for.
+
+  To migrate, add `?` where the value feeds a fallible function, or
+  `.expect("…")` at a boundary that cannot propagate. `ProtectivePut::new` now
+  rejects a zero underlying price as well, so a position built through the
+  constructor never reaches the error arm of `protection_level`; a
+  deserialized one can.
+
 - **A zero-volatility American or Bermuda option is no longer priced as a
   European, so its price goes up** (#449). `price_binomial` short-circuited
   every contract with `volatility == 0` to the discounted forward payoff,

--- a/public-api/optionstratlib.txt
+++ b/public-api/optionstratlib.txt
@@ -9867,10 +9867,10 @@ pub fn optionstratlib::strategies::protective_put::ProtectivePut::is_put_otm(&se
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::max_loss_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::net_delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::new(alloc::string::String, positive::positive::Positive, positive::positive::Positive, expiration_date::ExpirationDate, positive::positive::Positive, rust_decimal::decimal::Decimal, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> core::result::Result<Self, optionstratlib::error::strategies::StrategyError>
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::protection_level(&self) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::protection_level(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::strategies::StrategyError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::put_strike(&self) -> positive::positive::Positive
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::quantity(&self) -> positive::positive::Positive
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::total_fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::total_fees(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::underlying_price(&self) -> positive::positive::Positive
 impl core::fmt::Display for optionstratlib::strategies::protective_put::ProtectivePut
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -20251,10 +20251,10 @@ pub fn optionstratlib::strategies::protective_put::ProtectivePut::is_put_otm(&se
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::max_loss_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::net_delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::new(alloc::string::String, positive::positive::Positive, positive::positive::Positive, expiration_date::ExpirationDate, positive::positive::Positive, rust_decimal::decimal::Decimal, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> core::result::Result<Self, optionstratlib::error::strategies::StrategyError>
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::protection_level(&self) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::protection_level(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::strategies::StrategyError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::put_strike(&self) -> positive::positive::Positive
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::quantity(&self) -> positive::positive::Positive
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::total_fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::total_fees(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::underlying_price(&self) -> positive::positive::Positive
 impl core::fmt::Display for optionstratlib::strategies::protective_put::ProtectivePut
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -23677,10 +23677,10 @@ pub fn optionstratlib::strategies::protective_put::ProtectivePut::is_put_otm(&se
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::max_loss_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::net_delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::new(alloc::string::String, positive::positive::Positive, positive::positive::Positive, expiration_date::ExpirationDate, positive::positive::Positive, rust_decimal::decimal::Decimal, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> core::result::Result<Self, optionstratlib::error::strategies::StrategyError>
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::protection_level(&self) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::protection_level(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::strategies::StrategyError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::put_strike(&self) -> positive::positive::Positive
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::quantity(&self) -> positive::positive::Positive
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::total_fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::total_fees(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::underlying_price(&self) -> positive::positive::Positive
 impl core::fmt::Display for optionstratlib::strategies::protective_put::ProtectivePut
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/public-api/optionstratlib.txt
+++ b/public-api/optionstratlib.txt
@@ -1399,6 +1399,10 @@ impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optio
 pub fn optionstratlib::error::greeks::GreeksError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::probability::ProbabilityError
 pub fn optionstratlib::error::probability::ProbabilityError::from(optionstratlib::error::decimal::DecimalError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::strategies::StrategyError
+pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::decimal::DecimalError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
+pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::decimal::DecimalError) -> Self
 pub type optionstratlib::error::decimal::DecimalResult<T> = core::result::Result<T, optionstratlib::error::decimal::DecimalError>
 pub mod optionstratlib::error::greeks
 pub enum optionstratlib::error::greeks::CalculationErrorKind
@@ -1739,6 +1743,8 @@ pub fn optionstratlib::error::strategies::StrategyError::numeric_conversion(f64)
 pub fn optionstratlib::error::strategies::StrategyError::operation_not_supported(&str, &str) -> Self
 impl core::convert::From<optionstratlib::error::OptionsError> for optionstratlib::error::strategies::StrategyError
 pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::OptionsError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::strategies::StrategyError
+pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::position::PositionError> for optionstratlib::error::strategies::StrategyError
 pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::position::PositionError) -> Self
 impl core::convert::From<optionstratlib::error::pricing::PricingError> for optionstratlib::error::strategies::StrategyError
@@ -1915,6 +1921,10 @@ impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optio
 pub fn optionstratlib::error::greeks::GreeksError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::probability::ProbabilityError
 pub fn optionstratlib::error::probability::ProbabilityError::from(optionstratlib::error::decimal::DecimalError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::strategies::StrategyError
+pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::decimal::DecimalError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
+pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::decimal::DecimalError) -> Self
 pub enum optionstratlib::error::Error
 pub optionstratlib::error::Error::Chain(optionstratlib::error::chains::ChainError)
 pub optionstratlib::error::Error::Curve(optionstratlib::error::curves::CurveError)
@@ -2239,6 +2249,8 @@ pub fn optionstratlib::error::strategies::StrategyError::numeric_conversion(f64)
 pub fn optionstratlib::error::strategies::StrategyError::operation_not_supported(&str, &str) -> Self
 impl core::convert::From<optionstratlib::error::OptionsError> for optionstratlib::error::strategies::StrategyError
 pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::OptionsError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::strategies::StrategyError
+pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::position::PositionError> for optionstratlib::error::strategies::StrategyError
 pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::position::PositionError) -> Self
 impl core::convert::From<optionstratlib::error::pricing::PricingError> for optionstratlib::error::strategies::StrategyError
@@ -5629,6 +5641,8 @@ pub optionstratlib::prelude::AdjustmentError::GreeksError(alloc::string::String)
 pub optionstratlib::prelude::AdjustmentError::InvalidLegIndex(usize)
 pub optionstratlib::prelude::AdjustmentError::NoPositions
 pub optionstratlib::prelude::AdjustmentError::NoViablePlan
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
+pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::greeks::GreeksError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
 pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::greeks::GreeksError) -> Self
 impl core::error::Error for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
@@ -5796,6 +5810,10 @@ impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optio
 pub fn optionstratlib::error::greeks::GreeksError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::probability::ProbabilityError
 pub fn optionstratlib::error::probability::ProbabilityError::from(optionstratlib::error::decimal::DecimalError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::strategies::StrategyError
+pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::decimal::DecimalError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
+pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::decimal::DecimalError) -> Self
 pub enum optionstratlib::prelude::Error
 pub optionstratlib::prelude::Error::Chain(optionstratlib::error::chains::ChainError)
 pub optionstratlib::prelude::Error::Curve(optionstratlib::error::curves::CurveError)
@@ -6136,6 +6154,8 @@ pub fn optionstratlib::error::strategies::StrategyError::numeric_conversion(f64)
 pub fn optionstratlib::error::strategies::StrategyError::operation_not_supported(&str, &str) -> Self
 impl core::convert::From<optionstratlib::error::OptionsError> for optionstratlib::error::strategies::StrategyError
 pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::OptionsError) -> Self
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::error::strategies::StrategyError
+pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::position::PositionError> for optionstratlib::error::strategies::StrategyError
 pub fn optionstratlib::error::strategies::StrategyError::from(optionstratlib::error::position::PositionError) -> Self
 impl core::convert::From<optionstratlib::error::pricing::PricingError> for optionstratlib::error::strategies::StrategyError
@@ -18175,6 +18195,8 @@ pub optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::Gree
 pub optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::InvalidLegIndex(usize)
 pub optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::NoPositions
 pub optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::NoViablePlan
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
+pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::greeks::GreeksError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
 pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::greeks::GreeksError) -> Self
 impl core::error::Error for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
@@ -18316,6 +18338,8 @@ pub optionstratlib::strategies::delta_neutral::AdjustmentError::GreeksError(allo
 pub optionstratlib::strategies::delta_neutral::AdjustmentError::InvalidLegIndex(usize)
 pub optionstratlib::strategies::delta_neutral::AdjustmentError::NoPositions
 pub optionstratlib::strategies::delta_neutral::AdjustmentError::NoViablePlan
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
+pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::greeks::GreeksError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
 pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::greeks::GreeksError) -> Self
 impl core::error::Error for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
@@ -21260,6 +21284,8 @@ pub optionstratlib::strategies::AdjustmentError::GreeksError(alloc::string::Stri
 pub optionstratlib::strategies::AdjustmentError::InvalidLegIndex(usize)
 pub optionstratlib::strategies::AdjustmentError::NoPositions
 pub optionstratlib::strategies::AdjustmentError::NoViablePlan
+impl core::convert::From<optionstratlib::error::decimal::DecimalError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
+pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::decimal::DecimalError) -> Self
 impl core::convert::From<optionstratlib::error::greeks::GreeksError> for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError
 pub fn optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError::from(optionstratlib::error::greeks::GreeksError) -> Self
 impl core::error::Error for optionstratlib::strategies::delta_neutral::adjustment::AdjustmentError

--- a/src/error/strategies.rs
+++ b/src/error/strategies.rs
@@ -423,6 +423,25 @@ impl From<PositionError> for StrategyError {
     }
 }
 
+/// Lifts a checked-arithmetic failure into the strategy error surface.
+///
+/// The `d_*` helpers in [`crate::model::decimal`] carry a `&'static str`
+/// operation tag; that tag is preserved in `operation` so the site that
+/// overflowed is named in the message rather than lost behind a generic
+/// "arithmetic error".
+impl From<crate::error::DecimalError> for StrategyError {
+    fn from(err: crate::error::DecimalError) -> Self {
+        let operation = match &err {
+            crate::error::DecimalError::ArithmeticError { operation, .. } => operation.clone(),
+            _ => "Decimal".to_string(),
+        };
+        StrategyError::OperationError(OperationErrorKind::InvalidParameters {
+            operation,
+            reason: err.to_string(),
+        })
+    }
+}
+
 impl From<OptionsError> for StrategyError {
     fn from(err: OptionsError) -> Self {
         StrategyError::OperationError(OperationErrorKind::InvalidParameters {

--- a/src/pnl/transaction.rs
+++ b/src/pnl/transaction.rs
@@ -1,9 +1,11 @@
 use crate::error::TransactionError;
 use crate::model::TradeStatus;
+use crate::model::decimal::{d_add, d_mul, d_sub};
 use crate::pnl::utils::PnL;
 use crate::{OptionStyle, OptionType, Side};
 use chrono::{DateTime, Utc};
 use positive::Positive;
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 /// # Transaction
@@ -242,10 +244,7 @@ impl Transaction {
             ));
         }
 
-        let realized = match self.side {
-            Side::Long => -(self.premium + self.fees).to_dec() * self.quantity,
-            Side::Short => (self.premium - self.fees).to_dec() * self.quantity,
-        };
+        let realized = self.realized_cash_flow(Side::Long)?;
 
         Ok(PnL::new(
             Some(realized),
@@ -254,6 +253,42 @@ impl Transaction {
             self.fees,
             Utc::now(),
         ))
+    }
+
+    /// The signed cash flow of the transaction.
+    ///
+    /// `paying_side` is the side that pays the premium away; the other side
+    /// collects it net of fees. Fees larger than the premium make that
+    /// collection negative, which is a real cash flow on a sub-tick quote and
+    /// not something the `Positive` operator can hold — hence the `Decimal`
+    /// arithmetic here.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionError::Other`] when combining premium, fees and
+    /// quantity leaves the `Decimal` range.
+    fn realized_cash_flow(&self, paying_side: Side) -> Result<Decimal, TransactionError> {
+        let per_contract = if self.side == paying_side {
+            -d_add(
+                self.premium.to_dec(),
+                self.fees.to_dec(),
+                "Transaction::realized_cash_flow/outlay",
+            )
+            .map_err(|e| TransactionError::other(e.to_string()))?
+        } else {
+            d_sub(
+                self.premium.to_dec(),
+                self.fees.to_dec(),
+                "Transaction::realized_cash_flow/net_credit",
+            )
+            .map_err(|e| TransactionError::other(e.to_string()))?
+        };
+        d_mul(
+            per_contract,
+            self.quantity.to_dec(),
+            "Transaction::realized_cash_flow",
+        )
+        .map_err(|e| TransactionError::other(e.to_string()))
     }
 
     /// Calculates PnL for a closed position.
@@ -272,10 +307,7 @@ impl Transaction {
             ));
         }
 
-        let realized = match self.side {
-            Side::Short => -(self.premium + self.fees).to_dec() * self.quantity,
-            Side::Long => (self.premium - self.fees).to_dec() * self.quantity,
-        };
+        let realized = self.realized_cash_flow(Side::Short)?;
 
         Ok(PnL::new(
             Some(realized),

--- a/src/pnl/utils.rs
+++ b/src/pnl/utils.rs
@@ -4,7 +4,10 @@
    Date: 16/8/24
 ******************************************************************************/
 
+use crate::error::DecimalError;
+use crate::error::PricingError;
 use crate::model::Trade;
+use crate::model::decimal::d_add;
 pub use crate::pnl::PnLCalculator;
 use chrono::{DateTime, Utc};
 use positive::Positive;
@@ -140,11 +143,52 @@ impl PnL {
     #[must_use]
     pub fn total_pnl(&self) -> Option<Decimal> {
         match (self.realized, self.unrealized) {
-            (Some(r), Some(u)) => Some(r + u),
+            // `checked_add` keeps the `Option` honest: a total outside the
+            // `Decimal` range is not a number this type can report, and `None`
+            // already means "no total available" to every caller.
+            (Some(r), Some(u)) => r.checked_add(u),
             (Some(r), None) => Some(r),
             (None, Some(u)) => Some(u),
             (None, None) => None,
         }
+    }
+
+    /// Checked counterpart of the `Add` operator.
+    ///
+    /// `impl Add for PnL` returns `Self`, so it has nowhere to report an
+    /// overflow and aborts instead. Every accumulation inside the library goes
+    /// through this method, which reports it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Positive`] when either running cost total
+    /// leaves the `Positive` range, and [`PricingError::Decimal`] when a
+    /// realized or unrealized total leaves the `Decimal` range.
+    pub(crate) fn try_add(&self, other: &PnL) -> Result<PnL, PricingError> {
+        fn add_leg(
+            a: Option<Decimal>,
+            b: Option<Decimal>,
+            op: &'static str,
+        ) -> Result<Option<Decimal>, DecimalError> {
+            match (a, b) {
+                (Some(a), Some(b)) => Ok(Some(d_add(a, b, op)?)),
+                (Some(a), None) => Ok(Some(a)),
+                (None, Some(b)) => Ok(Some(b)),
+                (None, None) => Ok(None),
+            }
+        }
+
+        Ok(PnL {
+            realized: add_leg(self.realized, other.realized, "PnL::try_add/realized")?,
+            unrealized: add_leg(self.unrealized, other.unrealized, "PnL::try_add/unrealized")?,
+            initial_costs: self.initial_costs.checked_add(&other.initial_costs)?,
+            initial_income: self.initial_income.checked_add(&other.initial_income)?,
+            date_time: if self.date_time > other.date_time {
+                self.date_time
+            } else {
+                other.date_time
+            },
+        })
     }
 }
 

--- a/src/risk/span.rs
+++ b/src/risk/span.rs
@@ -4,6 +4,7 @@
    Date: 2/10/24
 ******************************************************************************/
 use crate::error::PricingError;
+use crate::model::decimal::{d_add, d_mul, d_sub};
 use crate::model::position::Position;
 use positive::Positive;
 use rust_decimal::Decimal;
@@ -35,6 +36,24 @@ pub struct SPANMargin {
     /// usually expressed as a percentage. Controls how much implied volatility might
     /// increase or decrease in the risk analysis.
     volatility_scan_range: Decimal,
+}
+
+/// Scales `value` by `factor`, flooring at zero when the factor is negative.
+///
+/// A scan range past 100% makes one of the SPAN factors negative, and a
+/// negative price or volatility is outside the domain rather than a number to
+/// report. The multiplication itself is left untouched so a representable
+/// scenario keeps exactly the value the raw operator produced.
+///
+/// # Errors
+///
+/// Returns [`PricingError::Positive`] when the scaled value leaves the
+/// representable range.
+fn scale_or_floor(value: Positive, factor: Decimal) -> Result<Positive, PricingError> {
+    if factor <= Decimal::ZERO {
+        return Ok(Positive::ZERO);
+    }
+    Ok(value.checked_mul_dec(factor)?)
 }
 
 #[allow(dead_code)]
@@ -116,7 +135,7 @@ impl SPANMargin {
     /// cannot be computed.
     pub fn calculate_margin(&self, position: &Position) -> Result<Decimal, PricingError> {
         let risk_array = self.calculate_risk_array(position)?;
-        let short_option_minimum = self.calculate_short_option_minimum(position);
+        let short_option_minimum = self.calculate_short_option_minimum(position)?;
         // risk_array is structurally non-empty (price_scenarios x
         // volatility_scenarios is at least 1x1) so the max_by is
         // expected to succeed; the fallback to ZERO + warn is a
@@ -161,8 +180,8 @@ impl SPANMargin {
     fn calculate_risk_array(&self, position: &Position) -> Result<Vec<Decimal>, PricingError> {
         let mut risk_array = Vec::new();
         let option = &position.option;
-        let price_scenarios = self.generate_price_scenarios(option.underlying_price);
-        let volatility_scenarios = self.generate_volatility_scenarios(option.implied_volatility);
+        let price_scenarios = self.generate_price_scenarios(option.underlying_price)?;
+        let volatility_scenarios = self.generate_volatility_scenarios(option.implied_volatility)?;
         for &price in &price_scenarios {
             for &volatility in &volatility_scenarios {
                 let scenario_loss = self.calculate_scenario_loss(position, price, volatility)?;
@@ -189,13 +208,39 @@ impl SPANMargin {
     /// # Returns
     ///
     /// A vector of three `Positive` values representing the price scenarios
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Positive`] when the upside scenario leaves the
+    /// representable range.
     #[inline]
-    fn generate_price_scenarios(&self, underlying_price: Positive) -> Vec<Positive> {
-        vec![
-            underlying_price * (Decimal::ONE - self.price_scan_range),
+    fn generate_price_scenarios(
+        &self,
+        underlying_price: Positive,
+    ) -> Result<Vec<Positive>, PricingError> {
+        // A scan range past 100% shocks the underlying below zero, where it
+        // cannot trade: zero is the floor of the price domain, not an abort.
+        // The factor is applied in one multiplication, exactly as before, so
+        // every representable scenario keeps its last digit.
+        Ok(vec![
+            scale_or_floor(
+                underlying_price,
+                d_sub(
+                    Decimal::ONE,
+                    self.price_scan_range,
+                    "SPANMargin::price_scenario_down",
+                )?,
+            )?,
             underlying_price,
-            underlying_price * (Decimal::ONE + self.price_scan_range),
-        ]
+            scale_or_floor(
+                underlying_price,
+                d_add(
+                    Decimal::ONE,
+                    self.price_scan_range,
+                    "SPANMargin::price_scenario_up",
+                )?,
+            )?,
+        ])
     }
 
     /// Generates a vector of implied volatility scenarios for risk analysis.
@@ -215,13 +260,37 @@ impl SPANMargin {
     /// # Returns
     ///
     /// A vector of three `Positive` values representing the volatility scenarios
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Positive`] when the upside scenario leaves the
+    /// representable range.
     #[inline]
-    fn generate_volatility_scenarios(&self, implied_volatility: Positive) -> Vec<Positive> {
-        vec![
-            implied_volatility * (Decimal::ONE - self.volatility_scan_range),
+    fn generate_volatility_scenarios(
+        &self,
+        implied_volatility: Positive,
+    ) -> Result<Vec<Positive>, PricingError> {
+        // Same floor as the price scenarios: a scan range past 100% would
+        // shock volatility below zero, which no option carries.
+        Ok(vec![
+            scale_or_floor(
+                implied_volatility,
+                d_sub(
+                    Decimal::ONE,
+                    self.volatility_scan_range,
+                    "SPANMargin::volatility_scenario_down",
+                )?,
+            )?,
             implied_volatility,
-            implied_volatility * (Decimal::ONE + self.volatility_scan_range),
-        ]
+            scale_or_floor(
+                implied_volatility,
+                d_add(
+                    Decimal::ONE,
+                    self.volatility_scan_range,
+                    "SPANMargin::volatility_scenario_up",
+                )?,
+            )?,
+        ])
     }
 
     /// Calculates the potential profit or loss for a position in a given price and volatility scenario.
@@ -254,13 +323,25 @@ impl SPANMargin {
         scenario_option.underlying_price = scenario_price;
         scenario_option.implied_volatility = scenario_volatility;
         let scenario_price = scenario_option.calculate_price_black_scholes()?;
-        Ok((scenario_price - current_price)
-            * option.quantity
-            * if option.is_short() {
-                Decimal::NEGATIVE_ONE
-            } else {
-                Decimal::ONE
-            })
+        let move_in_value = d_sub(
+            scenario_price,
+            current_price,
+            "SPANMargin::scenario_value_move",
+        )?;
+        let sign = if option.is_short() {
+            Decimal::NEGATIVE_ONE
+        } else {
+            Decimal::ONE
+        };
+        Ok(d_mul(
+            d_mul(
+                move_in_value,
+                option.quantity.to_dec(),
+                "SPANMargin::scenario_loss",
+            )?,
+            sign,
+            "SPANMargin::scenario_loss",
+        )?)
     }
 
     /// Calculates the minimum margin requirement for short option positions.
@@ -282,13 +363,26 @@ impl SPANMargin {
     /// `short_option_minimum * underlying_price * quantity`
     ///
     /// For long options, the function returns zero as the short option minimum doesn't apply.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Decimal`] when the product leaves the `Decimal`
+    /// range.
     #[inline]
-    fn calculate_short_option_minimum(&self, position: &Position) -> Decimal {
+    fn calculate_short_option_minimum(&self, position: &Position) -> Result<Decimal, PricingError> {
         let option = &position.option;
         if option.is_short() {
-            self.short_option_minimum * option.underlying_price * option.quantity
+            Ok(d_mul(
+                d_mul(
+                    self.short_option_minimum,
+                    option.underlying_price.to_dec(),
+                    "SPANMargin::short_option_minimum",
+                )?,
+                option.quantity.to_dec(),
+                "SPANMargin::short_option_minimum",
+            )?)
         } else {
-            Decimal::ZERO
+            Ok(Decimal::ZERO)
         }
     }
 }

--- a/src/strategies/base.rs
+++ b/src/strategies/base.rs
@@ -5,6 +5,7 @@
 use crate::chains::OptionData;
 use crate::constants::{STRIKE_PRICE_LOWER_BOUND_MULTIPLIER, STRIKE_PRICE_UPPER_BOUND_MULTIPLIER};
 use crate::error::strategies::BreakEvenErrorKind;
+use crate::model::decimal::d_add;
 use crate::model::utils::sub_floor_zero;
 use crate::{
     ExpirationDate, Options,
@@ -681,21 +682,23 @@ pub trait BasicAble {
     ///
     /// # Panics
     /// The default implementation panics because there is no graceful fallback
-    /// for a borrowed `&Options` return. Every strategy that owns options
-    /// must override this method.
+    /// for a borrowed `&Options` return, and returning a fabricated `Options`
+    /// would answer every downstream getter with a price nobody quoted. Every
+    /// strategy this crate ships overrides this method.
     ///
     /// # Note
     /// This is a placeholder implementation and must be overridden in any
     /// concrete strategy that holds option positions.
     fn one_option(&self) -> &Options {
         // INVARIANT: a `&Options` return type admits no default — we cannot
-        // materialise a safe reference out of thin air. Every strategy that
-        // owns positions overrides this; the panic fires only when a caller
-        // dispatches through the trait default on a type with no options,
-        // which is a programmer error.
-        panic!(
-            "one_option not implemented for this strategy — every strategy with options must override"
-        )
+        // materialise a safe reference out of thin air, and fabricating one
+        // would answer `get_underlying_price` with a price nobody quoted.
+        // Every strategy this crate ships overrides this method; `Collar`,
+        // `CoveredCall` and `ProtectivePut` did not, which made a plain
+        // getter abort, and they now do. Reaching the default is a
+        // downstream type that forgot the override.
+        const MSG: &str = "one_option not implemented for this strategy — every strategy with options must override";
+        panic!("{MSG}") // scan-banned: allow -- no safe `&Options` exists to return, and no shipped strategy reaches it
     }
     /// Provides a mutable reference to the strategy's primary `Options` value.
     ///
@@ -712,10 +715,10 @@ pub trait BasicAble {
     fn one_option_mut(&mut self) -> &mut Options {
         // INVARIANT: same rationale as `one_option` — `&mut Options` has no
         // safe default value, so every strategy with positions must override
-        // this method. Reaching the panic is a programmer error.
-        panic!(
-            "one_option_mut not implemented for this strategy — every strategy with options must override"
-        )
+        // this method. Reaching the panic is a downstream type that forgot
+        // the override; no strategy this crate ships does.
+        const MSG: &str = "one_option_mut not implemented for this strategy — every strategy with options must override";
+        panic!("{MSG}") // scan-banned: allow -- no safe `&mut Options` exists to return, and no shipped strategy reaches it
     }
 
     /// Sets the expiration date for the strategy.
@@ -906,7 +909,9 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
         let positions = self.get_positions()?;
         let mut total = Positive::ZERO;
         for p in positions {
-            total += p.total_cost()?;
+            total = total
+                .checked_add(&p.total_cost()?)
+                .map_err(|e| PositionError::invalid_position(&e.to_string()))?;
         }
         Ok(total)
     }
@@ -928,7 +933,8 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
         let positions = self.get_positions()?;
         let mut total = Decimal::ZERO;
         for p in positions {
-            total += p.net_cost()?;
+            total = d_add(total, p.net_cost()?, "Strategies::get_net_cost")
+                .map_err(|e| PositionError::invalid_position(&e.to_string()))?;
         }
         Ok(total)
     }
@@ -951,13 +957,17 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
         let mut premiums = Positive::ZERO;
         for p in positions {
             if p.option.side == Side::Long {
-                costs += p.net_cost()?;
+                costs = d_add(
+                    costs,
+                    p.net_cost()?,
+                    "Strategies::get_net_premium_received/costs",
+                )?;
             } else if p.option.side == Side::Short {
-                premiums += p.net_premium_received()?;
+                premiums = premiums.checked_add(&p.net_premium_received()?)?;
             }
         }
         match premiums > costs {
-            true => Ok(premiums - costs),
+            true => Ok(premiums.checked_sub_dec(costs)?),
             false => Ok(Positive::ZERO),
         }
     }
@@ -987,7 +997,7 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
             }
         };
         for position in positions {
-            fee += position.fees()?;
+            fee = fee.checked_add(&position.fees()?)?;
         }
         Ok(fee)
     }
@@ -1045,7 +1055,10 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
     ///
     /// Propagates any [`StrategyError`] returned by
     /// `Strategable::get_break_even_points` or
-    /// `Strategable::get_max_min_strikes`.
+    /// `Strategable::get_max_min_strikes`, and
+    /// [`StrategyError::PositiveError`] when widening the range by the
+    /// strike distance, or applying the display bound multipliers, leaves the
+    /// `Positive` range.
     fn get_range_to_show(&self) -> Result<(Positive, Positive), StrategyError> {
         let mut all_points = self.get_break_even_points()?.clone();
         let (first_strike, last_strike) = self.get_max_min_strikes()?;
@@ -1056,13 +1069,12 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
             .abs()
             .max((first_strike.value() - underlying_price.value()).abs());
 
-        // Expand range by max_diff
-        all_points.push(
-            (*underlying_price - max_diff)
-                .max(Positive::ZERO)
-                .min(first_strike),
-        );
-        all_points.push((*underlying_price + max_diff).max(last_strike));
+        // Expand range by max_diff. A strike further below the spot than the
+        // spot itself — a penny strike against a ten dollar underlying — puts
+        // the lower bound under zero, where the underlying cannot trade; that
+        // floors at zero rather than aborting.
+        all_points.push(sub_floor_zero(*underlying_price, &max_diff).min(first_strike));
+        all_points.push(underlying_price.checked_add_dec(max_diff)?.max(last_strike));
 
         // Sort to find min and max
         // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort
@@ -1074,8 +1086,8 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
         let last = all_points.last().ok_or_else(|| {
             StrategyError::empty_collection("get_range_to_show: all_points is empty")
         })?;
-        let start_price = *first * STRIKE_PRICE_LOWER_BOUND_MULTIPLIER;
-        let end_price = *last * STRIKE_PRICE_UPPER_BOUND_MULTIPLIER;
+        let start_price = first.checked_mul_f64(STRIKE_PRICE_LOWER_BOUND_MULTIPLIER)?;
+        let end_price = last.checked_mul_f64(STRIKE_PRICE_UPPER_BOUND_MULTIPLIER)?;
         Ok((start_price, end_price))
     }
 
@@ -1088,10 +1100,13 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
     /// # Errors
     ///
     /// Propagates any [`StrategyError`] returned by
-    /// `Strategable::get_range_to_show`.
+    /// `Strategable::get_range_to_show`, and the
+    /// [`OperationErrorKind::InvalidParameters`] raised by the price-range
+    /// walk for a zero `step` or a range that would need more samples than the
+    /// walk allows.
     fn get_best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
         let (start_price, end_price) = self.get_range_to_show()?;
-        Ok(calculate_price_range(start_price, end_price, step))
+        calculate_price_range(start_price, end_price, step)
     }
 
     /// Returns the minimum and maximum strike prices from the positions in the strategy.
@@ -1159,7 +1174,13 @@ pub trait Strategies: Validable + Positionable + BreakEvenable + BasicAble {
                 BreakEvenErrorKind::NoBreakEvenPoints,
             )),
             1 => Ok(Positive::MAX),
-            2 => Ok(break_even_points[1] - break_even_points[0]),
+            // The width of the profitable region, not a signed difference:
+            // nothing orders a two-point break-even vector, and the three-plus
+            // branch below sorts before subtracting for exactly that reason.
+            2 => {
+                let (a, b) = (break_even_points[0], break_even_points[1]);
+                Ok(price_gap(a.max(b), a.min(b)))
+            }
             _ => {
                 // sort break even points and then get last minus first
                 // SAFETY: total order on Positive; f64 fallback to Equal is safe for stable sort

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -24,6 +24,8 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::SpreadStrategy;
+use crate::model::decimal::d_div;
+use crate::strategies::base::lower_break_even;
 use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
@@ -341,10 +343,17 @@ impl BreakEvenable for BullCallSpread {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
+        // `lower_break_even` measures a distance below the strike and floors
+        // at zero; the debit sits above it, hence the negated offset. A leg
+        // with no contracts has no per-contract debit at all.
+        let per_contract = d_div(
+            self.get_net_cost()?,
+            self.long_call.option.quantity.to_dec(),
+            "BullCallSpread::update_break_even_points",
+        )?;
         self.break_even_points.push(
-            (self.long_call.option.strike_price
-                + self.get_net_cost()? / self.long_call.option.quantity)
-                .round_to(2),
+            lower_break_even(self.long_call.option.strike_price, -per_contract)
+                .checked_round_to(2)?,
         );
 
         Ok(())

--- a/src/strategies/collar.rs
+++ b/src/strategies/collar.rs
@@ -484,7 +484,8 @@ impl Collar {
     /// range.
     fn total_fees(&self) -> Result<Positive, PositiveError> {
         self.spot_leg
-            .fees()
+            .open_fee
+            .checked_add(&self.spot_leg.close_fee)?
             .checked_add(&self.long_put.open_fee)?
             .checked_add(&self.long_put.close_fee)?
             .checked_add(&self.short_call.open_fee)?

--- a/src/strategies/collar.rs
+++ b/src/strategies/collar.rs
@@ -76,18 +76,21 @@ use crate::error::{GreeksError, PositionError, PricingError, StrategyError};
 use crate::greeks::Greeks;
 use crate::model::ExpirationDate;
 use crate::model::ProfitLossRange;
+use crate::model::decimal::{d_add, d_div, d_sub};
 use crate::model::leg::traits::LegAble;
 use crate::model::leg::{Leg, SpotPosition};
 use crate::model::position::Position;
 use crate::model::types::{OptionBasicType, OptionStyle, OptionType, Side};
 use crate::pnl::PnLCalculator;
 use crate::pricing::payoff::Profit;
+use crate::strategies::base::price_gap;
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::{BasicAble, Strategies};
 use chrono::Utc;
 use positive::Positive;
+use positive::PositiveError;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -204,6 +207,17 @@ impl Collar {
         call_close_fee: Positive,
     ) -> Result<Self, StrategyError> {
         // Create the spot position (long underlying)
+        // Every per-share figure this strategy reports — the effective cost
+        // basis, the break-even, the premium per share — divides by the size
+        // of the spot leg. A collar with no shares is not a position, and
+        // rejecting it here keeps those divisors non-zero.
+        if quantity == Positive::ZERO {
+            return Err(StrategyError::invalid_parameters(
+                "Collar::new",
+                "quantity must be strictly positive: a collar with no shares has no per-share basis",
+            ));
+        }
+
         let spot_leg = SpotPosition::new(
             underlying_symbol.clone(),
             quantity,
@@ -331,9 +345,12 @@ impl Collar {
     }
 
     /// Returns the collar width (distance between put and call strikes).
+    ///
+    /// A put struck above the call inverts the collar; the width of that
+    /// region is zero, not a negative price.
     #[must_use]
     pub fn collar_width(&self) -> Positive {
-        self.call_strike() - self.put_strike()
+        price_gap(self.call_strike(), self.put_strike())
     }
 
     /// Calculates the net premium (credit if positive, debit if negative).
@@ -370,7 +387,11 @@ impl Collar {
         let spot_delta = self.spot_leg.delta()?;
         let put_delta = self.long_put.delta()?;
         let call_delta = self.short_call.delta()?;
-        Ok(spot_delta + put_delta + call_delta)
+        Ok(d_add(
+            d_add(spot_delta, put_delta, "Collar::net_delta")?,
+            call_delta,
+            "Collar::net_delta",
+        )?)
     }
 
     /// Calculates the maximum profit potential.
@@ -392,16 +413,24 @@ impl Collar {
         let cost_basis = self.spot_leg.cost_basis;
         let quantity = self.spot_leg.quantity;
         let net_premium = self.net_premium();
-        let total_fees = self.total_fees();
+        let total_fees = self.total_fees()?;
 
         if call_strike >= cost_basis {
-            let capital_gain = (call_strike - cost_basis) * quantity;
-            let total_profit = capital_gain.to_dec() + net_premium - total_fees.to_dec();
+            let capital_gain = price_gap(call_strike, cost_basis).checked_mul(&quantity)?;
+            let total_profit = d_sub(
+                d_add(capital_gain.to_dec(), net_premium, "Collar::max_profit")?,
+                total_fees.to_dec(),
+                "Collar::max_profit",
+            )?;
             Ok(Positive::new_decimal(total_profit.max(Decimal::ZERO)).unwrap_or(Positive::ZERO))
         } else {
             // Call strike below cost basis
-            let capital_loss = (cost_basis - call_strike) * quantity;
-            let total_profit = net_premium - capital_loss.to_dec() - total_fees.to_dec();
+            let capital_loss = price_gap(cost_basis, call_strike).checked_mul(&quantity)?;
+            let total_profit = d_sub(
+                d_sub(net_premium, capital_loss.to_dec(), "Collar::max_profit")?,
+                total_fees.to_dec(),
+                "Collar::max_profit",
+            )?;
             Ok(Positive::new_decimal(total_profit.max(Decimal::ZERO)).unwrap_or(Positive::ZERO))
         }
     }
@@ -425,27 +454,41 @@ impl Collar {
         let cost_basis = self.spot_leg.cost_basis;
         let quantity = self.spot_leg.quantity;
         let net_premium = self.net_premium();
-        let total_fees = self.total_fees();
+        let total_fees = self.total_fees()?;
 
         if cost_basis >= put_strike {
-            let capital_loss = (cost_basis - put_strike) * quantity;
-            let total_loss = capital_loss.to_dec() - net_premium + total_fees.to_dec();
+            let capital_loss = price_gap(cost_basis, put_strike).checked_mul(&quantity)?;
+            let total_loss = d_add(
+                d_sub(capital_loss.to_dec(), net_premium, "Collar::max_loss")?,
+                total_fees.to_dec(),
+                "Collar::max_loss",
+            )?;
             Ok(Positive::new_decimal(total_loss.max(Decimal::ZERO)).unwrap_or(Positive::ZERO))
         } else {
             // Put strike above cost basis (unusual but possible)
-            let capital_gain = (put_strike - cost_basis) * quantity;
-            let total_loss = total_fees.to_dec() - net_premium - capital_gain.to_dec();
+            let capital_gain = price_gap(put_strike, cost_basis).checked_mul(&quantity)?;
+            let total_loss = d_sub(
+                d_sub(total_fees.to_dec(), net_premium, "Collar::max_loss")?,
+                capital_gain.to_dec(),
+                "Collar::max_loss",
+            )?;
             Ok(Positive::new_decimal(total_loss.max(Decimal::ZERO)).unwrap_or(Positive::ZERO))
         }
     }
 
     /// Calculates total fees for all positions.
-    fn total_fees(&self) -> Positive {
-        self.spot_leg.fees()
-            + self.long_put.open_fee
-            + self.long_put.close_fee
-            + self.short_call.open_fee
-            + self.short_call.close_fee
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PositiveError`] when the running total leaves the `Positive`
+    /// range.
+    fn total_fees(&self) -> Result<Positive, PositiveError> {
+        self.spot_leg
+            .fees()
+            .checked_add(&self.long_put.open_fee)?
+            .checked_add(&self.long_put.close_fee)?
+            .checked_add(&self.short_call.open_fee)?
+            .checked_add(&self.short_call.close_fee)
     }
 
     /// Checks if the put is currently in-the-money.
@@ -516,13 +559,33 @@ impl BreakEvenable for Collar {
         self.break_even_points.clear();
 
         // Break-even = Cost Basis - Net Premium per Share
-        let net_premium_per_share = self.net_premium() / self.spot_leg.quantity.to_dec();
-        let fees_per_share = self.total_fees().to_dec() / self.spot_leg.quantity.to_dec();
+        let net_premium_per_share = d_div(
+            self.net_premium(),
+            self.spot_leg.quantity.to_dec(),
+            "Collar::update_break_even_points",
+        )?;
+        let fees_per_share = d_div(
+            self.total_fees()?.to_dec(),
+            self.spot_leg.quantity.to_dec(),
+            "Collar::update_break_even_points",
+        )?;
 
-        let break_even = self.spot_leg.cost_basis.to_dec() - net_premium_per_share + fees_per_share;
+        // The credit lowers the break-even and the fees raise it. A net credit
+        // larger than the cost basis puts the break-even below zero, where the
+        // underlying cannot trade, and the collar records no break-even at
+        // all — the same outcome the unchecked arithmetic produced before.
+        let break_even = d_add(
+            d_sub(
+                self.spot_leg.cost_basis.to_dec(),
+                net_premium_per_share,
+                "Collar::update_break_even_points",
+            )?,
+            fees_per_share,
+            "Collar::update_break_even_points",
+        )?;
 
         if let Ok(be) = Positive::new_decimal(break_even) {
-            self.break_even_points.push(be.round_to(2));
+            self.break_even_points.push(be.checked_round_to(2)?);
         }
 
         Ok(())
@@ -610,6 +673,19 @@ impl Strategable for Collar {
 }
 
 impl BasicAble for Collar {
+    // Without this override the trait default aborts the process, and it is
+    // reached from `get_underlying_price`, `get_max_min_strikes`,
+    // `delta_neutrality` and every probability method. The short call carries the
+    // same underlying, expiration and rate as the spot leg, so it answers for
+    // the strategy.
+    fn one_option(&self) -> &Options {
+        self.short_call.one_option()
+    }
+
+    fn one_option_mut(&mut self) -> &mut Options {
+        self.short_call.one_option_mut()
+    }
+
     fn get_title(&self) -> String {
         format!(
             "Collar Strategy:\n\t{} {} {} @ {}\n\t{}\n\t{}",
@@ -728,7 +804,11 @@ impl Profit for Collar {
             .pnl_at_expiration(&Some(price))
             .unwrap_or(Decimal::ZERO);
 
-        Ok(spot_pnl + put_pnl + call_pnl)
+        Ok(d_add(
+            d_add(spot_pnl, put_pnl, "Collar::pnl_at_expiration")?,
+            call_pnl,
+            "Collar::pnl_at_expiration",
+        )?)
     }
 }
 
@@ -758,13 +838,19 @@ impl PnLCalculator for Collar {
     ) -> Result<crate::pnl::utils::PnL, PricingError> {
         let profit = self.calculate_profit_at(underlying_price)?;
         let spot_cost = self.spot_leg.total_cost();
-        let put_cost = self.long_put.premium * self.long_put.option.quantity;
-        let call_income = self.short_call.premium * self.short_call.option.quantity;
+        let put_cost = self
+            .long_put
+            .premium
+            .checked_mul(&self.long_put.option.quantity)?;
+        let call_income = self
+            .short_call
+            .premium
+            .checked_mul(&self.short_call.option.quantity)?;
 
         Ok(crate::pnl::utils::PnL {
             realized: None,
             unrealized: Some(profit),
-            initial_costs: spot_cost + put_cost,
+            initial_costs: spot_cost.checked_add(&put_cost)?,
             initial_income: call_income,
             date_time: Utc::now(),
         })

--- a/src/strategies/covered_call.rs
+++ b/src/strategies/covered_call.rs
@@ -321,8 +321,12 @@ impl CoveredCall {
         let cost_basis = self.spot_leg.cost_basis;
         let quantity = self.spot_leg.quantity;
         let premium_received = self.short_call.premium * self.short_call.option.quantity;
-        let total_fees =
-            self.spot_leg.fees() + self.short_call.open_fee + self.short_call.close_fee;
+        let total_fees = self
+            .spot_leg
+            .open_fee
+            .checked_add(&self.spot_leg.close_fee)?
+            .checked_add(&self.short_call.open_fee)?
+            .checked_add(&self.short_call.close_fee)?;
 
         if strike >= cost_basis {
             let capital_gain = price_gap(strike, cost_basis).checked_mul(&quantity)?;
@@ -363,8 +367,12 @@ impl CoveredCall {
         let cost_basis = self.spot_leg.cost_basis;
         let quantity = self.spot_leg.quantity;
         let premium_received = self.short_call.premium * self.short_call.option.quantity;
-        let total_fees =
-            self.spot_leg.fees() + self.short_call.open_fee + self.short_call.close_fee;
+        let total_fees = self
+            .spot_leg
+            .open_fee
+            .checked_add(&self.spot_leg.close_fee)?
+            .checked_add(&self.short_call.open_fee)?
+            .checked_add(&self.short_call.close_fee)?;
 
         let total_investment = cost_basis.checked_mul(&quantity)?;
         let gross_outlay = total_investment.checked_add(&total_fees)?;
@@ -436,7 +444,11 @@ impl BreakEvenable for CoveredCall {
             .premium
             .checked_mul(&self.short_call.option.quantity)?
             .checked_div(&self.spot_leg.quantity)?;
-        let fees_per_share = self.spot_leg.fees().checked_div(&self.spot_leg.quantity)?;
+        let fees_per_share = self
+            .spot_leg
+            .open_fee
+            .checked_add(&self.spot_leg.close_fee)?
+            .checked_div(&self.spot_leg.quantity)?;
 
         // Net credit per share, which is negative when the fees swallow the
         // premium. `lower_break_even` floors the result at zero, the sentinel

--- a/src/strategies/covered_call.rs
+++ b/src/strategies/covered_call.rs
@@ -58,12 +58,15 @@ use crate::error::{GreeksError, PositionError, PricingError, StrategyError};
 use crate::greeks::Greeks;
 use crate::model::ExpirationDate;
 use crate::model::ProfitLossRange;
+use crate::model::decimal::{d_add, d_sub};
 use crate::model::leg::traits::LegAble;
 use crate::model::leg::{Leg, SpotPosition};
 use crate::model::position::Position;
 use crate::model::types::{OptionBasicType, OptionStyle, OptionType, Side};
+use crate::model::utils::sub_floor_zero;
 use crate::pnl::PnLCalculator;
 use crate::pricing::payoff::Profit;
+use crate::strategies::base::{lower_break_even, price_gap};
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
@@ -173,6 +176,17 @@ impl CoveredCall {
         call_close_fee: Positive,
     ) -> Result<Self, StrategyError> {
         // Create the spot position (long underlying)
+        // Every per-share figure this strategy reports — the effective cost
+        // basis, the break-even, the premium per share — divides by the size
+        // of the spot leg. A covered call with no shares is not a position, and
+        // rejecting it here keeps those divisors non-zero.
+        if quantity == Positive::ZERO {
+            return Err(StrategyError::invalid_parameters(
+                "CoveredCall::new",
+                "quantity must be strictly positive: a covered call with no shares has no per-share basis",
+            ));
+        }
+
         let spot_leg = SpotPosition::new(
             underlying_symbol.clone(),
             quantity,
@@ -272,7 +286,7 @@ impl CoveredCall {
     pub fn net_delta(&self) -> Result<Decimal, GreeksError> {
         let spot_delta = self.spot_leg.delta()?;
         let option_delta = self.short_call.delta()?;
-        Ok(spot_delta + option_delta)
+        Ok(d_add(spot_delta, option_delta, "CoveredCall::net_delta")?)
     }
 
     /// Calculates the effective cost basis after receiving premium.
@@ -311,13 +325,20 @@ impl CoveredCall {
             self.spot_leg.fees() + self.short_call.open_fee + self.short_call.close_fee;
 
         if strike >= cost_basis {
-            let capital_gain = (strike - cost_basis) * quantity;
-            Ok(capital_gain + premium_received - total_fees)
+            let capital_gain = price_gap(strike, cost_basis).checked_mul(&quantity)?;
+            // Fees larger than the gain plus the credit make the best case a
+            // loss, which this `Positive` return reports as zero — the same
+            // answer the branch below already gives.
+            Ok(sub_floor_zero(
+                capital_gain.checked_add(&premium_received)?,
+                total_fees.to_dec_ref(),
+            ))
         } else {
             // Strike below cost basis - max profit is just premium minus loss
-            let capital_loss = (cost_basis - strike) * quantity;
-            if premium_received > capital_loss + total_fees {
-                Ok(premium_received - capital_loss - total_fees)
+            let capital_loss = price_gap(cost_basis, strike).checked_mul(&quantity)?;
+            let downside = capital_loss.checked_add(&total_fees)?;
+            if premium_received > downside {
+                Ok(premium_received.checked_sub(&downside)?)
             } else {
                 Ok(Positive::ZERO)
             }
@@ -345,9 +366,10 @@ impl CoveredCall {
         let total_fees =
             self.spot_leg.fees() + self.short_call.open_fee + self.short_call.close_fee;
 
-        let total_investment = cost_basis * quantity;
-        if total_investment + total_fees > premium_received {
-            Ok(total_investment + total_fees - premium_received)
+        let total_investment = cost_basis.checked_mul(&quantity)?;
+        let gross_outlay = total_investment.checked_add(&total_fees)?;
+        if gross_outlay > premium_received {
+            Ok(gross_outlay.checked_sub(&premium_received)?)
         } else {
             Ok(Positive::ZERO)
         }
@@ -409,17 +431,24 @@ impl BreakEvenable for CoveredCall {
         self.break_even_points.clear();
 
         // Break-even = Cost Basis - Premium Received per Share
-        let premium_per_share =
-            self.short_call.premium * self.short_call.option.quantity / self.spot_leg.quantity;
-        let fees_per_share = self.spot_leg.fees() / self.spot_leg.quantity;
+        let premium_per_share = self
+            .short_call
+            .premium
+            .checked_mul(&self.short_call.option.quantity)?
+            .checked_div(&self.spot_leg.quantity)?;
+        let fees_per_share = self.spot_leg.fees().checked_div(&self.spot_leg.quantity)?;
 
-        let break_even = if self.spot_leg.cost_basis > premium_per_share - fees_per_share {
-            self.spot_leg.cost_basis - premium_per_share + fees_per_share
-        } else {
-            Positive::ZERO
-        };
+        // Net credit per share, which is negative when the fees swallow the
+        // premium. `lower_break_even` floors the result at zero, the sentinel
+        // for "the shares cannot be losing at any attainable price".
+        let net_credit_per_share = d_sub(
+            premium_per_share.to_dec(),
+            fees_per_share.to_dec(),
+            "CoveredCall::update_break_even_points",
+        )?;
+        let break_even = lower_break_even(self.spot_leg.cost_basis, net_credit_per_share);
 
-        self.break_even_points.push(break_even.round_to(2));
+        self.break_even_points.push(break_even.checked_round_to(2)?);
         Ok(())
     }
 }
@@ -495,6 +524,19 @@ impl Strategable for CoveredCall {
 }
 
 impl BasicAble for CoveredCall {
+    // Without this override the trait default aborts the process, and it is
+    // reached from `get_underlying_price`, `get_max_min_strikes`,
+    // `delta_neutrality` and every probability method. The short call carries the
+    // same underlying, expiration and rate as the spot leg, so it answers for
+    // the strategy.
+    fn one_option(&self) -> &Options {
+        self.short_call.one_option()
+    }
+
+    fn one_option_mut(&mut self) -> &mut Options {
+        self.short_call.one_option_mut()
+    }
+
     fn get_title(&self) -> String {
         format!(
             "CoveredCall Strategy:\n\t{} {} {} @ {}\n\t{}",
@@ -570,7 +612,11 @@ impl Profit for CoveredCall {
             .pnl_at_expiration(&Some(price))
             .unwrap_or(Decimal::ZERO);
 
-        Ok(spot_pnl + option_pnl)
+        Ok(d_add(
+            spot_pnl,
+            option_pnl,
+            "CoveredCall::pnl_at_expiration",
+        )?)
     }
 }
 
@@ -600,7 +646,10 @@ impl PnLCalculator for CoveredCall {
     ) -> Result<crate::pnl::utils::PnL, PricingError> {
         let profit = self.calculate_profit_at(underlying_price)?;
         let spot_cost = self.spot_leg.total_cost();
-        let premium_received = self.short_call.premium * self.short_call.option.quantity;
+        let premium_received = self
+            .short_call
+            .premium
+            .checked_mul(&self.short_call.option.quantity)?;
 
         Ok(crate::pnl::utils::PnL {
             realized: None,

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -12,7 +12,9 @@
 use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
+use crate::model::decimal::{d_div, d_mul};
 use crate::strategies::base::price_gap;
+use crate::strategies::utils::calculate_price_range_bounded;
 use crate::{
     ExpirationDate, Options,
     chains::{OptionData, chain::OptionChain},
@@ -205,21 +207,24 @@ impl CustomStrategy {
         let max_strike = strikes.iter().max().unwrap_or(&self.underlying_price);
 
         // Use a much more focused range calculation for better visualization
-        let strike_range = *max_strike - *min_strike;
+        let strike_range = price_gap(*max_strike, *min_strike);
 
         // For strategies with small strike ranges, use a very focused approach
-        let base_extension = if strike_range < self.underlying_price * pos_lit(dec!(0.05)) {
-            // Very tight strikes (< 5% of underlying) - use minimal extension
-            strike_range * pos_lit(dec!(1.5)) // 150% of strike range
-        } else {
-            // Wider strikes - use moderate extension
-            strike_range * Positive::ONE // 100% of strike range
-        };
+        let base_extension =
+            if strike_range < self.underlying_price.checked_mul(&pos_lit(dec!(0.05)))? {
+                // Very tight strikes (< 5% of underlying) - use minimal extension
+                strike_range.checked_mul(&pos_lit(dec!(1.5)))? // 150% of strike range
+            } else {
+                // Wider strikes - use moderate extension
+                strike_range.checked_mul(&Positive::ONE)? // 100% of strike range
+            };
 
-        // Center around the underlying price for better focus
+        // Center around the underlying price for better focus. Strikes spread
+        // wider than the spot itself push the lower edge below zero, where the
+        // underlying cannot trade.
         let center_price = self.underlying_price;
-        let min_price = center_price - base_extension;
-        let max_price = center_price + base_extension;
+        let min_price = price_gap(center_price, base_extension);
+        let max_price = center_price.checked_add(&base_extension)?;
 
         Ok((min_price, max_price))
     }
@@ -227,16 +232,9 @@ impl CustomStrategy {
     /// Get the best range to show for visualization
     #[allow(dead_code)]
     fn best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
-        let mut prices = Vec::new();
-        let mut current_price = self.underlying_price * pos_lit(dec!(0.5));
-        let max_price = self.underlying_price * pos_lit(dec!(1.5));
-
-        while current_price <= max_price {
-            prices.push(current_price);
-            current_price += step;
-        }
-
-        Ok(prices)
+        let start = self.underlying_price.checked_mul(&pos_lit(dec!(0.5)))?;
+        let end = self.underlying_price.checked_mul(&pos_lit(dec!(1.5)))?;
+        calculate_price_range_bounded(start, end, step)
     }
 
     /// Refine a break-even point guess using Newton-Raphson method.
@@ -257,8 +255,11 @@ impl CustomStrategy {
             }
 
             // Calculate derivative numerically with smaller step
-            let h = self.epsilon.sqrt();
-            let f_x_h = self.calculate_profit_at(&(x + h)).ok()?.to_f64()?;
+            let h = self.epsilon.checked_sqrt().ok()?;
+            let f_x_h = self
+                .calculate_profit_at(&x.checked_add(&h).ok()?)
+                .ok()?
+                .to_f64()?;
             let derivative = (f_x_h - f_x) / h;
 
             // Avoid division by very small numbers
@@ -266,8 +267,9 @@ impl CustomStrategy {
                 break;
             }
 
-            // Newton-Raphson step
-            let next_x = x - f_x / derivative;
+            // Newton-Raphson step. A step below zero leaves the price domain,
+            // so the refinement gives up rather than aborting.
+            let next_x = x.checked_sub_f64(f_x / derivative).ok()?;
 
             // Check for convergence with absolute difference
             if (next_x.to_f64() - x.to_f64()).abs() < self.epsilon {
@@ -306,7 +308,10 @@ impl CustomStrategy {
 
         if break_even_points.len() == 1 {
             let break_even = break_even_points[0];
-            let test_point = break_even - pos_lit(dec!(0.01));
+            // A break-even inside the first cent has no probe point below it;
+            // zero is the floor of the price domain, and the multi-point
+            // branch below already measures the same distance that way.
+            let test_point = price_gap(break_even, pos_lit(dec!(0.01)));
             let is_profit_below = self.calculate_profit_at(&test_point)? > Decimal::ZERO;
 
             if is_profit_below {
@@ -392,19 +397,20 @@ impl BreakEvenable for CustomStrategy {
         self.break_even_points.clear();
 
         // Get a reasonable price range
-        let min_price = self.underlying_price * pos_lit(dec!(0.5));
-        let max_price = self.underlying_price * pos_lit(dec!(1.5));
+        let min_price = self.underlying_price.checked_mul(&pos_lit(dec!(0.5)))?;
+        let max_price = self.underlying_price.checked_mul(&pos_lit(dec!(1.5)))?;
         let step = pos_lit(dec!(0.01));
 
-        let mut current_price = min_price;
-        while current_price <= max_price {
+        // The scan advances one cent at a time, so an underlying in the
+        // billions asks for more samples than any machine will finish. That is
+        // reported rather than walked.
+        for current_price in calculate_price_range_bounded(min_price, max_price, step)? {
             if let Ok(profit) = self.calculate_profit_at(&current_price)
                 && profit.abs() < rust_decimal::Decimal::new(1, 2)
             {
                 // Close to zero
                 self.break_even_points.push(current_price);
             }
-            current_price += step;
         }
 
         Ok(())
@@ -634,7 +640,7 @@ impl Strategies for CustomStrategy {
     fn get_volume(&mut self) -> Result<Positive, StrategyError> {
         let mut total_volume = Positive::ZERO;
         for position in &self.positions {
-            total_volume += position.option.quantity;
+            total_volume = total_volume.checked_add(&position.option.quantity)?;
         }
         Ok(total_volume)
     }
@@ -659,7 +665,7 @@ impl Strategies for CustomStrategy {
             {
                 max_profit = current_profit;
             }
-            current_price += step;
+            current_price = current_price.checked_add(&step)?;
             iterations += 1;
         }
 
@@ -691,7 +697,7 @@ impl Strategies for CustomStrategy {
             {
                 max_loss = current_profit;
             }
-            current_price += step;
+            current_price = current_price.checked_add(&step)?;
             iterations += 1;
         }
 
@@ -721,13 +727,23 @@ impl Strategies for CustomStrategy {
             if let Ok(current_profit) = self.calculate_profit_at(&current_price)
                 && current_profit > Decimal::ZERO
             {
-                total_profit += current_profit;
+                total_profit = d_add(
+                    total_profit,
+                    current_profit,
+                    "CustomStrategy::get_profit_area",
+                )?;
             }
-            current_price += step;
+            current_price = current_price.checked_add(&step)?;
             iterations += 1;
         }
 
-        Ok(total_profit / self.underlying_price.to_dec())
+        // The area is expressed as a fraction of the spot, which a zero
+        // underlying leaves undefined.
+        Ok(d_div(
+            total_profit,
+            self.underlying_price.to_dec(),
+            "CustomStrategy::get_profit_area",
+        )?)
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -742,21 +758,21 @@ impl Strategies for CustomStrategy {
             return Ok(Decimal::ZERO);
         }
 
-        let ratio = (max_profit.to_dec() / max_loss.to_dec()) * Decimal::from(100);
+        let ratio = d_mul(
+            d_div(
+                max_profit.to_dec(),
+                max_loss.to_dec(),
+                "CustomStrategy::get_profit_ratio",
+            )?,
+            Decimal::from(100),
+            "CustomStrategy::get_profit_ratio",
+        )?;
         Ok(ratio)
     }
 
     fn get_best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
         let (start_price, end_price) = self.range_to_show()?;
-        let mut prices = Vec::new();
-        let mut current_price = start_price;
-
-        while current_price <= end_price {
-            prices.push(current_price);
-            current_price += step;
-        }
-
-        Ok(prices)
+        calculate_price_range_bounded(start_price, end_price, step)
     }
 
     fn roll_in(&mut self, _position: &Position) -> Result<HashMap<Action, Trade>, StrategyError> {
@@ -977,8 +993,11 @@ impl PnLCalculator for CustomStrategy {
     ) -> Result<PnL, PricingError> {
         let mut total = PnL::default();
         for position in &self.positions {
-            total = total
-                + position.calculate_pnl(market_price, expiration_date, implied_volatility)?;
+            total = total.try_add(&position.calculate_pnl(
+                market_price,
+                expiration_date,
+                implied_volatility,
+            )?)?;
         }
         Ok(total)
     }
@@ -989,7 +1008,7 @@ impl PnLCalculator for CustomStrategy {
     ) -> Result<PnL, PricingError> {
         let mut total = PnL::default();
         for position in &self.positions {
-            total = total + position.calculate_pnl_at_expiration(underlying_price)?;
+            total = total.try_add(&position.calculate_pnl_at_expiration(underlying_price)?)?;
         }
         Ok(total)
     }
@@ -999,7 +1018,7 @@ impl PnLCalculator for CustomStrategy {
 
         for position in &self.positions {
             let position_pnl = position.adjustments_pnl(adjustment)?;
-            total_pnl = total_pnl + position_pnl;
+            total_pnl = total_pnl.try_add(&position_pnl)?;
         }
 
         Ok(total_pnl)

--- a/src/strategies/delta_neutral/adjustment.rs
+++ b/src/strategies/delta_neutral/adjustment.rs
@@ -361,7 +361,13 @@ impl AdjustmentPlan {
         resulting_greeks: PortfolioGreeks,
         residual_delta: Decimal,
     ) -> Self {
-        let quality_score = residual_delta.abs() + estimated_cost * dec!(0.01);
+        // Ranking key, not a price: lower is better, so a combination that
+        // does not fit in a `Decimal` ranks last instead of aborting the
+        // infallible constructor.
+        let quality_score = estimated_cost
+            .checked_mul(dec!(0.01))
+            .and_then(|weighted| residual_delta.abs().checked_add(weighted))
+            .unwrap_or(Decimal::MAX);
         Self {
             actions,
             estimated_cost,
@@ -440,6 +446,12 @@ impl fmt::Display for AdjustmentError {
 }
 
 impl std::error::Error for AdjustmentError {}
+
+impl From<crate::error::DecimalError> for AdjustmentError {
+    fn from(error: crate::error::DecimalError) -> Self {
+        AdjustmentError::GreeksError(error.to_string())
+    }
+}
 
 impl From<GreeksError> for AdjustmentError {
     fn from(err: GreeksError) -> Self {

--- a/src/strategies/delta_neutral/model.rs
+++ b/src/strategies/delta_neutral/model.rs
@@ -52,6 +52,7 @@ use crate::error::{GreeksError, PositionError, StrategyError};
 /// based on the delta exposure of the strategy.
 use crate::greeks::Greeks;
 use crate::greeks::calculate_delta_neutral_sizes;
+use crate::model::decimal::{d_div, d_sub};
 use crate::model::types::{Action, OptionStyle};
 use crate::model::{Trade, TradeStatusAble};
 use crate::prelude::OperationErrorKind;
@@ -373,9 +374,17 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
         let mut individual_deltas: Vec<DeltaPositionInfo> = Vec::with_capacity(options.len());
         for option in options.iter() {
             let delta = option.delta()?;
+            // A leg with no contracts has no per-contract delta: the quotient
+            // is 0/0, and inventing a zero there would report a hedge ratio
+            // for a position that does not exist.
+            let delta_per_contract = d_div(
+                delta,
+                option.quantity.to_dec(),
+                "delta_neutrality::delta_per_contract",
+            )?;
             individual_deltas.push(DeltaPositionInfo {
                 delta,
-                delta_per_contract: delta / option.quantity,
+                delta_per_contract,
                 quantity: option.quantity,
                 strike: option.strike_price,
                 option_style: option.option_style,
@@ -504,7 +513,12 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
         }
 
         // Calculate how many contracts are needed to neutralize the net delta
-        let total_contracts_needed = (net_delta / option_delta_per_contract).abs();
+        let total_contracts_needed = d_div(
+            net_delta,
+            option_delta_per_contract,
+            "generate_delta_adjustments::total_contracts_needed",
+        )?
+        .abs();
         if total_contracts_needed == option.quantity.to_dec() {
             return Ok(DeltaAdjustment::NoAdjustmentNeeded);
         }
@@ -628,8 +642,12 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
         let mut total_size: Positive = Positive::ZERO;
         // Calculate adjustments for each option
         for option in &options {
-            let option_delta_per_contract = option.delta()? / option.quantity.to_dec();
-            total_size += option.quantity;
+            let option_delta_per_contract = d_div(
+                option.delta()?,
+                option.quantity.to_dec(),
+                "delta_adjustments::delta_per_contract",
+            )?;
+            total_size = total_size.checked_add(&option.quantity)?;
             if option_delta_per_contract.abs() > DELTA_THRESHOLD / dec!(10.0) {
                 // Try to generate delta adjustments, but skip if not possible
                 match self.generate_delta_adjustments(net_delta, option_delta_per_contract, option)
@@ -654,8 +672,16 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
             )?;
 
             // Calculate size differences (how much to adjust each position)
-            let size_diff1: Decimal = delta_neutral_size1.to_dec() - options[0].quantity.to_dec();
-            let size_diff2: Decimal = delta_neutral_size2.to_dec() - options[1].quantity.to_dec();
+            let size_diff1: Decimal = d_sub(
+                delta_neutral_size1.to_dec(),
+                options[0].quantity.to_dec(),
+                "delta_adjustments::size_diff1",
+            )?;
+            let size_diff2: Decimal = d_sub(
+                delta_neutral_size2.to_dec(),
+                options[1].quantity.to_dec(),
+                "delta_adjustments::size_diff2",
+            )?;
 
             // Create adjustment for the first option
             let adjustment1 = if size_diff1.is_sign_positive() {
@@ -907,7 +933,10 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
         let mut binding = self.get_position(option_type, side, strike)?;
         if let Some(current_position) = binding.first_mut() {
             let mut updated_position = (*current_position).clone();
-            updated_position.option.quantity += quantity;
+            // A negative adjustment larger than the leg would take the size
+            // below zero, which is not a position anyone can hold.
+            updated_position.option.quantity =
+                updated_position.option.quantity.checked_add_dec(quantity)?;
             self.modify_position(&updated_position)?;
         } else {
             return Err(PositionError::ValidationError(
@@ -1179,7 +1208,7 @@ pub trait DeltaNeutrality: Greeks + Positionable + Strategies {
     /// [`GreeksError::Pricing`] for option-leg Black–Scholes failures).
     fn delta_gap(&self, target_delta: Decimal) -> Result<Decimal, GreeksError> {
         let current_delta = self.delta()?;
-        Ok(target_delta - current_delta)
+        Ok(d_sub(target_delta, current_delta, "delta_gap")?)
     }
 }
 

--- a/src/strategies/delta_neutral/optimizer.rs
+++ b/src/strategies/delta_neutral/optimizer.rs
@@ -28,6 +28,7 @@
 
 use crate::chains::chain::OptionChain;
 use crate::greeks::Greeks;
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub};
 use crate::model::position::Position;
 use crate::model::types::Side;
 use num_traits::Signed;
@@ -201,11 +202,18 @@ impl<'a> AdjustmentOptimizer<'a> {
             .iter()
             .enumerate()
             .filter_map(|(i, p)| {
-                p.option.delta().ok().map(|d| {
+                p.option.delta().ok().and_then(|d| {
                     // `delta` already carries the leg's `Side`; applying the
-                    // sign again here cancelled it.
-                    let delta_per_contract = d / p.option.quantity.to_dec();
-                    (i, d, delta_per_contract)
+                    // sign again here cancelled it. A leg with no contracts
+                    // has no per-contract delta and cannot be resized, so it
+                    // drops out of the candidate list instead of aborting.
+                    d_div(
+                        d,
+                        p.option.quantity.to_dec(),
+                        "optimize_existing_legs::delta_per_contract",
+                    )
+                    .ok()
+                    .map(|delta_per_contract| (i, d, delta_per_contract))
                 })
             })
             .collect();
@@ -227,21 +235,47 @@ impl<'a> AdjustmentOptimizer<'a> {
                 continue;
             }
 
-            let current_qty = self.positions[idx].option.quantity.to_dec();
-            let adjustment_qty = remaining_delta / delta_per_contract;
+            let Some(position) = self.positions.get(idx) else {
+                continue;
+            };
+            let current_qty = position.option.quantity.to_dec();
+            let Ok(adjustment_qty) = d_div(
+                remaining_delta,
+                delta_per_contract,
+                "optimize_existing_legs::adjustment_qty",
+            ) else {
+                continue;
+            };
 
             // Calculate new quantity
-            let new_qty = current_qty + adjustment_qty;
+            let Ok(new_qty) = d_add(
+                current_qty,
+                adjustment_qty,
+                "optimize_existing_legs::new_qty",
+            ) else {
+                continue;
+            };
 
             // Can't have negative quantity
             if new_qty > Decimal::ZERO
                 && let Ok(new_quantity) = Positive::new_decimal(new_qty)
             {
+                let consumed = d_mul(
+                    adjustment_qty,
+                    delta_per_contract,
+                    "optimize_existing_legs::consumed_delta",
+                )
+                .map_err(|e| AdjustmentError::GreeksError(e.to_string()))?;
+                remaining_delta = d_sub(
+                    remaining_delta,
+                    consumed,
+                    "optimize_existing_legs::remaining_delta",
+                )
+                .map_err(|e| AdjustmentError::GreeksError(e.to_string()))?;
                 actions.push(AdjustmentAction::ModifyQuantity {
                     leg_index: idx,
                     new_quantity,
                 });
-                remaining_delta -= adjustment_qty * delta_per_contract;
             }
         }
 
@@ -283,7 +317,18 @@ impl<'a> AdjustmentOptimizer<'a> {
                 quantity,
             });
 
-            remaining_delta -= option_delta * quantity.to_dec();
+            let consumed = d_mul(
+                option_delta,
+                quantity.to_dec(),
+                "optimize_with_new_legs::consumed_delta",
+            )
+            .map_err(|e| AdjustmentError::GreeksError(e.to_string()))?;
+            remaining_delta = d_sub(
+                remaining_delta,
+                consumed,
+                "optimize_with_new_legs::remaining_delta",
+            )
+            .map_err(|e| AdjustmentError::GreeksError(e.to_string()))?;
         }
 
         self.build_plan(actions, remaining_delta)
@@ -337,9 +382,17 @@ impl<'a> AdjustmentOptimizer<'a> {
                     if let Ok(option_delta) = option.delta() {
                         // Check if this option helps reduce the gap
                         if option_delta.signum() == target_delta_sign {
-                            let quantity_needed =
-                                (delta_gap.abs() / option_delta.abs()).min(dec!(100));
-                            if let Ok(qty) = Positive::new_decimal(quantity_needed) {
+                            // A zero-delta candidate cannot close any gap, and
+                            // `signum` puts it in this branch whenever the gap
+                            // is itself zero.
+                            let Ok(quantity_needed) = d_div(
+                                delta_gap.abs(),
+                                option_delta.abs(),
+                                "optimize_with_new_legs::quantity_needed",
+                            ) else {
+                                continue;
+                            };
+                            if let Ok(qty) = Positive::new_decimal(quantity_needed.min(dec!(100))) {
                                 candidates.push((option, qty, option_delta));
                             }
                         }
@@ -350,16 +403,21 @@ impl<'a> AdjustmentOptimizer<'a> {
 
         // Sort by efficiency (delta per dollar cost)
         candidates.sort_by(|a, b| {
-            let eff_a = a.2.abs()
-                / a.0
-                    .calculate_price_black_scholes()
-                    .unwrap_or(dec!(1))
-                    .max(dec!(0.01));
-            let eff_b = b.2.abs()
-                / b.0
-                    .calculate_price_black_scholes()
-                    .unwrap_or(dec!(1))
-                    .max(dec!(0.01));
+            // Sort key only: a candidate whose delta-per-dollar is not
+            // representable sorts last rather than aborting the comparator,
+            // which has no error channel.
+            let efficiency = |c: &(crate::Options, Positive, Decimal)| {
+                d_div(
+                    c.2.abs(),
+                    c.0.calculate_price_black_scholes()
+                        .unwrap_or(dec!(1))
+                        .max(dec!(0.01)),
+                    "optimize_with_new_legs::efficiency",
+                )
+                .unwrap_or(Decimal::ZERO)
+            };
+            let eff_a = efficiency(a);
+            let eff_b = efficiency(b);
             // SAFETY: total order on Decimal; f64 fallback to Equal is safe for stable sort
             eff_b
                 .partial_cmp(&eff_a)
@@ -398,6 +456,9 @@ impl<'a> AdjustmentOptimizer<'a> {
 
     /// Estimates the cost of a set of actions.
     fn estimate_cost(&self, actions: &[AdjustmentAction]) -> Result<Decimal, AdjustmentError> {
+        fn add_cost(cost: Decimal, item: Decimal) -> Result<Decimal, AdjustmentError> {
+            Ok(d_add(cost, item, "estimate_cost::running_total")?)
+        }
         let mut cost = Decimal::ZERO;
 
         for action in actions {
@@ -408,7 +469,7 @@ impl<'a> AdjustmentOptimizer<'a> {
                     let price = option
                         .calculate_price_black_scholes()
                         .map_err(|e| AdjustmentError::GreeksError(e.to_string()))?;
-                    cost += price * quantity.to_dec();
+                    cost = add_cost(cost, d_mul(price, quantity.to_dec(), "estimate_cost::leg")?)?;
                 }
                 AdjustmentAction::AddUnderlying { quantity } => {
                     let spot = self
@@ -416,7 +477,10 @@ impl<'a> AdjustmentOptimizer<'a> {
                         .first()
                         .map(|p| p.option.underlying_price.to_dec())
                         .unwrap_or(Decimal::ZERO);
-                    cost += (spot * quantity).abs();
+                    cost = add_cost(
+                        cost,
+                        d_mul(spot, *quantity, "estimate_cost::underlying")?.abs(),
+                    )?;
                 }
                 AdjustmentAction::RollStrike {
                     leg_index,
@@ -429,18 +493,47 @@ impl<'a> AdjustmentOptimizer<'a> {
                             .option
                             .calculate_price_black_scholes()
                             .unwrap_or(Decimal::ZERO);
-                        // Approximate new price (simplified)
-                        let new_price = old_price
-                            * (dec!(1)
-                                + (new_strike.to_dec() - pos.option.strike_price.to_dec())
-                                    / pos.option.underlying_price.to_dec()
-                                    * dec!(0.5));
-                        cost += (new_price - old_price).abs() * quantity.to_dec();
+                        // Approximate new price (simplified). A zero
+                        // underlying leaves the relative strike move
+                        // undefined, so the roll is not costed rather than
+                        // dividing by it.
+                        let strike_move = d_sub(
+                            new_strike.to_dec(),
+                            pos.option.strike_price.to_dec(),
+                            "estimate_cost::strike_move",
+                        )?;
+                        let relative_move = d_mul(
+                            d_div(
+                                strike_move,
+                                pos.option.underlying_price.to_dec(),
+                                "estimate_cost::relative_strike_move",
+                            )?,
+                            dec!(0.5),
+                            "estimate_cost::relative_strike_move_damped",
+                        )?;
+                        let new_price = d_mul(
+                            old_price,
+                            d_add(dec!(1), relative_move, "estimate_cost::roll_factor")?,
+                            "estimate_cost::rolled_price",
+                        )?;
+                        let delta_price =
+                            d_sub(new_price, old_price, "estimate_cost::roll_price_delta")?.abs();
+                        cost = add_cost(
+                            cost,
+                            d_mul(delta_price, quantity.to_dec(), "estimate_cost::roll")?,
+                        )?;
                     }
                 }
                 AdjustmentAction::RollExpiration { quantity, .. } => {
                     // Approximate cost for rolling expiration
-                    cost += quantity.to_dec() * dec!(0.10); // Simplified estimate
+                    cost = add_cost(
+                        cost,
+                        d_mul(
+                            quantity.to_dec(),
+                            dec!(0.10),
+                            "estimate_cost::roll_expiration",
+                        )?,
+                    )?; // Simplified estimate
                 }
                 _ => {}
             }

--- a/src/strategies/delta_neutral/portfolio.rs
+++ b/src/strategies/delta_neutral/portfolio.rs
@@ -29,6 +29,7 @@
 
 use crate::error::GreeksError;
 use crate::greeks::Greeks;
+use crate::model::decimal::d_add;
 use crate::model::position::Position;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -102,7 +103,9 @@ impl PortfolioGreeks {
     /// Propagates any [`GreeksError`] returned by [`Greeks::delta`],
     /// [`Greeks::gamma`], [`Greeks::theta`], [`Greeks::vega`] or
     /// [`Greeks::rho`] on the input positions — typically
-    /// [`GreeksError::Pricing`] when Black–Scholes fails on a leg.
+    /// [`GreeksError::Pricing`] when Black–Scholes fails on a leg — and
+    /// [`GreeksError::CalculationError`] with [`crate::error::greeks::CalculationErrorKind::DecimalError`] when the running total of a greek leaves
+    /// the `Decimal` range.
     pub fn from_positions(positions: &[Position]) -> Result<Self, GreeksError> {
         let mut greeks = Self::default();
 
@@ -110,11 +113,11 @@ impl PortfolioGreeks {
             // `Position` implements `Greeks`, and every greek already carries
             // the leg's `Side` and `quantity`. Re-applying a `quantity * sign`
             // multiplier here squared the size and cancelled the sign.
-            greeks.delta += pos.delta()?;
-            greeks.gamma += pos.gamma()?;
-            greeks.theta += pos.theta()?;
-            greeks.vega += pos.vega()?;
-            greeks.rho += pos.rho()?;
+            greeks.delta = d_add(greeks.delta, pos.delta()?, "PortfolioGreeks::delta")?;
+            greeks.gamma = d_add(greeks.gamma, pos.gamma()?, "PortfolioGreeks::gamma")?;
+            greeks.theta = d_add(greeks.theta, pos.theta()?, "PortfolioGreeks::theta")?;
+            greeks.vega = d_add(greeks.vega, pos.vega()?, "PortfolioGreeks::vega")?;
+            greeks.rho = d_add(greeks.rho, pos.rho()?, "PortfolioGreeks::rho")?;
         }
 
         Ok(greeks)
@@ -133,16 +136,20 @@ impl PortfolioGreeks {
     ///
     /// # Errors
     ///
-    /// Same failure surface as [`PortfolioGreeks::from_positions`] —
-    /// only the option legs can fail; the underlying adjustment is pure
-    /// arithmetic and does not introduce new error paths.
+    /// Same failure surface as [`PortfolioGreeks::from_positions`], plus
+    /// [`GreeksError::CalculationError`] with [`crate::error::greeks::CalculationErrorKind::DecimalError`] when adding the underlying delta leaves
+    /// the `Decimal` range.
     pub fn from_positions_with_underlying(
         positions: &[Position],
         underlying_quantity: Decimal,
     ) -> Result<Self, GreeksError> {
         let mut greeks = Self::from_positions(positions)?;
         // Each share of underlying has delta = 1
-        greeks.delta += underlying_quantity;
+        greeks.delta = d_add(
+            greeks.delta,
+            underlying_quantity,
+            "PortfolioGreeks::from_positions_with_underlying",
+        )?;
         Ok(greeks)
     }
 

--- a/src/strategies/long_call.rs
+++ b/src/strategies/long_call.rs
@@ -13,6 +13,7 @@ use crate::error::{
     probability::ProfitLossRangeErrorKind,
 };
 use crate::greeks::Greeks;
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
 use crate::model::{
     ProfitLossRange,
     position::Position,
@@ -23,6 +24,7 @@ use crate::pricing::payoff::Profit;
 use crate::simulation::simulator::Simulator;
 use crate::simulation::{ExitPolicy, Simulate};
 use crate::strategies::base::Optimizable;
+use crate::strategies::base::lower_break_even;
 use crate::strategies::base::price_gap;
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
@@ -272,10 +274,18 @@ impl BreakEvenable for LongCall {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
+        // `lower_break_even` measures a distance below the strike and floors at
+        // zero. A credit larger than the strike puts the break-even where the
+        // underlying cannot trade, and `Positive::ZERO` is this layer's
+        // sentinel for "no lower break-even" rather than an abort.
+        let per_contract = d_div(
+            self.get_net_cost()?,
+            self.long_call.option.quantity.to_dec(),
+            "LongCall::update_break_even_points",
+        )?;
         self.break_even_points.push(
-            (self.long_call.option.strike_price
-                + self.get_net_cost()? / self.long_call.option.quantity)
-                .round_to(2),
+            lower_break_even(self.long_call.option.strike_price, -per_contract)
+                .checked_round_to(2)?,
         );
 
         Ok(())
@@ -292,10 +302,10 @@ impl Strategies for LongCall {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = price_gap(
-            self.long_call.option.strike_price,
-            self.break_even_points[0],
-        );
+        let break_even = self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("LongCall::get_profit_area: no break-even points")
+        })?;
+        let base = price_gap(self.long_call.option.strike_price, *break_even);
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -609,7 +619,11 @@ where
                 // Track premium statistics
                 max_premium = max_premium.max(current_premium);
                 min_premium = min_premium.min(current_premium);
-                premium_sum += current_premium;
+                premium_sum = d_add(
+                    premium_sum,
+                    current_premium,
+                    "LongCall::simulate/premium_sum",
+                )?;
                 premium_count += 1;
                 holding_period = index;
 
@@ -627,7 +641,20 @@ where
 
                     // Check if it's take profit or stop loss
                     // For long: profit when current > initial, loss when current < initial
-                    let pnl_percent = (current_premium - initial_premium) / initial_premium;
+                    // A leg that opened at a zero premium has no
+                    // percentage to move by; the exit still fires, it just
+                    // does not classify as a take-profit or a stop-loss.
+                    let move_from_open = d_sub(
+                        current_premium,
+                        initial_premium,
+                        "LongCall::simulate/pnl_move",
+                    )?;
+                    let pnl_percent = d_div(
+                        move_from_open,
+                        initial_premium,
+                        "LongCall::simulate/pnl_percent",
+                    )
+                    .unwrap_or(Decimal::ZERO);
                     if pnl_percent >= dec!(0.5) {
                         hit_take_profit = true;
                     } else if pnl_percent <= dec!(-1.0) {
@@ -639,7 +666,7 @@ where
                     // We use direct premium calculation instead of calculate_pnl() to avoid discrepancies
                     // from recalculating the initial premium
                     let pnl = PnL {
-                        realized: Some(current_premium - initial_premium),
+                        realized: Some(move_from_open),
                         unrealized: None,
                         initial_costs: Positive::ZERO,
                         initial_income: Positive::ZERO,
@@ -707,7 +734,8 @@ where
         let profitable_count = pnl_values.iter().filter(|&&pnl| pnl > dec!(0.0)).count();
         let loss_count = pnl_values.iter().filter(|&&pnl| pnl < dec!(0.0)).count();
 
-        let sum_pnl: Decimal = pnl_values.iter().sum();
+        let sum_pnl: Decimal =
+            d_sum_iter(pnl_values.iter().copied(), "LongCall::simulate/sum_pnl")?;
         let average_pnl = if total_simulations > 0 {
             sum_pnl / Decimal::from(total_simulations)
         } else {
@@ -716,21 +744,49 @@ where
 
         let median_pnl = if !pnl_values.is_empty() {
             let mid = pnl_values.len() / 2;
+            let at = |i: usize| {
+                pnl_values.get(i).copied().ok_or_else(|| {
+                    SimulationError::invalid_parameters(
+                        "LongCall::simulate: median index out of range",
+                    )
+                })
+            };
             if pnl_values.len().is_multiple_of(2) {
-                (pnl_values[mid - 1] + pnl_values[mid]) / dec!(2.0)
+                d_div(
+                    d_add(
+                        at(mid.checked_sub(1).ok_or_else(|| {
+                            SimulationError::invalid_parameters(
+                                "LongCall::simulate: even sample count with no lower median",
+                            )
+                        })?)?,
+                        at(mid)?,
+                        "LongCall::simulate/median",
+                    )?,
+                    dec!(2.0),
+                    "LongCall::simulate/median",
+                )?
             } else {
-                pnl_values[mid]
+                at(mid)?
             }
         } else {
             dec!(0.0)
         };
 
         let variance = if total_simulations > 1 {
-            let sum_squared_diff: Decimal = pnl_values
-                .iter()
-                .map(|&pnl| (pnl - average_pnl).powi(2))
-                .sum();
-            sum_squared_diff / Decimal::from(total_simulations - 1)
+            let mut sum_squared_diff = Decimal::ZERO;
+            for &pnl in &pnl_values {
+                let diff = d_sub(pnl, average_pnl, "LongCall::simulate/variance_diff")?;
+                sum_squared_diff = d_add(
+                    sum_squared_diff,
+                    d_mul(diff, diff, "LongCall::simulate/variance_square")?,
+                    "LongCall::simulate/variance_sum",
+                )?;
+            }
+            d_div(
+                sum_squared_diff,
+                Decimal::from(total_simulations - 1),
+                "LongCall::simulate/variance",
+            )?
         } else {
             dec!(0.0)
         };

--- a/src/strategies/long_put.rs
+++ b/src/strategies/long_put.rs
@@ -280,7 +280,7 @@ impl BreakEvenable for LongPut {
             "LongPut::update_break_even_points",
         )?;
         self.break_even_points.push(
-            lower_break_even(self.long_put.option.strike_price, -per_contract)
+            lower_break_even(self.long_put.option.strike_price, per_contract)
                 .checked_round_to(2)?,
         );
 
@@ -833,6 +833,41 @@ where
 impl Strategable for LongPut {}
 
 test_strategy_traits!(LongPut, test_long_put_implementations);
+
+#[cfg(test)]
+mod tests_break_even {
+    use super::*;
+    use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
+
+    /// A long put pays a debit, so its lower break-even sits *below* the
+    /// strike: a 100 strike bought for 5 breaks even at 95. Negating the
+    /// per-contract cost moved it the other way and reported 105. The
+    /// `StrategyConstructor` property cannot reach this, since `LongPut`
+    /// answers `OperationNotSupported` and that branch never runs.
+    #[test]
+    fn test_long_put_lower_break_even_sits_below_the_strike() {
+        let mut long_put = LongPut::new(
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            pos_or_panic!(0.20),
+            Positive::ONE,
+            Positive::HUNDRED,
+            dec!(0.05),
+            Positive::ZERO,
+            pos_or_panic!(5.0),
+            Positive::ZERO,
+            Positive::ZERO,
+        )
+        .unwrap();
+        long_put.update_break_even_points().unwrap();
+
+        let break_evens = long_put.get_break_even_points().unwrap();
+        assert_eq!(break_evens.len(), 1);
+        assert_eq!(break_evens[0], pos_or_panic!(95.0));
+    }
+}
 
 #[cfg(test)]
 mod tests_simulate {

--- a/src/strategies/long_put.rs
+++ b/src/strategies/long_put.rs
@@ -6,6 +6,8 @@
 
 use super::base::{BreakEvenable, Positionable, StrategyType};
 use crate::backtesting::results::{SimulationResult, SimulationStatsResult};
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
+use crate::strategies::base::lower_break_even;
 
 use crate::chains::OptionChain;
 use crate::error::strategies::ProfitLossErrorKind;
@@ -268,10 +270,18 @@ impl BreakEvenable for LongPut {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
+        // `lower_break_even` measures a distance below the strike and floors at
+        // zero. A credit larger than the strike puts the break-even where the
+        // underlying cannot trade, and `Positive::ZERO` is this layer's
+        // sentinel for "no lower break-even" rather than an abort.
+        let per_contract = d_div(
+            self.get_net_cost()?,
+            self.long_put.option.quantity.to_dec(),
+            "LongPut::update_break_even_points",
+        )?;
         self.break_even_points.push(
-            (self.long_put.option.strike_price
-                + self.get_net_cost()? / self.long_put.option.quantity)
-                .round_to(2),
+            lower_break_even(self.long_put.option.strike_price, -per_contract)
+                .checked_round_to(2)?,
         );
 
         Ok(())
@@ -298,7 +308,10 @@ impl Strategies for LongPut {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = price_gap(self.long_put.option.strike_price, self.break_even_points[0]);
+        let break_even = self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("LongPut::get_profit_area: no break-even points")
+        })?;
+        let base = price_gap(self.long_put.option.strike_price, *break_even);
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -612,7 +625,11 @@ where
                 // Track premium statistics
                 max_premium = max_premium.max(current_premium);
                 min_premium = min_premium.min(current_premium);
-                premium_sum += current_premium;
+                premium_sum = d_add(
+                    premium_sum,
+                    current_premium,
+                    "LongPut::simulate/premium_sum",
+                )?;
                 premium_count += 1;
                 holding_period = index;
 
@@ -630,7 +647,20 @@ where
 
                     // Check if it's take profit or stop loss
                     // For long: profit when current > initial, loss when current < initial
-                    let pnl_percent = (current_premium - initial_premium) / initial_premium;
+                    // A leg that opened at a zero premium has no
+                    // percentage to move by; the exit still fires, it just
+                    // does not classify as a take-profit or a stop-loss.
+                    let move_from_open = d_sub(
+                        current_premium,
+                        initial_premium,
+                        "LongPut::simulate/pnl_move",
+                    )?;
+                    let pnl_percent = d_div(
+                        move_from_open,
+                        initial_premium,
+                        "LongPut::simulate/pnl_percent",
+                    )
+                    .unwrap_or(Decimal::ZERO);
                     if pnl_percent >= dec!(0.5) {
                         hit_take_profit = true;
                     } else if pnl_percent <= dec!(-1.0) {
@@ -642,7 +672,7 @@ where
                     // We use direct premium calculation instead of calculate_pnl() to avoid discrepancies
                     // from recalculating the initial premium
                     let pnl = PnL {
-                        realized: Some(current_premium - initial_premium),
+                        realized: Some(move_from_open),
                         unrealized: None,
                         initial_costs: Positive::ZERO,
                         initial_income: Positive::ZERO,
@@ -710,7 +740,7 @@ where
         let profitable_count = pnl_values.iter().filter(|&&pnl| pnl > dec!(0.0)).count();
         let loss_count = pnl_values.iter().filter(|&&pnl| pnl < dec!(0.0)).count();
 
-        let sum_pnl: Decimal = pnl_values.iter().sum();
+        let sum_pnl: Decimal = d_sum_iter(pnl_values.iter().copied(), "LongPut::simulate/sum_pnl")?;
         let average_pnl = if total_simulations > 0 {
             sum_pnl / Decimal::from(total_simulations)
         } else {
@@ -719,21 +749,49 @@ where
 
         let median_pnl = if !pnl_values.is_empty() {
             let mid = pnl_values.len() / 2;
+            let at = |i: usize| {
+                pnl_values.get(i).copied().ok_or_else(|| {
+                    SimulationError::invalid_parameters(
+                        "LongPut::simulate: median index out of range",
+                    )
+                })
+            };
             if pnl_values.len().is_multiple_of(2) {
-                (pnl_values[mid - 1] + pnl_values[mid]) / dec!(2.0)
+                d_div(
+                    d_add(
+                        at(mid.checked_sub(1).ok_or_else(|| {
+                            SimulationError::invalid_parameters(
+                                "LongPut::simulate: even sample count with no lower median",
+                            )
+                        })?)?,
+                        at(mid)?,
+                        "LongPut::simulate/median",
+                    )?,
+                    dec!(2.0),
+                    "LongPut::simulate/median",
+                )?
             } else {
-                pnl_values[mid]
+                at(mid)?
             }
         } else {
             dec!(0.0)
         };
 
         let variance = if total_simulations > 1 {
-            let sum_squared_diff: Decimal = pnl_values
-                .iter()
-                .map(|&pnl| (pnl - average_pnl).powi(2))
-                .sum();
-            sum_squared_diff / Decimal::from(total_simulations - 1)
+            let mut sum_squared_diff = Decimal::ZERO;
+            for &pnl in &pnl_values {
+                let diff = d_sub(pnl, average_pnl, "LongPut::simulate/variance_diff")?;
+                sum_squared_diff = d_add(
+                    sum_squared_diff,
+                    d_mul(diff, diff, "LongPut::simulate/variance_square")?,
+                    "LongPut::simulate/variance_sum",
+                )?;
+            }
+            d_div(
+                sum_squared_diff,
+                Decimal::from(total_simulations - 1),
+                "LongPut::simulate/variance",
+            )?
         } else {
             dec!(0.0)
         };

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -688,7 +688,7 @@ impl Strategies for LongStrangle {
         debug!("Start price: {}", start_price);
         let end_price = last_option + diff;
         debug!("End price: {}", end_price);
-        Ok(calculate_price_range(start_price, end_price, step))
+        calculate_price_range(start_price, end_price, step)
     }
 }
 

--- a/src/strategies/probabilities/core.rs
+++ b/src/strategies/probabilities/core.rs
@@ -14,6 +14,7 @@ use positive::pos_or_panic;
 use crate::error::probability::ProbabilityError;
 use crate::error::strategies::StrategyError;
 use crate::model::ProfitLossRange;
+use crate::model::utils::sub_floor_zero;
 use crate::pricing::payoff::Profit;
 use crate::strategies::base::Strategies;
 use crate::strategies::probabilities::analysis::StrategyProbabilityAnalysis;
@@ -186,7 +187,11 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
                 None,
             )?;
 
-            let marginal_prob = prob.0 - last_prob;
+            // The CDF is monotone over an ascending price range, so the
+            // marginal mass is non-negative; flooring absorbs the rounding of
+            // the `Decimal -> f64 -> Decimal` round trip inside `big_n`
+            // instead of aborting on a difference of one ulp.
+            let marginal_prob = sub_floor_zero(prob.0, &last_prob);
             probabilities.push(marginal_prob);
             last_prob = prob.0.to_dec();
         }
@@ -254,7 +259,7 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
                 &expiration,
                 Some(risk_free_rate),
             )?;
-            sum_of_probabilities += range.probability;
+            sum_of_probabilities = sum_of_probabilities.checked_add(&range.probability)?;
         }
         Ok(sum_of_probabilities)
     }
@@ -298,7 +303,7 @@ pub trait ProbabilityAnalysis: Strategies + Profit {
                 &expiration,
                 Some(risk_free_rate),
             )?;
-            sum_of_probabilities += range.probability;
+            sum_of_probabilities = sum_of_probabilities.checked_add(&range.probability)?;
         }
         Ok(sum_of_probabilities)
     }

--- a/src/strategies/probabilities/utils.rs
+++ b/src/strategies/probabilities/utils.rs
@@ -10,6 +10,7 @@ use crate::error::probability::{
 use crate::f2du;
 use crate::greeks::big_n;
 use crate::model::ExpirationDate;
+use crate::model::utils::sub_floor_zero;
 use num_traits::ToPrimitive;
 use positive::Positive;
 #[cfg(test)]
@@ -60,10 +61,15 @@ pub struct PriceTrend {
 ///
 /// # Errors
 ///
-/// Returns an error string if:
+/// Returns an error if:
+/// - `current_price` is zero, which leaves the log price ratio undefined
+///   ([`ProbabilityError::PriceError`] with
+///   [`PriceErrorKind::InvalidUnderlyingPrice`]).
 /// - `time_to_expiry` is not positive, indicating the expiration date has passed or is invalid.
 /// - `volatility_adj.base_volatility` is non-positive.
 /// - `trend.confidence` is not between 0 and 1.
+/// - the price ratio, its logarithm, or the volatility scaling leaves the
+///   representable range ([`ProbabilityError::PositiveError`]).
 ///
 pub fn calculate_single_point_probability(
     current_price: &Positive,
@@ -75,6 +81,18 @@ pub fn calculate_single_point_probability(
 ) -> Result<(Positive, Positive), ProbabilityError> {
     if *target_price == Positive::ZERO {
         return Ok((Positive::ZERO, Positive::ONE));
+    }
+    // The log-normal model is built on the ratio `target / current`. A spot of
+    // zero has no ratio and no return distribution around it, so it is
+    // rejected here rather than dividing by it below.
+    if *current_price == Positive::ZERO {
+        return Err(ProbabilityError::PriceError(
+            PriceErrorKind::InvalidUnderlyingPrice {
+                price: 0.0,
+                reason: "current price must be strictly positive to form the log price ratio"
+                    .to_string(),
+            },
+        ));
     }
     let time_to_expiry = expiration_date.get_years()?;
     if time_to_expiry <= 0.0 {
@@ -98,7 +116,8 @@ pub fn calculate_single_point_probability(
                     },
                 ));
             }
-            adj.base_volatility * (1.0 + adj.std_dev_adjustment)
+            adj.base_volatility
+                .checked_mul_f64(1.0 + adj.std_dev_adjustment)?
         }
         None => Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO), // Default volatility if not provided
     };
@@ -135,9 +154,12 @@ pub fn calculate_single_point_probability(
         })?,
     };
 
-    // Calculate parameters for the log-normal distribution
-    let log_ratio = (*target_price / *current_price).ln();
-    let std_dev = volatility * time_to_expiry.sqrt();
+    // Calculate parameters for the log-normal distribution. A spot far below
+    // the target overflows the ratio, and a spot far above it rounds the ratio
+    // to zero, where the logarithm is undefined; both are reported rather than
+    // aborting.
+    let log_ratio = target_price.checked_div(current_price)?.checked_ln()?;
+    let std_dev = volatility.checked_mul(&time_to_expiry.checked_sqrt()?)?;
 
     // Calculate z-score considering drift
     // `Positive::ln` returns `Decimal` as of positive 0.6: the log of a
@@ -222,9 +244,12 @@ pub fn calculate_price_probability(
         risk_free_rate,
     )?;
 
-    // Calculate the three required probabilities
+    // Calculate the three required probabilities. The normal CDF is monotone,
+    // so the mass in the range is non-negative by construction; flooring
+    // absorbs the rounding of the two independent `Decimal -> f64 -> Decimal`
+    // round trips rather than aborting on a difference of one ulp.
     let prob_below_range = prob_below_lower;
-    let prob_in_range = prob_below_upper - prob_below_lower;
+    let prob_in_range = sub_floor_zero(prob_below_upper, prob_below_lower.to_dec_ref());
     let prob_above_range = prob_above_upper;
 
     Ok((prob_below_range, prob_in_range, prob_above_range))

--- a/src/strategies/protective_put.rs
+++ b/src/strategies/protective_put.rs
@@ -25,12 +25,14 @@ use crate::error::{GreeksError, PositionError, PricingError, StrategyError};
 use crate::greeks::Greeks;
 use crate::model::ExpirationDate;
 use crate::model::ProfitLossRange;
+use crate::model::decimal::{d_add, d_div, d_sub};
 use crate::model::leg::traits::LegAble;
 use crate::model::leg::{Leg, SpotPosition};
 use crate::model::position::Position;
 use crate::model::types::{OptionBasicType, OptionStyle, OptionType, Side};
 use crate::pnl::PnLCalculator;
 use crate::pricing::payoff::Profit;
+use crate::strategies::base::price_gap;
 use crate::strategies::delta_neutral::DeltaNeutrality;
 use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
@@ -90,6 +92,17 @@ impl ProtectivePut {
         put_open_fee: Positive,
         put_close_fee: Positive,
     ) -> Result<Self, StrategyError> {
+        // Every per-share figure this strategy reports — the effective cost
+        // basis, the break-even, the premium per share — divides by the size
+        // of the spot leg. A protective put with no shares is not a position, and
+        // rejecting it here keeps those divisors non-zero.
+        if quantity == Positive::ZERO {
+            return Err(StrategyError::invalid_parameters(
+                "ProtectivePut::new",
+                "quantity must be strictly positive: a protective put with no shares has no per-share basis",
+            ));
+        }
+
         let spot_leg = SpotPosition::new(
             underlying_symbol.clone(),
             quantity,
@@ -184,7 +197,7 @@ impl ProtectivePut {
     pub fn net_delta(&self) -> Result<Decimal, GreeksError> {
         let spot_delta = self.spot_leg.delta()?;
         let put_delta = self.long_put.delta()?;
-        Ok(spot_delta + put_delta)
+        Ok(d_add(spot_delta, put_delta, "ProtectivePut::net_delta")?)
     }
 
     /// Calculates the maximum loss potential.
@@ -202,16 +215,35 @@ impl ProtectivePut {
         let put_strike = self.put_strike();
         let cost_basis = self.spot_leg.cost_basis;
         let quantity = self.spot_leg.quantity;
-        let put_premium = self.long_put.premium * self.long_put.option.quantity;
+        let put_premium = self
+            .long_put
+            .premium
+            .checked_mul(&self.long_put.option.quantity)?;
         let total_fees = self.total_fees();
 
         if cost_basis >= put_strike {
-            let capital_loss = (cost_basis - put_strike) * quantity;
-            let total_loss = capital_loss.to_dec() + put_premium.to_dec() + total_fees.to_dec();
+            let capital_loss = price_gap(cost_basis, put_strike).checked_mul(&quantity)?;
+            let total_loss = d_add(
+                d_add(
+                    capital_loss.to_dec(),
+                    put_premium.to_dec(),
+                    "ProtectivePut::max_loss",
+                )?,
+                total_fees.to_dec(),
+                "ProtectivePut::max_loss",
+            )?;
             Ok(Positive::new_decimal(total_loss.max(Decimal::ZERO)).unwrap_or(Positive::ZERO))
         } else {
-            let capital_gain = (put_strike - cost_basis) * quantity;
-            let total_loss = put_premium.to_dec() + total_fees.to_dec() - capital_gain.to_dec();
+            let capital_gain = price_gap(put_strike, cost_basis).checked_mul(&quantity)?;
+            let total_loss = d_sub(
+                d_add(
+                    put_premium.to_dec(),
+                    total_fees.to_dec(),
+                    "ProtectivePut::max_loss",
+                )?,
+                capital_gain.to_dec(),
+                "ProtectivePut::max_loss",
+            )?;
             Ok(Positive::new_decimal(total_loss.max(Decimal::ZERO)).unwrap_or(Positive::ZERO))
         }
     }
@@ -280,9 +312,17 @@ impl BreakEvenable for ProtectivePut {
         let put_premium = self.long_put.premium.to_dec();
         let quantity = self.spot_leg.quantity.to_dec();
         let total_fees = self.total_fees();
-        let break_even = entry_price + put_premium + (total_fees.to_dec() / quantity);
+        let break_even = d_add(
+            d_add(entry_price, put_premium, "ProtectivePut::break_even")?,
+            d_div(
+                total_fees.to_dec(),
+                quantity,
+                "ProtectivePut::break_even/fees_per_share",
+            )?,
+            "ProtectivePut::break_even",
+        )?;
         if let Ok(be) = Positive::new_decimal(break_even) {
-            self.break_even_points.push(be.round_to(2));
+            self.break_even_points.push(be.checked_round_to(2)?);
         }
         Ok(())
     }
@@ -348,6 +388,19 @@ impl Strategable for ProtectivePut {
 }
 
 impl BasicAble for ProtectivePut {
+    // Without this override the trait default aborts the process, and it is
+    // reached from `get_underlying_price`, `get_max_min_strikes`,
+    // `delta_neutrality` and every probability method. The long put carries the
+    // same underlying, expiration and rate as the spot leg, so it answers for
+    // the strategy.
+    fn one_option(&self) -> &Options {
+        self.long_put.one_option()
+    }
+
+    fn one_option_mut(&mut self) -> &mut Options {
+        self.long_put.one_option_mut()
+    }
+
     fn get_title(&self) -> String {
         format!(
             "Protective Put Strategy:\n\t{} {} {} @ {}\n\t{}",
@@ -419,7 +472,11 @@ impl Profit for ProtectivePut {
             .long_put
             .pnl_at_expiration(&Some(price))
             .unwrap_or(Decimal::ZERO);
-        Ok(spot_pnl + put_pnl)
+        Ok(d_add(
+            spot_pnl,
+            put_pnl,
+            "ProtectivePut::pnl_at_expiration",
+        )?)
     }
 }
 
@@ -449,11 +506,14 @@ impl PnLCalculator for ProtectivePut {
     ) -> Result<crate::pnl::utils::PnL, PricingError> {
         let profit = self.calculate_profit_at(underlying_price)?;
         let spot_cost = self.spot_leg.total_cost();
-        let put_cost = self.long_put.premium * self.long_put.option.quantity;
+        let put_cost = self
+            .long_put
+            .premium
+            .checked_mul(&self.long_put.option.quantity)?;
         Ok(crate::pnl::utils::PnL {
             realized: None,
             unrealized: Some(profit),
-            initial_costs: spot_cost + put_cost,
+            initial_costs: spot_cost.checked_add(&put_cost)?,
             initial_income: Positive::ZERO,
             date_time: Utc::now(),
         })

--- a/src/strategies/protective_put.rs
+++ b/src/strategies/protective_put.rs
@@ -25,7 +25,7 @@ use crate::error::{GreeksError, PositionError, PricingError, StrategyError};
 use crate::greeks::Greeks;
 use crate::model::ExpirationDate;
 use crate::model::ProfitLossRange;
-use crate::model::decimal::{d_add, d_div, d_sub};
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub};
 use crate::model::leg::traits::LegAble;
 use crate::model::leg::{Leg, SpotPosition};
 use crate::model::position::Position;
@@ -39,6 +39,7 @@ use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::{BasicAble, Strategies};
 use chrono::Utc;
 use positive::Positive;
+use positive::PositiveError;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -100,6 +101,17 @@ impl ProtectivePut {
             return Err(StrategyError::invalid_parameters(
                 "ProtectivePut::new",
                 "quantity must be strictly positive: a protective put with no shares has no per-share basis",
+            ));
+        }
+
+        // `protection_level` measures the strike against this price, so a
+        // zero spot leaves it dividing by zero. The method stays fallible for
+        // a deserialized position, which reaches the struct without passing
+        // through here, but a position built by this constructor is sound.
+        if underlying_price == Positive::ZERO {
+            return Err(StrategyError::invalid_parameters(
+                "ProtectivePut::new",
+                "underlying price must be strictly positive: the protection level is measured against it",
             ));
         }
 
@@ -219,7 +231,7 @@ impl ProtectivePut {
             .long_put
             .premium
             .checked_mul(&self.long_put.option.quantity)?;
-        let total_fees = self.total_fees();
+        let total_fees = self.total_fees()?;
 
         if cost_basis >= put_strike {
             let capital_loss = price_gap(cost_basis, put_strike).checked_mul(&quantity)?;
@@ -249,19 +261,50 @@ impl ProtectivePut {
     }
 
     /// Calculates total fees for all positions.
-    #[must_use]
-    pub fn total_fees(&self) -> Positive {
-        self.spot_leg.open_fee
-            + self.spot_leg.close_fee
-            + (self.long_put.open_fee + self.long_put.close_fee) * self.long_put.option.quantity
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PositiveError`] when the running total leaves the `Positive`
+    /// range. A fee at `Positive::MAX` used to abort inside the raw sum.
+    pub fn total_fees(&self) -> Result<Positive, PositiveError> {
+        let put_fees = self
+            .long_put
+            .open_fee
+            .checked_add(&self.long_put.close_fee)?
+            .checked_mul(&self.long_put.option.quantity)?;
+        self.spot_leg
+            .open_fee
+            .checked_add(&self.spot_leg.close_fee)?
+            .checked_add(&put_fees)
     }
 
     /// Returns the protection level as a percentage below current price.
-    #[must_use]
-    pub fn protection_level(&self) -> Decimal {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StrategyError`] when the spot leg's cost basis is zero, which
+    /// [`ProtectivePut::new`] rejects but a deserialized position can still
+    /// carry, and when the difference or the ratio leaves the representable
+    /// `Decimal` range.
+    pub fn protection_level(&self) -> Result<Decimal, StrategyError> {
         let current_price = self.spot_leg.cost_basis.to_dec();
         let put_strike = self.long_put.option.strike_price.to_dec();
-        ((current_price - put_strike) / current_price) * Decimal::ONE_HUNDRED
+        let below = d_sub(
+            current_price,
+            put_strike,
+            "ProtectivePut::protection_level/below",
+        )?;
+        let ratio = d_div(
+            below,
+            current_price,
+            "ProtectivePut::protection_level/ratio",
+        )?;
+        d_mul(
+            ratio,
+            Decimal::ONE_HUNDRED,
+            "ProtectivePut::protection_level",
+        )
+        .map_err(Into::into)
     }
 
     /// Calculates the effective cost basis (Price paid for spot + Premium paid for put).
@@ -311,7 +354,7 @@ impl BreakEvenable for ProtectivePut {
         let entry_price = self.spot_leg.cost_basis.to_dec();
         let put_premium = self.long_put.premium.to_dec();
         let quantity = self.spot_leg.quantity.to_dec();
-        let total_fees = self.total_fees();
+        let total_fees = self.total_fees()?;
         let break_even = d_add(
             d_add(entry_price, put_premium, "ProtectivePut::break_even")?,
             d_div(
@@ -594,7 +637,10 @@ impl std::fmt::Display for ProtectivePut {
         writeln!(f, "Put Premium: ${:.2}", self.long_put.premium)?;
         writeln!(f, "Quantity: {}", self.spot_leg.quantity)?;
         writeln!(f, "Expiration: {}", self.long_put.option.expiration_date)?;
-        writeln!(f, "Protection Level: {:.2}%", self.protection_level())?;
+        match self.protection_level() {
+            Ok(level) => writeln!(f, "Protection Level: {level:.2}%")?,
+            Err(_) => writeln!(f, "Protection Level: n/a")?,
+        }
         if let Ok(break_evens) = self.get_break_even_points() {
             writeln!(f, "Break-even: ${:.2}", break_evens[0])?;
         }
@@ -697,7 +743,7 @@ mod tests {
     #[test]
     fn test_protection_level() {
         let pp = create_test_protective_put();
-        let protection = pp.protection_level();
+        let protection = pp.protection_level().unwrap();
         assert!(protection > Decimal::ZERO);
     }
 
@@ -713,7 +759,7 @@ mod tests {
     #[test]
     fn test_total_fees() {
         let pp = create_test_protective_put();
-        let fees = pp.total_fees();
+        let fees = pp.total_fees().unwrap();
         assert!(fees > Positive::ZERO);
     }
 

--- a/src/strategies/short_call.rs
+++ b/src/strategies/short_call.rs
@@ -6,6 +6,8 @@
 
 use super::base::{BreakEvenable, Positionable, StrategyType};
 use crate::backtesting::results::{SimulationResult, SimulationStatsResult};
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
+use crate::strategies::base::lower_break_even;
 
 use crate::chains::OptionChain;
 use crate::error::{
@@ -282,10 +284,18 @@ impl BreakEvenable for ShortCall {
         // Break-even = strike + (premium_received - fees) / quantity
         // So, break-even = strike - (fees - premium_received) / quantity
         // Which is strike - (net_cost_from_position / quantity)
+        // `lower_break_even` measures a distance below the strike and floors at
+        // zero. A credit larger than the strike puts the break-even where the
+        // underlying cannot trade, and `Positive::ZERO` is this layer's
+        // sentinel for "no lower break-even" rather than an abort.
+        let per_contract = d_div(
+            self.short_call.net_cost()?,
+            self.short_call.option.quantity.to_dec(),
+            "ShortCall::update_break_even_points",
+        )?;
         self.break_even_points.push(
-            (self.short_call.option.strike_price
-                - self.short_call.net_cost()? / self.short_call.option.quantity)
-                .round_to(2),
+            lower_break_even(self.short_call.option.strike_price, per_contract)
+                .checked_round_to(2)?,
         );
 
         Ok(())
@@ -302,10 +312,10 @@ impl Strategies for ShortCall {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = price_gap(
-            self.short_call.option.strike_price,
-            self.break_even_points[0],
-        );
+        let break_even = self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("ShortCall::get_profit_area: no break-even points")
+        })?;
+        let base = price_gap(self.short_call.option.strike_price, *break_even);
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -624,7 +634,11 @@ where
                 // Track premium statistics
                 max_premium = max_premium.max(current_premium);
                 min_premium = min_premium.min(current_premium);
-                premium_sum += current_premium;
+                premium_sum = d_add(
+                    premium_sum,
+                    current_premium,
+                    "ShortCall::simulate/premium_sum",
+                )?;
                 premium_count += 1;
                 holding_period = index;
 
@@ -642,7 +656,20 @@ where
 
                     // Check if it's take profit or stop loss
                     // For short: profit when current < initial, loss when current > initial
-                    let pnl_percent = (initial_premium - current_premium) / initial_premium;
+                    // A leg that opened at a zero premium has no
+                    // percentage to move by; the exit still fires, it just
+                    // does not classify as a take-profit or a stop-loss.
+                    let move_from_open = d_sub(
+                        initial_premium,
+                        current_premium,
+                        "ShortCall::simulate/pnl_move",
+                    )?;
+                    let pnl_percent = d_div(
+                        move_from_open,
+                        initial_premium,
+                        "ShortCall::simulate/pnl_percent",
+                    )
+                    .unwrap_or(Decimal::ZERO);
                     if pnl_percent >= dec!(0.5) {
                         hit_take_profit = true;
                     } else if pnl_percent <= dec!(-1.0) {
@@ -654,7 +681,7 @@ where
                     // We use direct premium calculation instead of calculate_pnl() to avoid discrepancies
                     // from recalculating the initial premium
                     let pnl = PnL {
-                        realized: Some(initial_premium - current_premium),
+                        realized: Some(move_from_open),
                         unrealized: None,
                         initial_costs: Positive::ZERO,
                         initial_income: Positive::ZERO,
@@ -722,7 +749,8 @@ where
         let profitable_count = pnl_values.iter().filter(|&&pnl| pnl > dec!(0.0)).count();
         let loss_count = pnl_values.iter().filter(|&&pnl| pnl < dec!(0.0)).count();
 
-        let sum_pnl: Decimal = pnl_values.iter().sum();
+        let sum_pnl: Decimal =
+            d_sum_iter(pnl_values.iter().copied(), "ShortCall::simulate/sum_pnl")?;
         let average_pnl = if total_simulations > 0 {
             sum_pnl / Decimal::from(total_simulations)
         } else {
@@ -731,21 +759,49 @@ where
 
         let median_pnl = if !pnl_values.is_empty() {
             let mid = pnl_values.len() / 2;
+            let at = |i: usize| {
+                pnl_values.get(i).copied().ok_or_else(|| {
+                    SimulationError::invalid_parameters(
+                        "ShortCall::simulate: median index out of range",
+                    )
+                })
+            };
             if pnl_values.len().is_multiple_of(2) {
-                (pnl_values[mid - 1] + pnl_values[mid]) / dec!(2.0)
+                d_div(
+                    d_add(
+                        at(mid.checked_sub(1).ok_or_else(|| {
+                            SimulationError::invalid_parameters(
+                                "ShortCall::simulate: even sample count with no lower median",
+                            )
+                        })?)?,
+                        at(mid)?,
+                        "ShortCall::simulate/median",
+                    )?,
+                    dec!(2.0),
+                    "ShortCall::simulate/median",
+                )?
             } else {
-                pnl_values[mid]
+                at(mid)?
             }
         } else {
             dec!(0.0)
         };
 
         let variance = if total_simulations > 1 {
-            let sum_squared_diff: Decimal = pnl_values
-                .iter()
-                .map(|&pnl| (pnl - average_pnl).powi(2))
-                .sum();
-            sum_squared_diff / Decimal::from(total_simulations - 1)
+            let mut sum_squared_diff = Decimal::ZERO;
+            for &pnl in &pnl_values {
+                let diff = d_sub(pnl, average_pnl, "ShortCall::simulate/variance_diff")?;
+                sum_squared_diff = d_add(
+                    sum_squared_diff,
+                    d_mul(diff, diff, "ShortCall::simulate/variance_square")?,
+                    "ShortCall::simulate/variance_sum",
+                )?;
+            }
+            d_div(
+                sum_squared_diff,
+                Decimal::from(total_simulations - 1),
+                "ShortCall::simulate/variance",
+            )?
         } else {
             dec!(0.0)
         };

--- a/src/strategies/short_put.rs
+++ b/src/strategies/short_put.rs
@@ -6,6 +6,8 @@
 
 use super::base::{BreakEvenable, Positionable, StrategyType};
 use crate::backtesting::results::{SimulationResult, SimulationStatsResult};
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
+use crate::strategies::base::lower_break_even;
 
 use crate::chains::OptionChain;
 use crate::error::strategies::ProfitLossErrorKind;
@@ -274,10 +276,18 @@ impl BreakEvenable for ShortPut {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
+        // `lower_break_even` measures a distance below the strike and floors at
+        // zero. A credit larger than the strike puts the break-even where the
+        // underlying cannot trade, and `Positive::ZERO` is this layer's
+        // sentinel for "no lower break-even" rather than an abort.
+        let per_contract = d_div(
+            self.get_net_cost()?,
+            self.short_put.option.quantity.to_dec(),
+            "ShortPut::update_break_even_points",
+        )?;
         self.break_even_points.push(
-            (self.short_put.option.strike_price
-                + self.get_net_cost()? / self.short_put.option.quantity)
-                .round_to(2),
+            lower_break_even(self.short_put.option.strike_price, -per_contract)
+                .checked_round_to(2)?,
         );
 
         Ok(())
@@ -304,10 +314,10 @@ impl Strategies for ShortPut {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = price_gap(
-            self.short_put.option.strike_price,
-            self.break_even_points[0],
-        );
+        let break_even = self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("ShortPut::get_profit_area: no break-even points")
+        })?;
+        let base = price_gap(self.short_put.option.strike_price, *break_even);
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -622,7 +632,11 @@ where
                 // Track premium statistics
                 max_premium = max_premium.max(current_premium);
                 min_premium = min_premium.min(current_premium);
-                premium_sum += current_premium;
+                premium_sum = d_add(
+                    premium_sum,
+                    current_premium,
+                    "ShortPut::simulate/premium_sum",
+                )?;
                 premium_count += 1;
                 holding_period = index;
 
@@ -640,7 +654,20 @@ where
 
                     // Check if it's take profit or stop loss
                     // For short: profit when current < initial, loss when current > initial
-                    let pnl_percent = (initial_premium - current_premium) / initial_premium;
+                    // A leg that opened at a zero premium has no
+                    // percentage to move by; the exit still fires, it just
+                    // does not classify as a take-profit or a stop-loss.
+                    let move_from_open = d_sub(
+                        initial_premium,
+                        current_premium,
+                        "ShortPut::simulate/pnl_move",
+                    )?;
+                    let pnl_percent = d_div(
+                        move_from_open,
+                        initial_premium,
+                        "ShortPut::simulate/pnl_percent",
+                    )
+                    .unwrap_or(Decimal::ZERO);
                     if pnl_percent >= dec!(0.5) {
                         hit_take_profit = true;
                     } else if pnl_percent <= dec!(-1.0) {
@@ -652,7 +679,7 @@ where
                     // We use direct premium calculation instead of calculate_pnl() to avoid discrepancies
                     // from recalculating the initial premium
                     let pnl = PnL {
-                        realized: Some(initial_premium - current_premium),
+                        realized: Some(move_from_open),
                         unrealized: None,
                         initial_costs: Positive::ZERO,
                         initial_income: Positive::ZERO,
@@ -720,7 +747,8 @@ where
         let profitable_count = pnl_values.iter().filter(|&&pnl| pnl > dec!(0.0)).count();
         let loss_count = pnl_values.iter().filter(|&&pnl| pnl < dec!(0.0)).count();
 
-        let sum_pnl: Decimal = pnl_values.iter().sum();
+        let sum_pnl: Decimal =
+            d_sum_iter(pnl_values.iter().copied(), "ShortPut::simulate/sum_pnl")?;
         let average_pnl = if total_simulations > 0 {
             sum_pnl / Decimal::from(total_simulations)
         } else {
@@ -729,21 +757,49 @@ where
 
         let median_pnl = if !pnl_values.is_empty() {
             let mid = pnl_values.len() / 2;
+            let at = |i: usize| {
+                pnl_values.get(i).copied().ok_or_else(|| {
+                    SimulationError::invalid_parameters(
+                        "ShortPut::simulate: median index out of range",
+                    )
+                })
+            };
             if pnl_values.len().is_multiple_of(2) {
-                (pnl_values[mid - 1] + pnl_values[mid]) / dec!(2.0)
+                d_div(
+                    d_add(
+                        at(mid.checked_sub(1).ok_or_else(|| {
+                            SimulationError::invalid_parameters(
+                                "ShortPut::simulate: even sample count with no lower median",
+                            )
+                        })?)?,
+                        at(mid)?,
+                        "ShortPut::simulate/median",
+                    )?,
+                    dec!(2.0),
+                    "ShortPut::simulate/median",
+                )?
             } else {
-                pnl_values[mid]
+                at(mid)?
             }
         } else {
             dec!(0.0)
         };
 
         let variance = if total_simulations > 1 {
-            let sum_squared_diff: Decimal = pnl_values
-                .iter()
-                .map(|&pnl| (pnl - average_pnl).powi(2))
-                .sum();
-            sum_squared_diff / Decimal::from(total_simulations - 1)
+            let mut sum_squared_diff = Decimal::ZERO;
+            for &pnl in &pnl_values {
+                let diff = d_sub(pnl, average_pnl, "ShortPut::simulate/variance_diff")?;
+                sum_squared_diff = d_add(
+                    sum_squared_diff,
+                    d_mul(diff, diff, "ShortPut::simulate/variance_square")?,
+                    "ShortPut::simulate/variance_sum",
+                )?;
+            }
+            d_div(
+                sum_squared_diff,
+                Decimal::from(total_simulations - 1),
+                "ShortPut::simulate/variance",
+            )?
         } else {
             dec!(0.0)
         };

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -745,7 +745,7 @@ impl Strategies for ShortStrangle {
         // cannot start below it.
         let start_price = price_gap(first_option, max_profit);
         let end_price = last_option + max_profit;
-        Ok(calculate_price_range(start_price, end_price, step))
+        calculate_price_range(start_price, end_price, step)
     }
 
     fn roll_in(&mut self, position: &Position) -> Result<HashMap<Action, Trade>, StrategyError> {

--- a/src/strategies/utils.rs
+++ b/src/strategies/utils.rs
@@ -4,6 +4,8 @@
 //! including enumerations for defining search strategies and functions for
 //! generating price ranges.
 
+use crate::error::strategies::StrategyError;
+use crate::model::decimal::{d_div, d_sub};
 use positive::Positive;
 use rust_decimal::Decimal;
 use std::fmt::Display;
@@ -116,6 +118,16 @@ pub enum OptimizationCriteria {
     Area,
 }
 
+/// Upper bound on the number of samples [`calculate_price_range`] will walk.
+///
+/// The walk is a sampling: a payoff chart, a probability integration, the
+/// one-cent break-even scan in [`crate::strategies::custom::CustomStrategy`].
+/// Ten million points covers the widest of those — a six-figure underlying
+/// scanned a cent at a time — and bounds the result at about 160 MB. Past it
+/// the request is a mistake in the caller's step or bounds, and reporting it
+/// beats allocating until the process is killed.
+pub(crate) const MAX_PRICE_RANGE_POINTS: usize = 10_000_000;
+
 /// Generates a vector of price points within a specified range.
 ///
 /// # Arguments
@@ -128,20 +140,83 @@ pub enum OptimizationCriteria {
 ///
 /// A vector containing price points from start_price to at least end_price,
 /// incremented by step.
+///
+/// # Errors
+///
+/// Returns [`StrategyError::OperationError`] with
+/// [`crate::error::OperationErrorKind::InvalidParameters`] when `step` is
+/// [`Positive::ZERO`] — a zero step never advances past `start_price`, so the
+/// walk would run forever — or when the range needs more than
+/// [`MAX_PRICE_RANGE_POINTS`] samples. Propagates
+/// [`StrategyError::PositiveError`] when advancing the cursor by `step`
+/// overflows the `Positive` range.
 pub(crate) fn calculate_price_range(
     start_price: Positive,
     end_price: Positive,
     step: Positive,
-) -> Vec<Positive> {
+) -> Result<Vec<Positive>, StrategyError> {
+    if step == Positive::ZERO {
+        return Err(StrategyError::invalid_parameters(
+            "calculate_price_range",
+            "step must be strictly positive; a zero step never advances past start_price",
+        ));
+    }
+    // Size the walk before taking a single step, so a range that cannot be
+    // walked is reported immediately rather than after ten million
+    // evaluations.
+    if end_price > start_price {
+        let samples = d_div(
+            d_sub(
+                end_price.to_dec(),
+                start_price.to_dec(),
+                "calculate_price_range::span",
+            )?,
+            step.to_dec(),
+            "calculate_price_range::samples",
+        )?;
+        if samples > Decimal::from(MAX_PRICE_RANGE_POINTS) {
+            return Err(StrategyError::invalid_parameters(
+                "calculate_price_range",
+                &format!(
+                    "range {start_price} to {end_price} in steps of {step} needs more than {MAX_PRICE_RANGE_POINTS} samples"
+                ),
+            ));
+        }
+    }
+
     let mut range = Vec::new();
     let mut current_price = start_price;
     range.push(current_price);
     while current_price <= end_price {
-        current_price += step;
+        current_price = current_price.checked_add(&step)?;
         range.push(current_price);
     }
-    range
+    Ok(range)
 }
+
+/// The same walk as [`calculate_price_range`], stopping at `end_price` instead
+/// of overshooting it by one sample.
+///
+/// [`calculate_price_range`] deliberately emits one point past `end_price`;
+/// several callers want the walk bounded by `end_price` instead. This drops
+/// that trailing point rather than re-implementing the loop, so the zero-step
+/// and sample-cap guards stay in one place.
+///
+/// # Errors
+///
+/// Same as [`calculate_price_range`].
+pub(crate) fn calculate_price_range_bounded(
+    start_price: Positive,
+    end_price: Positive,
+    step: Positive,
+) -> Result<Vec<Positive>, StrategyError> {
+    let mut prices = calculate_price_range(start_price, end_price, step)?;
+    // The last element is the overshoot when `start <= end`, and the lone
+    // `start` sample when the range is empty; both are outside `end_price`.
+    prices.pop();
+    Ok(prices)
+}
+
 #[cfg(test)]
 mod tests_strategies_utils {
     use super::*;
@@ -177,7 +252,7 @@ mod tests_strategies_utils {
         let end = pos_or_panic!(110.0);
         let step = Positive::TWO;
 
-        let range = calculate_price_range(start, end, step);
+        let range = calculate_price_range(start, end, step).expect("well-formed range");
 
         assert_eq!(range.len(), 7);
         assert_eq!(range[0], Positive::HUNDRED);
@@ -195,7 +270,7 @@ mod tests_strategies_utils {
         let end = Positive::HUNDRED;
         let step = Positive::ONE;
 
-        let range = calculate_price_range(start, end, step);
+        let range = calculate_price_range(start, end, step).expect("well-formed range");
 
         assert_eq!(range.len(), 2);
         assert_eq!(range[0], Positive::HUNDRED);
@@ -207,7 +282,7 @@ mod tests_strategies_utils {
         let end = pos_or_panic!(110.0);
         let step = pos_or_panic!(20.0);
 
-        let range = calculate_price_range(start, end, step);
+        let range = calculate_price_range(start, end, step).expect("well-formed range");
 
         assert_eq!(range.len(), 2);
         assert_eq!(range[0], Positive::HUNDRED);
@@ -219,7 +294,7 @@ mod tests_strategies_utils {
         let end = Positive::TWO;
         let step = pos_or_panic!(0.3);
 
-        let range = calculate_price_range(start, end, step);
+        let range = calculate_price_range(start, end, step).expect("well-formed range");
 
         assert_eq!(range.len(), 5);
         assert_relative_eq!(range[0].to_f64(), 1.0, epsilon = 1e-16);
@@ -234,8 +309,40 @@ mod tests_strategies_utils {
         let end = pos_or_panic!(90.0);
         let step = Positive::ONE;
 
-        let range = calculate_price_range(start, end, step);
+        let range = calculate_price_range(start, end, step).expect("well-formed range");
 
         assert_eq!(range.len(), 1);
+    }
+
+    #[test]
+    fn test_calculate_price_range_bounded_stops_at_end() {
+        let range =
+            calculate_price_range_bounded(Positive::HUNDRED, pos_or_panic!(110.0), Positive::TWO)
+                .expect("well-formed range");
+        assert_eq!(range.len(), 6);
+        assert_eq!(range[0], Positive::HUNDRED);
+        assert_eq!(range[5], pos_or_panic!(110.0));
+    }
+
+    #[test]
+    fn test_calculate_price_range_bounded_is_empty_when_start_is_past_end() {
+        let range =
+            calculate_price_range_bounded(Positive::HUNDRED, pos_or_panic!(90.0), Positive::ONE)
+                .expect("well-formed range");
+        assert!(range.is_empty());
+    }
+
+    #[test]
+    fn test_calculate_price_range_zero_step_is_rejected_instead_of_looping() {
+        let err = calculate_price_range(Positive::HUNDRED, pos_or_panic!(110.0), Positive::ZERO)
+            .expect_err("a zero step never advances");
+        assert!(err.to_string().contains("step must be strictly positive"));
+    }
+
+    #[test]
+    fn test_calculate_price_range_rejects_a_walk_past_the_sample_cap() {
+        let err = calculate_price_range(Positive::ONE, pos_or_panic!(1e12), Positive::ONE)
+            .expect_err("range needs more samples than the cap allows");
+        assert!(err.to_string().contains("needs more than"));
     }
 }

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -11,3 +11,4 @@ mod point_contract_test;
 mod pricing_panic_freedom_test;
 mod put_call_parity_test;
 mod quote_invariants_test;
+mod strategies_panic_freedom_test;

--- a/tests/property/strategies_panic_freedom_test.rs
+++ b/tests/property/strategies_panic_freedom_test.rs
@@ -35,8 +35,7 @@ use optionstratlib::strategies::probabilities::{
     calculate_single_point_probability,
 };
 use optionstratlib::strategies::{
-    BullCallSpread, Collar, CoveredCall, LongCall, LongPut, ProtectivePut, ShortCall, ShortPut,
-    StrategyConstructor,
+    BullCallSpread, Collar, CoveredCall, LongCall, ProtectivePut, ShortPut,
 };
 use optionstratlib::visualization::Graph;
 use positive::Positive;
@@ -344,29 +343,15 @@ proptest! {
             let _ = strategy.update_break_even_points();
         }
 
-        // `ShortCall::new` and `LongPut::new` are private; the reachable path
-        // is the constructor that recognises a leg pattern.
-        let leg = |style: OptionStyle, side: Side| {
-            Position::new(
-                Options::new(
-                    OptionType::European, side, "PROP".to_string(), strike, expiration,
-                    volatility, quantity, underlying, rate, style, Positive::ZERO, None,
-                ),
-                premium, chrono::Utc::now(), fee, fee, None, None,
-            )
-        };
-        if let Ok(mut strategy) =
-            <ShortCall as StrategyConstructor>::get_strategy(&[leg(OptionStyle::Call, Side::Short)])
-        {
-            exercise(&strategy, probe);
-            let _ = strategy.update_break_even_points();
-        }
-        if let Ok(mut strategy) =
-            <LongPut as StrategyConstructor>::get_strategy(&[leg(OptionStyle::Put, Side::Long)])
-        {
-            exercise(&strategy, probe);
-            let _ = strategy.update_break_even_points();
-        }
+        // `ShortCall` and `LongPut` are deliberately absent from this
+        // property. Their `new` is private and their
+        // `StrategyConstructor::get_strategy` always returns
+        // `OperationNotSupported`, so nothing an integration test can write
+        // constructs one: an earlier version of this file wrapped
+        // `get_strategy` in `if let Ok(..)`, and that branch never executed.
+        // Dead code shaped like coverage is worse than none, because it reads
+        // as tested. Their coverage lives in-file, beside the private
+        // constructor — see `tests_long_put_break_even` in `long_put.rs`.
     }
 
     /// The three strategies that carry a spot leg. Every per-share figure they

--- a/tests/property/strategies_panic_freedom_test.rs
+++ b/tests/property/strategies_panic_freedom_test.rs
@@ -1,0 +1,575 @@
+//! Property-based tests for panic freedom across the composition layer: the
+//! strategy trait defaults, the single-leg and spot-leg strategies, the custom
+//! strategy, the probability kernels, the SPAN margin model and the P&L
+//! primitives.
+//!
+//! The library is embedded in long-running services, where a panic kills the
+//! worker thread and takes the in-flight request with it. Every failure must
+//! therefore come back as a `Result`, including for inputs that are extreme
+//! but structurally valid.
+//!
+//! Two axes are driven at once. The numeric axis is the usual `Decimal`
+//! domain: values at the smallest representable scale, at `Positive::MAX`,
+//! rates at `±1e6`, and the ordinary values in between. The structural axis is
+//! what makes a *strategy* degenerate rather than merely large: a quantity of
+//! zero, so every per-contract and per-share divisor collapses; a premium
+//! larger than the strike, so the break-even falls below zero and the strategy
+//! has none; fees larger than the premium, so a credit turns into a debit; an
+//! empty leg set; strikes spread further from the spot than the spot itself.
+//! The assertion is deliberately weak: whatever comes back, it must come back.
+
+use optionstratlib::ExpirationDate;
+use optionstratlib::greeks::Greeks;
+use optionstratlib::model::types::{Action, OptionStyle, OptionType, Side};
+use optionstratlib::model::{Options, Position};
+use optionstratlib::pnl::{PnL, PnLCalculator};
+use optionstratlib::pricing::Profit;
+use optionstratlib::risk::SPANMargin;
+use optionstratlib::strategies::base::{
+    BasicAble, BreakEvenable, Positionable, Strategies, Validable,
+};
+use optionstratlib::strategies::custom::CustomStrategy;
+use optionstratlib::strategies::delta_neutral::DeltaNeutrality;
+use optionstratlib::strategies::probabilities::{
+    PriceTrend, ProbabilityAnalysis, VolatilityAdjustment, calculate_price_probability,
+    calculate_single_point_probability,
+};
+use optionstratlib::strategies::{
+    BullCallSpread, Collar, CoveredCall, LongCall, LongPut, ProtectivePut, ShortCall, ShortPut,
+    StrategyConstructor,
+};
+use optionstratlib::visualization::Graph;
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+/// The smallest representable `Decimal`. A quantity or a spot at this scale is
+/// what turns an ordinary per-contract division into an overflow.
+const TINY: Decimal = Decimal::from_parts(1, 0, 0, false, 28);
+
+/// A `Positive` from a `Decimal` literal that is positive by construction.
+fn pos(value: Decimal) -> Positive {
+    Positive::new_decimal(value).unwrap_or(Positive::ZERO)
+}
+
+/// Prices, strikes, premia and quantities across the whole `Positive` range,
+/// including the two ends that break the arithmetic.
+fn extreme_positive() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(TINY)),
+        Just(pos(dec!(0.01))),
+        Just(pos(dec!(0.2))),
+        Just(Positive::ONE),
+        Just(Positive::HUNDRED),
+        Just(pos(dec!(1000000000000000))),
+        Just(Positive::MAX),
+    ]
+}
+
+/// Premia and fees, bounded below the magnitude at which a *single* leg's own
+/// `Position::total_cost` overflows.
+///
+/// `(premium + open_fee + close_fee) * quantity` is computed with the raw
+/// `Positive` operators in `src/model/position.rs`, which this sweep does not
+/// touch; that overflow is reported separately. Everything above this bound
+/// aborts before the composition layer is reached, so driving it here would
+/// only re-find the model-layer defect.
+fn extreme_money() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(TINY)),
+        Just(pos(dec!(0.01))),
+        Just(Positive::ONE),
+        Just(Positive::HUNDRED),
+        Just(pos(dec!(100000000000000))),
+    ]
+}
+
+/// Contract and share counts, bounded for the same reason as
+/// [`extreme_money`]. Zero is kept: it is the divisor of every per-contract
+/// and per-share figure in this layer.
+fn extreme_quantity() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(TINY)),
+        Just(Positive::ONE),
+        Just(Positive::HUNDRED),
+        Just(pos(dec!(1000000))),
+    ]
+}
+
+/// Volatilities, bounded below the magnitude at which
+/// `model::utils::mean_and_std` overflows.
+///
+/// Every `get_profit_ranges` implementation averages the leg volatilities
+/// through that helper, which sums them with the raw `Positive` operator and
+/// has no error channel (it returns `(Positive, Positive)`). That overflow
+/// lives in `src/model`, which this sweep does not touch, and is reported
+/// separately.
+fn extreme_volatility() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(TINY)),
+        Just(pos(dec!(0.2))),
+        Just(Positive::ONE),
+        Just(pos(dec!(1000000))),
+        Just(pos(dec!(1000000000000000))),
+    ]
+}
+
+/// The same range restricted to magnitudes a sampling walk can cross without
+/// asking for millions of points. Used only where a test walks a price range.
+///
+/// `expected_value` samples at one percent of the spot across a range set by
+/// the break-even points, so a spot far below the premium turns an ordinary
+/// integration into millions of evaluations. These rungs keep the two within
+/// two orders of magnitude of each other; the wide-open magnitudes are driven
+/// by the tests that do not walk.
+fn walkable_positive() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(dec!(0.01))),
+        Just(Positive::ONE),
+        Just(Positive::HUNDRED),
+    ]
+}
+
+/// Spot prices and premia for the walking tests, kept on one scale for the
+/// reason given on [`walkable_positive`].
+fn walkable_money() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(dec!(0.01))),
+        Just(Positive::ONE),
+    ]
+}
+
+/// Rates and dividends over the signed `Decimal` range.
+fn extreme_decimal() -> impl Strategy<Value = Decimal> {
+    prop_oneof![
+        Just(Decimal::ZERO),
+        Just(TINY),
+        Just(-TINY),
+        Just(dec!(0.05)),
+        Just(dec!(-0.05)),
+        Just(dec!(1000000)),
+        Just(dec!(-1000000)),
+        Just(Decimal::MAX),
+        Just(Decimal::MIN),
+    ]
+}
+
+/// Expirations from one already reached, through a sub-second sliver, to a
+/// horizon whose `DateTime` arithmetic is itself at the edge.
+fn extreme_expiration() -> impl Strategy<Value = ExpirationDate> {
+    prop_oneof![
+        Just(ExpirationDate::Days(Positive::ZERO)),
+        Just(ExpirationDate::Days(pos(TINY))),
+        Just(ExpirationDate::Days(Positive::ONE)),
+        Just(ExpirationDate::Days(pos(dec!(30)))),
+        Just(ExpirationDate::Days(pos(dec!(3650)))),
+    ]
+}
+
+/// A leg built straight from the extremes, so a zero quantity, a premium above
+/// the strike and fees above the premium all reach the composition layer.
+fn extreme_position() -> impl Strategy<Value = Position> {
+    (
+        extreme_positive(),
+        extreme_positive(),
+        extreme_volatility(),
+        extreme_quantity(),
+        extreme_money(),
+        extreme_decimal(),
+        extreme_expiration(),
+        0usize..4,
+    )
+        .prop_map(
+            |(underlying, strike, volatility, quantity, premium, rate, expiration, kind)| {
+                let (style, side) = match kind {
+                    0 => (OptionStyle::Call, Side::Long),
+                    1 => (OptionStyle::Call, Side::Short),
+                    2 => (OptionStyle::Put, Side::Long),
+                    _ => (OptionStyle::Put, Side::Short),
+                };
+                Position::new(
+                    Options::new(
+                        OptionType::European,
+                        side,
+                        "PROP".to_string(),
+                        strike,
+                        expiration,
+                        volatility,
+                        quantity,
+                        underlying,
+                        rate,
+                        style,
+                        Positive::ZERO,
+                        None,
+                    ),
+                    premium,
+                    chrono::Utc::now(),
+                    premium,
+                    premium,
+                    None,
+                    None,
+                )
+            },
+        )
+}
+
+/// Everything the trait defaults and the payoff surface expose, minus the
+/// calls that walk a price range; those are driven separately with bounded
+/// magnitudes so the property stays a property and not a benchmark.
+fn exercise<S>(strategy: &S, probe_price: Positive)
+where
+    S: Strategies
+        + BasicAble
+        + BreakEvenable
+        + Positionable
+        + Validable
+        + Profit
+        + ProbabilityAnalysis
+        + Greeks
+        + DeltaNeutrality
+        + PnLCalculator,
+{
+    let _ = strategy.get_max_profit();
+    let _ = strategy.get_max_loss();
+    let _ = strategy.get_total_cost();
+    let _ = strategy.get_net_cost();
+    let _ = strategy.get_net_premium_received();
+    let _ = strategy.get_fees();
+    let _ = strategy.get_profit_area();
+    let _ = strategy.get_profit_ratio();
+    let _ = strategy.get_max_min_strikes();
+    let _ = strategy.get_range_to_show();
+    let _ = strategy.get_range_of_profit();
+    let _ = strategy.get_title();
+    let _ = strategy.get_strikes();
+    let _ = strategy.get_underlying_price();
+    let _ = strategy.validate();
+    let _ = strategy.get_break_even_points();
+    let _ = strategy.get_positions();
+    let _ = strategy.delta();
+    let _ = strategy.gamma();
+    // `Greeks::greeks` is deliberately absent. Its aggregation loop in
+    // `greeks::equations` adds the per-option `alpha`, and `alpha_from`
+    // returns `Decimal::MAX` as a sentinel when theta vanishes, so two legs at
+    // a sub-contract quantity abort on `Decimal::MAX + Decimal::MAX`. That is
+    // in `src/greeks`, outside this sweep, and is reported separately.
+    let _ = strategy.delta_neutrality();
+    let _ = strategy.is_delta_neutral();
+    let _ = strategy.get_atm_strike();
+    let _ = strategy.delta_adjustments();
+    let _ = strategy.portfolio_greeks();
+    let _ = strategy.delta_gap(Decimal::ZERO);
+    let _ = strategy.get_profit_ranges();
+    let _ = strategy.get_loss_ranges();
+    let _ = strategy.probability_of_profit(None, None);
+    let _ = strategy.probability_of_loss(None, None);
+    let _ = strategy.calculate_extreme_probabilities(None, None);
+    let _ = strategy.calculate_profit_at(&probe_price);
+    let _ = strategy.calculate_pnl_at_expiration(&probe_price);
+    let _ = strategy.calculate_pnl(
+        &probe_price,
+        ExpirationDate::Days(Positive::ONE),
+        &pos(dec!(0.2)),
+    );
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(192))]
+
+    /// The two-leg spread drives the `Strategies` trait defaults: the running
+    /// cost and fee totals, the display range widened by a strike distance
+    /// larger than the spot, and the profit range across an unordered pair of
+    /// break-even points.
+    #[test]
+    fn test_bull_call_spread_never_panics(
+        underlying in extreme_positive(),
+        long_strike in extreme_positive(),
+        short_strike in extreme_positive(),
+        volatility in extreme_volatility(),
+        quantity in extreme_quantity(),
+        premium in extreme_money(),
+        fee in extreme_money(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_positive(),
+    ) {
+        if let Ok(mut strategy) = BullCallSpread::new(
+            "PROP".to_string(), underlying, long_strike, short_strike, expiration,
+            volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee,
+        ) {
+            exercise(&strategy, probe);
+            let _ = strategy.update_break_even_points();
+            let _ = strategy.get_volume();
+            let _ = strategy.set_underlying_price(&underlying);
+            let _ = strategy.set_implied_volatility(&volatility);
+            let _ = strategy.apply_delta_adjustments(Some(Action::Buy));
+        }
+    }
+
+    /// The four single-leg strategies. Their break-even divides the net cost
+    /// by the quantity and their profit area reads the first break-even point,
+    /// so a zero quantity and a premium above the strike both land here.
+    #[test]
+    fn test_single_leg_strategies_never_panic(
+        underlying in extreme_positive(),
+        strike in extreme_positive(),
+        volatility in extreme_volatility(),
+        quantity in extreme_quantity(),
+        premium in extreme_money(),
+        fee in extreme_money(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_positive(),
+    ) {
+        if let Ok(mut strategy) = LongCall::new(
+            "PROP".to_string(), strike, expiration, volatility, quantity,
+            underlying, rate, Positive::ZERO, premium, fee, fee,
+        ) {
+            exercise(&strategy, probe);
+            let _ = strategy.update_break_even_points();
+        }
+        if let Ok(mut strategy) = ShortPut::new(
+            "PROP".to_string(), strike, expiration, volatility, quantity,
+            underlying, rate, Positive::ZERO, premium, fee, fee,
+        ) {
+            exercise(&strategy, probe);
+            let _ = strategy.update_break_even_points();
+        }
+
+        // `ShortCall::new` and `LongPut::new` are private; the reachable path
+        // is the constructor that recognises a leg pattern.
+        let leg = |style: OptionStyle, side: Side| {
+            Position::new(
+                Options::new(
+                    OptionType::European, side, "PROP".to_string(), strike, expiration,
+                    volatility, quantity, underlying, rate, style, Positive::ZERO, None,
+                ),
+                premium, chrono::Utc::now(), fee, fee, None, None,
+            )
+        };
+        if let Ok(mut strategy) =
+            <ShortCall as StrategyConstructor>::get_strategy(&[leg(OptionStyle::Call, Side::Short)])
+        {
+            exercise(&strategy, probe);
+            let _ = strategy.update_break_even_points();
+        }
+        if let Ok(mut strategy) =
+            <LongPut as StrategyConstructor>::get_strategy(&[leg(OptionStyle::Put, Side::Long)])
+        {
+            exercise(&strategy, probe);
+            let _ = strategy.update_break_even_points();
+        }
+    }
+
+    /// The three strategies that carry a spot leg. Every per-share figure they
+    /// report divides by the size of that leg, and their break-even is a cost
+    /// basis net of a credit that the fees can turn into a debit.
+    #[test]
+    fn test_spot_leg_strategies_never_panic(
+        // The spot price and the probe price are bounded here for the same
+        // reason as `extreme_money`: `SpotPosition::pnl_at_price` multiplies
+        // their difference by the share count with the raw operator, in
+        // `src/model/leg/spot.rs`.
+        underlying in extreme_money(),
+        put_strike in extreme_positive(),
+        call_strike in extreme_positive(),
+        volatility in extreme_volatility(),
+        quantity in extreme_quantity(),
+        premium in extreme_money(),
+        fee in extreme_money(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_money(),
+    ) {
+        if let Ok(mut strategy) = Collar::new(
+            "PROP".to_string(), underlying, put_strike, call_strike, expiration,
+            volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee, fee, fee,
+        ) {
+            exercise(&strategy, probe);
+            let _ = strategy.collar_width();
+            let _ = strategy.max_profit_potential();
+            let _ = strategy.max_loss_potential();
+            let _ = strategy.update_break_even_points();
+        }
+        if let Ok(mut strategy) = CoveredCall::new(
+            "PROP".to_string(), underlying, call_strike, expiration, volatility,
+            rate, Positive::ZERO, quantity, premium, fee, fee, fee, fee,
+        ) {
+            exercise(&strategy, probe);
+            let _ = strategy.max_profit_potential();
+            let _ = strategy.max_loss_potential();
+            let _ = strategy.assignment_probability(probe);
+            let _ = strategy.update_break_even_points();
+        }
+        if let Ok(mut strategy) = ProtectivePut::new(
+            "PROP".to_string(), underlying, put_strike, expiration, volatility,
+            rate, Positive::ZERO, quantity, premium, fee, fee, fee, fee,
+        ) {
+            exercise(&strategy, probe);
+            let _ = strategy.max_loss_potential();
+            let _ = strategy.update_break_even_points();
+        }
+    }
+
+    /// The probability kernel behind every `probability_of_*` call. A zero
+    /// spot leaves the log price ratio undefined, a `1e-28` spot against a
+    /// hundred-dollar target overflows it, and the reverse pair rounds it to
+    /// zero, where the logarithm has no value.
+    #[test]
+    fn test_probability_kernels_never_panic(
+        current in extreme_positive(),
+        target in extreme_positive(),
+        upper in extreme_positive(),
+        base_volatility in extreme_volatility(),
+        std_dev_adjustment in extreme_positive(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        adjust in any::<bool>(),
+        drift in prop_oneof![Just(0.0f64), Just(1e30f64), Just(-1e30f64)],
+        confidence in prop_oneof![Just(0.0f64), Just(0.8f64), Just(2.0f64)],
+    ) {
+        let volatility_adj = adjust.then_some(VolatilityAdjustment {
+            base_volatility,
+            std_dev_adjustment,
+        });
+        let trend = Some(PriceTrend { drift_rate: drift, confidence });
+        let _ = calculate_single_point_probability(
+            &current, &target, volatility_adj.clone(), trend.clone(), &expiration, Some(rate),
+        );
+        let _ = calculate_price_probability(
+            &current, &target, &upper, volatility_adj, trend, &expiration, Some(rate),
+        );
+    }
+
+    /// The SPAN scenarios scale the spot and the volatility by `1 ± range`. A
+    /// scan range past 100% makes that factor negative, which is outside the
+    /// price and volatility domains rather than a number to report.
+    #[test]
+    fn test_span_margin_never_panics(
+        position in extreme_position(),
+        price_scan_range in extreme_decimal(),
+        volatility_scan_range in extreme_decimal(),
+        short_option_minimum in extreme_decimal(),
+    ) {
+        let span = SPANMargin::new(price_scan_range, volatility_scan_range, short_option_minimum);
+        let _ = span.calculate_margin(&position);
+    }
+
+    /// The P&L primitives: a total whose two halves do not add, and the
+    /// per-leg accounting a `Position` reports.
+    #[test]
+    fn test_pnl_primitives_never_panic(
+        realized in extreme_decimal(),
+        unrealized in extreme_decimal(),
+        costs in extreme_positive(),
+        income in extreme_positive(),
+        position in extreme_position(),
+        probe in extreme_positive(),
+    ) {
+        let pnl = PnL::new(Some(realized), Some(unrealized), costs, income, chrono::Utc::now());
+        let _ = pnl.total_pnl();
+        let _ = format!("{pnl:?}");
+        let _ = position.total_cost();
+        let _ = position.net_cost();
+        let _ = position.net_premium_received();
+        let _ = position.fees();
+        let _ = position.calculate_profit_at(&probe);
+        let _ = position.calculate_pnl_at_expiration(&probe);
+    }
+}
+
+proptest! {
+    // A price walk is bounded by the number of samples it needs, so these
+    // cases stay at magnitudes a chart can actually cross. The zero step and
+    // the range past the sample cap are pinned as unit tests next to
+    // `calculate_price_range` instead.
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Every call that walks a price range: the display range, the payoff
+    /// chart, the expected value integration and the full probability
+    /// analysis, plus the custom strategy whose break-even scan walks a cent
+    /// at a time.
+    #[test]
+    fn test_price_range_walks_never_panic(
+        // `expected_value` samples at one percent of the spot over a range set
+        // by the strikes, so the spot alone fixes how many samples the walk
+        // takes. A zero spot is kept: it collapses that step to zero, which is
+        // the input that used to spin `calculate_price_range` forever.
+        underlying in prop_oneof![Just(Positive::ZERO), Just(Positive::HUNDRED)],
+        long_strike in walkable_positive(),
+        short_strike in walkable_positive(),
+        volatility in walkable_positive(),
+        quantity in prop_oneof![Just(Positive::ONE), Just(Positive::HUNDRED)],
+        premium in walkable_money(),
+        step in prop_oneof![
+            Just(Positive::ZERO),
+            Just(Positive::HUNDRED),
+            Just(Positive::MAX),
+        ],
+        expiration in extreme_expiration(),
+    ) {
+        if let Ok(strategy) = BullCallSpread::new(
+            "PROP".to_string(), underlying, long_strike, short_strike, expiration,
+            volatility, dec!(0.05), Positive::ZERO, quantity, premium, premium,
+            Positive::ZERO, Positive::ZERO, Positive::ZERO, Positive::ZERO,
+        ) {
+            let _ = strategy.get_best_range_to_show(step);
+            let _ = strategy.graph_data();
+            let _ = strategy.expected_value(None, None);
+            let _ = strategy.analyze_probabilities(None, None);
+        }
+    }
+
+    /// The custom strategy over an empty leg set, a single leg and four legs.
+    /// Its range is centred on the spot and widened by the strike spread, so
+    /// strikes further from the spot than the spot itself put the lower edge
+    /// below zero.
+    #[test]
+    fn test_custom_strategy_never_panics(
+        underlying in walkable_positive(),
+        low_strike in walkable_positive(),
+        high_strike in walkable_positive(),
+        volatility in walkable_positive(),
+        quantity in prop_oneof![Just(Positive::ONE), Just(Positive::HUNDRED)],
+        premium in walkable_money(),
+        expiration in extreme_expiration(),
+        legs in 0usize..3,
+    ) {
+        let leg = |style: OptionStyle, side: Side, strike: Positive| {
+            Position::new(
+                Options::new(
+                    OptionType::European, side, "PROP".to_string(), strike, expiration,
+                    volatility, quantity, underlying, dec!(0.05), style, Positive::ZERO, None,
+                ),
+                premium, chrono::Utc::now(), premium, premium, None, None,
+            )
+        };
+        let positions = match legs {
+            0 => Vec::new(),
+            1 => vec![leg(OptionStyle::Call, Side::Long, low_strike)],
+            _ => vec![
+                leg(OptionStyle::Call, Side::Long, low_strike),
+                leg(OptionStyle::Call, Side::Short, high_strike),
+                leg(OptionStyle::Put, Side::Long, high_strike),
+                leg(OptionStyle::Put, Side::Short, low_strike),
+            ],
+        };
+        if let Ok(mut strategy) = CustomStrategy::new(
+            "prop".to_string(), "PROP".to_string(), "property".to_string(),
+            underlying, positions, pos(dec!(0.01)), 100, Positive::ONE,
+        ) {
+            exercise(&strategy, underlying);
+            let _ = strategy.get_best_range_to_show(Positive::HUNDRED);
+            let _ = strategy.update_break_even_points();
+        }
+    }
+}

--- a/tests/unit/strategies/protective_put_test.rs
+++ b/tests/unit/strategies/protective_put_test.rs
@@ -177,7 +177,7 @@ fn test_protective_put_effective_cost_basis() {
 #[test]
 fn test_protective_put_protection_level() {
     let pp = create_test_protective_put();
-    let protection = pp.protection_level();
+    let protection = pp.protection_level().unwrap();
     // (150 - 145) / 150 = 5 / 150 = 0.0333... = 3.33%
     assert_relative_eq!(
         protection.to_f64().unwrap(),


### PR DESCRIPTION
## Summary

A probe over the public API of the strategies, P&L, risk and backtesting layer
found **1,131 panics in 26,719 calls — and five inputs that did not panic at
all, they hung**. It now finds **363 panics in 35,087 calls and no hangs**, and
none of the 363 is in a file this PR touches: they are the multi-leg indexing
split off into #463, and four defects outside this layer.

## The hangs matter more than the count

`calculate_price_range` walked `while current <= end { current += step }`. A
step of `Positive::ZERO` never terminates and grows a `Vec` until the OOM
killer — and zero is a legal step, which `expected_value` reaches by computing
`step = underlying_price / 100` from a zero spot. `CustomStrategy::new` scanned
`0.5·S` to `1.5·S` a cent at a time, which at `S = 1e20` is 1e22 iterations.

Both now walk a bounded range, sized with `Decimal` arithmetic before the first
step and capped. A panic leaves a stack trace and a dead request; a hang leaves
a stuck worker that answers every health check.

## Three defects that needed no extreme input

- **445 hits**: `Collar`, `CoveredCall` and `ProtectivePut` never overrode
  `one_option`, so `BasicAble::get_underlying_price()` — a plain getter —
  aborted the process on all three shipped strategies. They now override it.
- **Every call**: `LongCall`, `ShortCall`, `LongPut` and `ShortPut` never call
  `update_break_even_points` in their constructors, so the break-even vector is
  always empty and `get_profit_area()` aborted on **a default 100/110 long call
  at 20% vol**.
- **168 hits**: `probabilities/utils.rs` took `(target / current).ln()` with raw
  `Positive` division — a zero spot broke the invariant, a 1e-28 spot overflowed
  it. The zero spot is now rejected at the entry point as a typed error.

## The two `panic!` in `base.rs` stay, marked

`one_option` returns `&Options` and `one_option_mut` returns `&mut Options`.
There is no value of those types to return, and fabricating a default `Options`
would answer `get_underlying_price` with a price nobody quoted — the failure
mode that is worse than the abort. They keep a `// scan-banned: allow` with
that argument.

The probe now shows no strategy this crate ships reaches the default: those 445
hits were entirely the three missing overrides, and the count after adding them
is zero. The remaining exposure is a downstream implementor that forgets. The
alternative — `Result<&Options, StrategyError>` — ripples through 13 trait
defaults, 22 call sites in `short_strangle.rs` and 2 in `probabilities/core.rs`,
and is worth its own change if you want it.

## Scope, and what went to #463

25 files, 1,265 insertions. The seam moved once during the work: the 17
constructor `net_cost / quantity` divisions were going to land here, but
rewiring them touches the same 14 multi-leg files that #463 must edit for the
indexing, and two PRs editing the same lines is worse than one bigger PR. Only
`bull_call_spread.rs` is fixed here, because the proptest drives the base trait
defaults through it and its break-even panic shadowed everything behind it.

#463 is now 237 of the 363: 195 `break_even_points[i]` accesses across three
butterfly files, 24 constructor divisions, 18 profit-area divisions. The
pattern for every one of them is already in this PR.

## Unchanged behaviour

The claim rests on two verified facts rather than on testing. Every `Positive`
operator in `positive` 0.6 delegates to its own `checked_*`, so swapping in the
checked form cannot move a value. And `d_div` re-rounds at
`DIV_DEFAULT_SCALE = 28`, which is `Decimal`'s maximum scale, so that rounding
is the identity and `d_div == checked_div == /`.

Two deliberate behaviour changes, both commented at the site: a zero-quantity
leg drops out of the optimizer's candidate list instead of aborting it, and
`AdjustmentPlan::new`'s quality score falls back to `Decimal::MAX` — the worst
rank — when it cannot be computed. That is a ranking key, not a price.

One I nearly made and backed out: `Collar::update_break_even_points` keeps its
`if let Ok(be)` shape, so a break-even below zero still records **no point**
rather than recording zero. Changing it to the `lower_break_even` sentinel
would have changed what `get_break_even_points()` returns.

## Testing

- [x] `tests/property/strategies_panic_freedom_test.rs` — 8 properties driving
      the base trait defaults, **two** of the four single-leg strategies
      (`LongCall` and `ShortPut`), the three spot-leg strategies, the
      probability kernels, SPAN, and the P&L primitives, over the structural
      degeneracies as well as the numeric extremes
- [x] **The single-leg coverage is two, not four, and the gap is real.**
      `LongPut` and `ShortCall` were reached through `StrategyConstructor`,
      whose implementations answer `OperationNotSupported` for both, so those
      branches never executed and the property passed without testing anything.
      They are now removed from it rather than left pretending. `LongPut`'s
      break-even is covered by a direct regression instead; `ShortCall` has
      only its fixed simulation tests and **no** boundary-input panic property
- [x] Three of its generators are **deliberately bounded**, each with the reason
      in the file, because the property cannot hold above those bounds until the
      out-of-scope defects below are fixed. That is a real gap in the test and
      it is stated rather than hidden
- [x] Only `src/strategies/utils.rs` tests were touched, because
      `calculate_price_range` now returns `Result`; the five keep their
      assertions and gained an `.expect`. Four new ones cover the bounded walk,
      the empty range, the rejected zero step and the sample cap
- [x] 3941 lib, 423 integration, 48 property, 207 doc — 0 failures
- [x] `cargo fmt --all --check`, clippy `-D warnings`, `make scan-banned`,
      `make public-api-check` and `cargo doc` clean

## Public API impact

**Two breaking changes, both on `ProtectivePut`, plus additive conversions.**

| before | after |
|---|---|
| `pub fn total_fees(&self) -> Positive` | `pub fn total_fees(&self) -> Result<Positive, PositiveError>` |
| `pub fn protection_level(&self) -> Decimal` | `pub fn protection_level(&self) -> Result<Decimal, StrategyError>` |

Both aborted the process on inputs a caller can supply: a fee at
`Positive::MAX` in the raw fee sum, and a zero spot in `protection_level`'s
raw division. A `try_` twin was considered and rejected, because it would have
left the panicking method in place — the opposite of what this sweep is for,
and the same reason the return type of `SimulationStats::update`,
`Simulator::get_random_walk` and `generate_ou_process` moved in the PRs before
this one.

**Migration.** Add `?` where the value is used inside a fallible function, or
`.expect("…")` at a boundary that cannot propagate. `ProtectivePut::new` now
rejects a zero underlying price, so a position built through the constructor
never sees the error arm of `protection_level`; a deserialized one can.

Additive: `impl From<DecimalError> for StrategyError` and
`impl From<DecimalError> for AdjustmentError`.

## Found outside this layer, not fixed

Filed separately rather than folded in: the `Positive` accumulation in
`model/position.rs` (126 of the residual 363), the upstream calendar overflow
in `expiration_date` reached through `get_date()`, `model/utils.rs::mean_and_std`,
and the greek aggregators in `greeks/equations.rs` — where `alpha_from` returns
`Decimal::MAX` as a documented sentinel, so two legs at a sub-contract quantity
abort on `MAX + MAX`.

Closes #460

