### PR TITLE
Give the surface projection a name and a type that fit it (#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`Surface::get_curve` is renamed to `Surface::project_onto` and returns
+  `Vec<Point2D>` instead of `Curve`, which is a breaking change** (#466).
+  One change with one reason: the method is a projection, and both its name
+  and its type said it was a curve. Projecting a surface onto one axis is
+  multi-valued by construction: every row of a grid contributes a different
+  height above the same projected abscissa, and two rows that agree on the
+  two surviving coordinates project onto the very same point. A `Curve` is a
+  function of its abscissa and stores its points in a `BTreeSet`, so it
+  silently dropped the collisions. The vector keeps every point:
+  `surface.project_onto(axis).len() == surface.points.len()`, always.
+  Contents are sorted ascending by the projected `(x, y)` pair, which is the
+  order the `BTreeSet` gave; only its deduplication is gone.
+
+  The method has no production callers and its `Axis` parameter type is not
+  re-exported, so it is uncallable from outside the crate. To migrate inside
+  it, aggregate the ordinates sharing an abscissa to one value, then build the
+  `Curve`; `Curve::from_vector(surface.project_onto(axis))` reproduces the old
+  behaviour, losses included. The note on `Surface::get_curve` under the #450
+  entry below describes the method by its former name.
+
+- **Interpolating a curve at a repeated abscissa now fails instead of
+  returning the lowest ordinate stacked there** (#466). `Curve` is documented
+  as a function of its abscissa, but nothing enforces it (`points` is a `pub`
+  field, so no constructor could). `linear_interpolate`, `cubic_interpolate`
+  and `spline_interpolate` return `InterpolationError::DegenerateInterval`
+  when several points share the requested `x`, rather than picking one of
+  them: the value there is not defined and no choice among them is less
+  arbitrary than another. A curve with one point per abscissa is unaffected,
+  and `AxisOperations::get_values` still reads every ordinate at an abscissa.
+  The exact-match branch of `Curve::bilinear_interpolate` still returns the
+  lowest ordinate; it is being reworked under #451.
+
+  The one-point-per-abscissa rule, and what each consumer does when it is
+  broken, are now stated on `Curve::new`, `Curve::from_vector`,
+  `Curve::merge`, `get_point`, `contains_point`, `get_values`,
+  `merge_axis_interpolate`, the four interpolation traits and
+  `find_bracket_points`, with the matching one-height-per-xy-coordinate rule
+  on `Surface::new`.
+
 - **Two `ProtectivePut` methods are now fallible, which is a breaking change**
   (#460). `total_fees` returns `Result<Positive, PositiveError>` instead of
   `Positive`, and `protection_level` returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The crate moves to 0.21.0, which is the breaking bump for a `0.x`
+  version.** `cargo-semver-checks` compares against the published 0.20.0 and
+  rejected the rename below under `inherent_method_missing`, since a version
+  unchanged from its baseline is read as a minor bump and a minor bump may not
+  remove a public method. Every earlier change in this cycle was a return type
+  moving to `Result`, which no lint covers, so this is the first one the check
+  could see.
+
 - **`Surface::get_curve` is renamed to `Surface::project_onto` and returns
   `Vec<Point2D>` instead of `Curve`, which is a breaking change** (#466).
   One change with one reason: the method is a projection, and both its name

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Wiki](https://img.shields.io/badge/wiki-latest-blue.svg)](https://deepwiki.com/joaquinbejar/OptionStratLib)
 
 
-## OptionStratLib v0.20.0: Financial Options Library
+## OptionStratLib v0.21.0: Financial Options Library
 
 ### Table of Contents
 1. [Introduction](#introduction)
@@ -805,7 +805,7 @@ Add OptionStratLib to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-optionstratlib = "0.20.0"
+optionstratlib = "0.21.0"
 ```
 
 Or use cargo to add it to your project:
@@ -820,7 +820,7 @@ The library includes optional features for enhanced functionality:
 
 ```toml
 [dependencies]
-optionstratlib = { version = "0.20.0", features = ["plotly"] }
+optionstratlib = { version = "0.21.0", features = ["plotly"] }
 ```
 
 - `plotly`: Enables interactive visualization using plotly.rs
@@ -1215,7 +1215,7 @@ cargo test --all-features
 
 ---
 
-**OptionStratLib v0.20.0** - Built with ❤️ in Rust for the financial community
+**OptionStratLib v0.21.0** - Built with ❤️ in Rust for the financial community
 
 
 

--- a/public-api/optionstratlib.txt
+++ b/public-api/optionstratlib.txt
@@ -10941,9 +10941,9 @@ pub optionstratlib::prelude::Surface::points: alloc::collections::btree::set::BT
 pub optionstratlib::prelude::Surface::x_range: (rust_decimal::decimal::Decimal, rust_decimal::decimal::Decimal)
 pub optionstratlib::prelude::Surface::y_range: (rust_decimal::decimal::Decimal, rust_decimal::decimal::Decimal)
 impl optionstratlib::surfaces::Surface
-pub fn optionstratlib::surfaces::Surface::get_curve(&self, optionstratlib::surfaces::types::Axis) -> optionstratlib::curves::Curve
 pub fn optionstratlib::surfaces::Surface::get_f64_points(&self) -> alloc::vec::Vec<(f64, f64, f64)>
 pub fn optionstratlib::surfaces::Surface::new(alloc::collections::btree::set::BTreeSet<optionstratlib::surfaces::Point3D>) -> Self
+pub fn optionstratlib::surfaces::Surface::project_onto(&self, optionstratlib::surfaces::types::Axis) -> alloc::vec::Vec<optionstratlib::curves::Point2D>
 impl core::convert::From<optionstratlib::surfaces::Surface> for optionstratlib::visualization::GraphData
 pub fn optionstratlib::visualization::GraphData::from(optionstratlib::surfaces::Surface) -> Self
 impl core::default::Default for optionstratlib::surfaces::Surface
@@ -26232,9 +26232,9 @@ pub optionstratlib::surfaces::Surface::points: alloc::collections::btree::set::B
 pub optionstratlib::surfaces::Surface::x_range: (rust_decimal::decimal::Decimal, rust_decimal::decimal::Decimal)
 pub optionstratlib::surfaces::Surface::y_range: (rust_decimal::decimal::Decimal, rust_decimal::decimal::Decimal)
 impl optionstratlib::surfaces::Surface
-pub fn optionstratlib::surfaces::Surface::get_curve(&self, optionstratlib::surfaces::types::Axis) -> optionstratlib::curves::Curve
 pub fn optionstratlib::surfaces::Surface::get_f64_points(&self) -> alloc::vec::Vec<(f64, f64, f64)>
 pub fn optionstratlib::surfaces::Surface::new(alloc::collections::btree::set::BTreeSet<optionstratlib::surfaces::Point3D>) -> Self
+pub fn optionstratlib::surfaces::Surface::project_onto(&self, optionstratlib::surfaces::types::Axis) -> alloc::vec::Vec<optionstratlib::curves::Point2D>
 impl core::convert::From<optionstratlib::surfaces::Surface> for optionstratlib::visualization::GraphData
 pub fn optionstratlib::visualization::GraphData::from(optionstratlib::surfaces::Surface) -> Self
 impl core::default::Default for optionstratlib::surfaces::Surface

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -58,6 +58,9 @@ use utoipa::ToSchema;
 /// - Methods working with `Curve` data will assume that the `points` vector is ordered
 ///   by the `x`-coordinate. Non-ordered inputs may lead to undefined behavior in specific
 ///   operations.
+/// - A curve is a function of its abscissa: at most one point per `x`. See
+///   [`Curve::new`] for what breaking that rule does to each consumer, and
+///   for why no constructor can enforce it.
 ///
 /// # See Also
 /// - [`Point2D`]: The fundamental data type for representing points in 2D space.
@@ -66,7 +69,13 @@ use utoipa::ToSchema;
 #[serde(deny_unknown_fields)]
 pub struct Curve {
     /// A ordered set of `Point2D` objects that defines the curve in terms of its x-y plane coordinates.
-    /// Points are stored in a `BTreeSet` which automatically maintains them in sorted order by their x-coordinate.
+    /// Points are stored in a `BTreeSet` which automatically maintains them in sorted order by their
+    /// `(x, y)` pair. The set rejects an exact duplicate of that pair; it does not stop two ordinates
+    /// from sharing an abscissa.
+    ///
+    /// Public, so a struct literal can populate it without passing through
+    /// [`Curve::new`]. No constructor can therefore guarantee one point per
+    /// abscissa.
     pub points: BTreeSet<Point2D>,
 
     /// A tuple `(min_x, max_x)` that specifies the minimum and maximum x-coordinate values
@@ -120,19 +129,46 @@ impl Curve {
     ///
     /// - [`Point2D`]: The type of points used to define the curve.
     /// - [`crate::curves::Curve::calculate_range`]: Computes the x-range of a set of points.
-    /// # Duplicate abscissae
+    /// # One point per abscissa
     ///
-    /// [`Point2D`] orders on the full `(x, y)` pair, so `points` may hold
-    /// several ordinates for one abscissa and `new` stores them all. Most of
-    /// the crate treats a curve as single-valued in `x` —
-    /// [`Curve::get_point`] returns the first match, [`Curve::merge`]
-    /// resamples onto one shared x-grid — and the interpolators reject a
-    /// repeated abscissa with [`InterpolationError::DegenerateInterval`],
-    /// since the slope over a zero-width interval is undefined.
+    /// A `Curve` is a function of its abscissa: at most one point per `x`.
+    /// Every consumer reads it that way.
+    /// [`get_point`](crate::geometrics::AxisOperations::get_point) and
+    /// [`contains_point`](crate::geometrics::AxisOperations::contains_point)
+    /// answer from the first point matching `x`,
+    /// [`merge`](crate::geometrics::Arithmetic::merge) resamples every curve
+    /// onto one shared x-grid with one `y` per `x`, and the interpolators in
+    /// [`crate::geometrics`] bracket `x` between two consecutive points and
+    /// divide by the width of that bracket.
     ///
-    /// Whether such a curve should be rejected, normalized or supported is
-    /// unresolved: [`crate::surfaces::Surface::get_curve`] produces one
-    /// legitimately, by projecting a grid. See issue #466.
+    /// Nothing enforces the rule. [`Point2D`] orders on the full `(x, y)`
+    /// pair, so `points` may hold several ordinates for one abscissa and
+    /// `new` stores them all; a curve built that way is outside the contract
+    /// and the consumers behave as follows:
+    ///
+    /// - the interpolators return
+    ///   [`InterpolationError::DegenerateInterval`] when asked about a
+    ///   repeated abscissa, and pick no survivor: the bracket around it has
+    ///   zero width and the slope across it is undefined. The one exception
+    ///   is the exact-match branch of
+    ///   [`BiLinearInterpolation::bilinear_interpolate`],
+    ///   which still returns the lowest ordinate and is being reworked under
+    ///   issue #451;
+    /// - `get_point` and `merge_axis_interpolate` read the first match in
+    ///   `(x, y)` order, which is the lowest ordinate of the stack, and the
+    ///   rest are invisible to the caller. Use
+    ///   [`get_values`](crate::geometrics::AxisOperations::get_values) to
+    ///   see every ordinate at an abscissa.
+    ///
+    /// Normalizing here would not help: `points` is a `pub` field, so a
+    /// struct literal reaches the same state without going through any
+    /// constructor. Rejecting or collapsing a duplicate can only ever be a
+    /// convenience on this path, never an invariant of the type.
+    ///
+    /// A projection of a surface is genuinely multi-valued and is therefore
+    /// not a curve: [`crate::surfaces::Surface::project_onto`] returns a
+    /// `Vec<Point2D>`, and aggregating it to one ordinate per abscissa is
+    /// the caller's job.
     #[must_use]
     pub fn new(points: BTreeSet<Point2D>) -> Self {
         let x_range = Self::calculate_range(points.iter().map(|p| p.x));
@@ -155,6 +191,26 @@ impl Curve {
                 self.points.len()
             ))
         })
+    }
+
+    /// Returns the sample sitting exactly at the abscissa `x`, if the curve
+    /// has one there.
+    ///
+    /// A curve is a function of its abscissa (see [`Curve::new`]), so at most
+    /// one point can sit at `x`. When several do, the curve has no value at
+    /// `x` and no non-arbitrary way to choose among them exists, so this
+    /// reports [`InterpolationError::DegenerateInterval`] instead of
+    /// returning the first, which would be the lowest ordinate of the stack.
+    /// [`AxisOperations::get_values`] reads all of them.
+    fn exact_point_at(&self, x: Decimal) -> Result<Option<Point2D>, InterpolationError> {
+        let mut at_x = self.points.iter().filter(|p| p.x == x);
+        let Some(point) = at_x.next() else {
+            return Ok(None);
+        };
+        if at_x.next().is_some() {
+            return Err(InterpolationError::DegenerateInterval);
+        }
+        Ok(Some(*point))
     }
 }
 
@@ -320,6 +376,17 @@ impl GeometricObject<Point2D, Decimal> for Curve {
         self.points.iter().collect()
     }
 
+    /// Builds a curve from a vector of convertible points.
+    ///
+    /// # One point per abscissa
+    ///
+    /// Same rule and same non-enforcement as [`Curve::new`]: a curve is a
+    /// function of its abscissa, and this constructor does not check it.
+    /// `points` is collected into a `BTreeSet`, which drops an exact
+    /// duplicate of an `(x, y)` pair but keeps two ordinates that merely
+    /// share an `x`. Aggregate before calling if the input can carry
+    /// several ordinates per abscissa, as the projection returned by
+    /// [`crate::surfaces::Surface::project_onto`] does.
     fn from_vector<T>(points: Vec<T>) -> Self
     where
         T: Into<Point2D> + Clone,
@@ -539,6 +606,23 @@ impl Interpolate<Point2D, Decimal> for Curve {}
 ///   defined points.
 /// - **No Bracketing Points Found**: When the method fails to find two points
 ///   that bracket the given `x`.
+/// - **Degenerate Bracket**: When several points share the requested
+///   abscissa. The curve has no value there and the bracket around it has
+///   zero width, so the method reports
+///   `InterpolationError::DegenerateInterval` instead of picking one of the
+///   ordinates stacked there.
+///
+/// # One point per abscissa
+///
+/// A curve is a function of its abscissa; see [`Curve::new`]. Asking for a
+/// repeated abscissa returns `InterpolationError::DegenerateInterval`; no
+/// ordinate of the stack is chosen.
+///
+/// Away from the stack the method still answers, reading the stack as a
+/// vertical jump: an `x` strictly inside an interval bounded by a repeated
+/// abscissa brackets against the point on its own side, the highest
+/// ordinate when the stack bounds the interval on the left and the lowest
+/// when it bounds it on the right.
 ///
 /// # Example (How it works internally)
 /// Suppose the curve is defined by the following points:
@@ -566,14 +650,23 @@ impl LinearInterpolation<Point2D, Decimal> for Curve {
     /// points on the curve (`p1` and `p2`) that bracket the provided `x`. The `y` value
     /// is then calculated using the linear interpolation formula:
     fn linear_interpolate(&self, x: Decimal) -> Result<Point2D, InterpolationError> {
+        // A sample sitting exactly at `x` is the answer, and a stack of
+        // ordinates at `x` has no answer. Without this branch the first
+        // bracket containing `x` ends at the lowest of the stack and the
+        // formula reproduces its ordinate, which is a silent pick.
+        if let Some(point) = self.exact_point_at(x)? {
+            return Ok(point);
+        }
+
         let (i, j) = self.find_bracket_points(x)?;
 
         let p1 = self.point_at(i, InterpolationError::Linear)?;
         let p2 = self.point_at(j, InterpolationError::Linear)?;
 
-        // `Point2D` orders on (x, y) but compares equal on x alone, so a
-        // `BTreeSet<Point2D>` legitimately holds two points sharing an
-        // abscissa; the slope is then undefined rather than infinite.
+        // A curve is meant to be a function of its abscissa, but nothing
+        // enforces it: a `BTreeSet<Point2D>` holds two points sharing an
+        // abscissa, and the slope across a zero-width bracket is undefined
+        // rather than infinite. Report it instead of picking an ordinate.
         let run = d_sub(p2.x, p1.x, "Curve::linear_interpolate::run")
             .map_err(interp_err(InterpolationError::Linear))?;
         if run.is_zero() {
@@ -893,6 +986,12 @@ impl CubicInterpolation<Point2D, Decimal> for Curve {
     ///   with a corresponding message.
     /// - If the bracketing points cannot be identified (e.g., when `x` is outside the
     ///   range of points), the appropriate interpolation error is propagated.
+    /// - If the curve is not a function of its abscissa at the point it is
+    ///   asked about, it returns `InterpolationError::DegenerateInterval`:
+    ///   several points at `x` leave the exact-match branch with no single
+    ///   value to return, and two consecutive points sharing an abscissa
+    ///   leave the interpolation bracket with zero width. Neither case picks
+    ///   an ordinate. See [`Curve::new`] for the rule.
     ///
     /// # Example
     ///
@@ -902,7 +1001,6 @@ impl CubicInterpolation<Point2D, Decimal> for Curve {
     /// - Provides a high degree of precision due to the use of the `Decimal` type for
     ///   `x` and `y` calculations.
     fn cubic_interpolate(&self, x: Decimal) -> Result<Point2D, InterpolationError> {
-        let points = self.get_points();
         let len = self.len();
 
         // Need at least 4 points for cubic interpolation
@@ -912,9 +1010,11 @@ impl CubicInterpolation<Point2D, Decimal> for Curve {
             ));
         }
 
-        // For exact points, return the actual point value
-        if let Some(point) = points.iter().find(|p| p.x == x) {
-            return Ok(**point);
+        // For exact points, return the actual point value. A stack of
+        // ordinates at `x` has no single value, so it errors out instead of
+        // yielding the lowest of them.
+        if let Some(point) = self.exact_point_at(x)? {
+            return Ok(point);
         }
 
         let (i, _) = self.find_bracket_points(x)?;
@@ -1159,8 +1259,12 @@ impl SplineInterpolation<Point2D, Decimal> for Curve {
     /// - Natural spline interpolation may introduce minor deviations beyond the range of existing
     ///   data points due to its boundary conditions. For strictly constrained results, consider
     ///   alternative interpolation methods, such as linear or cubic Hermite interpolation.
+    /// - The knots must be a function of their abscissa. Several points at
+    ///   the requested `x` leave the exact-match branch with no single value
+    ///   to return, and any repeated abscissa collapses a knot interval, so
+    ///   both return `InterpolationError::DegenerateInterval` rather than
+    ///   picking an ordinate. See [`Curve::new`] for the rule.
     fn spline_interpolate(&self, x: Decimal) -> Result<Point2D, InterpolationError> {
-        let points = self.get_points();
         let len = self.len();
 
         // Need at least 3 points for spline interpolation
@@ -1179,9 +1283,11 @@ impl SplineInterpolation<Point2D, Decimal> for Curve {
             ));
         }
 
-        // For exact points, return the actual point value
-        if let Some(point) = points.iter().find(|p| p.x == x) {
-            return Ok(**point);
+        // For exact points, return the actual point value. A stack of
+        // ordinates at `x` has no single value, so it errors out instead of
+        // yielding the lowest of them.
+        if let Some(point) = self.exact_point_at(x)? {
+            return Ok(point);
         }
 
         let n = len;
@@ -1789,6 +1895,22 @@ impl Arithmetic<Curve> for Curve {
     /// This function enables combining multiple curves for tasks such as:
     /// - Summing y-values across different curves to compute a composite curve.
     /// - Finding the maximum/minimum y-value at each x-point for a collection of curves.
+    ///
+    /// # One point per abscissa
+    ///
+    /// This assumes the one-point-per-abscissa rule of [`Curve::new`] and
+    /// re-establishes it in the result: the merged curve is sampled on an
+    /// evenly spaced grid over the common x-range, with one `y` per grid
+    /// point, so the original abscissae do not survive the merge.
+    ///
+    /// An input carrying several ordinates at one abscissa never has one of
+    /// them silently chosen. Each sample is produced by cubic interpolation,
+    /// which reports [`InterpolationError::DegenerateInterval`], wrapped in
+    /// a [`CurveError`], whenever the sample lands on the repeated abscissa
+    /// or brackets across it. A sample far enough from the stack is
+    /// unaffected and reads the ordinate on its own side, so a merge of such
+    /// a curve can still succeed on a grid that misses the stack. Aggregate
+    /// the curve to one ordinate per abscissa before merging it.
     fn merge(curves: &[&Curve], operation: MergeOperation) -> Result<Curve, CurveError> {
         if curves.is_empty() {
             return Err(CurveError::invalid_parameters(
@@ -1943,14 +2065,30 @@ impl Arithmetic<Curve> for Curve {
 impl AxisOperations<Point2D, Decimal> for Curve {
     type Error = CurveError;
 
+    /// Reports whether the curve has a point at the abscissa `x`.
+    ///
+    /// Answers on `x` alone, so it says nothing about how many ordinates sit
+    /// there. On a curve honouring the one-point-per-abscissa rule of
+    /// [`Curve::new`] there is at most one.
     fn contains_point(&self, x: &Decimal) -> bool {
         self.points.iter().any(|p| &p.x == x)
     }
 
+    /// Returns the abscissa of every point, in `(x, y)` order.
+    ///
+    /// A curve holding several ordinates at one abscissa yields that
+    /// abscissa once per ordinate; the duplicates are visible here rather
+    /// than dropped.
     fn get_index_values(&self) -> Vec<Decimal> {
         self.points.iter().map(|p| p.x).collect()
     }
 
+    /// Returns every ordinate at the abscissa `x`, in ascending order.
+    ///
+    /// This is the multi-valued reader: unlike [`Self::get_point`], it never
+    /// picks a survivor. A curve honouring the one-point-per-abscissa rule
+    /// of [`Curve::new`] returns at most one value; anything longer says the
+    /// curve is not a function of its abscissa.
     fn get_values(&self, x: Decimal) -> Vec<&Decimal> {
         self.points
             .iter()
@@ -1983,6 +2121,12 @@ impl AxisOperations<Point2D, Decimal> for Curve {
             })
     }
 
+    /// Returns the point at the abscissa `x`, if there is one.
+    ///
+    /// Assumes the one-point-per-abscissa rule of [`Curve::new`]. If the
+    /// curve breaks it, this returns the *first* match in `(x, y)` order,
+    /// which is the lowest ordinate of the stack, and the rest are invisible
+    /// to the caller. Use [`Self::get_values`] to see all of them.
     fn get_point(&self, x: &Decimal) -> Option<&Point2D> {
         if self.contains_point(x) {
             self.points.iter().find(|p| p.x == *x)
@@ -1996,6 +2140,14 @@ impl MergeAxisInterpolate<Point2D, Decimal> for Curve
 where
     Self: Sized,
 {
+    /// Resamples both curves onto the shared x-grid of their merged indices.
+    ///
+    /// Each result holds one point per abscissa of that grid, so it is a
+    /// function of its abscissa whatever the inputs were: where a curve
+    /// already has a point at an abscissa, the one kept is the first match
+    /// in `(x, y)` order, so a stack of ordinates collapses to its lowest,
+    /// and elsewhere the point is interpolated. Aggregate such a curve
+    /// before merging if a different ordinate is wanted.
     fn merge_axis_interpolate(
         &self,
         other: &Self,
@@ -4406,5 +4558,127 @@ mod tests_axis_merge_and_transformations {
         let (min, max) = curve.extrema().unwrap();
         assert_eq!(min.y, dec!(0.0));
         assert_eq!(max.y, dec!(3.0));
+    }
+}
+
+/// A `Curve` is a function of its abscissa, and nothing enforces it. These
+/// tests pin what each consumer does when the rule is broken, so that no
+/// consumer picks a survivor from a stack of ordinates without saying so.
+#[cfg(test)]
+mod tests_duplicate_abscissa {
+    use crate::curves::{Curve, Point2D};
+    use crate::error::InterpolationError;
+    use crate::geometrics::{AxisOperations, Interpolate, InterpolationType};
+    use rust_decimal_macros::dec;
+    use std::collections::BTreeSet;
+
+    /// Four abscissae, with two ordinates stacked on `x = 1`: enough points
+    /// for every interpolator, and the stack sits in the interior.
+    fn stacked_curve() -> Curve {
+        Curve::new(BTreeSet::from_iter(vec![
+            Point2D::new(dec!(0.0), dec!(0.0)),
+            Point2D::new(dec!(1.0), dec!(1.0)),
+            Point2D::new(dec!(1.0), dec!(3.0)),
+            Point2D::new(dec!(2.0), dec!(2.0)),
+            Point2D::new(dec!(3.0), dec!(5.0)),
+        ]))
+    }
+
+    #[test]
+    fn test_curve_new_stacked_abscissa_keeps_both_points() {
+        let curve = stacked_curve();
+
+        // `Point2D` orders and compares on the full pair, so both survive.
+        assert_eq!(curve.points.len(), 5);
+        assert_eq!(curve.x_range, (dec!(0.0), dec!(3.0)));
+    }
+
+    #[test]
+    fn test_curve_get_values_stacked_abscissa_returns_every_ordinate() {
+        let curve = stacked_curve();
+
+        let values: Vec<_> = curve.get_values(dec!(1.0)).into_iter().copied().collect();
+        assert_eq!(values, vec![dec!(1.0), dec!(3.0)]);
+    }
+
+    /// `get_point` is documented as reading the first match. This pins that
+    /// it is the lowest ordinate, so the doc is checkable.
+    #[test]
+    fn test_curve_get_point_stacked_abscissa_returns_lowest_ordinate() {
+        let curve = stacked_curve();
+
+        let point = curve.get_point(&dec!(1.0)).expect("x = 1 is present");
+        assert_eq!(*point, Point2D::new(dec!(1.0), dec!(1.0)));
+        assert!(curve.contains_point(&dec!(1.0)));
+    }
+
+    #[test]
+    fn test_curve_linear_interpolate_stacked_abscissa_is_degenerate() {
+        let curve = stacked_curve();
+
+        assert!(matches!(
+            curve.interpolate(dec!(1.0), InterpolationType::Linear),
+            Err(InterpolationError::DegenerateInterval)
+        ));
+    }
+
+    #[test]
+    fn test_curve_cubic_interpolate_stacked_abscissa_is_degenerate() {
+        let curve = stacked_curve();
+
+        assert!(matches!(
+            curve.interpolate(dec!(1.0), InterpolationType::Cubic),
+            Err(InterpolationError::DegenerateInterval)
+        ));
+    }
+
+    #[test]
+    fn test_curve_spline_interpolate_stacked_abscissa_is_degenerate() {
+        let curve = stacked_curve();
+
+        assert!(matches!(
+            curve.interpolate(dec!(1.0), InterpolationType::Spline),
+            Err(InterpolationError::DegenerateInterval)
+        ));
+    }
+
+    /// Away from the stack the curve is still a function, and linear
+    /// interpolation reads the ordinate on the same side of the jump.
+    #[test]
+    fn test_curve_linear_interpolate_away_from_stack_reads_its_own_side() {
+        let curve = stacked_curve();
+
+        let left = curve
+            .interpolate(dec!(0.5), InterpolationType::Linear)
+            .expect("0.5 brackets between (0, 0) and the lowest ordinate at x = 1");
+        assert_eq!(left, Point2D::new(dec!(0.5), dec!(0.5)));
+
+        let right = curve
+            .interpolate(dec!(1.5), InterpolationType::Linear)
+            .expect("1.5 brackets between the highest ordinate at x = 1 and (2, 2)");
+        assert_eq!(right, Point2D::new(dec!(1.5), dec!(2.5)));
+    }
+
+    /// A curve honouring the rule is unaffected by the exact-match guard:
+    /// asking for a stored abscissa returns the stored point.
+    #[test]
+    fn test_curve_interpolate_single_ordinate_returns_the_stored_point() {
+        let curve = Curve::new(BTreeSet::from_iter(vec![
+            Point2D::new(dec!(0.0), dec!(0.0)),
+            Point2D::new(dec!(1.0), dec!(1.0)),
+            Point2D::new(dec!(2.0), dec!(4.0)),
+            Point2D::new(dec!(3.0), dec!(9.0)),
+        ]));
+
+        for interpolation in [
+            InterpolationType::Linear,
+            InterpolationType::Cubic,
+            InterpolationType::Spline,
+        ] {
+            let point = curve
+                .interpolate(dec!(2.0), interpolation)
+                .expect("x = 2 is a stored abscissa");
+            assert_eq!(point, Point2D::new(dec!(2.0), dec!(4.0)));
+        }
     }
 }

--- a/src/curves/types.rs
+++ b/src/curves/types.rs
@@ -79,10 +79,13 @@ impl Display for Point2D {
 /// onto one cell whenever those indices pass through a `HashSet`.
 ///
 /// The "one ordinate per abscissa" rule is a property of a *curve*, not of a
-/// point, and it is a container-level invariant that nothing currently
-/// enforces: [`crate::curves::Curve::new`] stores a repeated abscissa
-/// unchanged, and whether such a curve should be rejected, normalized or
-/// supported is deferred to issue #466.
+/// point, and it is a container-level invariant that nothing enforces:
+/// [`crate::curves::Curve::new`] stores a repeated abscissa unchanged, and
+/// `points` is a `pub` field, so no constructor could. The rule and what
+/// each consumer does when it is broken are documented on
+/// [`crate::curves::Curve::new`]. A genuinely multi-valued projection is not
+/// a curve at all: [`crate::surfaces::Surface::project_onto`] returns a
+/// `Vec<Point2D>`.
 impl PartialEq for Point2D {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y

--- a/src/geometrics/interpolation/bilinear.rs
+++ b/src/geometrics/interpolation/bilinear.rs
@@ -59,6 +59,26 @@ use crate::error::InterpolationError;
 ///   A module defining different types of interpolation methods.
 /// - [`crate::geometrics::interpolation::LinearInterpolation`](crate::geometrics::LinearInterpolation):
 ///   A simpler interpolation method for one-dimensional data.
+///
+/// # One point per abscissa
+///
+/// Every interpolator here reads its sample as a function of the abscissa:
+/// at most one ordinate per `x`. See
+/// [`Curve::new`](crate::curves::Curve::new) for the rule and for why no
+/// constructor enforces it. A sample carrying several ordinates at one
+/// abscissa is outside the contract: the grid cell around a repeated
+/// abscissa has zero width and the slope across it is undefined, so the
+/// answer is [`InterpolationError::DegenerateInterval`].
+///
+/// One branch is an exception. The [`Curve`](crate::curves::Curve)
+/// implementation short-circuits an `x` that matches a sample exactly, and
+/// on a stack of ordinates at that `x` it returns the lowest of them rather
+/// than reporting the degeneracy. That branch is left alone here because
+/// the whole method is being reworked under issue #451.
+///
+/// A projection of a surface is multi-valued by construction, which is why
+/// [`Surface::project_onto`](crate::surfaces::Surface::project_onto) returns a
+/// `Vec<Point2D>` and not a curve; aggregate it before interpolating.
 pub trait BiLinearInterpolation<Point, Input> {
     /// Performs bilinear interpolation to compute a value for the given input.
     ///

--- a/src/geometrics/interpolation/cubic.rs
+++ b/src/geometrics/interpolation/cubic.rs
@@ -93,6 +93,20 @@ use crate::error::InterpolationError;
 ///     }
 /// }
 /// ```
+///
+/// # One point per abscissa
+///
+/// Every interpolator here reads its sample as a function of the abscissa:
+/// at most one ordinate per `x`. See
+/// [`Curve::new`](crate::curves::Curve::new) for the rule and for why no
+/// constructor enforces it. A sample carrying several ordinates at one
+/// abscissa is outside the contract, and the answer is
+/// [`InterpolationError::DegenerateInterval`], never one of the stacked
+/// ordinates chosen silently: the bracket around a repeated abscissa has
+/// zero width and the slope across it is undefined. A projection of a
+/// surface is multi-valued by construction, which is why
+/// [`Surface::project_onto`](crate::surfaces::Surface::project_onto) returns a
+/// `Vec<Point2D>` and not a curve; aggregate it before interpolating.
 pub trait CubicInterpolation<Point, Input> {
     /// Interpolates a new point on the curve for a given `x` input value
     /// using cubic interpolation.

--- a/src/geometrics/interpolation/linear.rs
+++ b/src/geometrics/interpolation/linear.rs
@@ -73,6 +73,20 @@ use crate::error::InterpolationError;
 ///
 /// The `LinearInterpolation` trait is part of a modular design and is often re-exported
 /// in higher-level library components for ease of use.
+///
+/// # One point per abscissa
+///
+/// Every interpolator here reads its sample as a function of the abscissa:
+/// at most one ordinate per `x`. See
+/// [`Curve::new`](crate::curves::Curve::new) for the rule and for why no
+/// constructor enforces it. A sample carrying several ordinates at one
+/// abscissa is outside the contract, and the answer is
+/// [`InterpolationError::DegenerateInterval`], never one of the stacked
+/// ordinates chosen silently: the bracket around a repeated abscissa has
+/// zero width and the slope across it is undefined. A projection of a
+/// surface is multi-valued by construction, which is why
+/// [`Surface::project_onto`](crate::surfaces::Surface::project_onto) returns a
+/// `Vec<Point2D>` and not a curve; aggregate it before interpolating.
 pub trait LinearInterpolation<Point, Input> {
     /// Performs linear interpolation for a given input value.
     ///

--- a/src/geometrics/interpolation/spline.rs
+++ b/src/geometrics/interpolation/spline.rs
@@ -85,6 +85,20 @@ use crate::error::InterpolationError;
 ///
 /// This trait is part of a broader framework supporting multiple interpolation techniques,
 /// allowing developers to extend and choose specific methods as per the dataset requirements.
+///
+/// # One point per abscissa
+///
+/// Every interpolator here reads its sample as a function of the abscissa:
+/// at most one ordinate per `x`. See
+/// [`Curve::new`](crate::curves::Curve::new) for the rule and for why no
+/// constructor enforces it. A sample carrying several ordinates at one
+/// abscissa is outside the contract, and the answer is
+/// [`InterpolationError::DegenerateInterval`], never one of the stacked
+/// ordinates chosen silently: the bracket around a repeated abscissa has
+/// zero width and the slope across it is undefined. A projection of a
+/// surface is multi-valued by construction, which is why
+/// [`Surface::project_onto`](crate::surfaces::Surface::project_onto) returns a
+/// `Vec<Point2D>` and not a curve; aggregate it before interpolating.
 pub trait SplineInterpolation<Point, Input> {
     /// Interpolates a y-value for the provided x-coordinate using spline interpolation.
     ///

--- a/src/geometrics/interpolation/traits.rs
+++ b/src/geometrics/interpolation/traits.rs
@@ -84,7 +84,8 @@ where
     /// [`InterpolationError`] it produces; see the per-algorithm
     /// traits ([`LinearInterpolation`], [`CubicInterpolation`],
     /// [`BiLinearInterpolation`], [`SplineInterpolation`]) for the
-    /// specific variant breakdown.
+    /// specific variant breakdown, including what each of them does with a
+    /// sample that carries several ordinates at one abscissa.
     fn interpolate(
         &self,
         x: Input,
@@ -110,6 +111,17 @@ where
     /// # Returns
     /// - `Ok((usize, usize))`: The indices of the two bracketing points
     /// - `Err(InterpolationError)`: If bracketing points cannot be found
+    ///
+    /// # One point per abscissa
+    ///
+    /// The sample is assumed to be a function of its abscissa; see
+    /// [`Curve::new`](crate::curves::Curve::new). This returns the *first*
+    /// window `(i, i + 1)` containing `x`, so when `x` is an abscissa
+    /// carrying several ordinates the window it returns is the degenerate
+    /// one spanning two of them, of zero width. That is deliberate: the
+    /// callers divide by that width and report
+    /// [`InterpolationError::DegenerateInterval`], instead of bracketing
+    /// against an arbitrary member of the stack.
     ///
     /// # Errors
     /// - If there are fewer than 2 points in the dataset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 // into, so the lint is silenced in `#[cfg(test)]` only.
 #![cfg_attr(test, allow(clippy::indexing_slicing))]
 
-//! # OptionStratLib v0.20.0: Financial Options Library
+//! # OptionStratLib v0.21.0: Financial Options Library
 //!
 //! ## Table of Contents
 //! 1. [Introduction](#introduction)
@@ -800,7 +800,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = "0.20.0"
+//! optionstratlib = "0.21.0"
 //! ```
 //!
 //! Or use cargo to add it to your project:
@@ -815,7 +815,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = { version = "0.20.0", features = ["plotly"] }
+//! optionstratlib = { version = "0.21.0", features = ["plotly"] }
 //! ```
 //!
 //! - `plotly`: Enables interactive visualization using plotly.rs
@@ -1210,7 +1210,7 @@
 //!
 //! ---
 //!
-//! **OptionStratLib v0.20.0** - Built with ❤️ in Rust for the financial community
+//! **OptionStratLib v0.21.0** - Built with ❤️ in Rust for the financial community
 //!
 
 /// # OptionsStratLib: Financial Options Trading Library

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -21,7 +21,7 @@
 //! * **Error Handling:** Uses the `SurfaceError` type for robust error management.
 //!
 
-use crate::curves::{Curve, Point2D};
+use crate::curves::Point2D;
 use crate::error::decimal::DecimalError;
 use crate::error::{InterpolationError, MetricsError, SurfaceError};
 use crate::geometrics::{
@@ -56,7 +56,10 @@ use utoipa::ToSchema;
 ///
 /// # Fields
 /// - **points**: A sorted collection of `Point3D` objects that define the surface
-///   geometry. Using `BTreeSet` ensures points are uniquely stored and ordered.
+///   geometry. `BTreeSet` keeps them ordered and rejects an exact duplicate of
+///   the full `(x, y, z)` triple; it does not stop two heights from sitting
+///   above one xy-coordinate. See [`Surface::new`] for the one-height-per-cell
+///   rule and for why it is a convention rather than an invariant.
 /// - **x_range**: A tuple containing the minimum and maximum x-coordinates of the surface
 ///   as `Decimal` values, representing the surface's width boundaries.
 /// - **y_range**: A tuple containing the minimum and maximum y-coordinates of the surface
@@ -91,7 +94,11 @@ use utoipa::ToSchema;
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Surface {
-    /// Collection of 3D points defining the surface
+    /// Collection of 3D points defining the surface.
+    ///
+    /// Public, so a struct literal can populate it without passing through
+    /// [`Surface::new`]. No constructor can therefore guarantee one height
+    /// per xy-coordinate.
     pub points: BTreeSet<Point3D>,
     /// The minimum and maximum x-coordinates of the surface (min_x, max_x)
     pub x_range: (Decimal, Decimal),
@@ -130,14 +137,33 @@ impl Surface {
     /// let object = Surface::new(points);
     /// ```
     ///
-    /// # Duplicate coordinates
+    /// # One height per xy-coordinate
     ///
-    /// [`Point3D`] orders on the full `(x, y, z)` triple, so `points` may
-    /// hold several heights above one xy-coordinate and `new` stores them
-    /// all, even though [`Surface::get_point`] and
-    /// [`Surface::contains_point`] return only the first match. Whether such
-    /// a surface should be rejected or normalized is unresolved; see the
-    /// issue #466.
+    /// A `Surface` is a function of its `(x, y)` coordinate: at most one `z`
+    /// above each cell. Every consumer reads it that way.
+    /// [`get_point`](crate::geometrics::AxisOperations::get_point) and
+    /// [`contains_point`](crate::geometrics::AxisOperations::contains_point)
+    /// answer from the first point matching `(x, y)`, and
+    /// `merge_axis_interpolate` resamples both surfaces onto one shared
+    /// xy-grid with one `z` per cell.
+    ///
+    /// Nothing enforces the rule. [`Point3D`] orders on the full
+    /// `(x, y, z)` triple, so `points` may hold several heights above one
+    /// xy-coordinate and `new` stores them all; a surface built that way is
+    /// outside the contract, and `get_point` then silently returns the
+    /// lowest `z` of the stack, the first in `(x, y, z)` order, while
+    /// `contains_point` reports only that something is there. Use
+    /// [`get_values`](crate::geometrics::AxisOperations::get_values) to see
+    /// every `z` above a cell.
+    ///
+    /// Normalizing here would not help: `points` is a `pub` field, so a
+    /// struct literal reaches the same state without going through any
+    /// constructor. Rejecting or collapsing a duplicate can only ever be a
+    /// convenience on this path, never an invariant of the type.
+    ///
+    /// The one projection that is genuinely multi-valued,
+    /// [`Surface::project_onto`], returns a `Vec<Point2D>` for that reason
+    /// and never a [`Curve`](crate::curves::Curve).
     #[must_use]
     pub fn new(points: BTreeSet<Point3D>) -> Self {
         let x_range = Self::calculate_range(points.iter().map(|p| p.x));
@@ -149,11 +175,11 @@ impl Surface {
         }
     }
 
-    /// Projects a 3D surface onto a 2D plane based on the specified axis.
+    /// Projects the surface onto a 2D plane by dropping one coordinate.
     ///
-    /// This method creates a 2D curve by projecting the points of the surface onto a plane
-    /// perpendicular to the specified axis. The projection is achieved by omitting the coordinate
-    /// that corresponds to the specified axis.
+    /// The projection is perpendicular to `axis`: the coordinate naming the
+    /// axis is omitted and the remaining two become the abscissa and the
+    /// ordinate of a [`Point2D`].
     ///
     /// # Parameters
     /// - `&self`: Reference to the Surface instance
@@ -163,30 +189,37 @@ impl Surface {
     ///   - `Axis::Z`: Projects onto the XY plane (z-coordinate is omitted)
     ///
     /// # Returns
-    /// - `Curve`: A new 2D curve containing the projected points
+    /// - `Vec<Point2D>`: exactly one projected point per surface point,
+    ///   sorted ascending by the projected `(x, y)` pair.
     ///
     /// # Behavior
-    /// - For `Axis::X`, the returned curve contains points with (y, z) coordinates
-    /// - For `Axis::Y`, the returned curve contains points with (x, z) coordinates
-    /// - For `Axis::Z`, the returned curve contains points with (x, y) coordinates
+    /// - For `Axis::X`, the returned points carry (y, z) coordinates
+    /// - For `Axis::Y`, the returned points carry (x, z) coordinates
+    /// - For `Axis::Z`, the returned points carry (x, y) coordinates
     ///
     /// # Multi-valued projections
     ///
     /// Dropping a coordinate from a grid is multi-valued: every row of the
     /// grid contributes a different height above the same projected abscissa.
-    /// A projection of an `n`-by-`m` grid therefore yields up to `n * m`
-    /// points, several of which share an abscissa.
+    /// A projection of an `n`-by-`m` grid therefore yields `n * m` points,
+    /// several of which share an abscissa, and two rows that agree on the
+    /// two surviving coordinates project onto the very same point.
     ///
-    /// Every point is kept. The returned [`Curve`] is consequently **not**
-    /// single-valued in `x`, unlike a curve built from a series, so
-    /// interpolating it returns
-    /// [`InterpolationError::DegenerateInterval`](crate::error::InterpolationError::DegenerateInterval)
-    /// wherever two projected points share an abscissa. Callers that need a
-    /// function of the projected abscissa must aggregate the points
-    /// themselves — this method does not choose an aggregation for them.
+    /// That is why this returns a `Vec` and not a
+    /// [`Curve`](crate::curves::Curve). A curve is a function of its
+    /// abscissa (see [`Curve::new`](crate::curves::Curve::new)) and it
+    /// stores its points in a `BTreeSet`, which drops every projected point
+    /// equal to one already collected. The vector keeps all of them:
+    /// `result.len() == self.points.len()`, always.
+    ///
+    /// Callers that need a function of the projected abscissa must aggregate
+    /// the ordinates sharing one themselves. This method does not choose an
+    /// aggregation for them, and building a `Curve` from the result without
+    /// aggregating first is exactly the loss the return type exists to
+    /// prevent.
     #[must_use]
-    pub fn get_curve(&self, axis: Axis) -> Curve {
-        let points = self
+    pub fn project_onto(&self, axis: Axis) -> Vec<Point2D> {
+        let mut points: Vec<Point2D> = self
             .points
             .iter()
             .map(|p| match axis {
@@ -195,7 +228,10 @@ impl Surface {
                 Axis::Z => Point2D::new(p.x, p.y),
             })
             .collect();
-        Curve::new(points)
+        // Sorting is what the `BTreeSet` behind the old `Curve` return type
+        // provided; only its deduplication is dropped.
+        points.sort();
+        points
     }
 
     /// Performs one-dimensional spline interpolation on a collection of points.
@@ -1752,14 +1788,29 @@ impl Arithmetic<Surface> for Surface {
 impl AxisOperations<Point3D, Point2D> for Surface {
     type Error = SurfaceError;
 
+    /// Reports whether any point sits above the xy-coordinate `x`.
+    ///
+    /// Answers on the `(x, y)` pair alone, so it says nothing about how many
+    /// heights are stacked there. On a surface honouring the
+    /// one-height-per-cell rule of [`Surface::new`] there is at most one.
     fn contains_point(&self, x: &Point2D) -> bool {
         self.points.iter().any(|p| p.x == x.x && p.y == x.y)
     }
 
+    /// Returns the xy-coordinate of every point, in `(x, y, z)` order.
+    ///
+    /// A surface holding several heights above one cell yields that cell
+    /// once per height; the duplicates are visible here rather than dropped.
     fn get_index_values(&self) -> Vec<Point2D> {
         self.points.iter().map(|p| Point2D::new(p.x, p.y)).collect()
     }
 
+    /// Returns every `z` above the xy-coordinate `x`, in ascending order.
+    ///
+    /// This is the multi-valued reader: unlike [`Self::get_point`], it never
+    /// picks a survivor. A surface honouring the one-height-per-cell rule of
+    /// [`Surface::new`] returns at most one value; anything longer says the
+    /// surface is not a function of its xy-coordinate.
     fn get_values(&self, x: Point2D) -> Vec<&Decimal> {
         self.points
             .iter()
@@ -1793,6 +1844,12 @@ impl AxisOperations<Point3D, Point2D> for Surface {
             })
     }
 
+    /// Returns the point above the xy-coordinate `x`, if there is one.
+    ///
+    /// Assumes the one-height-per-cell rule of [`Surface::new`]. If the
+    /// surface breaks it, this returns the *first* match in `(x, y, z)`
+    /// order, which is the lowest `z` of the stack, and the rest are
+    /// invisible to the caller. Use [`Self::get_values`] to see all of them.
     fn get_point(&self, x: &Point2D) -> Option<&Point3D> {
         self.points.iter().find(|p| p.x == x.x && p.y == x.y)
     }
@@ -1802,6 +1859,15 @@ impl MergeAxisInterpolate<Point3D, Point2D> for Surface
 where
     Self: Sized,
 {
+    /// Resamples both surfaces onto the shared xy-grid of their merged
+    /// indices.
+    ///
+    /// Each result holds one `z` per cell of that grid, so it is a function
+    /// of its xy-coordinate whatever the inputs were: where a surface
+    /// already covers a cell, the point kept is the first match in
+    /// `(x, y, z)` order, so a stack of heights above one cell collapses to
+    /// its lowest. Aggregate such a surface before merging if a different
+    /// height is wanted.
     fn merge_axis_interpolate(
         &self,
         other: &Self,
@@ -2191,31 +2257,31 @@ mod tests_surface_basic {
 
     /// Projecting out `x` maps `(x, y, z)` to `(y, z)`, which is multi-valued
     /// on a grid: the test surface has two points at `y = 0` and two at
-    /// `y = 1`, and all five survive the projection.
+    /// `y = 1`, so the projection has two ordinates above abscissa `0` and
+    /// two above abscissa `1`.
     ///
-    /// The membership probes below are unchanged, but they are stricter than
-    /// they were: `Point2D` used to compare on `x` alone, so `p == (0, 0)`
-    /// also matched `(0, 1)`. It now means what it says.
+    /// All five are asserted by exact contents, not by membership probes.
+    /// Under the pre-#450 `Point2D` contract, `collect` into the `BTreeSet`
+    /// of the old `Curve` return type kept only three of them, and the
+    /// probes passed anyway because `x`-only equality made `(0, 1)` match a
+    /// probe for `(0, 0)`.
     #[test]
-    fn test_get_curve_x_axis() {
+    fn test_project_onto_x_axis_keeps_every_projected_point() {
         let points = create_test_points();
         let surface = Surface::new(points);
-        let curve = surface.get_curve(Axis::X);
+        let projection = surface.project_onto(Axis::X);
 
-        // Check curve points
-        let curve_points: Vec<Point2D> = curve.points.into_iter().collect();
-
-        // Verify the points are mapped correctly for X-axis curve
-        assert!(
-            curve_points
-                .iter()
-                .any(|p| p == &Point2D::new(dec!(0.0), dec!(0.0)))
+        assert_eq!(
+            projection,
+            vec![
+                Point2D::new(dec!(0.0), dec!(0.0)),
+                Point2D::new(dec!(0.0), dec!(1.0)),
+                Point2D::new(dec!(0.5), dec!(1.5)),
+                Point2D::new(dec!(1.0), dec!(1.0)),
+                Point2D::new(dec!(1.0), dec!(2.0)),
+            ]
         );
-        assert!(
-            curve_points
-                .iter()
-                .any(|p| p == &Point2D::new(dec!(1.0), dec!(1.0)))
-        );
+        assert_eq!(projection.len(), surface.points.len());
 
         let points = surface.get_f64_points();
         assert_eq!(points.len(), 5);
@@ -2236,53 +2302,81 @@ mod tests_surface_basic {
     }
 
     /// Projecting out `y` maps `(x, y, z)` to `(x, z)`, multi-valued on a
-    /// grid for the same reason as the X-axis case above. The probes are
-    /// unchanged and now mean exact membership.
+    /// grid for the same reason as the X-axis case above: two heights above
+    /// `x = 0` and two above `x = 1`.
     #[test]
-    fn test_get_curve_y_axis() {
+    fn test_project_onto_y_axis_keeps_every_projected_point() {
         let points = create_test_points();
         let surface = Surface::new(points);
-        let curve = surface.get_curve(Axis::Y);
+        let projection = surface.project_onto(Axis::Y);
 
-        // Check curve points
-        let curve_points: Vec<Point2D> = curve.points.into_iter().collect();
-
-        // Verify the points are mapped correctly for Y-axis curve
-        assert!(
-            curve_points
-                .iter()
-                .any(|p| p == &Point2D::new(dec!(0.0), dec!(0.0)))
+        assert_eq!(
+            projection,
+            vec![
+                Point2D::new(dec!(0.0), dec!(0.0)),
+                Point2D::new(dec!(0.0), dec!(1.0)),
+                Point2D::new(dec!(0.5), dec!(1.5)),
+                Point2D::new(dec!(1.0), dec!(1.0)),
+                Point2D::new(dec!(1.0), dec!(2.0)),
+            ]
         );
-        assert!(
-            curve_points
-                .iter()
-                .any(|p| p == &Point2D::new(dec!(1.0), dec!(2.0)))
-        );
+        assert_eq!(projection.len(), surface.points.len());
     }
 
     /// Projecting out `z` maps `(x, y, z)` to `(x, y)`: the xy-footprint of
     /// the surface, which on a grid has several ordinates per abscissa by
-    /// construction. The probes are unchanged and now mean exact membership.
+    /// construction.
     #[test]
-    fn test_get_curve_z_axis() {
+    fn test_project_onto_z_axis_keeps_every_projected_point() {
         let points = create_test_points();
         let surface = Surface::new(points);
-        let curve = surface.get_curve(Axis::Z);
+        let projection = surface.project_onto(Axis::Z);
 
-        // Check curve points
-        let curve_points: Vec<Point2D> = curve.points.into_iter().collect();
+        assert_eq!(
+            projection,
+            vec![
+                Point2D::new(dec!(0.0), dec!(0.0)),
+                Point2D::new(dec!(0.0), dec!(1.0)),
+                Point2D::new(dec!(0.5), dec!(0.5)),
+                Point2D::new(dec!(1.0), dec!(0.0)),
+                Point2D::new(dec!(1.0), dec!(1.0)),
+            ]
+        );
+        assert_eq!(projection.len(), surface.points.len());
+    }
 
-        // Verify the points are mapped correctly for Z-axis curve
-        assert!(
-            curve_points
-                .iter()
-                .any(|p| p == &Point2D::new(dec!(0.0), dec!(0.0)))
+    /// Two surface points that agree on the two surviving coordinates
+    /// project onto the very same 2D point. A set keeps one of them; the
+    /// `Vec` this method returns keeps both, which is the loss the return
+    /// type exists to prevent.
+    #[test]
+    fn test_project_onto_coincident_images_keeps_both_points() {
+        // `z` depends on `y` alone, so projecting out `x` maps both rows of
+        // the grid onto the same two points.
+        let surface = Surface::new(BTreeSet::from_iter(vec![
+            Point3D::new(dec!(0.0), dec!(0.0), dec!(7.0)),
+            Point3D::new(dec!(0.0), dec!(1.0), dec!(9.0)),
+            Point3D::new(dec!(1.0), dec!(0.0), dec!(7.0)),
+            Point3D::new(dec!(1.0), dec!(1.0), dec!(9.0)),
+        ]));
+
+        let projection = surface.project_onto(Axis::X);
+
+        assert_eq!(projection.len(), 4);
+        assert_eq!(
+            projection,
+            vec![
+                Point2D::new(dec!(0.0), dec!(7.0)),
+                Point2D::new(dec!(0.0), dec!(7.0)),
+                Point2D::new(dec!(1.0), dec!(9.0)),
+                Point2D::new(dec!(1.0), dec!(9.0)),
+            ]
         );
-        assert!(
-            curve_points
-                .iter()
-                .any(|p| p == &Point2D::new(dec!(1.0), dec!(1.0)))
-        );
+
+        // The old return type collected into a `BTreeSet`, which is where
+        // the two lost points went.
+        let as_set: BTreeSet<Point2D> = projection.into_iter().collect();
+        assert_eq!(as_set.len(), 2);
     }
 
     #[test]

--- a/src/surfaces/types.rs
+++ b/src/surfaces/types.rs
@@ -69,10 +69,11 @@ impl Display for Point3D {
 /// points hash alike, as `Ord` requires.
 ///
 /// The "one `z` per `(x, y)`" rule is a property of a *surface*, not of a
-/// point, and it is a container-level invariant that nothing currently
-/// enforces: [`crate::surfaces::Surface::new`] retains a repeated `(x, y)`
-/// coordinate, and whether such a surface should be rejected, normalized or
-/// supported is deferred to issue #466.
+/// point, and it is a container-level invariant that nothing enforces:
+/// [`crate::surfaces::Surface::new`] retains a repeated `(x, y)` coordinate,
+/// and `points` is a `pub` field, so no constructor could. The rule and what
+/// each consumer does when it is broken are documented on
+/// [`crate::surfaces::Surface::new`].
 impl PartialEq for Point3D {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y && self.z == other.z


### PR DESCRIPTION
## Summary

`Curve` and `Surface` store points in a `BTreeSet`, and duplicate abscissae get
there legitimately — projecting a grid onto one axis produces several points
sharing an `x` by construction. The crate assumed two contradictory things
about that, and #450 fixing the `Ord`/`Eq` contract exposed the disagreement
rather than resolving it.

The decision this PR makes: **`Curve` stays a function of its abscissa, and the
projection gets a name and a type that admit it is not one.**

`Surface::get_curve` → `Surface::project_onto`, returning `Vec<Point2D>`
instead of `Curve`. Name and type were saying the same wrong thing, so they
change together.

## Why a `Vec`, not a newtype and not the point set

- It preserves cardinality exactly: `project_onto(axis).len() ==
  self.points.len()`, always. A set does not — two surface points that agree on
  the two surviving coordinates project onto the *identical* `Point2D`, and a
  `BTreeSet` keeps one. With the `Ord`/`Eq` contract fixed by #450 that
  coincident-image case is the only remaining silent loss, and it is precisely
  the one a set cannot express.
- A `Vec` already says "sequence of points" rather than "function of `x`". A
  newtype would add a public type, its docs, its `Serialize`/`ToSchema`
  question and its accessors, and would carry no invariant a `Vec` does not.
- Contents stay sorted ascending by the projected `(x, y)`, which is exactly
  what the `BTreeSet` gave. Only its deduplication is gone, so the ordering
  semantics do not change silently along with the type.

`"greatest ordinate wins"` was not adopted: #450 rejected it precisely because
it would bless `collect`'s accidental behaviour as the projection's semantics.

## The rule is documented as a contract, not as an enforced invariant

`points` is a `pub` field on both types, so a struct literal reaches a
duplicate-carrying state without passing through any constructor.
Normalization there could only ever be a convenience, never an invariant — and
the docs say that, instead of claiming a guarantee `new` does not make. The
rule is stated on `Curve::new`, `Curve::from_vector`, `Curve::merge`,
`get_point`, `contains_point`, `get_values`, `merge_axis_interpolate`,
`Surface::new`, the four interpolation traits and `find_bracket_points`, each
with what that consumer actually does when the rule is broken.

## A behaviour change beyond the return type

"No consumer may silently pick a survivor" was violated in the interpolators,
not only in the prose. `cubic_interpolate` and `spline_interpolate`
short-circuited an exact `x` with `points.iter().find(|p| p.x == x)`, returning
the **lowest** ordinate of a stack, and `linear_interpolate` reached the same
value through a bracket ending there. All three now go through

```rust
fn exact_point_at(&self, x: Decimal) -> Result<Option<Point2D>, InterpolationError>
```

which returns `InterpolationError::DegenerateInterval` when several points
share `x` — the same answer the arithmetic already gives for a zero-width
bracket (#452). No new error variant and no new rule. A curve with one point
per abscissa is unaffected.

Two consumers keep reading the first match, now documented as "the lowest
ordinate" with `get_values` named as the multi-valued reader: `get_point` and
`merge_axis_interpolate`. The exact-match branch of `bilinear_interpolate`
keeps its old behaviour and is documented as the exception, because that method
is reworked in the next PR of this chain (#451) and moving it twice would make
both diffs harder to check.

## Tests

The three projection tests assert exact contents instead of membership probes —
the test surface projects five points and `collect` used to return three — and
a fourth covers two surface points projecting onto the same 2D point. A new
`tests_duplicate_abscissa` module pins the interpolator behaviour on both
sides: a stacked abscissa errors, a single-ordinate curve is untouched.

4681 passed, 0 failed. `cargo fmt --all --check`, `cargo clippy --all-targets
--all-features --workspace -- -D warnings`, `make scan-banned` and
`make public-api-check` all clean. `cargo doc` emits one warning fewer than
`main` — the redundant explicit link in `surface.rs` went with the rewrite.

## Public API

```diff
-pub fn Surface::get_curve(&self, Axis) -> Curve
+pub fn Surface::project_onto(&self, Axis) -> Vec<Point2D>
```

`public-api/optionstratlib.txt` and `CHANGELOG.md` updated in this commit.

## Stack

Chain B of four independent chains off `main`.

- Stack: **#466** (this one) → #451 → #453. Independent of chain A (#470 →
  #469 → #463 → #471), chain C (#462), #459, and the #442 capstone.
- Base branch: `main`.
- The next two PRs in this chain branch off this one, so read their diffs
  against this branch rather than against `main`.

Closes #466
