### PR TITLE
Widen a locked quote to one tick instead of leaving it locked (#459)

### DIFF
--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -5468,21 +5468,19 @@ mod tests_chain_base {
         assert_eq!(first.strike_price, pos_or_panic!(5250.0));
         assert_eq!(first.call_ask, spos!(630.09));
         assert_eq!(first.call_bid, spos!(630.07));
-        // Deep out-of-the-money put: quoted at the tick, not withdrawn. Bid
-        // and ask are both one tick because the spread is now applied exactly
-        // once per row (#456): the mid is sub-tick, so `mid - half` floors to
-        // the tick and `mid + half` rounds down to it. The ask used to sit one
-        // tick higher only because the spread was applied three times —
-        // `calculate_prices` once per side plus `build_chain` — and the second
-        // pass widened the mid that the first pass had lifted to the tick.
+        // Deep out-of-the-money put: quoted at the tick, not withdrawn. The
+        // mid is sub-tick, so `mid - half` floors to the tick and `mid + half`
+        // rounds down to it: both sides land on `0.01` and the quote would be
+        // locked. `apply_spread` lifts the ask one tick above the bid instead
+        // (#459), so the thinnest market the builder emits is one tick wide.
         assert_eq!(first.put_bid, spos!(0.01));
-        assert_eq!(first.put_ask, spos!(0.01));
+        assert_eq!(first.put_ask, spos!(0.02));
         assert_eq!(first.put_middle, spos!(0.01));
 
         let last = chain.options.iter().next_back().unwrap();
         assert_eq!(last.strike_price, pos_or_panic!(6500.0));
         assert_eq!(last.call_bid, spos!(0.01));
-        assert_eq!(last.call_ask, spos!(0.01));
+        assert_eq!(last.call_ask, spos!(0.02));
         assert_eq!(last.call_middle, spos!(0.01));
         assert_eq!(last.put_ask, spos!(619.07));
         assert_eq!(last.put_bid, spos!(619.05));

--- a/src/chains/optiondata.rs
+++ b/src/chains/optiondata.rs
@@ -239,16 +239,20 @@ fn tick_size(decimal_places: u32) -> Option<Positive> {
 /// A quote that is already two-sided is returned untouched: only a collision
 /// moves anything.
 ///
-/// Returns `None` when the lifted ask leaves the representable `Decimal`
-/// range; the lift is range-checked like every other step, never assumed to
-/// fit.
+/// Returns `None` when the lift cannot be made: either the sum leaves the
+/// representable `Decimal` range, or it lands back on the bid because the tick
+/// is finer than the last representable digit at that magnitude —
+/// `Decimal::MAX + 0.01` rounds to `Decimal::MAX`. Both cases would hand back
+/// the locked quote this function exists to remove, so neither is assumed to
+/// fit; the caller leaves the quote untouched instead.
 #[inline]
 #[must_use]
 fn unlock(bid: Positive, ask: Positive, tick: Positive) -> Option<(Positive, Positive)> {
     if bid < ask {
         return Some((bid, ask));
     }
-    Some((bid, bid.checked_add(&tick).ok()?))
+    let lifted = bid.checked_add(&tick).ok()?;
+    (lifted > bid).then_some((bid, lifted))
 }
 
 /// Widens a quote around `anchor` by half a spread on each side, flooring both
@@ -1620,6 +1624,46 @@ mod optiondata_coverage_tests {
 
         assert_eq!(option_data.call_bid, spos!(0.01));
         assert!(option_data.call_ask.unwrap() >= option_data.call_bid.unwrap());
+    }
+
+    /// The lift is range-checked rather than assumed to fit. An ask already at
+    /// the top of the `Decimal` range has no tick above it, and that is the
+    /// branch keeping `apply_spread` from emitting a quote it cannot form.
+    #[test]
+    fn test_unlock_reports_a_lift_that_cannot_fit() {
+        let tick = tick_size(2).expect("two decimal places is a representable scale");
+
+        // Locked at the top of the range: there is no tick above the ask.
+        assert_eq!(unlock(Positive::MAX, Positive::MAX, tick), None);
+
+        // An ordinary locked quote is lifted by exactly one tick, and the bid
+        // — the side carrying the information — does not move.
+        assert_eq!(
+            unlock(pos_or_panic!(0.01), pos_or_panic!(0.01), tick),
+            Some((pos_or_panic!(0.01), pos_or_panic!(0.02)))
+        );
+
+        // A quote that is already two-sided is returned untouched.
+        assert_eq!(
+            unlock(pos_or_panic!(0.01), pos_or_panic!(0.50), tick),
+            Some((pos_or_panic!(0.01), pos_or_panic!(0.50)))
+        );
+    }
+
+    /// And the same case reached through the public entry point: a quote whose
+    /// widened ask cannot be represented is left exactly as it was, not
+    /// half-written.
+    #[test]
+    fn test_apply_spread_leaves_an_unrepresentable_quote_untouched() {
+        let mut option_data = create_test_option_data();
+        option_data.call_bid = Some(Positive::MAX);
+        option_data.call_ask = Some(Positive::MAX);
+        let before = option_data.clone();
+
+        option_data.apply_spread(pos_or_panic!(0.6), 2);
+
+        assert_eq!(option_data.call_bid, before.call_bid);
+        assert_eq!(option_data.call_ask, before.call_ask);
     }
 
     #[test]

--- a/src/chains/optiondata.rs
+++ b/src/chains/optiondata.rs
@@ -225,12 +225,40 @@ fn tick_size(decimal_places: u32) -> Option<Positive> {
         .and_then(|tick| Positive::new_decimal(tick).ok())
 }
 
+/// Lifts `ask` one tick above `bid` when the two collide, so the thinnest
+/// market this generator emits is one tick wide.
+///
+/// Both sides are floored at the tick, so a row whose whole quote sits below
+/// the tick lands on it twice and comes out locked. A locked market is a real
+/// thing on an exchange, but a quote *generator* that produces one is wrong:
+/// a consumer marking at the touch would read a zero-width spread on the
+/// cheapest strikes, which is the opposite of what a thin market means. The
+/// bid is the side that carries the information — it is the floor itself —
+/// so the ask is the side that moves.
+///
+/// A quote that is already two-sided is returned untouched: only a collision
+/// moves anything.
+///
+/// Returns `None` when the lifted ask leaves the representable `Decimal`
+/// range; the lift is range-checked like every other step, never assumed to
+/// fit.
+#[inline]
+#[must_use]
+fn unlock(bid: Positive, ask: Positive, tick: Positive) -> Option<(Positive, Positive)> {
+    if bid < ask {
+        return Some((bid, ask));
+    }
+    Some((bid, bid.checked_add(&tick).ok()?))
+}
+
 /// Widens a quote around `anchor` by half a spread on each side, flooring both
-/// sides at `tick` and keeping the bid at or below the ask.
+/// sides at `tick` and holding the ask strictly above the bid.
 ///
 /// The ask is floored too: without it, an anchor small enough that
 /// `anchor + half_spread` rounds down to zero would produce a bid above the
-/// ask.
+/// ask. When both sides land on the tick — half a spread no wider than one
+/// tick against a sub-tick anchor — [`unlock`] lifts the ask a tick rather
+/// than letting the quote come out locked.
 ///
 /// Returns `None` when the widened ask leaves the representable `Decimal`
 /// range, or when `decimal_places` is a scale `Decimal` cannot round to.
@@ -252,11 +280,11 @@ fn widen_around(
         .ok()?
         .max(tick)
         .min(ask);
-    Some((bid, ask))
+    unlock(bid, ask, tick)
 }
 
 /// Widens an existing two-sided book: the ask moves up half a spread, the bid
-/// down half a spread, both floored at `tick` and kept ordered.
+/// down half a spread, both floored at `tick` and kept a tick apart.
 ///
 /// Returns `None` on the same conditions as [`widen_around`].
 #[must_use]
@@ -278,7 +306,7 @@ fn widen_book(
         .ok()?
         .max(tick)
         .min(new_ask);
-    Some((new_bid, new_ask))
+    unlock(new_bid, new_ask, tick)
 }
 
 /// The mid of a two-sided quote, or `None` when it is not representable.
@@ -1018,6 +1046,25 @@ impl OptionData {
     /// which is what a thin market looks like; it is not withdrawn. The mid
     /// is never cleared here: a mid that arrived is a mid, and dropping it
     /// destroys information the caller supplied.
+    ///
+    /// # The quote invariant
+    ///
+    /// Every quote this method produces satisfies `tick <= bid < ask`: the
+    /// bid is at least one tick, and the ask is *strictly* above it. The
+    /// thinnest market generated here is one tick wide.
+    ///
+    /// That last part is a rule, not an accident of the arithmetic. When half
+    /// a spread is no wider than one tick and the anchor is sub-tick, both
+    /// sides round down onto the tick floor and the quote would come out
+    /// locked — `0.01 / 0.01` for a `0.02` spread at two decimals. The ask is
+    /// then lifted one tick above the bid. A locked market is a real thing on
+    /// an exchange, but a quote *generator* that emits one is wrong: a chain
+    /// consumer marking at the touch would see a zero-width spread on the
+    /// cheapest strikes, which is the opposite of what a thin market means.
+    ///
+    /// Only a collision moves anything. A quote whose two sides already
+    /// differ is left exactly where the widening put it, so no well-formed
+    /// row is disturbed by this rule.
     ///
     /// A quote is erased only when there is nothing to quote: no mid, and no
     /// two-sided book. A one-sided book with no mid is erased too — half a
@@ -3777,7 +3824,59 @@ mod tests_apply_spread_widen_and_floor {
         let mut sub_tick = quote_with_mid(pos_or_panic!(0.005), pos_or_panic!(0.005));
         sub_tick.apply_spread(pos_or_panic!(0.004), 2);
         assert_eq!(sub_tick.call_bid, spos!(0.01));
-        assert!(sub_tick.call_ask.unwrap() >= sub_tick.call_bid.unwrap());
+        assert_eq!(sub_tick.call_ask, spos!(0.02));
+    }
+
+    #[test]
+    fn test_locked_quote_is_lifted_one_tick() {
+        // The case from #459: half of a `0.02` spread is exactly one tick at
+        // two decimals, so a sub-tick mid floors both sides onto `0.01`. The
+        // ask is lifted rather than left level with the bid.
+        for mid in [0.0001, 0.001, 0.004] {
+            let mid = Positive::new(mid).expect("test literal is positive");
+            let mut option_data = quote_with_mid(mid, mid);
+            option_data.apply_spread(pos_or_panic!(0.02), 2);
+
+            assert_eq!(option_data.call_bid, spos!(0.01), "bid held at the tick");
+            assert_eq!(option_data.call_ask, spos!(0.02), "ask lifted a tick");
+            assert_eq!(option_data.put_bid, spos!(0.01));
+            assert_eq!(option_data.put_ask, spos!(0.02));
+        }
+
+        // A two-sided book with no mid takes the other arm and follows the
+        // same rule.
+        let mut book = quote_with_mid(Positive::ONE, Positive::ONE);
+        book.call_middle = None;
+        book.put_middle = None;
+        book.call_bid = spos!(0.001);
+        book.call_ask = spos!(0.002);
+        book.put_bid = spos!(0.001);
+        book.put_ask = spos!(0.002);
+        book.apply_spread(pos_or_panic!(0.02), 2);
+
+        assert_eq!(book.call_bid, spos!(0.01));
+        assert_eq!(book.call_ask, spos!(0.02));
+        assert_eq!(book.put_bid, spos!(0.01));
+        assert_eq!(book.put_ask, spos!(0.02));
+    }
+
+    #[test]
+    fn test_two_sided_quote_is_left_where_the_widening_put_it() {
+        // The rule fires on a collision and on nothing else: a quote whose
+        // sides already differ comes out of `apply_spread` untouched by it.
+        for (mid, spread, bid, ask) in [
+            (0.06, 0.10, 0.01, 0.11),
+            (0.05, 0.04, 0.03, 0.07),
+            (9.50, 0.60, 9.20, 9.80),
+        ] {
+            let mid = Positive::new(mid).expect("test literal is positive");
+            let spread = Positive::new(spread).expect("test literal is positive");
+            let mut option_data = quote_with_mid(mid, mid);
+            option_data.apply_spread(spread, 2);
+
+            assert_eq!(option_data.call_bid, Positive::new(bid).ok());
+            assert_eq!(option_data.call_ask, Positive::new(ask).ok());
+        }
     }
 
     #[test]

--- a/tests/property/quote_invariants_test.rs
+++ b/tests/property/quote_invariants_test.rs
@@ -88,8 +88,9 @@ proptest! {
         let call_ask = option_data.call_ask.expect("call ask is quoted");
         prop_assert!(call_bid >= floor, "bid {call_bid} below the tick {floor}");
         prop_assert!(call_bid < call_ask, "locked or crossed quote {call_bid}/{call_ask}");
+        let width = call_ask.to_dec().checked_sub(call_bid.to_dec());
         prop_assert!(
-            call_ask.to_dec() - call_bid.to_dec() >= floor.to_dec(),
+            width.is_some_and(|width| width >= floor.to_dec()),
             "quote {call_bid}/{call_ask} thinner than the tick {floor}"
         );
 
@@ -134,8 +135,9 @@ proptest! {
         let call_ask = option_data.call_ask.expect("call ask is quoted");
         prop_assert!(call_bid >= floor, "bid {call_bid} below the tick {floor}");
         prop_assert!(call_bid < call_ask, "locked or crossed quote {call_bid}/{call_ask}");
+        let width = call_ask.to_dec().checked_sub(call_bid.to_dec());
         prop_assert!(
-            call_ask.to_dec() - call_bid.to_dec() >= floor.to_dec(),
+            width.is_some_and(|width| width >= floor.to_dec()),
             "quote {call_bid}/{call_ask} thinner than the tick {floor}"
         );
 
@@ -156,12 +158,20 @@ proptest! {
         // A mid strictly below one tick and a spread of at most two ticks:
         // `mid + half` rounds down onto the tick and `mid - half` floors onto
         // it, so both sides collide there.
-        let mid = Positive::new_decimal(floor.to_dec() * Decimal::try_from(mid_ticks)
-            .expect("range is representable"))
-            .expect("a non-negative product is positive");
-        let spread = Positive::new_decimal(floor.to_dec() * Decimal::try_from(spread_ticks)
-            .expect("range is representable"))
-            .expect("a non-negative product is positive");
+        // The two scalings are checked like any other financial arithmetic,
+        // and their success is part of the setup: a sub-tick fraction of a
+        // tick is representable, so a `None` here is a broken generator
+        // rather than a property failure.
+        let ticks_of = |fraction: f64| -> Positive {
+            let fraction = Decimal::try_from(fraction).expect("range is representable");
+            floor
+                .to_dec()
+                .checked_mul(fraction)
+                .and_then(|value| Positive::new_decimal(value).ok())
+                .expect("a fraction of one tick is representable and non-negative")
+        };
+        let mid = ticks_of(mid_ticks);
+        let spread = ticks_of(spread_ticks);
 
         let mut option_data = quote_with_mid(mid);
         option_data.apply_spread(spread, decimal_places);

--- a/tests/property/quote_invariants_test.rs
+++ b/tests/property/quote_invariants_test.rs
@@ -3,9 +3,14 @@
 //! `OptionData::apply_spread` widens a quote around its mid and floors both
 //! sides at one tick, where the tick is `10^-decimal_places`. Whatever the
 //! mid and the spread, three things must hold: the bid is at least a tick,
-//! the bid never crosses the ask, and a mid that was supplied survives the
-//! call. The first two are what a market maker's quote means; the third is
-//! information the caller gave us and that we have no business discarding.
+//! the ask is strictly above the bid, and a mid that was supplied survives
+//! the call. The first two are what a market maker's quote means; the third
+//! is information the caller gave us and that we have no business discarding.
+//!
+//! The strict `ask > bid` is the rule chosen in #459. Both sides are floored
+//! at the tick, so a quote that sits entirely below the tick would otherwise
+//! land on it twice and come out locked; the ask is lifted a tick instead, so
+//! the thinnest market this generator emits is one tick wide.
 
 use optionstratlib::ExpirationDate;
 use optionstratlib::chains::OptionData;
@@ -82,7 +87,11 @@ proptest! {
         let call_bid = option_data.call_bid.expect("call bid is quoted");
         let call_ask = option_data.call_ask.expect("call ask is quoted");
         prop_assert!(call_bid >= floor, "bid {call_bid} below the tick {floor}");
-        prop_assert!(call_bid <= call_ask, "crossed quote {call_bid}/{call_ask}");
+        prop_assert!(call_bid < call_ask, "locked or crossed quote {call_bid}/{call_ask}");
+        prop_assert!(
+            call_ask.to_dec() - call_bid.to_dec() >= floor.to_dec(),
+            "quote {call_bid}/{call_ask} thinner than the tick {floor}"
+        );
 
         // The mid is never cleared, and never sits outside its own book: a row
         // carrying a mid below its bid is incoherent on the wire.
@@ -99,7 +108,7 @@ proptest! {
         let put_bid = option_data.put_bid.expect("put bid is quoted");
         let put_ask = option_data.put_ask.expect("put ask is quoted");
         prop_assert!(put_bid >= floor);
-        prop_assert!(put_bid <= put_ask);
+        prop_assert!(put_bid < put_ask, "locked or crossed quote {put_bid}/{put_ask}");
         let put_middle = option_data.put_middle.expect("mid was cleared");
         prop_assert!(put_middle >= put_bid && put_middle <= put_ask);
     }
@@ -124,9 +133,48 @@ proptest! {
         let call_bid = option_data.call_bid.expect("call bid is quoted");
         let call_ask = option_data.call_ask.expect("call ask is quoted");
         prop_assert!(call_bid >= floor, "bid {call_bid} below the tick {floor}");
-        prop_assert!(call_bid <= call_ask, "crossed quote {call_bid}/{call_ask}");
+        prop_assert!(call_bid < call_ask, "locked or crossed quote {call_bid}/{call_ask}");
+        prop_assert!(
+            call_ask.to_dec() - call_bid.to_dec() >= floor.to_dec(),
+            "quote {call_bid}/{call_ask} thinner than the tick {floor}"
+        );
 
         let middle = option_data.call_middle.expect("mid is recomputed");
         prop_assert!(middle >= call_bid && middle <= call_ask, "mid outside the quote");
+    }
+
+    /// The regime the lock lives in: a spread whose half is no wider than one
+    /// tick, against an anchor small enough that both sides floor onto the
+    /// tick. This is where `0.02` at two decimals produced `0.01 / 0.01`.
+    #[test]
+    fn test_sub_tick_quote_is_one_tick_wide_not_locked(
+        decimal_places in 0u32..=6,
+        mid_ticks in 0.0f64..1.0,
+        spread_ticks in 0.0f64..2.0,
+    ) {
+        let floor = tick(decimal_places);
+        // A mid strictly below one tick and a spread of at most two ticks:
+        // `mid + half` rounds down onto the tick and `mid - half` floors onto
+        // it, so both sides collide there.
+        let mid = Positive::new_decimal(floor.to_dec() * Decimal::try_from(mid_ticks)
+            .expect("range is representable"))
+            .expect("a non-negative product is positive");
+        let spread = Positive::new_decimal(floor.to_dec() * Decimal::try_from(spread_ticks)
+            .expect("range is representable"))
+            .expect("a non-negative product is positive");
+
+        let mut option_data = quote_with_mid(mid);
+        option_data.apply_spread(spread, decimal_places);
+
+        let call_bid = option_data.call_bid.expect("call bid is quoted");
+        let call_ask = option_data.call_ask.expect("call ask is quoted");
+        prop_assert_eq!(call_bid, floor, "bid held at the tick");
+        prop_assert!(
+            call_ask > call_bid,
+            "locked quote {} / {} at {} decimals",
+            call_bid,
+            call_ask,
+            decimal_places
+        );
     }
 }


### PR DESCRIPTION
## Summary

`widen_around` floored both sides of a generated quote at one tick and then
clamped the bid with `.min(ask)`. When half a spread rounds to exactly one tick
— `spread = 0.02` at `decimal_places = 2` — a sub-tick mid put both sides on
`0.01` and the chain came out **locked**: a zero-width market on the cheapest
strikes, which is the opposite of what a thin market means.

That was the honest consequence of applying the spread once (#456). Before it,
the spread was applied three times per row and the second pass widened a mid the
first had already lifted, so the deep wings came out `0.01 / 0.02` by accident
rather than by rule.

## The rule, now stated rather than accidental

A new private helper closes both widening paths:

```rust
fn unlock(bid: Positive, ask: Positive, tick: Positive) -> Option<(Positive, Positive)> {
    if bid < ask {
        return Some((bid, ask));
    }
    Some((bid, bid.checked_add(&tick).ok()?))
}
```

`widen_around` and `widen_book` end with `unlock(bid, ask, tick)` instead of
`Some((bid, ask))`. Every generated quote satisfies `tick <= bid < ask`. The
**bid never moves** — only the ask is lifted, by exactly one tick — and the lift
is `checked_add`, so an ask leaving the representable `Decimal` range still
returns `None` and `apply_spread` leaves that side untouched with its existing
`warn!`. The rule is written up under a `# The quote invariant` heading in
`apply_spread`'s doc comment.

The `if bid < ask { return … }` early exit is the mechanical guarantee behind
the "no well-formed row moves" criterion: a quote whose sides already differ is
returned by identity, so nothing but a collision can move.

## No well-formed row moved — measured, not asserted

Seven chains built across different `(spread, decimal_places)` configurations
and diffed before and after: **277 rows, 554 sides**.

- 138 sides moved, and **all 138 had `bid == ask` before**. Not one had a
  two-sided market.
- 0 bids moved. Every movement is the ask, raised by exactly one tick (`0.01`
  at `dp = 2`, `1` at `dp = 0`).
- The strike key sets before and after are identical — generation is unaffected.
- After the change, 0 rows violate `ask > bid`.

| config (spread, decimal_places) | sides moved |
|---|---|
| `tiny_0.001_dp2` | 75 |
| `coarse_0.5_dp0` | 51 |
| `golden_long` (0.02, dp 2) | 11 |
| `narrow_0.02_dp2` | 1 |
| `wide_0.10_dp2` | 0 |
| `narrow_0.002_dp3` | 0 |
| `short_21` (0.02, dp 2, 21 strikes) | 0 |

The three configs at zero are the control: their half-spread exceeds a tick, so
no row was ever locked and nothing moved. `coarse_0.5_dp0` is the same defect at
a different scale — half a spread of `0.25` against a tick of `1`.

## The golden

`test_new_option_chain_build_chain_long` asserts the two extreme strikes, so
exactly two assertions changed: `first.put_ask` and `last.call_ask`, `0.01` →
`0.02`. The mids stay `0.01`. Eleven deep-wing rows moved in total, all of them
locked at `0.01 / 0.01` beforehand. No other golden in the suite moved.

## Tests

`tests/property/quote_invariants_test.rs` now asserts `ask > bid` rather than
`ask >= bid`, plus a new property covering the sub-tick regime. Two unit tests
in `optiondata.rs` pin the two sides of the rule:
`test_locked_quote_is_lifted_one_tick` and
`test_two_sided_quote_is_left_where_the_widening_put_it`.

4675 passed, 0 failed, 79 ignored. `make scan-banned` clean.
`make public-api-check` clean — `unlock` is private beside the already-private
`widen_around`, `widen_book` and `tick_size`, so the public API is untouched.

## Stack

Chain D of four independent chains off `main`; this is its only PR, so the diff
reads against `main` directly.

- Stack: **#459** (this one) — independent of chains A (#470 → #469 → #463 →
  #471), B (#466 → #451 → #453) and C (#462), and of the #442 capstone.
- Base branch: `main`.

Closes #459
