### PR TITLE
Make the model layer the strategies run through panic-free (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `merge_axis_interpolate`, the four interpolation traits and
   `find_bracket_points`, with the matching one-height-per-xy-coordinate rule
   on `Surface::new`.
+- **`model::utils::mean_and_std` is now fallible, which is a breaking change**
+  (#470). It returns `Result<(Positive, Positive), PositiveError>` instead of
+  `(Positive, Positive)`. It summed with the raw `Positive` operator, which
+  panics on overflow, and divided by `vec.len() as f64`, which divides by zero
+  on an empty sample; every `get_profit_ranges` implementation averages its leg
+  volatilities through it. The returned figures are unchanged for every sample
+  the panicking form accepted — the squared deviations are still taken in
+  `f64` — but a deviation that overflows is now reported instead of collapsing
+  to zero through `unwrap_or(Positive::ZERO)`. To migrate, add `?` where the
+  value feeds a fallible function.
+
+  `PositionError` gains a `PositiveError` variant in the same change, so
+  `Position::total_cost` and `Position::fees` can carry the cause of a
+  `Positive` overflow instead of flattening it into a message. Both already
+  returned `Result`, so their signatures are unchanged. Matching exhaustively
+  on `PositionError` needs a new arm.
+
+  `model::resolve_expiration_date` and `model::reject_unrepresentable_expiration`
+  are new. `ExpirationDate::get_date()` aborts with
+  `` `DateTime + TimeDelta` overflowed `` for a day count no calendar can
+  represent, and every strategy reaches it through
+  `calculate_pnl_at_expiration`; these resolve or reject it instead. The guard
+  #441 added inside `OptionChain::build_chain` is replaced by a call to the
+  shared one. The instant returned is identical for every input the panicking
+  form accepted.
 
 - **Two `ProtectivePut` methods are now fallible, which is a breaking change**
   (#460). `total_fees` returns `Result<Positive, PositiveError>` instead of

--- a/public-api/optionstratlib.txt
+++ b/public-api/optionstratlib.txt
@@ -1501,6 +1501,7 @@ pub mod optionstratlib::error::position
 pub enum optionstratlib::error::position::PositionError
 pub optionstratlib::error::position::PositionError::DecimalError(optionstratlib::error::decimal::DecimalError)
 pub optionstratlib::error::position::PositionError::LimitError(optionstratlib::error::position::PositionLimitErrorKind)
+pub optionstratlib::error::position::PositionError::PositiveError(positive::error::PositiveError)
 pub optionstratlib::error::position::PositionError::StrategyError(optionstratlib::error::position::StrategyErrorKind)
 pub optionstratlib::error::position::PositionError::UpdateError(optionstratlib::error::position::PositionUpdateErrorKind)
 pub optionstratlib::error::position::PositionError::ValidationError(optionstratlib::error::position::PositionValidationErrorKind)
@@ -2098,6 +2099,7 @@ pub fn optionstratlib::error::OptionsError::from(optionstratlib::error::pricing:
 pub enum optionstratlib::error::PositionError
 pub optionstratlib::error::PositionError::DecimalError(optionstratlib::error::decimal::DecimalError)
 pub optionstratlib::error::PositionError::LimitError(optionstratlib::error::position::PositionLimitErrorKind)
+pub optionstratlib::error::PositionError::PositiveError(positive::error::PositiveError)
 pub optionstratlib::error::PositionError::StrategyError(optionstratlib::error::position::StrategyErrorKind)
 pub optionstratlib::error::PositionError::UpdateError(optionstratlib::error::position::PositionUpdateErrorKind)
 pub optionstratlib::error::PositionError::ValidationError(optionstratlib::error::position::PositionValidationErrorKind)
@@ -4262,7 +4264,7 @@ pub fn optionstratlib::model::utils::create_sample_option_with_date(financial_ty
 pub fn optionstratlib::model::utils::create_sample_option_with_days(financial_types::OptionStyle, financial_types::Side, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> optionstratlib::model::option::Options
 pub fn optionstratlib::model::utils::create_sample_position(financial_types::OptionStyle, financial_types::Side, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> optionstratlib::model::position::Position
 pub fn optionstratlib::model::utils::generate_price_points(rust_decimal::decimal::Decimal, rust_decimal::decimal::Decimal, usize) -> alloc::vec::Vec<rust_decimal::decimal::Decimal>
-pub fn optionstratlib::model::utils::mean_and_std(alloc::vec::Vec<positive::positive::Positive>) -> (positive::positive::Positive, positive::positive::Positive)
+pub fn optionstratlib::model::utils::mean_and_std(alloc::vec::Vec<positive::positive::Positive>) -> core::result::Result<(positive::positive::Positive, positive::positive::Positive), positive::error::PositiveError>
 pub fn optionstratlib::model::utils::positive_f64_to_f64(alloc::vec::Vec<positive::positive::Positive>) -> alloc::vec::Vec<f64>
 #[repr(u8)] pub enum optionstratlib::model::BasicAxisTypes
 pub optionstratlib::model::BasicAxisTypes::Charm
@@ -4635,6 +4637,8 @@ pub fn optionstratlib::model::position::Position::exercised(&self) -> core::resu
 pub fn optionstratlib::model::position::Position::expired(&self) -> core::result::Result<optionstratlib::model::Trade, optionstratlib::error::trade::TradeError>
 pub fn optionstratlib::model::position::Position::open(&self) -> core::result::Result<optionstratlib::model::Trade, optionstratlib::error::trade::TradeError>
 pub fn optionstratlib::model::position::Position::status_other(&self) -> core::result::Result<optionstratlib::model::Trade, optionstratlib::error::trade::TradeError>
+pub fn optionstratlib::model::reject_unrepresentable_expiration(&expiration_date::ExpirationDate) -> core::result::Result<(), expiration_date::error::ExpirationDateError>
+pub fn optionstratlib::model::resolve_expiration_date(&expiration_date::ExpirationDate) -> core::result::Result<chrono::datetime::DateTime<chrono::offset::utc::Utc>, expiration_date::error::ExpirationDateError>
 pub fn optionstratlib::model::save_trades(&[optionstratlib::model::Trade], &str) -> core::io::error::Result<()>
 pub mod optionstratlib::pnl
 pub mod optionstratlib::pnl::model
@@ -6044,6 +6048,7 @@ pub fn optionstratlib::error::OptionsError::from(optionstratlib::error::pricing:
 pub enum optionstratlib::prelude::PositionError
 pub optionstratlib::prelude::PositionError::DecimalError(optionstratlib::error::decimal::DecimalError)
 pub optionstratlib::prelude::PositionError::LimitError(optionstratlib::error::position::PositionLimitErrorKind)
+pub optionstratlib::prelude::PositionError::PositiveError(positive::error::PositiveError)
 pub optionstratlib::prelude::PositionError::StrategyError(optionstratlib::error::position::StrategyErrorKind)
 pub optionstratlib::prelude::PositionError::UpdateError(optionstratlib::error::position::PositionUpdateErrorKind)
 pub optionstratlib::prelude::PositionError::ValidationError(optionstratlib::error::position::PositionValidationErrorKind)

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -25,13 +25,14 @@ use crate::model::decimal::{d_add, d_div, d_exp, d_mul, d_sub, d_sum_iter};
 use crate::model::utils::sub_floor_zero;
 use crate::model::{
     BasicAxisTypes, ExpirationDate, OptionStyle, OptionType, Options, Position, Side,
+    reject_unrepresentable_expiration,
 };
 use crate::strategies::utils::FindOptimalSide;
 use crate::surfaces::{BasicSurfaces, Point3D, Surface};
 use crate::utils::Len;
 use crate::utils::others::get_random_element;
 use crate::volatility::VolatilitySmile;
-use chrono::{Duration, NaiveDate, Utc};
+use chrono::{NaiveDate, Utc};
 use num_traits::{FromPrimitive, ToPrimitive};
 use positive::Positive;
 #[cfg(test)]
@@ -253,35 +254,6 @@ impl<'de> Deserialize<'de> for OptionChain {
     }
 }
 
-/// Rejects a relative expiration that no calendar date can represent.
-///
-/// [`ExpirationDate::get_date_string`] resolves `Days(n)` as `now + n days`
-/// with `DateTime + TimeDelta`, which panics on overflow instead of
-/// reporting it. A chain built from a caller-supplied day count reaches that
-/// addition directly, so the span is validated here first.
-///
-/// # Errors
-///
-/// Returns [`ChainError::invalid_parameters`] when the day count is outside
-/// the range a `DateTime<Utc>` can hold.
-fn reject_unrepresentable_expiration(expiration_date: &ExpirationDate) -> Result<(), ChainError> {
-    let ExpirationDate::Days(days) = expiration_date else {
-        return Ok(());
-    };
-    let out_of_range = || {
-        ChainError::invalid_parameters(
-            "expiration_date",
-            &format!("expiration of {days} days is outside the representable calendar range"),
-        )
-    };
-    let whole_days = days.to_dec().trunc().to_i64().ok_or_else(out_of_range)?;
-    let span = Duration::try_days(whole_days).ok_or_else(out_of_range)?;
-    Utc::now()
-        .checked_add_signed(span)
-        .ok_or_else(out_of_range)?;
-    Ok(())
-}
-
 impl OptionChain {
     /// Creates a new `OptionChain` for a specific underlying instrument and expiration date.
     ///
@@ -398,6 +370,7 @@ impl OptionChain {
     /// Returns `ChainError` if:
     /// - `underlying_price` is missing from price params
     /// - `expiration_date` is missing from price params
+    /// - `expiration_date` is a day count no calendar instant can represent
     /// - Failed to get days from expiration date
     /// - Failed to get date string from expiration date
     #[inline(never)]

--- a/src/error/position.rs
+++ b/src/error/position.rs
@@ -13,11 +13,13 @@
 //! ## Error Types
 //!
 //! ### Position Error (`PositionError`)
-//! The main error type with four variants:
+//! The main error type with six variants:
 //! * `StrategyError` - For strategy operation failures
 //! * `ValidationError` - For position validation failures
 //! * `LimitError` - For position limit violations
 //! * `UpdateError` - For position update failures
+//! * `DecimalError` - For `Decimal` arithmetic failures
+//! * `PositiveError` - For `Positive` arithmetic failures
 //!
 //! ### Strategy Errors (`StrategyErrorKind`)
 //! Handles specific strategy-related errors:
@@ -130,6 +132,19 @@ pub enum PositionError {
     /// `#[from]` cascade so callers keep matching `PositionError`.
     #[error(transparent)]
     DecimalError(#[from] crate::error::DecimalError),
+
+    /// `Positive` arithmetic failures propagated from cost and fee
+    /// computations (overflow, division by zero, broken positivity
+    /// invariant).
+    ///
+    /// Produced when a checked `Positive` helper surfaces a
+    /// [`positive::PositiveError`] from inside a `Position` method (for
+    /// example `total_cost` or `fees`, where the premium and the fees are
+    /// accumulated and then scaled by the contract quantity). Propagated
+    /// transparently via the `#[from]` cascade so callers keep matching
+    /// `PositionError`.
+    #[error(transparent)]
+    PositiveError(#[from] positive::PositiveError),
 }
 
 /// Specific errors that can occur in strategy operations

--- a/src/model/expiration.rs
+++ b/src/model/expiration.rs
@@ -1,7 +1,191 @@
-/// Re-export of `ExpirationDate` from the standalone `expiration_date` crate.
-///
-/// This module re-exports the `ExpirationDate` enum and its error type from the
-/// external `expiration_date` crate, which provides all the core functionality
-/// for handling financial instrument expiration dates.
+//! Re-export of `ExpirationDate` from the standalone `expiration_date` crate.
+//!
+//! This module re-exports the `ExpirationDate` enum and its error type from the
+//! external `expiration_date` crate, which provides all the core functionality
+//! for handling financial instrument expiration dates.
+//!
+//! It also owns the single calendar-overflow guard the rest of the crate uses.
+//! The `expiration_date` crate resolves a relative `Days(n)` with the `+`
+//! operator on `DateTime<Utc>` and with `TimeDelta::days`, both of which abort
+//! the process on overflow instead of reporting it, so every call site in this
+//! library goes through [`resolve_expiration_date`] or
+//! [`reject_unrepresentable_expiration`] rather than calling `get_date` and
+//! friends directly.
+
+use chrono::{DateTime, TimeDelta, Utc};
 pub use expiration_date::ExpirationDate;
 pub use expiration_date::error::ExpirationDateError;
+use positive::Positive;
+
+/// Hour of the fixed resolution base used by
+/// `ExpirationDate::get_date_with_options(true)` and therefore by
+/// `ExpirationDate::get_date_string`.
+const FIXED_BASE_HOUR: u32 = 18;
+
+/// Minute of the fixed resolution base. See [`FIXED_BASE_HOUR`].
+const FIXED_BASE_MINUTE: u32 = 30;
+
+/// Reports a day count that no calendar instant can represent.
+#[cold]
+#[inline(never)]
+fn unrepresentable(days: Positive) -> ExpirationDateError {
+    ExpirationDateError::ArithmeticOverflow(format!(
+        "expiration of {days} days is outside the representable calendar range"
+    ))
+}
+
+/// Adds a whole number of days to `base` without aborting on overflow.
+///
+/// Mirrors `base + Duration::days(i64::try_from(days)?)`, the expression the
+/// `expiration_date` crate uses, step by step: the same `Positive` to `i64`
+/// conversion, the same day-to-span conversion and the same addition, each
+/// through its checked counterpart. The instant returned is therefore
+/// identical for every input the panicking form would have accepted.
+fn checked_offset_days(
+    base: DateTime<Utc>,
+    days: Positive,
+) -> Result<DateTime<Utc>, ExpirationDateError> {
+    let whole_days = i64::try_from(days)?;
+    let span = TimeDelta::try_days(whole_days).ok_or_else(|| unrepresentable(days))?;
+    base.checked_add_signed(span)
+        .ok_or_else(|| unrepresentable(days))
+}
+
+/// The base a relative expiration is resolved from: the reference datetime
+/// when one has been installed, the current instant otherwise.
+fn relative_base() -> DateTime<Utc> {
+    ExpirationDate::get_reference_datetime().unwrap_or_else(Utc::now)
+}
+
+/// The fixed base `ExpirationDate::get_date_string` resolves from: today at
+/// [`FIXED_BASE_HOUR`]:[`FIXED_BASE_MINUTE`] UTC.
+fn fixed_base() -> Option<DateTime<Utc>> {
+    Utc::now()
+        .date_naive()
+        .and_hms_opt(FIXED_BASE_HOUR, FIXED_BASE_MINUTE, 0)
+        .map(|naive| DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc))
+}
+
+/// Resolves an expiration into a calendar instant without aborting on overflow.
+///
+/// Drop-in replacement for [`ExpirationDate::get_date`]: it returns the same
+/// instant for every representable input, and a typed error instead of a
+/// process abort for the rest. `Days(1_000_000_000)` overflows the
+/// `DateTime + TimeDelta` addition and `Days(1e15)` overflows `TimeDelta`
+/// itself; both come back as [`ExpirationDateError::ArithmeticOverflow`].
+///
+/// # Errors
+///
+/// * [`ExpirationDateError::ArithmeticOverflow`] - the day count is outside
+///   the range a `DateTime<Utc>` can hold.
+/// * [`ExpirationDateError::ConversionError`] - the day count does not fit an
+///   `i64`, propagated from the `Positive` conversion.
+#[must_use = "the resolved instant carries the failure the panicking form would have aborted on"]
+pub fn resolve_expiration_date(
+    expiration_date: &ExpirationDate,
+) -> Result<DateTime<Utc>, ExpirationDateError> {
+    match expiration_date {
+        ExpirationDate::Days(days) => checked_offset_days(relative_base(), *days),
+        ExpirationDate::DateTime(datetime) => Ok(*datetime),
+    }
+}
+
+/// Rejects a relative expiration that no calendar instant can represent.
+///
+/// Validates the day count against both bases the `expiration_date` crate
+/// resolves from — the relative one used by `get_date` and the fixed 18:30 UTC
+/// one used by `get_date_string` — so a caller that goes on to invoke either
+/// of them cannot reach their panicking arithmetic. Prefer
+/// [`resolve_expiration_date`] where the resolved instant is what is wanted;
+/// this guard exists for the call sites that need the formatted string or the
+/// day count instead.
+///
+/// # Errors
+///
+/// * [`ExpirationDateError::ArithmeticOverflow`] - the day count is outside
+///   the range a `DateTime<Utc>` can hold, from either base.
+/// * [`ExpirationDateError::ConversionError`] - the day count does not fit an
+///   `i64`, propagated from the `Positive` conversion.
+pub fn reject_unrepresentable_expiration(
+    expiration_date: &ExpirationDate,
+) -> Result<(), ExpirationDateError> {
+    let ExpirationDate::Days(days) = expiration_date else {
+        return Ok(());
+    };
+    checked_offset_days(relative_base(), *days)?;
+    let fixed = fixed_base().ok_or_else(|| unrepresentable(*days))?;
+    checked_offset_days(fixed, *days)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    fn pos(value: rust_decimal::Decimal) -> Positive {
+        Positive::new_decimal(value).unwrap_or(Positive::ZERO)
+    }
+
+    #[test]
+    fn test_resolve_expiration_date_days_matches_get_date() {
+        let expiration = ExpirationDate::Days(pos(dec!(30.0)));
+        let resolved = resolve_expiration_date(&expiration).expect("30 days is representable");
+        let reference = expiration.get_date().expect("30 days is representable");
+        assert_eq!(resolved.date_naive(), reference.date_naive());
+    }
+
+    #[test]
+    fn test_resolve_expiration_date_datetime_is_returned_unchanged() {
+        let instant = Utc::now();
+        let resolved = resolve_expiration_date(&ExpirationDate::DateTime(instant))
+            .expect("an explicit instant is always representable");
+        assert_eq!(resolved, instant);
+    }
+
+    #[test]
+    fn test_resolve_expiration_date_datetime_overflow_returns_error() {
+        let error = resolve_expiration_date(&ExpirationDate::Days(pos(dec!(1000000000.0))))
+            .expect_err("a billion days overflows the calendar");
+        assert!(matches!(error, ExpirationDateError::ArithmeticOverflow(_)));
+    }
+
+    #[test]
+    fn test_resolve_expiration_date_span_overflow_returns_error() {
+        let error = resolve_expiration_date(&ExpirationDate::Days(pos(dec!(1000000000000000.0))))
+            .expect_err("1e15 days overflows TimeDelta itself");
+        assert!(matches!(error, ExpirationDateError::ArithmeticOverflow(_)));
+    }
+
+    #[test]
+    fn test_resolve_expiration_date_beyond_i64_returns_error() {
+        let error = resolve_expiration_date(&ExpirationDate::Days(Positive::MAX))
+            .expect_err("Positive::MAX days does not fit an i64");
+        assert!(matches!(
+            error,
+            ExpirationDateError::ConversionError { .. } | ExpirationDateError::PositiveError(_)
+        ));
+    }
+
+    #[test]
+    fn test_reject_unrepresentable_expiration_accepts_ordinary_horizons() {
+        for days in [dec!(0.0), dec!(1.0), dec!(30.0), dec!(3650.0)] {
+            reject_unrepresentable_expiration(&ExpirationDate::Days(pos(days)))
+                .expect("ordinary horizons are representable");
+        }
+    }
+
+    #[test]
+    fn test_reject_unrepresentable_expiration_rejects_billion_days() {
+        let error =
+            reject_unrepresentable_expiration(&ExpirationDate::Days(pos(dec!(1000000000.0))))
+                .expect_err("a billion days overflows the calendar");
+        assert!(matches!(error, ExpirationDateError::ArithmeticOverflow(_)));
+    }
+
+    #[test]
+    fn test_reject_unrepresentable_expiration_accepts_any_datetime() {
+        reject_unrepresentable_expiration(&ExpirationDate::DateTime(Utc::now()))
+            .expect("an explicit instant needs no calendar arithmetic");
+    }
+}

--- a/src/model/leg/future.rs
+++ b/src/model/leg/future.rs
@@ -42,6 +42,7 @@
 
 use crate::error::GreeksError;
 use crate::model::ExpirationDate;
+use crate::model::expiration::resolve_expiration_date;
 use crate::model::leg::traits::{Expirable, LegAble, Marginable};
 use crate::model::types::Side;
 use chrono::{DateTime, Utc};
@@ -373,9 +374,12 @@ impl Marginable for FuturePosition {
 
 impl Expirable for FuturePosition {
     fn expiration_timestamp(&self) -> i64 {
-        self.expiration_date
-            .get_date()
-            .map(|d| d.timestamp())
+        // The resolver rather than `get_date`, which aborts on a day count no
+        // calendar instant can hold instead of reporting it. The `unwrap_or`
+        // was never reached for that input, because there was nothing to
+        // unwrap: the process was already gone.
+        resolve_expiration_date(&self.expiration_date)
+            .map(|date| date.timestamp())
             .unwrap_or(0)
     }
 
@@ -384,9 +388,8 @@ impl Expirable for FuturePosition {
     }
 
     fn is_expired(&self) -> bool {
-        self.expiration_date
-            .get_date()
-            .map(|d| d < Utc::now())
+        resolve_expiration_date(&self.expiration_date)
+            .map(|date| date < Utc::now())
             .unwrap_or(false)
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -132,6 +132,7 @@ pub use axis::BasicAxisTypes;
 pub use balance::*;
 pub use expiration::ExpirationDate;
 pub use expiration::ExpirationDateError;
+pub use expiration::{reject_unrepresentable_expiration, resolve_expiration_date};
 pub use option::Options;
 pub use position::Position;
 pub use profit_range::ProfitLossRange;

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -6,6 +6,7 @@ use crate::error::{
 };
 use crate::greeks::Greeks;
 use crate::model::decimal::d_sub;
+use crate::model::expiration::resolve_expiration_date;
 use crate::model::types::{OptionBasicType, OptionStyle, OptionType, Side};
 use crate::model::utils::calculate_optimal_price_range;
 use crate::pnl::utils::{PnL, PnLCalculator};
@@ -916,7 +917,7 @@ impl PnLCalculator for Options {
             unrealized,
             Positive::new_decimal(initial_costs)?,
             Positive::new_decimal(initial_income)?,
-            current_option.expiration_date.get_date()?,
+            resolve_expiration_date(&current_option.expiration_date)?,
         ))
     }
 
@@ -937,7 +938,7 @@ impl PnLCalculator for Options {
             None,
             Positive::new_decimal(initial_costs)?,
             Positive::new_decimal(initial_income)?,
-            self.expiration_date.get_date()?,
+            resolve_expiration_date(&self.expiration_date)?,
         ))
     }
 }
@@ -1153,6 +1154,32 @@ mod tests_options {
     use chrono::{Duration, Utc};
     use num_traits::ToPrimitive;
     use rust_decimal_macros::dec;
+
+    /// A day count no calendar instant can hold is a value a caller can build
+    /// and hand to any public method. Both P&L entry points resolved it
+    /// through `ExpirationDate::get_date`, which aborts on the overflow
+    /// rather than reporting it, so the `Result` these return could never be
+    /// reached for that input.
+    #[test]
+    fn test_pnl_reports_an_unrepresentable_expiration_instead_of_aborting() {
+        let mut option = create_sample_option_simplest(OptionStyle::Call, Side::Long);
+        option.expiration_date = ExpirationDate::Days(pos_or_panic!(1_000_000_000.0));
+
+        assert!(
+            option
+                .calculate_pnl_at_expiration(&Positive::HUNDRED)
+                .is_err()
+        );
+        assert!(
+            option
+                .calculate_pnl(
+                    &Positive::HUNDRED,
+                    ExpirationDate::Days(pos_or_panic!(1_000_000_000.0)),
+                    &pos_or_panic!(0.2),
+                )
+                .is_err()
+        );
+    }
 
     #[test]
     fn test_new_option() {

--- a/src/model/position.rs
+++ b/src/model/position.rs
@@ -11,6 +11,7 @@ use crate::error::{
 };
 use crate::greeks::Greeks;
 use crate::model::decimal::{d_add, d_mul, d_sub};
+use crate::model::expiration::resolve_expiration_date;
 use crate::model::trade::TradeStatusAble;
 use crate::model::types::{Action, OptionBasicType, OptionStyle, Side};
 use crate::model::{Trade, TradeAble, TradeStatus};
@@ -242,20 +243,22 @@ impl Position {
     ///
     /// # Returns
     ///
-    /// A `f64` representing the total cost of the position. THE VALUE IS ALWAYS POSITIVE
+    /// A `Positive` representing the total cost of the position. THE VALUE IS ALWAYS POSITIVE
     ///
     /// # Errors
     ///
-    /// Currently infallible — long positions accumulate only
-    /// non-negative `Positive` terms and short positions delegate
-    /// to `fees()`, which is itself infallible under the current
-    /// implementation. The `Result` signature is retained so future
-    /// implementations that validate fee configuration or surface
-    /// overflow on `Positive` arithmetic can return
-    /// `PositionError` without a breaking change.
+    /// Returns [`PositionError::PositiveError`] when accumulating the premium
+    /// and the two fees, or scaling the accumulated per-contract cost by the
+    /// contract quantity, overflows the `Positive` range. The raw `Positive`
+    /// operators abort on overflow, so every step is taken through its
+    /// checked counterpart.
     pub fn total_cost(&self) -> Result<Positive, PositionError> {
         let total_cost = match self.option.side {
-            Side::Long => (self.premium + self.open_fee + self.close_fee) * self.option.quantity,
+            Side::Long => self
+                .premium
+                .checked_add(&self.open_fee)?
+                .checked_add(&self.close_fee)?
+                .checked_mul(&self.option.quantity)?,
             Side::Short => self.fees()?,
         };
 
@@ -307,17 +310,13 @@ impl Position {
     ///
     /// # Errors
     ///
-    /// Currently infallible — long positions return
-    /// `Ok(Positive::ZERO)` (no premium received) and short
-    /// positions return `Ok(self.premium * self.option.quantity)`.
-    /// The `Result` signature is retained so future implementations
-    /// that treat long-side calls as a programmer error, or that
-    /// surface overflow on the `premium × quantity` product, can
-    /// return `PositionError` without a breaking change.
+    /// Returns [`PositionError::PositiveError`] when the short-side
+    /// `premium × quantity` product overflows the `Positive` range. Long
+    /// positions receive no premium and are infallible.
     pub fn premium_received(&self) -> Result<Positive, PositionError> {
         match self.option.side {
             Side::Long => Ok(Positive::ZERO),
-            Side::Short => Ok(self.premium * self.option.quantity),
+            Side::Short => Ok(self.premium.checked_mul(&self.option.quantity)?),
         }
     }
 
@@ -341,9 +340,9 @@ impl Position {
     ///
     /// # Errors
     ///
-    /// Propagates any `PositionError` raised by `total_cost()` (no
-    /// variant is surfaced under the current implementation, but
-    /// the call site keeps the `?` for forward compatibility).
+    /// Propagates any `PositionError` raised by `total_cost()`, and returns
+    /// [`PositionError::PositiveError`] when scaling the premium by the
+    /// contract quantity overflows the `Positive` range.
     ///
     /// When the short-side net amount `premium − total_cost` is
     /// negative the function returns `Ok(Positive::ZERO)` (clamped)
@@ -354,10 +353,10 @@ impl Position {
             Side::Long => Ok(Positive::ZERO),
             Side::Short => {
                 // max profit is premium received - fees (cost)
-                let premium = self.premium * self.option.quantity;
+                let premium = self.premium.checked_mul(&self.option.quantity)?;
                 let total_cost = self.total_cost()?;
                 if premium >= total_cost {
-                    Ok(premium - total_cost)
+                    Ok(premium.checked_sub(&total_cost)?)
                 } else {
                     Ok(Positive::ZERO)
                 }
@@ -655,10 +654,9 @@ impl Position {
     ///
     /// # Errors
     ///
-    /// Currently only propagates arithmetic-failure variants surfaced by the
-    /// premium × quantity and fee additions; in practice infallible for all
-    /// valid positions, but the `Result` signature is retained to let
-    /// callers handle future overflow paths uniformly.
+    /// Propagates the [`PositionError::PositiveError`] raised by `total_cost`,
+    /// `fees` and `premium_received` when the fee or premium accumulation, or
+    /// its product with the contract quantity, overflows the `Positive` range.
     pub fn net_cost(&self) -> Result<Decimal, PositionError> {
         match self.option.side {
             Side::Long => Ok(self.total_cost()?.to_dec()),
@@ -689,32 +687,46 @@ impl Position {
     /// # Returns
     ///
     /// - `Some(Positive)` containing the break-even price if the position has non-zero quantity
-    /// - `None` if the position has zero quantity (no contracts) or if the position total
-    ///   cost cannot be calculated
+    /// - `None` if the position has zero quantity (no contracts), if the position total
+    ///   cost cannot be calculated, or if the break-even price is not representable as a
+    ///   `Positive` — a cost per contract above the strike puts it below zero, and a cost
+    ///   per contract near `Positive::MAX` overflows the sum
     ///
     #[must_use]
     pub fn break_even(&self) -> Option<Positive> {
         if self.option.quantity == Positive::ZERO {
             return None;
         }
-        if let Ok(position_total_cost) = self.total_cost() {
-            let total_cost_per_contract = position_total_cost / self.option.quantity;
-            match (&self.option.side, &self.option.option_style) {
-                (Side::Long, OptionStyle::Call) => {
-                    Some(self.option.strike_price + total_cost_per_contract)
-                }
-                (Side::Short, OptionStyle::Call) => {
-                    Some(self.option.strike_price + self.premium - total_cost_per_contract)
-                }
-                (Side::Long, OptionStyle::Put) => {
-                    Some(self.option.strike_price - total_cost_per_contract)
-                }
-                (Side::Short, OptionStyle::Put) => {
-                    Some(self.option.strike_price - self.premium + total_cost_per_contract)
-                }
-            }
-        } else {
-            None
+        let position_total_cost = self.total_cost().ok()?;
+        // The raw `Positive` operators abort on overflow and on a difference
+        // that would go below zero; a long put whose cost per contract exceeds
+        // its strike reaches the latter with entirely ordinary numbers.
+        let total_cost_per_contract = position_total_cost
+            .checked_div(&self.option.quantity)
+            .ok()?;
+        match (&self.option.side, &self.option.option_style) {
+            (Side::Long, OptionStyle::Call) => self
+                .option
+                .strike_price
+                .checked_add(&total_cost_per_contract)
+                .ok(),
+            (Side::Short, OptionStyle::Call) => self
+                .option
+                .strike_price
+                .checked_add(&self.premium)
+                .and_then(|total| total.checked_sub(&total_cost_per_contract))
+                .ok(),
+            (Side::Long, OptionStyle::Put) => self
+                .option
+                .strike_price
+                .checked_sub(&total_cost_per_contract)
+                .ok(),
+            (Side::Short, OptionStyle::Put) => self
+                .option
+                .strike_price
+                .checked_sub(&self.premium)
+                .and_then(|net| net.checked_add(&total_cost_per_contract))
+                .ok(),
         }
     }
 
@@ -771,12 +783,15 @@ impl Position {
     ///
     /// # Errors
     ///
-    /// Currently infallible in practice; the `Result` signature is retained
-    /// so that future fee models that can overflow `Positive` (e.g. tiered
-    /// fee schedules multiplied by very large quantities) can surface their
-    /// failures without a breaking API change.
+    /// Returns [`PositionError::PositiveError`] when adding the two fees, or
+    /// scaling their sum by the contract quantity, overflows the `Positive`
+    /// range. The raw `Positive` operators abort on overflow, so both steps
+    /// are taken through their checked counterparts.
     pub fn fees(&self) -> Result<Positive, PositionError> {
-        Ok((self.open_fee + self.close_fee) * self.option.quantity)
+        Ok(self
+            .open_fee
+            .checked_add(&self.close_fee)?
+            .checked_mul(&self.option.quantity)?)
     }
 
     /// Validates the position to ensure it meets all necessary conditions for trading.
@@ -962,8 +977,16 @@ mod tests_transaction_able_default {
 
 impl TradeAble for Position {
     fn trade(&self) -> Result<Trade, TradeError> {
+        let fee = self
+            .open_fee
+            .checked_add(&self.close_fee)
+            .map_err(|error| {
+                TradeError::invalid_trade(&format!(
+                    "open and close fees overflow the Positive range: {error}"
+                ))
+            })?;
         if let (Ok(expiry), Some(timestamp)) = (
-            self.option.expiration_date.get_date(),
+            resolve_expiration_date(&self.option.expiration_date),
             Utc::now().timestamp_nanos_opt(),
         ) {
             Ok(Trade {
@@ -971,7 +994,7 @@ impl TradeAble for Position {
                 action: Action::Buy,
                 side: self.option.side,
                 option_style: self.option.option_style,
-                fee: self.open_fee + self.close_fee,
+                fee,
                 symbol: None,
                 strike: self.option.strike_price,
                 expiry,
@@ -1131,10 +1154,25 @@ impl PnLCalculator for Position {
     ) -> Result<PnL, PricingError> {
         let initial_cost = self.total_cost()?;
         let initial_income = self.premium_received()?;
-        let date_time = self.option.expiration_date.get_date()?;
+        // `ExpirationDate::get_date` resolves a relative expiration with the
+        // `+` operator on `DateTime<Utc>`, which aborts past the calendar
+        // range instead of reporting it.
+        let date_time = resolve_expiration_date(&self.option.expiration_date)?;
 
-        let realized = self.option.intrinsic_value(*underlying_price)? - initial_cost.to_dec()
-            + initial_income.to_dec();
+        // A cost or an income at the top of the `Positive` range overflows the
+        // raw `Decimal` operators, so the running total is taken through
+        // `d_sub`/`d_add` exactly as `pnl_at_expiration` does.
+        let intrinsic = self.option.intrinsic_value(*underlying_price)?;
+        let net_after_cost = d_sub(
+            intrinsic,
+            initial_cost.to_dec(),
+            "position::calculate_pnl_at_expiration::net",
+        )?;
+        let realized = d_add(
+            net_after_cost,
+            initial_income.to_dec(),
+            "position::calculate_pnl_at_expiration::total",
+        )?;
         Ok(PnL::new(
             Some(realized),
             Some(Decimal::ZERO),

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -8,7 +8,7 @@ use crate::model::Position;
 use crate::model::types::{OptionStyle, OptionType, Side};
 use crate::{ExpirationDate, Options};
 use chrono::{NaiveDateTime, TimeZone, Utc};
-use positive::Positive;
+use positive::{Positive, PositiveError};
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 use std::ops::Mul;
@@ -395,14 +395,24 @@ pub fn create_sample_option_simplest_strike(
 ///
 /// # Arguments
 ///
-/// * `vec` - A `Vec<Positive>` containing the data for which the mean and standard deviation
-///   are to be calculated.
+/// * `vec` - A non-empty `Vec<Positive>` containing the data for which the mean and standard
+///   deviation are to be calculated.
 ///
 /// # Returns
 ///
 /// A tuple containing:
 /// - `Positive` - The mean of the provided vector.
 /// - `Positive` - The standard deviation of the provided vector.
+///
+/// # Errors
+///
+/// Returns [`PositiveError::ArithmeticError`] when the sample is empty — no
+/// mean is defined for it — and when accumulating the values or the squared
+/// deviations overflows the `Positive` range. Returns
+/// [`PositiveError::InvalidValue`] when a squared deviation is not
+/// representable as a finite `f64`. The raw `Positive` operators abort the
+/// process in all of those cases, so every step is taken through its checked
+/// counterpart.
 ///
 /// # Example
 ///
@@ -415,7 +425,7 @@ pub fn create_sample_option_simplest_strike(
 ///     Positive::new(2.0)?, Positive::new(4.0)?, Positive::new(4.0)?, Positive::new(4.0)?,
 ///     Positive::new(5.0)?, Positive::new(5.0)?, Positive::new(7.0)?, Positive::new(9.0)?,
 /// ];
-/// let (mean, std) = mean_and_std(data);
+/// let (mean, std) = mean_and_std(data)?;
 ///
 /// assert_eq!(mean.to_f64(), 5.0);
 /// assert_eq!(std.to_f64(), 4.0_f64.sqrt());
@@ -428,23 +438,38 @@ pub fn create_sample_option_simplest_strike(
 /// - The mean is computed by summing the `Positive` values and dividing by the count of elements.
 /// - The standard deviation is derived from the variance, which is the average of the squared differences
 ///   from the mean. The variance is then converted into standard deviation by taking its square root.
-/// - This function assumes the vector is non-empty and filled with valid `Positive` values.
 ///
 /// Note: The `Positive` type and associated operations are defined in the `crate::model::types` module.
-#[must_use]
-pub fn mean_and_std(vec: Vec<Positive>) -> (Positive, Positive) {
-    let mean = vec.iter().sum::<Positive>() / vec.len() as f64;
-    // `(x - mean).powi(2)` is mathematically non-negative, and so is
-    // `sqrt(variance)`. The `Positive::ZERO` fallback on the checked
-    // constructors is therefore unreachable and only exists to keep these
-    // call sites free of `.unwrap()`/`.expect()`.
-    let variance = vec
-        .iter()
-        .map(|x| Positive::new((x.to_f64() - mean.to_f64()).powi(2)).unwrap_or(Positive::ZERO))
-        .sum::<Positive>()
-        / vec.len() as f64;
-    let std = variance.to_f64().sqrt();
-    (mean, Positive::new(std).unwrap_or(Positive::ZERO))
+pub fn mean_and_std(vec: Vec<Positive>) -> Result<(Positive, Positive), PositiveError> {
+    if vec.is_empty() {
+        return Err(PositiveError::ArithmeticError {
+            operation: "mean_and_std".to_string(),
+            reason: "an empty sample has no mean".to_string(),
+        });
+    }
+    // `Decimal::from(usize)` is exact for every length a `Vec` can hold, so
+    // the divisor introduces no rounding of its own.
+    let count = Decimal::from(vec.len());
+
+    let mut total = Positive::ZERO;
+    for value in &vec {
+        total = total.checked_add(value)?;
+    }
+    let mean = total.checked_div_dec(count)?;
+
+    // The squared deviations are taken in `f64`, as they always have been, so
+    // the returned figures are unchanged for every sample the panicking form
+    // accepted. What changes is the reporting: a deviation that overflows
+    // `f64` now surfaces instead of collapsing to zero.
+    let mut squared_deviations = Positive::ZERO;
+    for value in &vec {
+        let deviation = Positive::new((value.to_f64() - mean.to_f64()).powi(2))?;
+        squared_deviations = squared_deviations.checked_add(&deviation)?;
+    }
+    let variance = squared_deviations.checked_div_dec(count)?;
+    let std = Positive::new(variance.to_f64().sqrt())?;
+
+    Ok((mean, std))
 }
 
 /// Trait for rounding operations on numeric types, specifically for financial calculations.
@@ -609,7 +634,7 @@ mod tests_mean_and_std {
             pos_or_panic!(7.0),
             pos_or_panic!(9.0),
         ];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 5.0, epsilon = 0.0001);
         assert_relative_eq!(std.to_f64(), 2.0, epsilon = 0.0001);
@@ -623,7 +648,7 @@ mod tests_mean_and_std {
             pos_or_panic!(5.0),
             pos_or_panic!(5.0),
         ];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 5.0, epsilon = 0.0001);
         assert_relative_eq!(std.to_f64(), 0.0, epsilon = 0.0001);
@@ -632,7 +657,7 @@ mod tests_mean_and_std {
     #[test]
     fn test_single_value() {
         let values = vec![pos_or_panic!(3.0)];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 3.0, epsilon = 0.0001);
         assert_relative_eq!(std.to_f64(), 0.0, epsilon = 0.0001);
@@ -641,7 +666,7 @@ mod tests_mean_and_std {
     #[test]
     fn test_small_numbers() {
         let values = vec![pos_or_panic!(0.1), pos_or_panic!(0.2), pos_or_panic!(0.3)];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 0.2, epsilon = 0.0001);
         assert_relative_eq!(std.to_f64(), 0.08164966, epsilon = 0.0001);
@@ -654,7 +679,7 @@ mod tests_mean_and_std {
             pos_or_panic!(2000.0),
             pos_or_panic!(3000.0),
         ];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 2000.0, epsilon = 0.0001);
         assert_relative_eq!(std.to_f64(), 816.4966, epsilon = 0.1);
@@ -668,17 +693,24 @@ mod tests_mean_and_std {
             pos_or_panic!(50.0),
             pos_or_panic!(500.0),
         ];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 138.875, epsilon = 0.001);
         assert_relative_eq!(std.to_f64(), 209.392, epsilon = 0.001);
     }
 
     #[test]
-    #[should_panic]
     fn test_empty_vector() {
         let values: Vec<Positive> = vec![];
-        let _ = mean_and_std(values);
+        let error = mean_and_std(values).expect_err("an empty sample has no mean");
+        assert!(matches!(error, PositiveError::ArithmeticError { .. }));
+    }
+
+    #[test]
+    fn test_sum_overflow_returns_error() {
+        let values = vec![Positive::MAX, Positive::MAX];
+        let error = mean_and_std(values).expect_err("two maxima overflow the sum");
+        assert!(matches!(error, PositiveError::ArithmeticError { .. }));
     }
 
     #[test]
@@ -690,7 +722,7 @@ mod tests_mean_and_std {
             pos_or_panic!(4.0),
             pos_or_panic!(5.0),
         ];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 3.0, epsilon = 0.0001);
         assert_relative_eq!(std.to_f64(), std::f64::consts::SQRT_2, epsilon = 0.0001);
@@ -699,7 +731,7 @@ mod tests_mean_and_std {
     #[test]
     fn test_result_is_positive() {
         let values = vec![Positive::ONE, Positive::TWO, pos_or_panic!(3.0)];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert!(mean > Positive::ZERO);
         assert!(std > Positive::ZERO);
@@ -712,7 +744,7 @@ mod tests_mean_and_std {
             pos_or_panic!(2.34567890),
             pos_or_panic!(3.45678901),
         ];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 2.34567860, epsilon = 0.00000001);
         assert_relative_eq!(std.to_f64(), 0.90721797, epsilon = 0.00000001);
@@ -725,7 +757,7 @@ mod tests_mean_and_std {
             pos_or_panic!(0.134567890),
             pos_or_panic!(0.145678901),
         ];
-        let (mean, std) = mean_and_std(values);
+        let (mean, std) = mean_and_std(values).expect("the sample is non-empty and finite");
 
         assert_relative_eq!(mean.to_f64(), 0.13456786, epsilon = 0.00000001);
         assert_relative_eq!(std.to_f64(), 0.00907213, epsilon = 0.00000001);

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -841,7 +841,7 @@ impl ProbabilityAnalysis for BearCallSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.short_call.option.implied_volatility,
             self.long_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(None, Some(break_even_point), Positive::ZERO)?;
 
@@ -867,7 +867,7 @@ impl ProbabilityAnalysis for BearCallSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.short_call.option.implied_volatility,
             self.long_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(None, Some(break_even_point), Positive::ZERO)?;
 

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -843,7 +843,7 @@ impl ProbabilityAnalysis for BearPutSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.long_put.option.implied_volatility,
             self.short_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(self.short_put.option.strike_price), // Price below short strike is max profit
@@ -873,7 +873,7 @@ impl ProbabilityAnalysis for BearPutSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.long_put.option.implied_volatility,
             self.short_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(
             Some(break_even_point), // Lower bound is break even point

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -855,7 +855,7 @@ impl ProbabilityAnalysis for BullCallSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.long_call.option.implied_volatility,
             self.short_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_point),
@@ -886,7 +886,7 @@ impl ProbabilityAnalysis for BullCallSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.long_call.option.implied_volatility,
             self.short_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(
             Some(self.long_call.option.strike_price),

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -954,7 +954,7 @@ impl ProbabilityAnalysis for BullPutSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.short_put.option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(Some(break_even_point), None, Positive::ZERO)?;
 
@@ -981,7 +981,7 @@ impl ProbabilityAnalysis for BullPutSpread {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.short_put.option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(
             Some(self.long_put.option.strike_price),

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -999,7 +999,7 @@ impl ProbabilityAnalysis for CallButterfly {
             self.long_call.option.implied_volatility,
             self.short_call_low.option.implied_volatility,
             self.short_call_high.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_points[0]),
@@ -1031,7 +1031,7 @@ impl ProbabilityAnalysis for CallButterfly {
             self.long_call.option.implied_volatility,
             self.short_call_low.option.implied_volatility,
             self.short_call_high.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range_lower =
             ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;

--- a/src/strategies/custom.rs
+++ b/src/strategies/custom.rs
@@ -905,7 +905,7 @@ impl ProbabilityAnalysis for CustomStrategy {
             .iter()
             .map(|position| position.option.implied_volatility)
             .collect();
-        let (mean_volatility, std_dev) = mean_and_std(implied_volatilities);
+        let (mean_volatility, std_dev) = mean_and_std(implied_volatilities)?;
 
         let (mut profit_ranges, _) = self.get_profit_loss_zones(break_even_points)?;
 
@@ -942,7 +942,7 @@ impl ProbabilityAnalysis for CustomStrategy {
             .iter()
             .map(|position| position.option.implied_volatility)
             .collect();
-        let (mean_volatility, std_dev) = mean_and_std(implied_volatilities);
+        let (mean_volatility, std_dev) = mean_and_std(implied_volatilities)?;
 
         let (_, mut loss_ranges) = self.get_profit_loss_zones(break_even_points)?;
 

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -1064,7 +1064,7 @@ impl ProbabilityAnalysis for IronButterfly {
             self.short_put.option.implied_volatility,
             self.long_call.option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_points[0]),
@@ -1097,7 +1097,7 @@ impl ProbabilityAnalysis for IronButterfly {
             self.short_put.option.implied_volatility,
             self.long_call.option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range_lower =
             ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -1092,7 +1092,7 @@ impl ProbabilityAnalysis for IronCondor {
             self.short_put.option.implied_volatility,
             self.long_call.option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_points[0]),
@@ -1125,7 +1125,7 @@ impl ProbabilityAnalysis for IronCondor {
             self.short_put.option.implied_volatility,
             self.long_call.option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range_lower =
             ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -1034,7 +1034,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
             self.long_call_low.option.implied_volatility,
             self.short_call.option.implied_volatility,
             self.long_call_high.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_points[0]),
@@ -1067,7 +1067,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
             self.long_call_low.option.implied_volatility,
             self.short_call.option.implied_volatility,
             self.long_call_high.option.implied_volatility,
-        ]);
+        ])?;
 
         let volatility_adjustment = Some(VolatilityAdjustment {
             base_volatility: mean_volatility,

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -834,7 +834,7 @@ impl ProbabilityAnalysis for LongStraddle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut lower_profit_range =
             ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
@@ -876,7 +876,7 @@ impl ProbabilityAnalysis for LongStraddle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.long_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(
             Some(break_even_points[0]),

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -909,7 +909,7 @@ impl ProbabilityAnalysis for LongStrangle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.long_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut lower_profit_range =
             ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
@@ -951,7 +951,7 @@ impl ProbabilityAnalysis for LongStrangle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.long_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(
             Some(break_even_points[0]),

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -838,7 +838,7 @@ impl ProbabilityAnalysis for PoorMansCoveredCall {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.short_call.option.implied_volatility,
             self.long_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(Some(break_even_point), None, Positive::ZERO)?;
 
@@ -865,7 +865,7 @@ impl ProbabilityAnalysis for PoorMansCoveredCall {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             self.long_call.option.implied_volatility,
             self.short_call.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(None, Some(break_even_point), Positive::ZERO)?;
 

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -1006,7 +1006,7 @@ impl ProbabilityAnalysis for ShortButterflySpread {
             self.short_call_low.option.implied_volatility,
             self.long_call.option.implied_volatility,
             self.short_call_high.option.implied_volatility,
-        ]);
+        ])?;
 
         let volatility_adjustment = Some(VolatilityAdjustment {
             base_volatility: mean_volatility,
@@ -1052,7 +1052,7 @@ impl ProbabilityAnalysis for ShortButterflySpread {
             self.short_call_low.option.implied_volatility,
             self.long_call.option.implied_volatility,
             self.short_call_high.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut loss_range = ProfitLossRange::new(
             Some(break_even_points[0]),

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -885,7 +885,7 @@ impl ProbabilityAnalysis for ShortStraddle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.short_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_points[0]),
@@ -916,7 +916,7 @@ impl ProbabilityAnalysis for ShortStraddle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.short_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut lower_loss_range =
             ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -1178,7 +1178,7 @@ impl ProbabilityAnalysis for ShortStrangle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.short_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut profit_range = ProfitLossRange::new(
             Some(break_even_points[0]),
@@ -1209,7 +1209,7 @@ impl ProbabilityAnalysis for ShortStrangle {
         let (mean_volatility, std_dev) = mean_and_std(vec![
             option.implied_volatility,
             self.short_put.option.implied_volatility,
-        ]);
+        ])?;
 
         let mut lower_loss_range =
             ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -6,6 +6,7 @@
 mod chains_panic_freedom_test;
 mod curves_panic_freedom_test;
 mod greeks_bounds_test;
+mod model_panic_freedom_test;
 mod panic_freedom_test;
 mod point_contract_test;
 mod pricing_panic_freedom_test;

--- a/tests/property/model_panic_freedom_test.rs
+++ b/tests/property/model_panic_freedom_test.rs
@@ -1,0 +1,170 @@
+//! Property-based tests for panic freedom in the model layer.
+//!
+//! The library is embedded in long-running services, where a panic kills the
+//! worker thread and takes the in-flight request with it. Every failure must
+//! therefore come back as a `Result`, including for inputs that are extreme
+//! but structurally valid.
+//!
+//! Three families are driven here. `Position`'s cost and premium arithmetic,
+//! which accumulates a premium and two fees and scales the total by the
+//! contract quantity — the product overflows `Positive` long before the
+//! factors do, and the break-even subtracts a per-contract cost from a strike
+//! that may be smaller than it. The resolution of a relative expiration, whose
+//! `DateTime + TimeDelta` addition overflows past a horizon of roughly
+//! 260 000 years. And `mean_and_std`, which sums a sample and divides by its
+//! length, so it meets both an overflow and an empty divisor. The assertion is
+//! deliberately weak: whatever comes back, it must come back.
+
+use optionstratlib::model::types::{OptionStyle, OptionType, Side};
+use optionstratlib::model::utils::mean_and_std;
+use optionstratlib::model::{
+    ExpirationDate, Options, Position, TradeAble, reject_unrepresentable_expiration,
+    resolve_expiration_date,
+};
+use optionstratlib::pnl::PnLCalculator;
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+/// The smallest representable `Decimal`. A quantity at this scale is what
+/// turns an ordinary per-contract division into an overflow.
+const TINY: Decimal = Decimal::from_parts(1, 0, 0, false, 28);
+
+/// A `Positive` from a `Decimal` literal that is non-negative by construction.
+fn pos(value: Decimal) -> Positive {
+    Positive::new_decimal(value).unwrap_or(Positive::ZERO)
+}
+
+/// Prices, strikes, premia, fees and quantities across the whole `Positive`
+/// range, including the two ends that break the arithmetic.
+fn extreme_positive() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(TINY)),
+        Just(pos(dec!(0.01))),
+        Just(Positive::ONE),
+        Just(Positive::HUNDRED),
+        Just(pos(dec!(1000))),
+        Just(pos(dec!(1000000000000000))),
+        Just(Positive::MAX),
+    ]
+}
+
+/// Rates over the signed `Decimal` range.
+fn extreme_decimal() -> impl Strategy<Value = Decimal> {
+    prop_oneof![
+        Just(Decimal::ZERO),
+        Just(dec!(0.05)),
+        Just(dec!(-0.05)),
+        Just(dec!(1000000)),
+        Just(dec!(-1000000)),
+        Just(Decimal::MAX),
+        Just(Decimal::MIN),
+    ]
+}
+
+/// Expirations from one already reached to horizons past the calendar itself:
+/// a billion days overflows the `DateTime + TimeDelta` addition, `1e15` days
+/// overflows `TimeDelta`, and `Positive::MAX` days does not fit the `i64` day
+/// count the conversion goes through.
+fn extreme_expiration() -> impl Strategy<Value = ExpirationDate> {
+    prop_oneof![
+        Just(ExpirationDate::Days(Positive::ZERO)),
+        Just(ExpirationDate::Days(pos(TINY))),
+        Just(ExpirationDate::Days(pos(dec!(30)))),
+        Just(ExpirationDate::Days(pos(dec!(3650)))),
+        Just(ExpirationDate::Days(pos(dec!(1000000000)))),
+        Just(ExpirationDate::Days(pos(dec!(1000000000000000)))),
+        Just(ExpirationDate::Days(Positive::MAX)),
+        Just(ExpirationDate::DateTime(chrono::Utc::now())),
+    ]
+}
+
+/// The four side and style combinations, so the break-even reaches both the
+/// addition and the subtraction of each.
+fn extreme_kind() -> impl Strategy<Value = (Side, OptionStyle)> {
+    prop_oneof![
+        Just((Side::Long, OptionStyle::Call)),
+        Just((Side::Short, OptionStyle::Call)),
+        Just((Side::Long, OptionStyle::Put)),
+        Just((Side::Short, OptionStyle::Put)),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Every monetary figure a `Position` exposes, over premia and fees that
+    /// overflow their own accumulation and quantities that overflow the
+    /// product with it.
+    #[test]
+    fn test_position_costs_never_panic(
+        strike in extreme_positive(),
+        underlying in extreme_positive(),
+        premium in extreme_positive(),
+        open_fee in extreme_positive(),
+        close_fee in extreme_positive(),
+        quantity in extreme_positive(),
+        volatility in extreme_positive(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_positive(),
+        (side, style) in extreme_kind(),
+    ) {
+        let position = Position::new(
+            Options::new(
+                OptionType::European,
+                side,
+                "PROP".to_string(),
+                strike,
+                expiration,
+                volatility,
+                quantity,
+                underlying,
+                rate,
+                style,
+                Positive::ZERO,
+                None,
+            ),
+            premium,
+            chrono::Utc::now(),
+            open_fee,
+            close_fee,
+            None,
+            None,
+        );
+
+        let _ = position.total_cost();
+        let _ = position.fees();
+        let _ = position.net_cost();
+        let _ = position.premium_received();
+        let _ = position.net_premium_received();
+        let _ = position.break_even();
+        let _ = position.validate();
+        let _ = position.trade();
+        let _ = position.pnl_at_expiration(&Some(&probe));
+        let _ = position.pnl_at_expiration(&None);
+        let _ = position.unrealized_pnl(probe);
+        let _ = position.calculate_pnl_at_expiration(&probe);
+    }
+
+    /// The relative-expiration resolver over horizons the calendar cannot
+    /// hold. Both entry points must report rather than abort, and they must
+    /// agree: a day count the guard accepts is one the resolver can resolve.
+    #[test]
+    fn test_expiration_resolution_never_panics(expiration in extreme_expiration()) {
+        let resolved = resolve_expiration_date(&expiration);
+        let accepted = reject_unrepresentable_expiration(&expiration);
+        if accepted.is_ok() {
+            prop_assert!(resolved.is_ok());
+        }
+    }
+
+    /// The sample mean and standard deviation over values that overflow their
+    /// own sum, and over the empty sample that has no mean at all.
+    #[test]
+    fn test_mean_and_std_never_panics(sample in prop::collection::vec(extreme_positive(), 0..6)) {
+        let _ = mean_and_std(sample);
+    }
+}

--- a/tests/property/strategies_panic_freedom_test.rs
+++ b/tests/property/strategies_panic_freedom_test.rs
@@ -67,15 +67,32 @@ fn extreme_positive() -> impl Strategy<Value = Positive> {
     ]
 }
 
-/// Premia and fees, bounded below the magnitude at which a *single* leg's own
-/// `Position::total_cost` overflows.
-///
-/// `(premium + open_fee + close_fee) * quantity` is computed with the raw
-/// `Positive` operators in `src/model/position.rs`, which this sweep does not
-/// touch; that overflow is reported separately. Everything above this bound
-/// aborts before the composition layer is reached, so driving it here would
-/// only re-find the model-layer defect.
+/// Premia and fees over the whole `Positive` range, up to and including the
+/// magnitude at which a single leg's own `Position::total_cost` overflows.
 fn extreme_money() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(pos(TINY)),
+        Just(pos(dec!(0.01))),
+        Just(Positive::ONE),
+        Just(Positive::HUNDRED),
+        Just(pos(dec!(100000000000000))),
+        Just(Positive::MAX),
+    ]
+}
+
+/// Premia, fees and spot prices for the spot-leg strategies, bounded below the
+/// magnitude at which the *infallible* signatures they run through overflow.
+///
+/// `LegAble::pnl_at_price`, `LegAble::total_cost` and `LegAble::fees` return a
+/// bare `Decimal` or `Positive` (`src/model/leg/spot.rs:251`, `:262` and
+/// `:269`) and `Collar::net_premium` returns a bare `Decimal`
+/// (`src/strategies/collar.rs:361`). All four multiply and add with the raw
+/// operators and have nowhere to report an overflow, so they abort. Lifting
+/// this bound needs those signatures to gain an error channel, which is a
+/// change to the `LegAble` trait and to the spot-leg strategies, both outside
+/// the model-layer sweep that unbounded the generators above.
+fn spot_leg_money() -> impl Strategy<Value = Positive> {
     prop_oneof![
         Just(Positive::ZERO),
         Just(pos(TINY)),
@@ -86,9 +103,8 @@ fn extreme_money() -> impl Strategy<Value = Positive> {
     ]
 }
 
-/// Contract and share counts, bounded for the same reason as
-/// [`extreme_money`]. Zero is kept: it is the divisor of every per-contract
-/// and per-share figure in this layer.
+/// Contract and share counts. Zero is kept: it is the divisor of every
+/// per-contract and per-share figure in this layer.
 fn extreme_quantity() -> impl Strategy<Value = Positive> {
     prop_oneof![
         Just(Positive::ZERO),
@@ -99,14 +115,9 @@ fn extreme_quantity() -> impl Strategy<Value = Positive> {
     ]
 }
 
-/// Volatilities, bounded below the magnitude at which
-/// `model::utils::mean_and_std` overflows.
-///
-/// Every `get_profit_ranges` implementation averages the leg volatilities
-/// through that helper, which sums them with the raw `Positive` operator and
-/// has no error channel (it returns `(Positive, Positive)`). That overflow
-/// lives in `src/model`, which this sweep does not touch, and is reported
-/// separately.
+/// Volatilities over the whole `Positive` range, up to and including the
+/// magnitude at which averaging them through `model::utils::mean_and_std`
+/// overflows.
 fn extreme_volatility() -> impl Strategy<Value = Positive> {
     prop_oneof![
         Just(Positive::ZERO),
@@ -115,6 +126,7 @@ fn extreme_volatility() -> impl Strategy<Value = Positive> {
         Just(Positive::ONE),
         Just(pos(dec!(1000000))),
         Just(pos(dec!(1000000000000000))),
+        Just(Positive::MAX),
     ]
 }
 
@@ -160,8 +172,10 @@ fn extreme_decimal() -> impl Strategy<Value = Decimal> {
     ]
 }
 
-/// Expirations from one already reached, through a sub-second sliver, to a
-/// horizon whose `DateTime` arithmetic is itself at the edge.
+/// Expirations from one already reached, through a sub-second sliver, to
+/// horizons past the calendar itself: a billion days overflows the
+/// `DateTime + TimeDelta` addition, `1e15` days overflows `TimeDelta`, and
+/// `Positive::MAX` days does not even fit the `i64` day count.
 fn extreme_expiration() -> impl Strategy<Value = ExpirationDate> {
     prop_oneof![
         Just(ExpirationDate::Days(Positive::ZERO)),
@@ -169,6 +183,9 @@ fn extreme_expiration() -> impl Strategy<Value = ExpirationDate> {
         Just(ExpirationDate::Days(Positive::ONE)),
         Just(ExpirationDate::Days(pos(dec!(30)))),
         Just(ExpirationDate::Days(pos(dec!(3650)))),
+        Just(ExpirationDate::Days(pos(dec!(1000000000)))),
+        Just(ExpirationDate::Days(pos(dec!(1000000000000000)))),
+        Just(ExpirationDate::Days(Positive::MAX)),
     ]
 }
 
@@ -359,20 +376,19 @@ proptest! {
     /// basis net of a credit that the fees can turn into a debit.
     #[test]
     fn test_spot_leg_strategies_never_panic(
-        // The spot price and the probe price are bounded here for the same
-        // reason as `extreme_money`: `SpotPosition::pnl_at_price` multiplies
-        // their difference by the share count with the raw operator, in
-        // `src/model/leg/spot.rs`.
-        underlying in extreme_money(),
+        // Every monetary argument of this test goes through an infallible
+        // signature in the spot leg; see [`spot_leg_money`] for the four sites
+        // and why they are not this sweep's to fix.
+        underlying in spot_leg_money(),
         put_strike in extreme_positive(),
         call_strike in extreme_positive(),
         volatility in extreme_volatility(),
         quantity in extreme_quantity(),
-        premium in extreme_money(),
-        fee in extreme_money(),
+        premium in spot_leg_money(),
+        fee in spot_leg_money(),
         rate in extreme_decimal(),
         expiration in extreme_expiration(),
-        probe in extreme_money(),
+        probe in spot_leg_money(),
     ) {
         if let Ok(mut strategy) = Collar::new(
             "PROP".to_string(), underlying, put_strike, call_strike, expiration,


### PR DESCRIPTION
## Summary

Three defects in the model layer that the composition sweep (#468) reached but
could not fix in scope. Together they were **126 of the 363 panics that sweep
left behind**, and they are why its property test had to bound three of its
generators.

## 1. `Position` cost arithmetic

`total_cost` and `fees` accumulated the premium and the two fees and scaled the
result by the contract quantity with the raw `Positive` operators — inside
functions that already returned `Result<Positive, PositionError>` and so had
somewhere to put the failure all along.

Every step is checked now. `PositionError` grows a `PositiveError` variant so
the cause is carried rather than flattened into a message; the alternative the
issue offered, mapping through `PositionError::invalid_position`, would have
thrown the typed cause away at the only place it is known.

Both doc comments claimed the function was "currently infallible". That was
true when written and stops being true here, so the paragraphs are gone rather
than left to mislead.

## 2. Calendar overflow through `get_date()`

`ExpirationDate::Days(1e9)` aborted with `` `DateTime + TimeDelta` overflowed ``
inside `expiration_date` 0.3.0, and **every strategy reaches it** through
`calculate_pnl_at_expiration`. This was the single largest residual.

#441 guarded the one call site in `OptionChain::build_chain`. This is the
general case, so the guard moves to `src/model/expiration.rs` as
`resolve_expiration_date` and `reject_unrepresentable_expiration`, and
`build_chain` calls the shared one instead of keeping its own copy.

The resolution mirrors the upstream expression step by step — the same
`Positive` → `i64` conversion, the same day-to-span conversion, the same
addition — each through its checked counterpart. The instant returned is
therefore identical for every input the panicking form accepted; only the
inputs it used to abort on behave differently, and those now report.

## 3. `mean_and_std`

```rust
vec.iter().sum::<Positive>() / vec.len() as f64
```

Overflowed on the sum and divided by zero on an empty vector. It returns
`Result<(Positive, Positive), PositiveError>` now, and the sixteen
`get_profit_ranges` implementations that average their leg volatilities through
it propagate.

The squared deviations are still taken in `f64`, exactly as before, so the
returned figures are unchanged for every sample the panicking form accepted.
What changes is the reporting: a deviation that overflows `f64` used to
collapse to zero through `unwrap_or(Positive::ZERO)` and now surfaces.

## What this unlocks in the property test

The strategies sweep can now drive what it had to avoid:

- **premium and fees** — unbounded, `Positive::MAX` included
- **volatility** — unbounded, `Positive::MAX` included
- **expirations** — a billion days, `1e15` days and `Positive::MAX` days: past
  the calendar, past `TimeDelta`, and past the `i64` day count respectively

The three doc comments explaining why each bound existed are gone with the
bounds.

**One bound survives**, narrowed and renamed to `spot_leg_money` so it says
what it actually is: the spot-leg strategies run through
`LegAble::pnl_at_price`, `LegAble::total_cost`, `LegAble::fees` and
`Collar::net_premium`, all of which return a bare `Decimal` or `Positive` and
have nowhere to report an overflow. Lifting it needs those signatures to gain
an error channel — which is #471, the last PR of this chain. The comment on the
generator names the four functions and their line numbers rather than saying
"outside this sweep".

## Tests

4684 passed, 0 failed. 66 property tests, up from 63 — a new
`tests/property/model_panic_freedom_test.rs` drives the three fixed sites
directly. Existing tests pass unedited.

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features
--workspace -- -D warnings`, `make scan-banned` and `make public-api-check`
clean.

## Public API

```diff
-pub fn model::utils::mean_and_std(Vec<Positive>) -> (Positive, Positive)
+pub fn model::utils::mean_and_std(Vec<Positive>) -> Result<(Positive, Positive), PositiveError>
+pub enum variant PositionError::PositiveError(PositiveError)
+pub fn model::resolve_expiration_date(&ExpirationDate) -> Result<DateTime<Utc>, ExpirationDateError>
+pub fn model::reject_unrepresentable_expiration(&ExpirationDate) -> Result<(), ExpirationDateError>
```

Snapshot regenerated and committed.

**Expect `semver` to fail on this PR until the 0.21.0 bump lands.** `PositionError`
is not `#[non_exhaustive]`, so adding a variant trips `enum_variant_added`
against a `Cargo.toml` still reading 0.20.0 — the same reason #473 went red,
diagnosed there. Rebasing onto a `main` that carries the bump clears it; no
change to this diff is needed. The `mean_and_std` retyping has no lint of its
own, which is the gap #455 exists for, so it is declared here instead.

## Stack

Chain A of four independent chains off `main`, and the bottom of its chain.

- Stack: **#470** (this one) → #469 → #463 → #471. Independent of chain B
  (#466 → #451 → #453), chain C (#462), #459, and the #442 capstone.
- Base branch: `main`.
- The next three PRs in this chain branch off this one, so read their diffs
  against this branch rather than against `main`.

Closes #470
