### PR TITLE
Stop a lost race on file removal failing the coverage job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`prepare_file_path` reported failure for a file that was already gone.**
+  It tested `Path::exists` and then removed, so anything deleting the file in
+  between made `remove_file` fail with `NotFound` — for a postcondition that
+  already held. Every `write_html` / `write_png` caller inherited it. Two
+  tests sharing a working directory were enough to lose the race, and it
+  aborted a whole `cargo tarpaulin` run on `main` with `Failed to remove
+  existing file: multiple_curves_test.html`, taking a coverage report down
+  over a file nobody was reading. The removal is now attempted
+  unconditionally and `NotFound` is accepted, which also makes the function
+  idempotent for concurrent writers downstream.
+- The four `plotters` tests that came in `_bis` pairs wrote to the same two
+  paths as their originals, so they raced each other by construction. Each
+  pair now writes its own file.
+
 ### Changed
 
 - **Two `ProtectivePut` methods are now fallible, which is a breaking change**

--- a/src/curves/visualization/plotters.rs
+++ b/src/curves/visualization/plotters.rs
@@ -216,14 +216,14 @@ mod tests {
 
         #[cfg(feature = "plotly")]
         {
-            let file_path_html = "single_curve_test.html".as_ref();
+            let file_path_html = "single_curve_bis_test.html".as_ref();
 
             curve.write_html(file_path_html).unwrap();
             cleanup_image(file_path_html);
 
             #[cfg(feature = "static_export")]
             {
-                let file_path_png = "single_curve_test.png".as_ref();
+                let file_path_png = "single_curve_bis_test.png".as_ref();
                 // PNG rendering requires a headless browser, which may not be available in CI
                 if curve.write_png(file_path_png).is_ok() {
                     cleanup_image(file_path_png);
@@ -324,13 +324,13 @@ mod tests {
 
         #[cfg(feature = "plotly")]
         {
-            let file_path_html = "multiple_curves_test.html".as_ref();
+            let file_path_html = "multiple_curves_bis_test.html".as_ref();
             curve_vector.write_html(file_path_html).unwrap();
             cleanup_image(file_path_html);
 
             #[cfg(feature = "static_export")]
             {
-                let file_path_png = "multiple_curves_test.png".as_ref();
+                let file_path_png = "multiple_curves_bis_test.png".as_ref();
                 // PNG rendering requires a headless browser, which may not be available in CI
                 if curve_vector.write_png(file_path_png).is_ok() {
                     cleanup_image(file_path_png);

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -1,11 +1,13 @@
 use std::io::Error as IoError;
+use std::io::ErrorKind;
 use std::path::Path;
 use tracing::{debug, error, trace};
 
 /// Prepares a path for writing by removing any existing file and creating necessary directories.
 ///
 /// This function:
-/// 1. Removes the file if it already exists
+/// 1. Removes the file if it already exists, and accepts a file that is
+///    already gone: the guarantee is that nothing sits at `path` afterwards
 /// 2. Creates all parent directories if they don't exist
 ///
 /// # Arguments
@@ -23,19 +25,26 @@ use tracing::{debug, error, trace};
 /// (typically `PermissionDenied`, `NotFound` on a broken symlink
 /// ancestor, or the platform-specific disk-full case).
 pub fn prepare_file_path(path: &Path) -> Result<(), IoError> {
-    // Remove file if it already exists
-    if path.exists() {
-        match std::fs::remove_file(path) {
-            Ok(_) => {}
-            Err(e) => {
-                error!("Failed to remove existing file: {}", path.display());
-                return Err(IoError::new(
-                    e.kind(),
-                    format!("Failed to remove existing file: {}", path.display()),
-                ));
-            }
-        };
-        trace!("Removed existing file: {}", path.display());
+    // What this has to guarantee is that nothing sits at `path`, so a file
+    // that is already gone satisfies it. Testing `exists()` first and removing
+    // afterwards is a race — anything else deleting the file in between makes
+    // the removal fail with `NotFound` for a postcondition that already holds
+    // — so the removal is attempted unconditionally and that one kind is
+    // accepted. Two tests in one working directory are enough to lose the
+    // race: it aborted a coverage run on `main` with `Failed to remove
+    // existing file: multiple_curves_test.html`, kind `NotFound`.
+    match std::fs::remove_file(path) {
+        Ok(()) => trace!("Removed existing file: {}", path.display()),
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            trace!("Nothing to remove at: {}", path.display());
+        }
+        Err(e) => {
+            error!("Failed to remove existing file: {}", path.display());
+            return Err(IoError::new(
+                e.kind(),
+                format!("Failed to remove existing file: {}", path.display()),
+            ));
+        }
     }
 
     // Create parent directories if they don't exist
@@ -56,4 +65,47 @@ pub fn prepare_file_path(path: &Path) -> Result<(), IoError> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// The postcondition is "nothing sits at `path`", so a path that is
+    /// already clear is a success, not a failure. Calling twice in a row is
+    /// the sequential form of the race that aborted a coverage run: two tests
+    /// sharing a working directory, one removing the file between the other's
+    /// existence check and its removal.
+    #[test]
+    fn test_prepare_file_path_accepts_a_path_with_no_file() {
+        let dir = std::env::temp_dir().join("optionstratlib_prepare_file_path");
+        fs::create_dir_all(&dir).expect("the temp directory is writable");
+        let path = dir.join("absent.html");
+        let _ = fs::remove_file(&path);
+
+        prepare_file_path(&path).expect("an absent file is already prepared");
+
+        fs::write(&path, b"contents").expect("the temp directory is writable");
+        prepare_file_path(&path).expect("an existing file is removed");
+        assert!(!path.exists());
+
+        prepare_file_path(&path).expect("preparing twice is not an error");
+        assert!(!path.exists());
+    }
+
+    /// The parent directories are still created for a path that does not have
+    /// them yet, which is the other half of what this does.
+    #[test]
+    fn test_prepare_file_path_creates_missing_parents() {
+        let dir = std::env::temp_dir().join("optionstratlib_prepare_file_path/nested/deeper");
+        let _ = fs::remove_dir_all(
+            std::env::temp_dir().join("optionstratlib_prepare_file_path/nested"),
+        );
+        let path = dir.join("target.html");
+
+        prepare_file_path(&path).expect("the parents are created");
+
+        assert!(dir.exists());
+    }
 }


### PR DESCRIPTION
## Summary

`code_coverage_report` failed on `main` after #472 merged, for a reason that has nothing to do with #472:

```
curves::visualization::plotters::tests::test_multiple_curves_plot panicked at plotters.rs:264
called `Result::unwrap()` on an `Err` value: Io(Custom { kind: NotFound,
  error: "Failed to remove existing file: multiple_curves_test.html" })
test result: FAILED. 3982 passed; 1 failed
ERROR cargo_tarpaulin: Test failed during run
```

Two defects stacked on top of each other, and both are fixed here.

## The library one

`prepare_file_path` tested `Path::exists` and then called `remove_file`:

```rust
if path.exists() {
    match std::fs::remove_file(path) {
        Err(e) => return Err(...),   // e.kind() == NotFound
```

The guarantee it owes its callers is that nothing sits at `path` afterwards. A file that is *already* gone satisfies that, but the check-then-act shape turns it into a failure: anything deleting the file between the two calls makes the removal fail with `NotFound` for a postcondition that already holds. Every `write_html` and `write_png` caller inherited it, so a downstream service writing charts from two threads hits it too.

The removal is now attempted unconditionally and `NotFound` accepted — which is exactly what `cleanup_image`, the helper in the same file's own test module, was already doing.

## The test one

`multiple_curves_test.html` is written by **two** tests, `test_multiple_curves_plot` and `test_multiple_curves_plot_bis`, and `single_curve_test.html` by another such pair. Rust runs tests in parallel threads in one working directory, so each pair raced by construction; one test's `cleanup_image` removed the file inside the other's `prepare_file_path`. Each pair now writes its own path.

## Why it is worth its own PR

The failure is not deterministic, so it lands on whichever PR happens to be in flight — it has already put a red check on a merge queue that had nothing to do with it. And tarpaulin fails the entire run on one failed test, so the coverage report disappears with it. A coverage job that goes red for a reason nobody reads is how a real coverage regression gets waved through.

## Testing

- [x] Two regressions on `prepare_file_path`: a path with no file is prepared successfully, and preparing twice in a row — the sequential form of the lost race — is not an error. The parent-directory half is covered too, since that behaviour moved next to the rewritten branch
- [x] 3985 lib tests, 0 failures; `cargo fmt --all --check` and clippy `-D warnings` clean

## Public API impact

None. `prepare_file_path` keeps its signature; only the error it produces for an absent file changes, from `Err(NotFound)` to `Ok(())`.