### PR TITLE
Price the arithmetic Asian on a divided difference, not a cancellation (#462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The four `plotters` tests that came in `_bis` pairs wrote to the same two
   paths as their originals, so they raced each other by construction. Each
   pair now writes its own file.
+- **The arithmetic Asian is accurate at short maturities, where it used to
+  return confident wrong prices** (#462). The general branch of the
+  Turnbull-Wakeman second moment recovered `σ²_asian·T` from the difference of
+  two terms that grow as `2S²/(a·c·T²)` while the answer shrinks with `T`; at
+  fourteen minutes to expiry the terms are around `2.8e15` and the signal is
+  `3.7e-8`. It overpriced by a factor of **612** at eighty-six seconds and
+  collapsed to approximately zero below `1e-5` days. The moment is now twice
+  the first divided difference of `φ(w) = (e^w − 1)/w`, which makes all three
+  removable singularities ordinary points and never subtracts two terms larger
+  than the result. Relative error across the nine maturities of the issue's
+  table is now at most `6.9e-12`, against `1e-9` asserted.
+
+  Prices are **bit-for-bit unchanged at 7, 30, 90, 182.5 and 365 days**, call
+  and put. One ordinary maturity moves: **at 1 day the price changes by a
+  relative `2.5e-10`, and it moves toward the reference** — measured against
+  50-digit `mpmath` quadrature, the old value sat `2.5e-10` away from it and
+  the new one sits `8.5e-14` away. A one-day option moving by `2.5e-10`
+  relative is orders of magnitude below a tick, so no quoted price changes;
+  the direction and size are stated here so the claim can be checked rather
+  than taken.
 
 ### Changed
 

--- a/src/pricing/asian.rs
+++ b/src/pricing/asian.rs
@@ -469,16 +469,33 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
 ///
 /// The building block of both Turnbull-Wakeman moments: `M1 = S φ(bT)` and
 /// `M2 = 2 S² (φ(cT) - φ(bT)) / (aT)`. The `w = 0` singularity is removable
-/// and the limit is `∫₀^1 ds = 1`, which the guard returns exactly rather
-/// than dividing by the rate that vanished.
+/// and the limit is `∫₀^1 ds = 1`, which the series below returns exactly
+/// rather than dividing by the rate that vanished.
+///
+/// Small `w` is summed rather than evaluated, and at the *same*
+/// [`M2_SERIES_THRESHOLD`] the second moment uses. Sharing the constant is
+/// the point, not a convenience: the two moments have to change regime
+/// together. When they did not, `M1` collapsed to exactly `S` below a cutoff
+/// of its own while `M2` went on evaluating the real carry, and the price
+/// jumped twofold across that cutoff — `S = K = 100`, `σ = 1e-5`, `T = 1`
+/// priced at `4.6066e-4` for `b = 9.99999e-11` and at `2.3033e-4` for
+/// `b = 1e-10`, for a `1e-16` change in the rate.
+///
+/// The closed form loses the leading digits of `e^w` to the `1 /`
+/// amplification exactly as it does inside `φ(z) - φ(x)`: `e^w` rounds at
+/// `Decimal`'s scale, so `(e^w - 1) / w` carries a relative error of about
+/// `u / |w|` — `1e-18` at `w = 1e-10`, but `1e-8` by `w = 1e-20`, past the
+/// `1e-9` bound the issue sets. The series has no such subtraction and
+/// truncates at `w⁶ / 7!`, a relative `2e-4 w⁶`, which is `2e-22` at the
+/// threshold.
 ///
 /// # Errors
 ///
 /// Returns [`PricingError::Decimal`] when `e^w` leaves the representable
 /// `Decimal` range.
 fn growth_average(w: Decimal) -> Result<Decimal, PricingError> {
-    if w.is_zero() {
-        return Ok(Decimal::ONE);
+    if w.abs() < M2_SERIES_THRESHOLD {
+        return growth_average_series(w);
     }
     Ok(d_div(
         d_sub(
@@ -488,6 +505,42 @@ fn growth_average(w: Decimal) -> Result<Decimal, PricingError> {
         )?,
         w,
         "pricing::asian::growth_average",
+    )?)
+}
+
+/// `φ(w)` summed as `Σ_{n ≥ 0} wⁿ / (n+1)! = 1 + w/2 + w²/6 + …`, which
+/// carries the leading `1` explicitly instead of recovering it from
+/// `e^w - 1`.
+///
+/// `w = 0` gives exactly `1` here, every term after the first vanishing, so
+/// the removable singularity needs no guard of its own.
+///
+/// # Errors
+///
+/// Returns [`PricingError::Decimal`] when a power, a factorial or the running
+/// sum leaves the representable `Decimal` range.
+fn growth_average_series(w: Decimal) -> Result<Decimal, PricingError> {
+    // The `n = 0` term is `w⁰ / 1! = 1`, the `1` the correction is added to.
+    let mut w_power = Decimal::ONE;
+    let mut factorial = Decimal::ONE;
+    let mut correction = Decimal::ZERO;
+    for n in 1..M2_SERIES_TERMS {
+        w_power = d_mul(w_power, w, "pricing::asian::phi::series::power")?;
+        factorial = d_mul(
+            factorial,
+            Decimal::from(n + 1),
+            "pricing::asian::phi::series::factorial",
+        )?;
+        correction = d_add(
+            correction,
+            d_div(w_power, factorial, "pricing::asian::phi::series::term")?,
+            "pricing::asian::phi::series::correction",
+        )?;
+    }
+    Ok(d_add(
+        Decimal::ONE,
+        correction,
+        "pricing::asian::phi::series",
     )?)
 }
 
@@ -649,9 +702,11 @@ fn second_moment_series(x: Decimal, z: Decimal) -> Result<Decimal, PricingError>
 /// Returns [`PricingError::Decimal`] when `e^{bT}` or the product with `S`
 /// leaves the representable `Decimal` range.
 fn arithmetic_average_forward(s: Decimal, b: Decimal, t: Decimal) -> Result<Decimal, PricingError> {
-    if b.abs() < dec!(1e-10) {
-        return Ok(s);
-    }
+    // No cutoff of its own. A `|b| < 1e-10` shortcut to exactly `S` used to
+    // live here, which put this moment in a different limit regime from the
+    // second one and made the price discontinuous across the boundary.
+    // `growth_average` handles a vanishing `bT` by summing its series, and
+    // returns exactly `1` at zero.
     let bt = d_mul(b, t, "pricing::asian::average_forward::bt")?;
     Ok(d_mul(
         s,
@@ -888,6 +943,58 @@ mod tests {
             Positive::ZERO,
             None,
         )
+    }
+
+    fn low_vol_option(risk_free_rate: Decimal) -> Options {
+        Options::new(
+            OptionType::Asian {
+                averaging_type: AsianAveragingType::Arithmetic,
+            },
+            Side::Long,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(pos_or_panic!(365.0)),
+            Positive::new_decimal(dec!(1e-5)).unwrap(),
+            Positive::ONE,
+            Positive::HUNDRED,
+            risk_free_rate,
+            OptionStyle::Call,
+            Positive::ZERO,
+            None,
+        )
+    }
+
+    /// The two moments have to change limit regime at the same place. `M1`
+    /// used to collapse to exactly `S` below `|b| = 1e-10` while `M2` went on
+    /// evaluating the real carry, so the price jumped by a factor of two
+    /// across a cutoff only one of them had: `4.6066e-4` against `2.3033e-4`
+    /// for a `1e-16` change in the rate, on a contract that is otherwise
+    /// ordinary. Sharing `M2_SERIES_THRESHOLD` is what removes the seam.
+    #[test]
+    fn test_arithmetic_asian_low_volatility_carry_boundary_is_continuous() {
+        let price_at = |rate: Decimal| asian_black_scholes(&low_vol_option(rate)).unwrap();
+
+        let below = price_at(dec!(9.99999e-11));
+        let at = price_at(dec!(1e-10));
+        let above = price_at(dec!(1.00001e-10));
+
+        // Neighbours a relative 1e-5 apart in the rate, on either side of the
+        // cutoff that used to be there. The gaps are 2.5e-15 and 2.5e-14
+        // absolute, a relative 1.1e-11 and 1.1e-10 on a price of 2.3e-4,
+        // against the factor of two the seam used to produce.
+        assert_decimal_eq!(below, at, dec!(1e-13));
+        assert_decimal_eq!(above, at, dec!(1e-13));
+        assert!(
+            below < at && at < above,
+            "the price must stay monotone in the carry across the old cutoff: {below} {at} {above}"
+        );
+
+        // And it is the carry that moves it: three decades up, the price has
+        // to have moved by more than that gap.
+        assert!(
+            price_at(dec!(1e-7)) > at + dec!(1e-13),
+            "a real carry must price above the vanishing one"
+        );
     }
 
     /// `b = 0` zeroes the outer rate of the Turnbull-Wakeman second moment.

--- a/src/pricing/asian.rs
+++ b/src/pricing/asian.rs
@@ -32,6 +32,55 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 use rust_decimal_macros::dec;
 
+/// Terms kept in the small-argument series for the scaled second moment.
+///
+/// Six carry `g(x, z)` through `(x, z)^5` and truncate at `2 h_6 / 8!`, a
+/// relative `3.5e-4 u^6` at `u = max(|x|, |z|)`.
+const M2_SERIES_TERMS: u32 = 6;
+
+/// `max(|bT|, |cT|)` below which the scaled second moment is summed as a
+/// series rather than evaluated in closed form.
+///
+/// Measured, not chosen. Both forms were run against 50-digit `mpmath`
+/// quadrature on `E[A²] = (2 S² / T²) ∫₀^T e^{bu} ∫₀^u e^{at} dt du` at
+/// `S = 100`, `σ = 20%`, `b = 4%`, twelve maturities per decade. Relative
+/// error of the second moment:
+///
+/// | `u` | 6-term series | divided difference |
+/// |---|---|---|
+/// | `3.1e-3` | `7.0e-20` | `2.8e-24` |
+/// | `2.1e-3` | `7.0e-21` | `5.4e-23` |
+/// | `1.5e-3` | `7.0e-22` | `2.5e-22` |
+/// | `9.9e-4` | `7.0e-23` | `6.2e-22` |
+/// | `8.2e-4` | `2.2e-23` | `6.9e-22` |
+///
+/// The series falls as `u^6`; the closed form rises as `u^-2`, the `1 / y`
+/// amplification of the rounding `e^w` leaves inside `φ(z) - φ(x)`, which
+/// reaches a relative `4e-8` by `u = 1.2e-10`. They cross at `u ≈ 1.2e-3` at
+/// a relative `3e-22`, and this is that crossing to the decade.
+const M2_SERIES_THRESHOLD: Decimal = dec!(1e-3);
+
+/// `|aT|` below which the divided difference collapses onto the derivative
+/// at the midpoint.
+///
+/// Measured the same way, sweeping `a` through zero at `b = a - σ²`,
+/// `σ = 20%`, `T = 1` — the `b = -σ²` boundary contract itself:
+///
+/// | `|y|` | midpoint `2 φ'(m)` | divided difference |
+/// |---|---|---|
+/// | `1e-6` | `2.1e-14` | `6.4e-16` |
+/// | `1e-7` | `2.1e-16` | `6.4e-17` |
+/// | `1e-8` | `2.1e-18` | `7.0e-18` |
+/// | `1e-9` | `2.1e-20` | `4.5e-18` |
+/// | `1e-10` | `2.1e-22` | `1.6e-17` |
+///
+/// The midpoint truncation falls as `y² / 48`. The divided difference falls
+/// with `y` too — the `e^w` error at `x` and at `z` nearly cancels once the
+/// two arguments coincide — but only until the `φ(z) - φ(x)` rounding floor
+/// turns it round near `1e-9`. They cross just under `3e-8` at a relative
+/// `2e-17`; this is that crossing to the decade.
+const M2_MIDPOINT_THRESHOLD: Decimal = dec!(1e-8);
+
 /// Prices an Asian option using the appropriate method based on averaging type.
 ///
 /// # Arguments
@@ -256,8 +305,6 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     let sigma_sq = d_mul(sigma_dec, sigma_dec, "pricing::asian::arithmetic::sigma_sq")?;
     let s_dec = s.to_dec();
     let s_sq = d_powd(s_dec, Decimal::TWO, "pricing::asian::arithmetic::s_sq")?;
-    let t_sq = d_powd(t_dec, Decimal::TWO, "pricing::asian::arithmetic::t_sq")?;
-    let bt = d_mul(b, t_dec, "pricing::asian::arithmetic::bt")?;
     let two_b_plus_var = d_add(
         d_mul(dec!(2), b, "pricing::asian::arithmetic::two_b")?,
         sigma_sq,
@@ -276,230 +323,42 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     // over the averaging window,
     //
     //     M2 = (2 S² / T²) ∫₀^T e^{b u} ∫₀^u e^{a t} dt du
-    //        = (2 S² / (a T²)) [ (e^{c T} - 1) / c - (e^{b T} - 1) / b ],
+    //        = (2 S² / (a T²)) [ (e^{c T} - 1) / c - (e^{b T} - 1) / b ].
     //
-    // which is the closed form expanded in the `else` branch below. All three
-    // of its denominators are removable: at `b = 0` (`r = q`), at `a = 0`
-    // (`b = -σ²`) and at `c = 0` (`b = -σ²/2`) the vanishing factor is
-    // cancelled by a bracket that vanishes with it, and M2 stays finite. Every
-    // limit below was taken by going back to the integral and evaluating the
-    // degenerate exponential directly instead of dividing by its rate —
-    // `∫₀^T e^{0·u} du = T` for `b = 0`, `∫₀^u e^{0·t} dt = u` for `a = 0`,
-    // `∫₀^T e^{0·u} du = T` again for `c = 0` — which is the same value as
-    // differentiating the bracket at the zero. They are exact, not
-    // approximations. `r = q` lands on `b = 0` and `r = 0, q = 4%, σ = 20%,
-    // T = 1` lands exactly on `a = 0`; both are ordinary contracts, so no
-    // boundary may raise.
-    let m2 = if b.abs() < dec!(1e-10) {
-        // `b → 0`, i.e. `r = q`. The outer growth term degenerates to
-        // `∫₀^T e^{0·u} du` and the inner rate to `a = σ²`, so
-        //
-        //     M2 = (2 S² / T²) ∫₀^T ∫₀^u e^{σ² t} dt du
-        //        = (2 S² / T²) ∫₀^T (e^{σ² u} - 1) / σ² du
-        //        = (2 S² / (σ² T²)) [ (e^{σ² T} - 1) / σ² - T ],
-        //
-        // the second integration having used `∫₀^T e^{σ² u} du =
-        // (e^{σ² T} - 1) / σ²` and `∫₀^T du = T`. The general form tends to
-        // the same value: `a, c → σ²` and `(e^{b T} - 1) / b → T`.
-        //
-        // This is *not* `S² e^{σ² T}`, which is `E[S_T²]` — the second moment
-        // of the terminal price rather than of its average. At `σ = 20%,
-        // T = 1` they are `1.01347 S²` against `1.04081 S²`, and the moment
-        // matching turns that gap into `σ_adj = σ` instead of the correct
-        // `σ_adj ≈ σ / √3`. `r = q` is a forward-priced or fully-carried
-        // underlying, so this branch has to be the limit and not a stand-in.
-        //
-        // Collecting the whole expression on `x = σ² T` gives the form
-        // evaluated below,
-        //
-        //     M2 = 2 S² (e^x - 1 - x) / x² = S² (1 + x/3 + x²/12 + …),
-        //
-        // one division shorter and, since `e^x - 1 - x` is an exact `Decimal`
-        // subtraction, carrying every digit `e^x` had.
-        let x = d_mul(
-            sigma_sq,
-            t_dec,
-            "pricing::asian::arithmetic::m2::b_limit::var_t",
-        )?;
-        if x < dec!(1e-6) {
-            // `e^x` is stored to 28 decimal places, so the `x² / 2` that
-            // leads `e^x - 1 - x` sinks below that floor as `x` shrinks and
-            // the closed form loses it: at `x = 1e-14` it valued a worthless
-            // contract at 31, and below `x ≈ 1e-13` the `2 S² / x²` scale
-            // leaves `Decimal` altogether. The two-term series truncates at
-            // `x² / 12`, a relative `x / 4 ≤ 2.5e-7` on the matched variance,
-            // against the closed form's `6e-28 / x³`; they cross at
-            // `x ≈ 2e-7`, so below `1e-6` the series is the better of the
-            // two. It also absorbs `σ² = 0` (σ under `1e-14` underflows the
-            // scale), where `M2 = S²` exactly and there is nothing to divide
-            // by.
-            d_mul(
-                s_sq,
-                d_add(
-                    Decimal::ONE,
-                    d_div(x, dec!(3), "pricing::asian::arithmetic::m2::b_limit::third")?,
-                    "pricing::asian::arithmetic::m2::b_limit::series",
-                )?,
-                "pricing::asian::arithmetic::m2::b_limit::small_variance",
-            )?
-        } else {
-            let bracket = d_sub(
-                d_sub(
-                    d_exp(x, "pricing::asian::arithmetic::m2::b_limit::exp_x")?,
-                    Decimal::ONE,
-                    "pricing::asian::arithmetic::m2::b_limit::exp_x_less_one",
-                )?,
-                x,
-                "pricing::asian::arithmetic::m2::b_limit::bracket",
-            )?;
-            d_mul(
-                d_div(
-                    d_mul(
-                        dec!(2),
-                        s_sq,
-                        "pricing::asian::arithmetic::m2::b_limit::two_s_sq",
-                    )?,
-                    d_mul(x, x, "pricing::asian::arithmetic::m2::b_limit::x_sq")?,
-                    "pricing::asian::arithmetic::m2::b_limit::scale",
-                )?,
-                bracket,
-                "pricing::asian::arithmetic::m2::b_limit",
-            )?
-        }
-    } else if b_plus_var.abs() < dec!(1e-10) {
-        // `a → 0`, i.e. `b = -σ²`. The inner integral degenerates to
-        // `∫₀^u dt = u`, leaving
-        //
-        //     M2 = (2 S² / T²) [ T e^{b T} / b - (e^{b T} - 1) / b² ].
-        //
-        // `b ≈ -σ²` is non-zero here: the driftless branch above owns `b = 0`,
-        // and `σ = 0` returned long before this point.
-        let exp_bt = d_exp(bt, "pricing::asian::arithmetic::m2::a_limit::exp_bt")?;
-        let b_sq = d_mul(b, b, "pricing::asian::arithmetic::m2::a_limit::b_sq")?;
-        let bracket = d_sub(
-            d_div(
-                d_mul(
-                    t_dec,
-                    exp_bt,
-                    "pricing::asian::arithmetic::m2::a_limit::t_exp_bt",
-                )?,
-                b,
-                "pricing::asian::arithmetic::m2::a_limit::first",
-            )?,
-            d_div(
-                d_sub(
-                    exp_bt,
-                    dec!(1),
-                    "pricing::asian::arithmetic::m2::a_limit::exp_bt_less_one",
-                )?,
-                b_sq,
-                "pricing::asian::arithmetic::m2::a_limit::second",
-            )?,
-            "pricing::asian::arithmetic::m2::a_limit::bracket",
-        )?;
-        d_mul(
-            d_div(
-                d_mul(
-                    dec!(2),
-                    s_sq,
-                    "pricing::asian::arithmetic::m2::a_limit::two_s_sq",
-                )?,
-                t_sq,
-                "pricing::asian::arithmetic::m2::a_limit::scale",
-            )?,
-            bracket,
-            "pricing::asian::arithmetic::m2::a_limit",
-        )?
-    } else if two_b_plus_var.abs() < dec!(1e-10) {
-        // `c → 0`, i.e. `b = -σ²/2`. The outer integral's growth term
-        // degenerates to `∫₀^T du = T`, leaving
-        //
-        //     M2 = (2 S² / (a T²)) [ T - (e^{b T} - 1) / b ].
-        //
-        // `a ≈ σ²/2` and `b ≈ -σ²/2` are both non-zero here for the same
-        // reason as in the branch above.
-        let exp_bt = d_exp(bt, "pricing::asian::arithmetic::m2::c_limit::exp_bt")?;
-        let bracket = d_sub(
-            t_dec,
-            d_div(
-                d_sub(
-                    exp_bt,
-                    dec!(1),
-                    "pricing::asian::arithmetic::m2::c_limit::exp_bt_less_one",
-                )?,
-                b,
-                "pricing::asian::arithmetic::m2::c_limit::second",
-            )?,
-            "pricing::asian::arithmetic::m2::c_limit::bracket",
-        )?;
-        d_mul(
-            d_div(
-                d_mul(
-                    dec!(2),
-                    s_sq,
-                    "pricing::asian::arithmetic::m2::c_limit::two_s_sq",
-                )?,
-                d_mul(
-                    b_plus_var,
-                    t_sq,
-                    "pricing::asian::arithmetic::m2::c_limit::denominator",
-                )?,
-                "pricing::asian::arithmetic::m2::c_limit::scale",
-            )?,
-            bracket,
-            "pricing::asian::arithmetic::m2::c_limit",
-        )?
-    } else {
-        let term1_exp = d_exp(
-            d_mul(
-                two_b_plus_var,
-                t_dec,
-                "pricing::asian::arithmetic::m2::term1_exponent",
-            )?,
-            "pricing::asian::arithmetic::m2::term1_exp",
-        )?;
-        let term1 = d_div(
-            d_mul(
-                d_mul(dec!(2), s_sq, "pricing::asian::arithmetic::m2::two_s_sq")?,
-                term1_exp,
-                "pricing::asian::arithmetic::m2::term1_numerator",
-            )?,
-            d_mul(
-                d_mul(
-                    b_plus_var,
-                    two_b_plus_var,
-                    "pricing::asian::arithmetic::m2::term1_roots",
-                )?,
-                t_sq,
-                "pricing::asian::arithmetic::m2::term1_denominator",
-            )?,
-            "pricing::asian::arithmetic::m2::term1",
-        )?;
-
-        let term2 = d_mul(
-            d_div(
-                d_mul(dec!(2), s_sq, "pricing::asian::arithmetic::m2::two_s_sq2")?,
-                d_mul(b, t_sq, "pricing::asian::arithmetic::m2::b_t_sq")?,
-                "pricing::asian::arithmetic::m2::term2_scale",
-            )?,
-            d_sub(
-                d_div(
-                    dec!(1),
-                    two_b_plus_var,
-                    "pricing::asian::arithmetic::m2::term2_first",
-                )?,
-                d_div(
-                    d_exp(bt, "pricing::asian::arithmetic::m2::exp_bt")?,
-                    b_plus_var,
-                    "pricing::asian::arithmetic::m2::term2_second",
-                )?,
-                "pricing::asian::arithmetic::m2::term2_bracket",
-            )?,
-            "pricing::asian::arithmetic::m2::term2",
-        )?;
-
-        d_add(term1, term2, "pricing::asian::arithmetic::m2")?
-    };
+    // Both brackets are windows of `e^{w t}`, so the whole expression is
+    // carried by the single function
+    //
+    //     φ(w) = (e^w - 1) / w = ∫₀^1 e^{w s} ds,   φ(0) = 1,
+    //
+    // read at the three dimensionless rates `x = b T`, `z = c T` and
+    // `y = a T`, which satisfy `y = z - x`. Collecting on them,
+    //
+    //     M2 = S² g(x, z),   g(x, z) = 2 (φ(z) - φ(x)) / (z - x),
+    //
+    // twice the first divided difference of `φ`. That is the natural object
+    // here: it is symmetric, entire in both arguments, and each of the three
+    // apparent poles of the closed form is an ordinary point of it. `b = 0`
+    // is `x = 0` and `c = 0` is `z = 0`, both covered by `φ(0) = 1`; `a = 0`
+    // is `z = x`, where a divided difference is the derivative `2 φ'(x)`. No
+    // branch has to reconstruct a limit the expression does not already hold,
+    // and — the point of this shape — nothing is recovered from a difference
+    // of two terms larger than the answer.
+    let x = d_mul(b, t_dec, "pricing::asian::arithmetic::m2::outer_rate")?;
+    let z = d_mul(
+        two_b_plus_var,
+        t_dec,
+        "pricing::asian::arithmetic::m2::total_rate",
+    )?;
+    let y = d_mul(
+        b_plus_var,
+        t_dec,
+        "pricing::asian::arithmetic::m2::inner_rate",
+    )?;
+    let m2 = d_mul(
+        s_sq,
+        scaled_second_moment(x, z, y)?,
+        "pricing::asian::arithmetic::m2",
+    )?;
 
     // Forward price of the average
     let f_adj = m1;
@@ -606,6 +465,173 @@ fn arithmetic_asian_price(option: &Options) -> Result<Decimal, PricingError> {
     Ok(apply_side(price, option))
 }
 
+/// Average of `e^{w s}` over the unit interval, `φ(w) = (e^w - 1) / w`.
+///
+/// The building block of both Turnbull-Wakeman moments: `M1 = S φ(bT)` and
+/// `M2 = 2 S² (φ(cT) - φ(bT)) / (aT)`. The `w = 0` singularity is removable
+/// and the limit is `∫₀^1 ds = 1`, which the guard returns exactly rather
+/// than dividing by the rate that vanished.
+///
+/// # Errors
+///
+/// Returns [`PricingError::Decimal`] when `e^w` leaves the representable
+/// `Decimal` range.
+fn growth_average(w: Decimal) -> Result<Decimal, PricingError> {
+    if w.is_zero() {
+        return Ok(Decimal::ONE);
+    }
+    Ok(d_div(
+        d_sub(
+            d_exp(w, "pricing::asian::growth_average::exp")?,
+            Decimal::ONE,
+            "pricing::asian::growth_average::numerator",
+        )?,
+        w,
+        "pricing::asian::growth_average",
+    )?)
+}
+
+/// The Turnbull-Wakeman second moment of the arithmetic average, divided by
+/// `S²`.
+///
+/// `g(x, z) = 2 (φ(z) - φ(x)) / (z - x)` at `x = bT`, `z = (2b + σ²) T` and
+/// `y = (b + σ²) T`, which equals `z - x` and is passed separately because
+/// the product is better conditioned than the difference. `g` is symmetric,
+/// entire, and equals `1 + (x + z) / 3 + …` at the origin, so the moment
+/// ratio `M2 / M1²` it feeds tends to `1` and the matched variance to `0` as
+/// the window closes.
+///
+/// Three regimes, each chosen where its error is the smaller of the two
+/// available (see [`M2_SERIES_THRESHOLD`] and [`M2_MIDPOINT_THRESHOLD`] for
+/// the measurements):
+///
+/// - `max(|x|, |z|) < M2_SERIES_THRESHOLD` — the power series. Both `φ` are
+///   within `u / 2` of `1` there, so the closed form would recover `g / 2`
+///   from a difference of two numbers a decade or more larger than it, and
+///   lose the leading `e^w` digits to the `1 /` amplification.
+/// - `|y| < M2_MIDPOINT_THRESHOLD` — the derivative at the midpoint,
+///   `2 φ'(m)`, `m = (x + z) / 2`. A divided difference over a vanishing
+///   interval is a derivative; the midpoint makes the neglected term
+///   `φ'''(m) (y / 2)² / 6` rather than the first-order `φ''(x) y / 2`.
+/// - otherwise the divided difference itself.
+///
+/// # Errors
+///
+/// Returns [`PricingError::Decimal`] when any exponential or product leaves
+/// the representable `Decimal` range.
+fn scaled_second_moment(x: Decimal, z: Decimal, y: Decimal) -> Result<Decimal, PricingError> {
+    if x.abs().max(z.abs()) < M2_SERIES_THRESHOLD {
+        return second_moment_series(x, z);
+    }
+
+    if y.abs() < M2_MIDPOINT_THRESHOLD {
+        // `z = x` to within the threshold, so
+        //
+        //     g = 2 φ'(m) = 2 [m e^m - e^m + 1] / m²,   m = (x + z) / 2.
+        //
+        // `m` cannot vanish here: `m = 0` means `z = -x`, hence
+        // `|y| = |z - x| = 2 max(|x|, |z|)`, which the branch above already
+        // took when that maximum was small and which fails this test when it
+        // was not.
+        let m = d_div(
+            d_add(x, z, "pricing::asian::m2::midpoint::sum")?,
+            dec!(2),
+            "pricing::asian::m2::midpoint",
+        )?;
+        debug_assert!(!m.is_zero(), "midpoint branch reached with x = -z");
+        let exp_m = d_exp(m, "pricing::asian::m2::midpoint::exp")?;
+        return Ok(d_div(
+            d_mul(
+                dec!(2),
+                d_add(
+                    d_mul(
+                        exp_m,
+                        d_sub(m, Decimal::ONE, "pricing::asian::m2::midpoint::m_less_one")?,
+                        "pricing::asian::m2::midpoint::exp_term",
+                    )?,
+                    Decimal::ONE,
+                    "pricing::asian::m2::midpoint::bracket",
+                )?,
+                "pricing::asian::m2::midpoint::numerator",
+            )?,
+            d_mul(m, m, "pricing::asian::m2::midpoint::m_sq")?,
+            "pricing::asian::m2::midpoint::derivative",
+        )?);
+    }
+
+    Ok(d_div(
+        d_mul(
+            dec!(2),
+            d_sub(
+                growth_average(z)?,
+                growth_average(x)?,
+                "pricing::asian::m2::divided_difference::numerator",
+            )?,
+            "pricing::asian::m2::divided_difference::scaled",
+        )?,
+        y,
+        "pricing::asian::m2::divided_difference",
+    )?)
+}
+
+/// `g(x, z)` summed term by term instead of evaluated in closed form.
+///
+/// `φ(w) = Σ_{n ≥ 0} w^n / (n + 1)!` is entire, so its divided difference is
+/// too, and the difference of powers telescopes:
+///
+/// ```text
+/// g(x, z) = 2 Σ_{n ≥ 1} (z^n - x^n) / ((z - x) (n + 1)!)
+///         = 2 Σ_{k ≥ 0} h_k(x, z) / (k + 2)!
+///         = 1 + (x + z) / 3 + (x² + x z + z²) / 12 + …
+/// ```
+///
+/// with `h_k(x, z) = Σ_{j=0}^{k} x^j z^{k-j}` the complete homogeneous
+/// symmetric polynomial, accumulated by `h_k = x h_{k-1} + z^k`. Nothing
+/// cancels: the leading `1` is exact and every correction is added to it at
+/// its own scale, so the result carries the digits the divided difference
+/// spends on `φ(z) - φ(x)`. At `x = 0` this is the driftless series
+/// `1 + z / 3 + z² / 12 + …` of the `b = 0` limit.
+///
+/// # Errors
+///
+/// Returns [`PricingError::Decimal`] when a power or a factorial leaves the
+/// representable `Decimal` range, which the [`M2_SERIES_THRESHOLD`] bound on
+/// `x` and `z` rules out for every admissible contract.
+fn second_moment_series(x: Decimal, z: Decimal) -> Result<Decimal, PricingError> {
+    // `h_0 = 1`, `z^0 = 1`, `(0 + 2)! = 2`, so the `k = 0` term is exactly 1.
+    let mut h = Decimal::ONE;
+    let mut z_power = Decimal::ONE;
+    let mut factorial = dec!(2);
+    let mut correction = Decimal::ZERO;
+    for k in 1..M2_SERIES_TERMS {
+        z_power = d_mul(z_power, z, "pricing::asian::m2::series::z_power")?;
+        h = d_add(
+            d_mul(x, h, "pricing::asian::m2::series::shift")?,
+            z_power,
+            "pricing::asian::m2::series::homogeneous",
+        )?;
+        factorial = d_mul(
+            factorial,
+            Decimal::from(k + 2),
+            "pricing::asian::m2::series::factorial",
+        )?;
+        correction = d_add(
+            correction,
+            d_div(
+                d_mul(dec!(2), h, "pricing::asian::m2::series::twice")?,
+                factorial,
+                "pricing::asian::m2::series::term",
+            )?,
+            "pricing::asian::m2::series::correction",
+        )?;
+    }
+    Ok(d_add(
+        Decimal::ONE,
+        correction,
+        "pricing::asian::m2::series",
+    )?)
+}
+
 /// Arithmetic average of the deterministic carry path, `S (e^{bT} - 1) / (bT)`.
 ///
 /// This is the Turnbull-Wakeman first moment `M1`. It carries no volatility:
@@ -629,15 +655,7 @@ fn arithmetic_average_forward(s: Decimal, b: Decimal, t: Decimal) -> Result<Deci
     let bt = d_mul(b, t, "pricing::asian::average_forward::bt")?;
     Ok(d_mul(
         s,
-        d_div(
-            d_sub(
-                d_exp(bt, "pricing::asian::average_forward::exp_bt")?,
-                dec!(1),
-                "pricing::asian::average_forward::numerator",
-            )?,
-            bt,
-            "pricing::asian::average_forward::ratio",
-        )?,
+        growth_average(bt)?,
         "pricing::asian::average_forward",
     )?)
 }
@@ -1134,5 +1152,223 @@ mod tests {
             "OTM Asian call should have low value: {}",
             price
         );
+    }
+    /// `S = K = 100`, `σ = 20%`, `r = 8%`, `q = 4%` — the contract of the
+    /// short-maturity table, parameterised by a maturity in days.
+    fn create_short_maturity_option(days: Decimal, style: OptionStyle) -> Options {
+        Options::new(
+            OptionType::Asian {
+                averaging_type: AsianAveragingType::Arithmetic,
+            },
+            Side::Long,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(Positive::new_decimal(days).unwrap()),
+            Positive::new_decimal(dec!(0.2)).unwrap(),
+            Positive::ONE,
+            Positive::HUNDRED,
+            dec!(0.08),
+            style,
+            Positive::new_decimal(dec!(0.04)).unwrap(),
+            None,
+        )
+    }
+
+    /// `S = K = 100`, `σ = 20%`, `r = 0` at a chosen maturity, so the
+    /// dividend yield alone selects the removable boundary: `q = 4%` puts the
+    /// carry on `b = -σ²` and `q = 2%` on `b = -σ²/2`. The same two contracts
+    /// as `create_turnbull_wakeman_boundary_option`, with the window free.
+    fn create_boundary_option_at(dividend_yield: Decimal, days: Decimal) -> Options {
+        Options::new(
+            OptionType::Asian {
+                averaging_type: AsianAveragingType::Arithmetic,
+            },
+            Side::Long,
+            "TEST".to_string(),
+            Positive::HUNDRED,
+            ExpirationDate::Days(Positive::new_decimal(days).unwrap()),
+            Positive::new_decimal(dec!(0.2)).unwrap(),
+            Positive::ONE,
+            Positive::HUNDRED,
+            Decimal::ZERO,
+            OptionStyle::Call,
+            Positive::new_decimal(dividend_yield).unwrap(),
+            None,
+        )
+    }
+
+    /// Distance from a reference as a fraction of it. The maturities below
+    /// span three decades of price, so a single absolute tolerance would mean
+    /// something different on every row.
+    fn relative_error(value: Decimal, reference: Decimal) -> Decimal {
+        ((value - reference) / reference).abs()
+    }
+
+    /// Every maturity of the short-maturity table, against 50-digit `mpmath`
+    /// quadrature on the integral the second moment is defined by,
+    ///
+    ///     E[A²] = (2 S² / T²) ∫₀^T e^{b u} ∫₀^u e^{a t} dt du,
+    ///
+    /// with the moment matching and the normal legs carried at 50 digits too.
+    /// The quadrature agrees with the closed form to `1e-38` at every row, so
+    /// the reference does not assume either.
+    ///
+    /// | maturity | reference | before |
+    /// |---|---|---|
+    /// | 0.5 days | `0.171855815411` | `0.171855815757` |
+    /// | 0.2 days | `0.108377120846` | `0.108377149270` |
+    /// | 0.1 days | `0.076521744333` | `0.076522709098` |
+    /// | 0.05 days | `0.054052666108` | `0.054005346244` |
+    /// | 0.02 days | `0.034154202089` | `0.034378185828` |
+    /// | 0.01 days | `0.024139351974` | `0.041790507589` |
+    /// | 0.005 days | `0.017063436757` | `0.234996014908` |
+    /// | 0.002 days | `0.010788684989` | `0.875324687084` |
+    /// | 0.001 days | `0.007627618506` | `4.678919422800` |
+    ///
+    /// As the window closes the quantity the second moment has to deliver,
+    /// `σ²_asian T`, falls to `3.7e-8` at eighty-six seconds while the two
+    /// terms the closed form used to subtract grow past `2.8e15`, which is
+    /// how the last row came to be priced at 612 times its value.
+    ///
+    /// The bound asserted is `1e-9`; the measured worst case is `6.9e-12`, on
+    /// the last row, and it comes from the `f64` normal CDF behind `big_n`
+    /// rather than from the second moment.
+    #[test]
+    fn test_arithmetic_asian_short_maturity_matches_quadrature() {
+        let reference = [
+            (dec!(0.5), dec!(0.17185581541141069723)),
+            (dec!(0.2), dec!(0.10837712084561396701)),
+            (dec!(0.1), dec!(0.076521744332875558055)),
+            (dec!(0.05), dec!(0.054052666108035095143)),
+            (dec!(0.02), dec!(0.034154202088962484802)),
+            (dec!(0.01), dec!(0.024139351973902131194)),
+            (dec!(0.005), dec!(0.017063436757072324427)),
+            (dec!(0.002), dec!(0.010788684989048071953)),
+            (dec!(0.001), dec!(0.0076276185063713378631)),
+        ];
+
+        for (days, expected) in reference {
+            let option = create_short_maturity_option(days, OptionStyle::Call);
+            let price = asian_black_scholes(&option).unwrap();
+            let error = relative_error(price, expected);
+            assert!(
+                error < dec!(1e-9),
+                "{days} days priced {price} against {expected}, a relative {error}"
+            );
+        }
+    }
+
+    /// The moment-matched Asian is a Black formula on the forward `M1`, so it
+    /// owes the ordinary parity `C - P = e^{-rT} (M1 - K)` whatever the
+    /// matched volatility turns out to be. At eighty-six seconds `M1 - K` is
+    /// `5.48e-6` on a `100` underlying, so the identity is a real constraint
+    /// on the last three digits of both legs rather than a restatement of the
+    /// formula: `e^{-rT} (M1 - K) = 5.4794510539814525e-6` at 50 digits.
+    #[test]
+    fn test_arithmetic_asian_short_maturity_holds_put_call_parity() {
+        let call = asian_black_scholes(&create_short_maturity_option(
+            dec!(0.001),
+            OptionStyle::Call,
+        ))
+        .unwrap();
+        let put = asian_black_scholes(&create_short_maturity_option(dec!(0.001), OptionStyle::Put))
+            .unwrap();
+
+        assert_decimal_eq!(call - put, dec!(0.0000054794510539814525), dec!(1e-18));
+    }
+
+    /// The series and the divided difference have to meet at the threshold
+    /// they are separated by, otherwise the switch is a discontinuity in the
+    /// price surface rather than a change of method.
+    ///
+    /// `u = max(|bT|, |cT|) = 0.12 T` here, so `1e-3` sits at `3.0416666…`
+    /// days: `3.04166666` is summed and `3.0416667` is evaluated in closed
+    /// form. The gap between them is `2.9e-9`, which is the whole of the
+    /// genuine `dP/dT ≈ 25.7` across the `1.1e-10` years that separate the
+    /// two maturities; the formulas themselves differ by less than `1e-20`.
+    /// The tolerance is `1e-7`.
+    #[test]
+    fn test_arithmetic_asian_series_threshold_is_continuous() {
+        let summed = asian_black_scholes(&create_short_maturity_option(
+            dec!(3.04166666),
+            OptionStyle::Call,
+        ))
+        .unwrap();
+        let closed_form = asian_black_scholes(&create_short_maturity_option(
+            dec!(3.0416667),
+            OptionStyle::Call,
+        ))
+        .unwrap();
+
+        assert_decimal_eq!(summed, closed_form, dec!(1e-7));
+        assert!(
+            summed < closed_form,
+            "the price must stay monotone in T across the threshold: {summed} {closed_form}"
+        );
+    }
+
+    /// Same check at the other threshold, where the divided difference gives
+    /// way to the derivative at the midpoint.
+    ///
+    /// `y = aT` is `1.01e-8` at `q = 0.0399999899` and `9.9e-9` at
+    /// `q = 0.0399999901`, so the pair straddles `1e-8` at `T = 1`. Their gap
+    /// is `4.5e-9`, all of it the genuine `dP/dq ≈ 22.7` over the `2e-10`
+    /// that separates the two yields. The tolerance is `1e-7`, and the exact
+    /// boundary `q = 4%` has to sit between them.
+    #[test]
+    fn test_arithmetic_asian_midpoint_threshold_is_continuous() {
+        let closed_form =
+            asian_black_scholes(&create_boundary_option_at(dec!(0.0399999899), dec!(365.0)))
+                .unwrap();
+        let midpoint =
+            asian_black_scholes(&create_boundary_option_at(dec!(0.0399999901), dec!(365.0)))
+                .unwrap();
+        let at = asian_black_scholes(&create_boundary_option_at(dec!(0.04), dec!(365.0))).unwrap();
+
+        assert_decimal_eq!(closed_form, midpoint, dec!(1e-7));
+        assert!(
+            at < midpoint && midpoint < closed_form,
+            "the price must stay monotone in q across the threshold: {closed_form} {midpoint} {at}"
+        );
+    }
+
+    /// The two removable boundaries `#445` added — `b = -σ²`, which empties
+    /// the inner integral, and `b = -σ²/2`, which empties the outer one — at
+    /// maturities short enough to have broken them.
+    ///
+    /// They failed a decade or two later than the general branch rather than
+    /// differently: both held to about `1e-4` days and then drifted onto the
+    /// spot-volatility price, a factor `√3` too high, by `1e-8` days. Against
+    /// the same 50-digit quadrature:
+    ///
+    /// | contract | maturity | reference | before |
+    /// |---|---|---|---|
+    /// | `b = -σ²` | 0.01 days | `0.0240845905435` | `+1.2e-10` |
+    /// | `b = -σ²` | 0.001 days | `0.0076221400994` | `-5.7e-8` |
+    /// | `b = -σ²/2` | 0.01 days | `0.0240982866889` | `-4.0e-10` |
+    /// | `b = -σ²/2` | 0.001 days | `0.0076235098840` | `-5.1e-7` |
+    ///
+    /// Neither is a branch any more: `b = -σ²` is `z = x`, `b = -σ²/2` is
+    /// `z = 0`, and at these maturities both land in the series, which never
+    /// divides by the rate that vanished.
+    #[test]
+    fn test_arithmetic_asian_removable_boundaries_hold_at_short_maturity() {
+        let reference = [
+            (dec!(0.04), dec!(0.01), dec!(0.024084590543502699977)),
+            (dec!(0.04), dec!(0.001), dec!(0.0076221400994210520537)),
+            (dec!(0.02), dec!(0.01), dec!(0.024098286688876302321)),
+            (dec!(0.02), dec!(0.001), dec!(0.0076235098840218887521)),
+        ];
+
+        for (dividend_yield, days, expected) in reference {
+            let option = create_boundary_option_at(dividend_yield, days);
+            let price = asian_black_scholes(&option).unwrap();
+            let error = relative_error(price, expected);
+            assert!(
+                error < dec!(1e-9),
+                "q = {dividend_yield} at {days} days priced {price} against {expected}, \
+                 a relative {error}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

The general branch of the arithmetic Asian priced every non-degenerate
contract, and it lost all its precision as maturity shortened — returning
confident wrong values rather than errors. At 86 seconds to expiry it
overpriced by a factor of **612**.

`term1` and `term2` each grow as `2S²/(a·c·T²)` and cancel down to about `S²`,
while the quantity extracted from their difference is `σ²_asian·T`, which
*shrinks* with `T`. At 14 minutes the terms are around `2.8e15` and the signal
is `3.7e-8`. Below `1e-5` days it collapsed the other way, to approximately
zero.

## The rewrite

Writing `x = bT`, `z = cT` and `y = aT = z − x`, the entire second moment is
carried by one function:

```text
φ(w) = (e^w − 1) / w = ∫₀¹ e^{ws} ds,   φ(0) = 1

M2 = S² g(x, z),   g(x, z) = 2 (φ(z) − φ(x)) / (z − x)
```

twice the first divided difference of `φ`. It is symmetric, entire in both
arguments, and **each of the three apparent poles of the closed form is an
ordinary point of it**: `b = 0` is `x = 0` and `c = 0` is `z = 0`, both covered
by `φ(0) = 1`; `b = −σ²` is `z = x`, where a divided difference is the
derivative `2φ'(x)`.

So the four rate-keyed branches — the general one plus the three removable
limits, two of them added by #445 — collapse into one expression with two
numerical fallbacks. Nothing is recovered from a difference of two terms larger
than the answer, which is the property the old form lacked.

## Both thresholds are measured, not chosen

Against 50-digit `mpmath` quadrature on
`E[A²] = (2S²/T²) ∫₀^T e^{bu} ∫₀^u e^{at} dt du`, twelve maturities per decade.

**Series below `max(|x|,|z|) = 1e-3`** — relative error of the second moment:

| `u` | 6-term series | divided difference |
|---|---|---|
| `3.1e-3` | `7.0e-20` | `2.8e-24` |
| `2.1e-3` | `7.0e-21` | `5.4e-23` |
| `1.5e-3` | `7.0e-22` | `2.5e-22` |
| `9.9e-4` | `7.0e-23` | `6.2e-22` |
| `8.2e-4` | `2.2e-23` | `6.9e-22` |

The series falls as `u⁶`; the closed form rises as `u⁻²`, the `1/y`
amplification of the rounding `e^w` leaves inside `φ(z) − φ(x)`. They cross at
`u ≈ 1.2e-3`, so the threshold is `1e-3`.

**Midpoint derivative below `|y| = 1e-8`** — sweeping `a` through zero at
`b = a − σ²`, `σ = 20%`, `T = 1`, which is the `b = −σ²` boundary contract:

| `\|y\|` | midpoint `2φ'(m)` | divided difference |
|---|---|---|
| `1e-6` | `2.1e-14` | `6.4e-16` |
| `1e-7` | `2.1e-16` | `6.4e-17` |
| `1e-8` | `2.1e-18` | `7.0e-18` |
| `1e-9` | `2.1e-20` | `4.5e-18` |
| `1e-10` | `2.1e-22` | `1.6e-17` |

The midpoint truncation falls as `y²/48`; the divided difference falls with `y`
too, until the `φ(z) − φ(x)` rounding floor turns it round near `1e-9`. They
cross just under `3e-8`, so the threshold is `1e-8`.

Both tables are in the doc comments of `M2_SERIES_THRESHOLD` and
`M2_MIDPOINT_THRESHOLD`, so the next person to move one can see what it costs.

## The table, regenerated

Asserted bound `1e-9`; worst measured **`6.9e-12`**, and it comes from the
`f64` normal CDF behind `big_n` rather than from the moment.

| maturity | crate now | reference (50 dp) | relative | was |
|---|---|---|---|---|
| 0.5 days | 0.171855815411 | 0.171855815411 | 1.6e-13 | 2.0e-9 |
| 0.2 days | 0.108377120846 | 0.108377120846 | 2.9e-13 | 2.6e-7 |
| 0.1 days | 0.076521744333 | 0.076521744333 | 3.2e-13 | 1.3e-5 |
| 0.05 days | 0.054052666108 | 0.054052666108 | 4.0e-13 | −8.8e-4 |
| 0.02 days | 0.034154202089 | 0.034154202089 | 5.1e-13 | +6.6e-3 |
| 0.01 days | 0.024139351974 | 0.024139351974 | 2.1e-12 | **+73%** |
| 0.005 days | 0.017063436757 | 0.017063436757 | 1.7e-12 | **+1277%** |
| 0.002 days | 0.010788684989 | 0.010788684989 | 3.5e-12 | **80×** |
| 0.001 days | 0.007627618506 | 0.007627618506 | 6.9e-12 | **612×** |

The reference was rebuilt independently of the implementation, and the
quadrature agrees with the closed form to `1e-38` at every row, so it assumes
neither. Put-call parity is asserted separately at 86 seconds, where
`e^{−rT}(M1 − K) = 5.4794510539814525e-6` is small enough that the identity
constrains the last digits of both legs rather than restating the formula.

## Ordinary maturities

Bit-for-bit identical at **7, 30, 90, 182.5 and 365 days**, call and put,
verified by diffing the printed prices against `main`.

One does move, and it is worth stating rather than burying: **at 1 day the
price changes by a relative `2.5e-10`**. It is a correction, not a regression —
the old value sat `2.5e-10` from the 50-digit reference and the new one sits
`8.5e-14` from it:

| | old | new | reference |
|---|---|---|---|
| 1 day call | 0.2438268020005283 | 0.2438268019395450 | 0.2438268019395657 |
| relative error | 2.5e-10 | 8.5e-14 | |

## Tests

No existing assertion, tolerance or expected value changed, and no test was
removed — the diff over the test module adds only.

Three test **doc comments** did change. Two described the cancellation between
two large terms and the `1e-6` straddle of the old series threshold; neither
mechanism exists any more, and prose asserting a mechanism the code no longer
has reads as a claim about the current implementation. The old and new
sentences are in the commit body.

New: `test_arithmetic_asian_short_maturity_matches_quadrature` (the nine rows),
`..._holds_put_call_parity`, `..._series_threshold_is_continuous`,
`..._midpoint_threshold_is_continuous` (both switchovers are a change of method
and not a discontinuity in the price surface), and
`..._removable_boundaries_hold_at_short_maturity`.

4677 passed, 0 failed. `cargo fmt --all --check`, `cargo clippy --all-targets
--all-features --workspace -- -D warnings`, `make scan-banned` and
`make public-api-check` clean. Public API unchanged.

One incidental fix: the series doc block is now fenced as `text`. Indented,
rustdoc took it for Rust and tried to compile `Σ_{n ≥ 0}` as a doctest.

## Stack

Chain C of four independent chains off `main`; this is its only PR, so the diff
reads against `main` directly.

- Stack: **#462** (this one) — independent of chain A (#470 → #469 → #463 →
  #471), chain B (#466 → #451 → #453), #459, and the #442 capstone.
- Base branch: `main`.

Closes #462
