### PR TITLE
Refuse the alpha sentinel in an aggregate instead of aborting or dropping a leg (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,10 +223,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Decimal::MAX + Decimal::MAX`.
 
   The quieter half is the one worth knowing about. A single sentinel leg beside
-  an ordinary one did *not* abort: `Decimal::MAX + x` for `|x| < 1` rescales and
-  rounds straight back to `Decimal::MAX`, so the addition succeeds, the running
-  total stands still, and the ordinary leg's alpha is dropped without a trace.
-  `checked_add` cannot detect that, because nothing overflowed. Both halves are
+  an ordinary one did *not* abort: `Decimal::MAX + x` for `|x| < 0.5` rescales
+  the addend down to zero and rounds straight back to `Decimal::MAX`, so the
+  addition succeeds, the running total stands still, and the ordinary leg's
+  alpha is dropped without a trace. `checked_add` cannot detect that, because
+  nothing overflowed. Both halves are
   now a `GreeksError` naming the leg that carried the sentinel, raised by an
   explicit guard ahead of the arithmetic rather than by the arithmetic itself.
   The remaining twenty-two accumulations moved to checked addition, so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Aggregating greeks aborted the process on two legs whose theta had
+  vanished, and returned a silently-wrong total when one such leg met an
+  ordinary one** (#469). `Greeks::greeks` and the twelve per-greek aggregators
+  summed their legs with the raw `Decimal` operator, which panics on overflow.
+  For eleven of the twelve that needs an extreme book; for `alpha` it does not.
+  `alpha` returns `Decimal::MAX` as a documented sentinel when a leg's theta
+  rounds to zero while its gamma does not — an at-the-money contract at a
+  quantity around `1e-27` is enough — so two such legs aborted on
+  `Decimal::MAX + Decimal::MAX`.
+
+  The quieter half is the one worth knowing about. A single sentinel leg beside
+  an ordinary one did *not* abort: `Decimal::MAX + x` for `|x| < 1` rescales and
+  rounds straight back to `Decimal::MAX`, so the addition succeeds, the running
+  total stands still, and the ordinary leg's alpha is dropped without a trace.
+  `checked_add` cannot detect that, because nothing overflowed. Both halves are
+  now a `GreeksError` naming the leg that carried the sentinel, raised by an
+  explicit guard ahead of the arithmetic rather than by the arithmetic itself.
+  The remaining twenty-two accumulations moved to checked addition, so an
+  ordinary sum that leaves the representable range is reported instead of
+  aborting; every sum that stayed inside it is unchanged, `Decimal::checked_add`
+  and `Add::add` being the same operation but for the overflow arm.
+
+  **A lone sentinel leg still returns the sentinel**, as does a sentinel beside
+  legs whose own alpha is zero, because no contribution is lost in those sums.
+  `OptionData::greeks_snapshot` therefore behaves exactly as before: it computes
+  the twelve greeks for one option and maps an `alpha` of `Decimal::MAX` to
+  `None` on the wire. Chain snapshots have not started failing. The sentinel
+  itself is unchanged, and so is the single-option `greeks::alpha`.
 - **Every arithmetic Asian option with `r = q` was mispriced** (#454). The
   Turnbull-Wakeman second moment short-circuited its removable `b = 0`
   singularity to `M2 = S² e^{σ² T}`, which is `E[S_T²]`: the second moment of

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -232,7 +232,7 @@ pub trait Greeks {
         let mut vega = Decimal::ZERO;
         let mut rho = Decimal::ZERO;
         let mut rho_d = Decimal::ZERO;
-        let mut alpha = Decimal::ZERO;
+        let mut alpha = AlphaSum::default();
         let mut vanna = Decimal::ZERO;
         let mut vomma = Decimal::ZERO;
         let mut veta = Decimal::ZERO;
@@ -246,13 +246,7 @@ pub trait Greeks {
             vega = d_add(vega, single.vega, "greeks::aggregate::vega")?;
             rho = d_add(rho, single.rho, "greeks::aggregate::rho")?;
             rho_d = d_add(rho_d, single.rho_d, "greeks::aggregate::rho_d")?;
-            alpha = add_alpha(
-                alpha,
-                single.alpha,
-                option,
-                index,
-                "greeks::aggregate::alpha",
-            )?;
+            alpha = alpha.push(single.alpha, option, index, "greeks::aggregate::alpha")?;
             vanna = d_add(vanna, single.vanna, "greeks::aggregate::vanna")?;
             vomma = d_add(vomma, single.vomma, "greeks::aggregate::vomma")?;
             veta = d_add(veta, single.veta, "greeks::aggregate::veta")?;
@@ -266,7 +260,7 @@ pub trait Greeks {
             vega,
             rho,
             rho_d,
-            alpha,
+            alpha: alpha.total,
             vanna,
             vomma,
             veta,
@@ -417,17 +411,12 @@ pub trait Greeks {
     /// the sentinel and another leg contributes to the same sum.
     fn alpha(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
-        let mut alpha_value = Decimal::ZERO;
+        let mut alpha_value = AlphaSum::default();
         for (index, option) in options.into_iter().enumerate() {
-            alpha_value = add_alpha(
-                alpha_value,
-                alpha(option)?,
-                option,
-                index,
-                "greeks::alpha::aggregate",
-            )?;
+            alpha_value =
+                alpha_value.push(alpha(option)?, option, index, "greeks::alpha::aggregate")?;
         }
-        Ok(alpha_value)
+        Ok(alpha_value.total)
     }
 
     /// Calculates the aggregate vanna value for all options.
@@ -1854,20 +1843,62 @@ fn alpha_from(gamma: Decimal, theta: Decimal) -> Result<Decimal, GreeksError> {
 /// sentinel would meet a contribution, and
 /// [`crate::error::DecimalError::Overflow`] when an ordinary sum leaves the
 /// representable range.
-#[inline]
-fn add_alpha(
+/// Running alpha aggregate.
+///
+/// The two facts the rule needs — whether a real contribution has been made,
+/// and whether the sentinel has been seen — cannot be read back off a
+/// `Decimal` total, and inferring them from it makes the answer depend on the
+/// order the legs arrive in. Reading "no contribution yet" as `total ==
+/// ZERO` mistakes a pair of legs that cancel for no legs at all: `[+5, -5,
+/// sentinel]` returned the sentinel while `[sentinel, +5, -5]` was refused,
+/// for the same three legs. A sum has no business depending on leg order, so
+/// the facts are carried rather than inferred.
+#[derive(Clone, Copy, Debug, Default)]
+struct AlphaSum {
     total: Decimal,
-    value: Decimal,
-    option: &Options,
-    index: usize,
-    op: &'static str,
-) -> Result<Decimal, GreeksError> {
-    let sentinel_meets_a_contribution = (value == Decimal::MAX && total != Decimal::ZERO)
-        || (total == Decimal::MAX && value != Decimal::ZERO);
-    if sentinel_meets_a_contribution {
-        return Err(alpha_sentinel_error(option, index));
+    contributed: bool,
+    sentinel: bool,
+}
+
+impl AlphaSum {
+    /// Folds one leg's alpha in, refusing exactly the sums that would lose a
+    /// contribution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GreeksError::CalculationError`] naming the leg when the
+    /// sentinel would meet a contribution in either order, or a second
+    /// sentinel, and [`crate::error::DecimalError::Overflow`] when an
+    /// ordinary sum leaves the representable range.
+    fn push(
+        mut self,
+        value: Decimal,
+        option: &Options,
+        index: usize,
+        op: &'static str,
+    ) -> Result<Self, GreeksError> {
+        if value == Decimal::MAX {
+            // A second sentinel would leave the range; a sentinel after a
+            // contribution would swallow it.
+            if self.contributed || self.sentinel {
+                return Err(alpha_sentinel_error(option, index));
+            }
+            self.sentinel = true;
+            self.total = Decimal::MAX;
+            return Ok(self);
+        }
+        // A leg whose own alpha is zero adds nothing and loses nothing, so it
+        // neither counts as a contribution nor conflicts with the sentinel.
+        if value.is_zero() {
+            return Ok(self);
+        }
+        if self.sentinel {
+            return Err(alpha_sentinel_error(option, index));
+        }
+        self.contributed = true;
+        self.total = d_add(self.total, value, op)?;
+        Ok(self)
     }
-    Ok(d_add(total, value, op)?)
 }
 
 /// Builds the error [`add_alpha`] returns, naming the leg that carries the
@@ -5715,6 +5746,44 @@ mod tests_checked_aggregation {
     use crate::{ExpirationDate, Options};
     use positive::{Positive, pos_or_panic};
     use rust_decimal_macros::dec;
+
+    /// A sum must not depend on the order its terms arrive in. Inferring "no
+    /// contribution yet" from `total == ZERO` broke that: two legs whose
+    /// alphas cancel look identical to no legs at all, so `[+5, -5, sentinel]`
+    /// returned the sentinel while `[sentinel, +5, -5]` was refused, for the
+    /// same three legs. Both are refused now, because in both a real
+    /// contribution meets the sentinel.
+    #[test]
+    fn test_alpha_sum_refuses_the_sentinel_whatever_the_leg_order() {
+        let option = leg(
+            OptionType::European,
+            Positive::HUNDRED,
+            pos_or_panic!(30.0),
+            pos_or_panic!(0.2),
+            OptionStyle::Call,
+            Side::Long,
+            Positive::ONE,
+        );
+        let fold = |values: &[Decimal]| -> Result<Decimal, GreeksError> {
+            let mut sum = AlphaSum::default();
+            for (index, value) in values.iter().enumerate() {
+                sum = sum.push(*value, &option, index, "test::alpha_sum")?;
+            }
+            Ok(sum.total)
+        };
+
+        assert!(fold(&[dec!(5), dec!(-5), Decimal::MAX]).is_err());
+        assert!(fold(&[Decimal::MAX, dec!(5), dec!(-5)]).is_err());
+
+        // The two allowed shapes stay allowed, in either order.
+        assert_eq!(fold(&[Decimal::MAX]).unwrap(), Decimal::MAX);
+        assert_eq!(
+            fold(&[Decimal::ZERO, Decimal::MAX, Decimal::ZERO]).unwrap(),
+            Decimal::MAX
+        );
+        // And an ordinary sum is still an ordinary sum.
+        assert_eq!(fold(&[dec!(5), dec!(-5)]).unwrap(), Decimal::ZERO);
+    }
 
     /// A quantity small enough that the daily theta of an ordinary at-the-money
     /// contract rounds to zero at `Decimal`'s twenty-eight-digit scale while its

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -399,7 +399,7 @@ pub trait Greeks {
     /// [`alpha`] answers `Decimal::MAX` for a leg whose theta has vanished, and
     /// that value cannot be added to a real one. Two such legs leave the
     /// representable range. One beside an ordinary leg does not, which is
-    /// worse: `Decimal::MAX` plus a value below one rescales and rounds
+    /// worse: `Decimal::MAX` plus a value below `0.5` rescales and rounds
     /// straight back to `Decimal::MAX`, so the arithmetic succeeds while the
     /// ordinary leg's contribution is silently dropped.
     ///
@@ -1788,7 +1788,10 @@ pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
 /// sentinel with another leg's contribution at all, and report which leg
 /// carried it; see [`add_alpha`]. That covers the abort and the quieter
 /// failure beside it, where `Decimal::MAX` plus a small value rescales back to
-/// `Decimal::MAX` and drops the other leg without any arithmetic error.
+/// `Decimal::MAX` and drops the other leg without any arithmetic error. That
+/// second mechanism is a property of `Decimal`, not of this sentinel, and is
+/// pinned by `model::decimal`'s
+/// `checked_add_near_max_reports_ok_without_moving_the_value`.
 ///
 /// Nothing prevents a caller from reaching the sentinel, so it is described
 /// here rather than declared impossible: no constructor bounds the quantity
@@ -1819,11 +1822,13 @@ fn alpha_from(gamma: Decimal, theta: Decimal) -> Result<Decimal, GreeksError> {
 ///
 /// [`alpha_from`] answers `Decimal::MAX` for a leg whose theta has vanished.
 /// That value cannot be added to a real one: `Decimal::MAX` plus anything of
-/// magnitude below one rescales and rounds straight back to `Decimal::MAX`, so
-/// `checked_add` answers `Some` with the accumulator standing still and the
+/// magnitude below `0.5` rescales and rounds straight back to `Decimal::MAX`,
+/// so `checked_add` answers `Some` with the accumulator standing still and the
 /// other leg's alpha silently dropped. `checked_add` cannot detect that — the
 /// arithmetic genuinely succeeded — so the guard is explicit rather than
-/// arithmetic, and it runs before [`d_add`] is reached.
+/// arithmetic, and it runs before [`d_add`] is reached. The mechanism is pinned
+/// by `model::decimal`'s
+/// `checked_add_near_max_reports_ok_without_moving_the_value`.
 ///
 /// Refused, therefore:
 ///

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -211,7 +211,12 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if any individual Greek calculation fails.
+    /// Returns a `GreeksError` if any individual Greek calculation fails, or
+    /// [`crate::error::DecimalError::Overflow`] (wrapped by `GreeksError`) when
+    /// one of the twelve running sums leaves the representable `Decimal` range.
+    /// The `alpha` sum is the one that reaches that limit on ordinary input:
+    /// [`alpha`] returns `Decimal::MAX` whenever a leg's theta vanishes, so two
+    /// such legs overflow.
     fn greeks(&self) -> Result<Greek, GreeksError> {
         // Aggregate option by option rather than greek by greek, so the shared
         // Black-Scholes kernels are computed once per option instead of once
@@ -232,18 +237,18 @@ pub trait Greeks {
         let mut color = Decimal::ZERO;
         for option in options {
             let single = greeks_for(option)?;
-            delta += single.delta;
-            gamma += single.gamma;
-            theta += single.theta;
-            vega += single.vega;
-            rho += single.rho;
-            rho_d += single.rho_d;
-            alpha += single.alpha;
-            vanna += single.vanna;
-            vomma += single.vomma;
-            veta += single.veta;
-            charm += single.charm;
-            color += single.color;
+            delta = d_add(delta, single.delta, "greeks::aggregate::delta")?;
+            gamma = d_add(gamma, single.gamma, "greeks::aggregate::gamma")?;
+            theta = d_add(theta, single.theta, "greeks::aggregate::theta")?;
+            vega = d_add(vega, single.vega, "greeks::aggregate::vega")?;
+            rho = d_add(rho, single.rho, "greeks::aggregate::rho")?;
+            rho_d = d_add(rho_d, single.rho_d, "greeks::aggregate::rho_d")?;
+            alpha = d_add(alpha, single.alpha, "greeks::aggregate::alpha")?;
+            vanna = d_add(vanna, single.vanna, "greeks::aggregate::vanna")?;
+            vomma = d_add(vomma, single.vomma, "greeks::aggregate::vomma")?;
+            veta = d_add(veta, single.veta, "greeks::aggregate::veta")?;
+            charm = d_add(charm, single.charm, "greeks::aggregate::charm")?;
+            color = d_add(color, single.color, "greeks::aggregate::color")?;
         }
         Ok(Greek {
             delta,
@@ -268,12 +273,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or delta calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or delta calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn delta(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut delta_value = Decimal::ZERO;
         for option in options {
-            delta_value += delta(option)?;
+            delta_value = d_add(delta_value, delta(option)?, "greeks::delta::aggregate")?;
         }
         Ok(delta_value)
     }
@@ -285,12 +292,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or gamma calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or gamma calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn gamma(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut gamma_value = Decimal::ZERO;
         for option in options {
-            gamma_value += gamma(option)?;
+            gamma_value = d_add(gamma_value, gamma(option)?, "greeks::gamma::aggregate")?;
         }
         Ok(gamma_value)
     }
@@ -302,12 +311,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or theta calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or theta calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn theta(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut theta_value = Decimal::ZERO;
         for option in options {
-            theta_value += theta(option)?;
+            theta_value = d_add(theta_value, theta(option)?, "greeks::theta::aggregate")?;
         }
         Ok(theta_value)
     }
@@ -319,12 +330,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or vega calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or vega calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn vega(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut vega_value = Decimal::ZERO;
         for option in options {
-            vega_value += vega(option)?;
+            vega_value = d_add(vega_value, vega(option)?, "greeks::vega::aggregate")?;
         }
         Ok(vega_value)
     }
@@ -336,12 +349,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or rho calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or rho calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn rho(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut rho_value = Decimal::ZERO;
         for option in options {
-            rho_value += rho(option)?;
+            rho_value = d_add(rho_value, rho(option)?, "greeks::rho::aggregate")?;
         }
         Ok(rho_value)
     }
@@ -353,12 +368,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or rho_d calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or rho_d calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn rho_d(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut rho_d_value = Decimal::ZERO;
         for option in options {
-            rho_d_value += rho_d(option)?;
+            rho_d_value = d_add(rho_d_value, rho_d(option)?, "greeks::rho_d::aggregate")?;
         }
         Ok(rho_d_value)
     }
@@ -368,14 +385,28 @@ pub trait Greeks {
     /// Alpha represents the ratio between gamma and theta, providing insight into
     /// the option's risk/reward efficiency with respect to time decay.
     ///
+    /// # The sentinel in a sum
+    ///
+    /// [`alpha`] answers `Decimal::MAX` for a leg whose theta has vanished, and
+    /// summing that is degenerate in both directions. Two such legs leave the
+    /// representable range and are reported as an error. A single one beside an
+    /// ordinary leg is *not*: `Decimal::MAX` plus a value below one rescales and
+    /// rounds straight back to `Decimal::MAX`, so the sum stands still and the
+    /// ordinary leg's contribution is lost. Callers that need to tell the two
+    /// apart should check the per-leg [`alpha`] for the sentinel before summing.
+    ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or alpha calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or alpha calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum leaves
+    /// the representable `Decimal` range. Unlike the other eleven, that limit is
+    /// reachable on ordinary input: [`alpha`] returns `Decimal::MAX` whenever a leg's
+    /// theta vanishes, so two such legs overflow.
     fn alpha(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut alpha_value = Decimal::ZERO;
         for option in options {
-            alpha_value += alpha(option)?;
+            alpha_value = d_add(alpha_value, alpha(option)?, "greeks::alpha::aggregate")?;
         }
         Ok(alpha_value)
     }
@@ -387,12 +418,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or vanna calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or vanna calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn vanna(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut vanna_value = Decimal::ZERO;
         for option in options {
-            vanna_value += vanna(option)?;
+            vanna_value = d_add(vanna_value, vanna(option)?, "greeks::vanna::aggregate")?;
         }
         Ok(vanna_value)
     }
@@ -404,12 +437,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or vomma calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or vomma calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn vomma(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut vomma_value = Decimal::ZERO;
         for option in options {
-            vomma_value += vomma(option)?;
+            vomma_value = d_add(vomma_value, vomma(option)?, "greeks::vomma::aggregate")?;
         }
         Ok(vomma_value)
     }
@@ -421,12 +456,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or veta calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or veta calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn veta(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut veta_value = Decimal::ZERO;
         for option in options {
-            veta_value += veta(option)?;
+            veta_value = d_add(veta_value, veta(option)?, "greeks::veta::aggregate")?;
         }
         Ok(veta_value)
     }
@@ -438,12 +475,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or charm calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or charm calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn charm(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut charm_value = Decimal::ZERO;
         for option in options {
-            charm_value += charm(option)?;
+            charm_value = d_add(charm_value, charm(option)?, "greeks::charm::aggregate")?;
         }
         Ok(charm_value)
     }
@@ -455,12 +494,14 @@ pub trait Greeks {
     ///
     /// # Errors
     ///
-    /// Returns a `GreeksError` if the options can't be retrieved or color calculation fails.
+    /// Returns a `GreeksError` if the options can't be retrieved or color calculation
+    /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum
+    /// leaves the representable `Decimal` range.
     fn color(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut color_value = Decimal::ZERO;
         for option in options {
-            color_value += color(option)?;
+            color_value = d_add(color_value, color(option)?, "greeks::color::aggregate")?;
         }
         Ok(color_value)
     }
@@ -1718,6 +1759,27 @@ pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
 /// Returns `Decimal::MAX` as a sentinel when theta vanishes but gamma does not.
 /// Callers that publish the value are responsible for mapping it to something
 /// meaningful; see `OptionData::calculate_greeks`.
+///
+/// # Why the sentinel is still `Decimal::MAX`
+///
+/// The sentinel used to be a live hazard: [`Greeks::alpha`] and
+/// [`Greeks::greeks`] summed it across a strategy's legs with the raw `+`
+/// operator, so two legs whose theta vanished aborted the process on
+/// `Decimal::MAX + Decimal::MAX`. Both aggregators now add with
+/// [`crate::model::decimal::d_add`], which reports that sum as a
+/// [`GreeksError`] overflow instead, and that was the whole of the danger.
+///
+/// Nothing prevents a caller from reaching the sentinel, so it is described
+/// here rather than declared impossible: no constructor bounds the quantity
+/// away from it. An ordinary at-the-money contract held at a quantity around
+/// `1e-27` has a daily theta that rounds to zero at `Decimal`'s
+/// twenty-eight-digit scale while its gamma still rounds to `1e-28`, which is
+/// the state this branch answers.
+///
+/// Replacing the sentinel would change the documented return of the public
+/// [`alpha`] and ripple into `OptionData::calculate_greeks`, which already maps
+/// it to `None`, without buying any safety the checked aggregation does not
+/// already provide.
 ///
 /// # Errors
 ///
@@ -5544,5 +5606,297 @@ mod tests_side_sign_convention {
             ok(theta(&long_call), "theta").is_sign_negative(),
             "a long call pays decay, so theta must be negative"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests_checked_aggregation {
+    use super::*;
+    use crate::error::decimal::DecimalError;
+    use crate::error::greeks::CalculationErrorKind;
+    use crate::model::types::OptionType;
+    use crate::{ExpirationDate, Options};
+    use positive::{Positive, pos_or_panic};
+    use rust_decimal_macros::dec;
+
+    /// A quantity small enough that the daily theta of an ordinary at-the-money
+    /// contract rounds to zero at `Decimal`'s twenty-eight-digit scale while its
+    /// gamma still rounds to a non-zero value. That is exactly the state
+    /// [`alpha_from`] answers with the `Decimal::MAX` sentinel.
+    const SENTINEL_QUANTITY: Decimal = Decimal::from_parts(1, 0, 0, false, 27);
+
+    /// The smallest thing that implements [`Greeks`]: a bare list of legs.
+    struct Legs(Vec<Options>);
+
+    impl Greeks for Legs {
+        fn get_options(&self) -> Result<Vec<&Options>, GreeksError> {
+            Ok(self.0.iter().collect())
+        }
+    }
+
+    fn positive(value: Decimal) -> Positive {
+        match Positive::new_decimal(value) {
+            Ok(v) => v,
+            Err(e) => panic!("fixture quantity should be positive: {e}"),
+        }
+    }
+
+    fn leg(
+        option_type: OptionType,
+        strike: Positive,
+        days: Positive,
+        implied_volatility: Positive,
+        style: OptionStyle,
+        side: Side,
+        quantity: Positive,
+    ) -> Options {
+        Options::new(
+            option_type,
+            side,
+            "TEST".to_string(),
+            strike,
+            ExpirationDate::Days(days),
+            implied_volatility,
+            quantity,
+            Positive::HUNDRED,
+            dec!(0.05),
+            style,
+            Positive::ZERO,
+            None,
+        )
+    }
+
+    /// An at-the-money call at [`SENTINEL_QUANTITY`], whose alpha is the
+    /// `Decimal::MAX` sentinel.
+    fn sentinel_leg() -> Options {
+        leg(
+            OptionType::European,
+            Positive::HUNDRED,
+            pos_or_panic!(30.0),
+            pos_or_panic!(0.2),
+            OptionStyle::Call,
+            Side::Long,
+            positive(SENTINEL_QUANTITY),
+        )
+    }
+
+    fn ok(result: Result<Decimal, GreeksError>, what: &str) -> Decimal {
+        match result {
+            Ok(value) => value,
+            Err(e) => panic!("{what} should compute: {e}"),
+        }
+    }
+
+    fn expect_overflow(result: Result<Decimal, GreeksError>, what: &str) {
+        match result {
+            Ok(value) => panic!("{what} should overflow, got {value}"),
+            Err(GreeksError::CalculationError(CalculationErrorKind::DecimalError(
+                DecimalError::Overflow { operation, .. },
+            ))) => {
+                assert!(
+                    operation.starts_with("greeks::"),
+                    "the overflow should name the greeks call-site, got {operation}"
+                );
+            }
+            Err(e) => panic!("{what} should report a decimal overflow, got {e}"),
+        }
+    }
+
+    /// The fixture has to actually reach the sentinel, otherwise the two-leg
+    /// tests below prove nothing.
+    #[test]
+    fn test_alpha_sub_contract_quantity_returns_the_sentinel() {
+        let option = sentinel_leg();
+        assert_eq!(
+            ok(theta(&option), "theta"),
+            Decimal::ZERO,
+            "the fixture's daily theta must round to zero"
+        );
+        assert_ne!(
+            ok(gamma(&option), "gamma"),
+            Decimal::ZERO,
+            "the fixture's gamma must stay non-zero, or alpha takes the zero branch"
+        );
+        assert_eq!(
+            ok(alpha(&option), "alpha"),
+            Decimal::MAX,
+            "a vanished theta against a live gamma is the sentinel"
+        );
+    }
+
+    /// The defect this module exists for: two legs at the sentinel used to sum
+    /// `Decimal::MAX + Decimal::MAX` with the raw operator and abort the
+    /// process. The checked aggregation reports it instead.
+    #[test]
+    fn test_alpha_two_sentinel_legs_reports_overflow() {
+        let legs = Legs(vec![sentinel_leg(), sentinel_leg()]);
+        expect_overflow(legs.alpha(), "the aggregate alpha of two sentinel legs");
+    }
+
+    /// Same for the twelve-field aggregate, which is the call the strategies
+    /// panic-freedom proptest used to skip.
+    #[test]
+    fn test_greeks_two_sentinel_legs_reports_overflow() {
+        let legs = Legs(vec![sentinel_leg(), sentinel_leg()]);
+        match legs.greeks() {
+            Ok(g) => panic!("greeks() should overflow on two sentinel legs, got {g:?}"),
+            Err(GreeksError::CalculationError(CalculationErrorKind::DecimalError(
+                DecimalError::Overflow { operation, .. },
+            ))) => assert_eq!(operation, "greeks::aggregate::alpha"),
+            Err(e) => panic!("greeks() should report a decimal overflow, got {e}"),
+        }
+    }
+
+    /// A single sentinel leg on its own is not an overflow, so a one-leg
+    /// position keeps returning the documented sentinel rather than an error.
+    #[test]
+    fn test_alpha_one_sentinel_leg_still_returns_the_sentinel() {
+        let legs = Legs(vec![sentinel_leg()]);
+        assert_eq!(ok(legs.alpha(), "alpha"), Decimal::MAX);
+    }
+
+    /// A sentinel leg beside an ordinary one is **not** reported, and the
+    /// ordinary leg's contribution is lost: `Decimal::MAX + x` for a small `x`
+    /// rescales and rounds straight back to `Decimal::MAX`, so `checked_add`
+    /// answers `Some` with the accumulator standing still.
+    ///
+    /// That is a property of the sentinel, not of the checked addition, and it
+    /// predates this change. It is pinned here so the limit is visible: only a
+    /// second leg large enough to carry the sum past the range — the other
+    /// sentinel above, or any alpha of magnitude one or more — surfaces.
+    #[test]
+    fn test_alpha_sentinel_absorbs_a_small_leg_without_moving() {
+        // An at-the-money call at 80% volatility, whose alpha is about -0.11.
+        let ordinary = leg(
+            OptionType::European,
+            Positive::HUNDRED,
+            pos_or_panic!(30.0),
+            pos_or_panic!(0.8),
+            OptionStyle::Call,
+            Side::Long,
+            Positive::ONE,
+        );
+        let ordinary_alpha = ok(alpha(&ordinary), "alpha");
+        assert!(
+            ordinary_alpha != Decimal::ZERO && ordinary_alpha.abs() < Decimal::ONE,
+            "the fixture must contribute a small non-zero alpha, got {ordinary_alpha}"
+        );
+
+        let legs = Legs(vec![sentinel_leg(), ordinary]);
+        assert_eq!(
+            ok(legs.alpha(), "alpha"),
+            Decimal::MAX,
+            "the sum stands still: the sentinel absorbs the ordinary leg"
+        );
+    }
+
+    /// Every leg combination whose sums stay inside the `Decimal` range must
+    /// aggregate to exactly what the raw `+` operator produced.
+    ///
+    /// `Decimal::checked_add` and `Add::add` both dispatch to the same
+    /// `add_impl`; they differ only in whether a non-`Ok` result panics or
+    /// yields `None`. This walks a matrix of legs and asserts the equality
+    /// term by term, for the twelve-field aggregate and for each of the twelve
+    /// per-greek aggregators.
+    #[test]
+    fn test_checked_aggregation_matches_the_unchecked_sum() {
+        let mut options = Vec::new();
+        for style in [OptionStyle::Call, OptionStyle::Put] {
+            for side in [Side::Long, Side::Short] {
+                for strike in [pos_or_panic!(80.0), Positive::HUNDRED, pos_or_panic!(120.0)] {
+                    options.push(leg(
+                        OptionType::European,
+                        strike,
+                        pos_or_panic!(30.0),
+                        pos_or_panic!(0.2),
+                        style,
+                        side,
+                        pos_or_panic!(3.0),
+                    ));
+                    options.push(leg(
+                        OptionType::European,
+                        strike,
+                        pos_or_panic!(3650.0),
+                        pos_or_panic!(0.8),
+                        style,
+                        side,
+                        pos_or_panic!(0.25),
+                    ));
+                }
+            }
+        }
+        let legs = Legs(options);
+
+        // The reference: the pre-change accumulation, greek by greek, with the
+        // raw operator. None of these legs approaches the range limit.
+        let mut reference = Greek {
+            delta: Decimal::ZERO,
+            gamma: Decimal::ZERO,
+            theta: Decimal::ZERO,
+            vega: Decimal::ZERO,
+            rho: Decimal::ZERO,
+            rho_d: Decimal::ZERO,
+            alpha: Decimal::ZERO,
+            vanna: Decimal::ZERO,
+            vomma: Decimal::ZERO,
+            veta: Decimal::ZERO,
+            charm: Decimal::ZERO,
+            color: Decimal::ZERO,
+        };
+        for option in &legs.0 {
+            reference.delta += ok(delta(option), "delta");
+            reference.gamma += ok(gamma(option), "gamma");
+            reference.theta += ok(theta(option), "theta");
+            reference.vega += ok(vega(option), "vega");
+            reference.rho += ok(rho(option), "rho");
+            reference.rho_d += ok(rho_d(option), "rho_d");
+            reference.alpha += ok(alpha(option), "alpha");
+            reference.vanna += ok(vanna(option), "vanna");
+            reference.vomma += ok(vomma(option), "vomma");
+            reference.veta += ok(veta(option), "veta");
+            reference.charm += ok(charm(option), "charm");
+            reference.color += ok(color(option), "color");
+        }
+
+        let Ok(aggregate) = legs.greeks() else {
+            panic!("the aggregate should compute for ordinary legs");
+        };
+        assert_eq!(
+            aggregate, reference,
+            "greeks() must match the unchecked sum"
+        );
+
+        for (name, aggregated, expected) in [
+            ("delta", legs.delta(), reference.delta),
+            ("gamma", legs.gamma(), reference.gamma),
+            ("theta", legs.theta(), reference.theta),
+            ("vega", legs.vega(), reference.vega),
+            ("rho", legs.rho(), reference.rho),
+            ("rho_d", legs.rho_d(), reference.rho_d),
+            ("alpha", legs.alpha(), reference.alpha),
+            ("vanna", legs.vanna(), reference.vanna),
+            ("vomma", legs.vomma(), reference.vomma),
+            ("veta", legs.veta(), reference.veta),
+            ("charm", legs.charm(), reference.charm),
+            ("color", legs.color(), reference.color),
+        ] {
+            assert_eq!(
+                ok(aggregated, name),
+                expected,
+                "{name} must match the unchecked sum"
+            );
+        }
+    }
+
+    /// An empty leg set aggregates to zero rather than erroring, on both paths.
+    #[test]
+    fn test_checked_aggregation_of_no_legs_is_zero() {
+        let legs = Legs(Vec::new());
+        assert_eq!(ok(legs.alpha(), "alpha"), Decimal::ZERO);
+        let Ok(aggregate) = legs.greeks() else {
+            panic!("an empty leg set should aggregate to zero");
+        };
+        assert_eq!(aggregate.delta, Decimal::ZERO);
+        assert_eq!(aggregate.alpha, Decimal::ZERO);
     }
 }

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -4,7 +4,7 @@
    Date: 11/8/24
 ******************************************************************************/
 use crate::constants::{TRADING_DAYS, ZERO};
-use crate::error::greeks::GreeksError;
+use crate::error::greeks::{CalculationErrorKind, GreeksError};
 use crate::greeks::utils::{big_n, d1, n};
 use crate::model::decimal::{d_add, d_div, d_exp, d_mul, d_sub};
 use crate::model::types::{OptionStyle, OptionType};
@@ -214,9 +214,12 @@ pub trait Greeks {
     /// Returns a `GreeksError` if any individual Greek calculation fails, or
     /// [`crate::error::DecimalError::Overflow`] (wrapped by `GreeksError`) when
     /// one of the twelve running sums leaves the representable `Decimal` range.
-    /// The `alpha` sum is the one that reaches that limit on ordinary input:
-    /// [`alpha`] returns `Decimal::MAX` whenever a leg's theta vanishes, so two
-    /// such legs overflow.
+    ///
+    /// The `alpha` sum has one further failure of its own, and it is reachable
+    /// on ordinary input. [`alpha`] returns `Decimal::MAX` for a leg whose theta
+    /// has vanished, and that value cannot be added to a real one; a leg
+    /// carrying it beside any other contribution is refused by [`add_alpha`],
+    /// which names the leg. See [`Greeks::alpha`].
     fn greeks(&self) -> Result<Greek, GreeksError> {
         // Aggregate option by option rather than greek by greek, so the shared
         // Black-Scholes kernels are computed once per option instead of once
@@ -235,7 +238,7 @@ pub trait Greeks {
         let mut veta = Decimal::ZERO;
         let mut charm = Decimal::ZERO;
         let mut color = Decimal::ZERO;
-        for option in options {
+        for (index, option) in options.into_iter().enumerate() {
             let single = greeks_for(option)?;
             delta = d_add(delta, single.delta, "greeks::aggregate::delta")?;
             gamma = d_add(gamma, single.gamma, "greeks::aggregate::gamma")?;
@@ -243,7 +246,13 @@ pub trait Greeks {
             vega = d_add(vega, single.vega, "greeks::aggregate::vega")?;
             rho = d_add(rho, single.rho, "greeks::aggregate::rho")?;
             rho_d = d_add(rho_d, single.rho_d, "greeks::aggregate::rho_d")?;
-            alpha = d_add(alpha, single.alpha, "greeks::aggregate::alpha")?;
+            alpha = add_alpha(
+                alpha,
+                single.alpha,
+                option,
+                index,
+                "greeks::aggregate::alpha",
+            )?;
             vanna = d_add(vanna, single.vanna, "greeks::aggregate::vanna")?;
             vomma = d_add(vomma, single.vomma, "greeks::aggregate::vomma")?;
             veta = d_add(veta, single.veta, "greeks::aggregate::veta")?;
@@ -388,25 +397,35 @@ pub trait Greeks {
     /// # The sentinel in a sum
     ///
     /// [`alpha`] answers `Decimal::MAX` for a leg whose theta has vanished, and
-    /// summing that is degenerate in both directions. Two such legs leave the
-    /// representable range and are reported as an error. A single one beside an
-    /// ordinary leg is *not*: `Decimal::MAX` plus a value below one rescales and
-    /// rounds straight back to `Decimal::MAX`, so the sum stands still and the
-    /// ordinary leg's contribution is lost. Callers that need to tell the two
-    /// apart should check the per-leg [`alpha`] for the sentinel before summing.
+    /// that value cannot be added to a real one. Two such legs leave the
+    /// representable range. One beside an ordinary leg does not, which is
+    /// worse: `Decimal::MAX` plus a value below one rescales and rounds
+    /// straight back to `Decimal::MAX`, so the arithmetic succeeds while the
+    /// ordinary leg's contribution is silently dropped.
+    ///
+    /// Both are refused, by an explicit guard rather than by the arithmetic;
+    /// see [`add_alpha`]. A sentinel leg that is the only leg, or that sits
+    /// beside legs whose own alpha is zero, still reports the sentinel, because
+    /// nothing is lost in those sums.
     ///
     /// # Errors
     ///
     /// Returns a `GreeksError` if the options can't be retrieved or alpha calculation
     /// fails, and [`crate::error::DecimalError::Overflow`] when the running sum leaves
-    /// the representable `Decimal` range. Unlike the other eleven, that limit is
-    /// reachable on ordinary input: [`alpha`] returns `Decimal::MAX` whenever a leg's
-    /// theta vanishes, so two such legs overflow.
+    /// the representable `Decimal` range. Returns
+    /// [`GreeksError::CalculationError`] naming the leg when that leg's alpha is
+    /// the sentinel and another leg contributes to the same sum.
     fn alpha(&self) -> Result<Decimal, GreeksError> {
         let options = self.get_options()?;
         let mut alpha_value = Decimal::ZERO;
-        for option in options {
-            alpha_value = d_add(alpha_value, alpha(option)?, "greeks::alpha::aggregate")?;
+        for (index, option) in options.into_iter().enumerate() {
+            alpha_value = add_alpha(
+                alpha_value,
+                alpha(option)?,
+                option,
+                index,
+                "greeks::alpha::aggregate",
+            )?;
         }
         Ok(alpha_value)
     }
@@ -1765,9 +1784,11 @@ pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
 /// The sentinel used to be a live hazard: [`Greeks::alpha`] and
 /// [`Greeks::greeks`] summed it across a strategy's legs with the raw `+`
 /// operator, so two legs whose theta vanished aborted the process on
-/// `Decimal::MAX + Decimal::MAX`. Both aggregators now add with
-/// [`crate::model::decimal::d_add`], which reports that sum as a
-/// [`GreeksError`] overflow instead, and that was the whole of the danger.
+/// `Decimal::MAX + Decimal::MAX`. Both aggregators now refuse to combine the
+/// sentinel with another leg's contribution at all, and report which leg
+/// carried it; see [`add_alpha`]. That covers the abort and the quieter
+/// failure beside it, where `Decimal::MAX` plus a small value rescales back to
+/// `Decimal::MAX` and drops the other leg without any arithmetic error.
 ///
 /// Nothing prevents a caller from reaching the sentinel, so it is described
 /// here rather than declared impossible: no constructor bounds the quantity
@@ -1778,7 +1799,7 @@ pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
 ///
 /// Replacing the sentinel would change the documented return of the public
 /// [`alpha`] and ripple into `OptionData::calculate_greeks`, which already maps
-/// it to `None`, without buying any safety the checked aggregation does not
+/// it to `None`, without buying any safety the guarded aggregation does not
 /// already provide.
 ///
 /// # Errors
@@ -1791,6 +1812,79 @@ fn alpha_from(gamma: Decimal, theta: Decimal) -> Result<Decimal, GreeksError> {
         (_, val) if val == Decimal::ZERO => Ok(Decimal::MAX),
         _ => Ok(d_div(gamma, theta, "greeks::alpha")?),
     }
+}
+
+/// Combines one leg's alpha into a running total, refusing the `Decimal::MAX`
+/// sentinel wherever summing it would lose a contribution.
+///
+/// [`alpha_from`] answers `Decimal::MAX` for a leg whose theta has vanished.
+/// That value cannot be added to a real one: `Decimal::MAX` plus anything of
+/// magnitude below one rescales and rounds straight back to `Decimal::MAX`, so
+/// `checked_add` answers `Some` with the accumulator standing still and the
+/// other leg's alpha silently dropped. `checked_add` cannot detect that — the
+/// arithmetic genuinely succeeded — so the guard is explicit rather than
+/// arithmetic, and it runs before [`d_add`] is reached.
+///
+/// Refused, therefore:
+///
+/// - a sentinel leg meeting a total that already carries a contribution, and
+/// - a contribution meeting a total that is already the sentinel,
+///
+/// which between them cover a sentinel beside an ordinary leg in either order,
+/// and two sentinels (which would also have left the representable range).
+///
+/// Allowed, because nothing is lost: a sentinel that is the only leg, and a
+/// sentinel beside legs whose own alpha is zero — the value `alpha` returns
+/// for a vanished gamma. A one-leg aggregate therefore still reports the
+/// documented sentinel, which is what `OptionData::greeks_snapshot` reads to
+/// map the published `alpha` to `None`.
+///
+/// Only the two alpha accumulation paths use this. None of the other eleven
+/// greeks has a sentinel, so a `Decimal::MAX` among those is a real value that
+/// must sum, or overflow, normally.
+///
+/// # Errors
+///
+/// Returns [`GreeksError::CalculationError`] naming the offending leg when the
+/// sentinel would meet a contribution, and
+/// [`crate::error::DecimalError::Overflow`] when an ordinary sum leaves the
+/// representable range.
+#[inline]
+fn add_alpha(
+    total: Decimal,
+    value: Decimal,
+    option: &Options,
+    index: usize,
+    op: &'static str,
+) -> Result<Decimal, GreeksError> {
+    let sentinel_meets_a_contribution = (value == Decimal::MAX && total != Decimal::ZERO)
+        || (total == Decimal::MAX && value != Decimal::ZERO);
+    if sentinel_meets_a_contribution {
+        return Err(alpha_sentinel_error(option, index));
+    }
+    Ok(d_add(total, value, op)?)
+}
+
+/// Builds the error [`add_alpha`] returns, naming the leg that carries the
+/// sentinel.
+///
+/// Filed under [`CalculationErrorKind::ThetaError`] because a vanished theta is
+/// the cause; there is no alpha-specific variant, and this matches how
+/// `greeks::numerical` reports the same family of failures.
+#[cold]
+#[inline(never)]
+fn alpha_sentinel_error(option: &Options, index: usize) -> GreeksError {
+    GreeksError::CalculationError(CalculationErrorKind::ThetaError {
+        reason: format!(
+            "leg {index} ({symbol} {strike} {style:?} {side:?}) has a vanished theta, \
+             so its alpha is the Decimal::MAX sentinel and cannot be summed into an \
+             aggregate; read the leg's own alpha instead",
+            symbol = option.underlying_symbol,
+            strike = option.strike_price,
+            style = option.option_style,
+            side = option.side,
+        ),
+    })
 }
 
 /// Computes the vanna of an option.
@@ -5612,8 +5706,6 @@ mod tests_side_sign_convention {
 #[cfg(test)]
 mod tests_checked_aggregation {
     use super::*;
-    use crate::error::decimal::DecimalError;
-    use crate::error::greeks::CalculationErrorKind;
     use crate::model::types::OptionType;
     use crate::{ExpirationDate, Options};
     use positive::{Positive, pos_or_panic};
@@ -5687,18 +5779,18 @@ mod tests_checked_aggregation {
         }
     }
 
-    fn expect_overflow(result: Result<Decimal, GreeksError>, what: &str) {
+    /// Asserts that `result` is the sentinel refusal, and that its message
+    /// names the offending leg.
+    fn expect_sentinel_refusal(result: Result<Decimal, GreeksError>, what: &str) {
         match result {
-            Ok(value) => panic!("{what} should overflow, got {value}"),
-            Err(GreeksError::CalculationError(CalculationErrorKind::DecimalError(
-                DecimalError::Overflow { operation, .. },
-            ))) => {
+            Ok(value) => panic!("{what} should be refused, got {value}"),
+            Err(GreeksError::CalculationError(CalculationErrorKind::ThetaError { reason })) => {
                 assert!(
-                    operation.starts_with("greeks::"),
-                    "the overflow should name the greeks call-site, got {operation}"
+                    reason.contains("leg ") && reason.contains("sentinel"),
+                    "the refusal should name the leg and the sentinel, got {reason}"
                 );
             }
-            Err(e) => panic!("{what} should report a decimal overflow, got {e}"),
+            Err(e) => panic!("{what} should report the sentinel refusal, got {e}"),
         }
     }
 
@@ -5726,46 +5818,40 @@ mod tests_checked_aggregation {
 
     /// The defect this module exists for: two legs at the sentinel used to sum
     /// `Decimal::MAX + Decimal::MAX` with the raw operator and abort the
-    /// process. The checked aggregation reports it instead.
+    /// process. The aggregate refuses them instead.
     #[test]
-    fn test_alpha_two_sentinel_legs_reports_overflow() {
+    fn test_alpha_two_sentinel_legs_are_refused() {
         let legs = Legs(vec![sentinel_leg(), sentinel_leg()]);
-        expect_overflow(legs.alpha(), "the aggregate alpha of two sentinel legs");
+        expect_sentinel_refusal(legs.alpha(), "the aggregate alpha of two sentinel legs");
     }
 
     /// Same for the twelve-field aggregate, which is the call the strategies
     /// panic-freedom proptest used to skip.
     #[test]
-    fn test_greeks_two_sentinel_legs_reports_overflow() {
+    fn test_greeks_two_sentinel_legs_are_refused() {
         let legs = Legs(vec![sentinel_leg(), sentinel_leg()]);
         match legs.greeks() {
-            Ok(g) => panic!("greeks() should overflow on two sentinel legs, got {g:?}"),
-            Err(GreeksError::CalculationError(CalculationErrorKind::DecimalError(
-                DecimalError::Overflow { operation, .. },
-            ))) => assert_eq!(operation, "greeks::aggregate::alpha"),
-            Err(e) => panic!("greeks() should report a decimal overflow, got {e}"),
+            Ok(g) => panic!("greeks() should refuse two sentinel legs, got {g:?}"),
+            Err(GreeksError::CalculationError(CalculationErrorKind::ThetaError { reason })) => {
+                assert!(
+                    reason.contains("sentinel"),
+                    "the refusal should mention the sentinel, got {reason}"
+                );
+            }
+            Err(e) => panic!("greeks() should report the sentinel refusal, got {e}"),
         }
     }
 
-    /// A single sentinel leg on its own is not an overflow, so a one-leg
-    /// position keeps returning the documented sentinel rather than an error.
-    #[test]
-    fn test_alpha_one_sentinel_leg_still_returns_the_sentinel() {
-        let legs = Legs(vec![sentinel_leg()]);
-        assert_eq!(ok(legs.alpha(), "alpha"), Decimal::MAX);
-    }
-
-    /// A sentinel leg beside an ordinary one is **not** reported, and the
-    /// ordinary leg's contribution is lost: `Decimal::MAX + x` for a small `x`
-    /// rescales and rounds straight back to `Decimal::MAX`, so `checked_add`
-    /// answers `Some` with the accumulator standing still.
+    /// A sentinel leg beside an ordinary one is refused, in either order.
     ///
-    /// That is a property of the sentinel, not of the checked addition, and it
-    /// predates this change. It is pinned here so the limit is visible: only a
-    /// second leg large enough to carry the sum past the range — the other
-    /// sentinel above, or any alpha of magnitude one or more — surfaces.
+    /// This is the case `checked_add` cannot detect and so the one an explicit
+    /// guard has to catch: `Decimal::MAX` plus a value below one rescales and
+    /// rounds straight back to `Decimal::MAX`, so the addition genuinely
+    /// succeeds and returns `Some`, with the accumulator standing still and the
+    /// ordinary leg's alpha dropped. Reporting an aggregate that is wrong in a
+    /// way the caller cannot see is worse than reporting nothing.
     #[test]
-    fn test_alpha_sentinel_absorbs_a_small_leg_without_moving() {
+    fn test_alpha_sentinel_beside_an_ordinary_leg_is_refused() {
         // An at-the-money call at 80% volatility, whose alpha is about -0.11.
         let ordinary = leg(
             OptionType::European,
@@ -5781,12 +5867,69 @@ mod tests_checked_aggregation {
             ordinary_alpha != Decimal::ZERO && ordinary_alpha.abs() < Decimal::ONE,
             "the fixture must contribute a small non-zero alpha, got {ordinary_alpha}"
         );
-
-        let legs = Legs(vec![sentinel_leg(), ordinary]);
+        // The unguarded arithmetic really does succeed and stand still, which
+        // is what makes the guard necessary.
         assert_eq!(
-            ok(legs.alpha(), "alpha"),
-            Decimal::MAX,
-            "the sum stands still: the sentinel absorbs the ordinary leg"
+            Decimal::MAX.checked_add(ordinary_alpha),
+            Some(Decimal::MAX),
+            "checked_add cannot detect this, so the guard must"
+        );
+
+        expect_sentinel_refusal(
+            Legs(vec![sentinel_leg(), ordinary.clone()]).alpha(),
+            "the aggregate alpha with the sentinel leg first",
+        );
+        expect_sentinel_refusal(
+            Legs(vec![ordinary, sentinel_leg()]).alpha(),
+            "the aggregate alpha with the sentinel leg last",
+        );
+    }
+
+    /// A single sentinel leg is not a sum: nothing is dropped, so it keeps
+    /// reporting the documented sentinel rather than an error.
+    ///
+    /// `OptionData::greeks_snapshot` depends on this. It calls `greeks()` on one
+    /// option through `impl Greeks for Options` and maps an `alpha` of
+    /// `Decimal::MAX` to `None` on the wire; refusing a lone sentinel would
+    /// drop the other eleven greeks from that snapshot too.
+    #[test]
+    fn test_alpha_one_sentinel_leg_still_returns_the_sentinel() {
+        let legs = Legs(vec![sentinel_leg()]);
+        assert_eq!(ok(legs.alpha(), "alpha"), Decimal::MAX);
+        let Ok(aggregate) = legs.greeks() else {
+            panic!("a lone sentinel leg should still aggregate");
+        };
+        assert_eq!(aggregate.alpha, Decimal::MAX);
+    }
+
+    /// A sentinel beside a leg whose own alpha is zero is not refused either:
+    /// `alpha` returns zero for a vanished gamma, and adding zero drops
+    /// nothing. Refusing it would be a false positive.
+    #[test]
+    fn test_alpha_sentinel_beside_a_zero_alpha_leg_is_allowed() {
+        // At expiry gamma vanishes, which is the branch `alpha_from` answers
+        // with zero.
+        let expired = leg(
+            OptionType::European,
+            Positive::HUNDRED,
+            Positive::ZERO,
+            pos_or_panic!(0.2),
+            OptionStyle::Call,
+            Side::Long,
+            Positive::ONE,
+        );
+        assert_eq!(
+            ok(alpha(&expired), "alpha"),
+            Decimal::ZERO,
+            "the fixture must contribute exactly zero"
+        );
+        assert_eq!(
+            ok(Legs(vec![sentinel_leg(), expired.clone()]).alpha(), "alpha"),
+            Decimal::MAX
+        );
+        assert_eq!(
+            ok(Legs(vec![expired, sentinel_leg()]).alpha(), "alpha"),
+            Decimal::MAX
         );
     }
 

--- a/src/greeks/equations.rs
+++ b/src/greeks/equations.rs
@@ -218,7 +218,7 @@ pub trait Greeks {
     /// The `alpha` sum has one further failure of its own, and it is reachable
     /// on ordinary input. [`alpha`] returns `Decimal::MAX` for a leg whose theta
     /// has vanished, and that value cannot be added to a real one; a leg
-    /// carrying it beside any other contribution is refused by [`add_alpha`],
+    /// carrying it beside any other contribution is refused by `AlphaSum::push`,
     /// which names the leg. See [`Greeks::alpha`].
     fn greeks(&self) -> Result<Greek, GreeksError> {
         // Aggregate option by option rather than greek by greek, so the shared
@@ -398,7 +398,7 @@ pub trait Greeks {
     /// ordinary leg's contribution is silently dropped.
     ///
     /// Both are refused, by an explicit guard rather than by the arithmetic;
-    /// see [`add_alpha`]. A sentinel leg that is the only leg, or that sits
+    /// see `AlphaSum::push`. A sentinel leg that is the only leg, or that sits
     /// beside legs whose own alpha is zero, still reports the sentinel, because
     /// nothing is lost in those sums.
     ///
@@ -1775,7 +1775,7 @@ pub fn alpha(option: &Options) -> Result<Decimal, GreeksError> {
 /// operator, so two legs whose theta vanished aborted the process on
 /// `Decimal::MAX + Decimal::MAX`. Both aggregators now refuse to combine the
 /// sentinel with another leg's contribution at all, and report which leg
-/// carried it; see [`add_alpha`]. That covers the abort and the quieter
+/// carried it; see `AlphaSum::push`. That covers the abort and the quieter
 /// failure beside it, where `Decimal::MAX` plus a small value rescales back to
 /// `Decimal::MAX` and drops the other leg without any arithmetic error. That
 /// second mechanism is a property of `Decimal`, not of this sentinel, and is
@@ -1853,11 +1853,25 @@ fn alpha_from(gamma: Decimal, theta: Decimal) -> Result<Decimal, GreeksError> {
 /// sentinel]` returned the sentinel while `[sentinel, +5, -5]` was refused,
 /// for the same three legs. A sum has no business depending on leg order, so
 /// the facts are carried rather than inferred.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct AlphaSum {
     total: Decimal,
     contributed: bool,
-    sentinel: bool,
+    /// The leg that carried the sentinel, described when it arrived.
+    ///
+    /// The description is kept rather than the fact alone, because the leg
+    /// that *reveals* the conflict is not the leg that caused it: when the
+    /// sentinel arrives first, the ordinary leg behind it is the one being
+    /// refused, and naming that one would report a vanished theta for a leg
+    /// whose theta is fine.
+    sentinel: Option<SentinelLeg>,
+}
+
+/// A leg whose alpha is the `Decimal::MAX` sentinel, described for the error.
+#[derive(Clone, Debug)]
+struct SentinelLeg {
+    index: usize,
+    description: String,
 }
 
 impl AlphaSum {
@@ -1879,11 +1893,15 @@ impl AlphaSum {
     ) -> Result<Self, GreeksError> {
         if value == Decimal::MAX {
             // A second sentinel would leave the range; a sentinel after a
-            // contribution would swallow it.
-            if self.contributed || self.sentinel {
-                return Err(alpha_sentinel_error(option, index));
+            // contribution would swallow it. Either way the arriving leg is
+            // the sentinel, so it is the one to name.
+            if self.contributed || self.sentinel.is_some() {
+                return Err(alpha_sentinel_error(index, &describe_leg(option)));
             }
-            self.sentinel = true;
+            self.sentinel = Some(SentinelLeg {
+                index,
+                description: describe_leg(option),
+            });
             self.total = Decimal::MAX;
             return Ok(self);
         }
@@ -1892,8 +1910,10 @@ impl AlphaSum {
         if value.is_zero() {
             return Ok(self);
         }
-        if self.sentinel {
-            return Err(alpha_sentinel_error(option, index));
+        if let Some(sentinel) = &self.sentinel {
+            // The arriving leg is the ordinary one. The sentinel came earlier,
+            // and it is the leg whose theta vanished.
+            return Err(alpha_sentinel_error(sentinel.index, &sentinel.description));
         }
         self.contributed = true;
         self.total = d_add(self.total, value, op)?;
@@ -1901,24 +1921,32 @@ impl AlphaSum {
     }
 }
 
-/// Builds the error [`add_alpha`] returns, naming the leg that carries the
-/// sentinel.
+/// Describes a leg for the sentinel error.
+fn describe_leg(option: &Options) -> String {
+    format!(
+        "{symbol} {strike} {style:?} {side:?}",
+        symbol = option.underlying_symbol,
+        strike = option.strike_price,
+        style = option.option_style,
+        side = option.side,
+    )
+}
+
+/// Builds the error `AlphaSum::push` returns, naming the leg that carries the
+/// sentinel — which is not always the leg that was arriving when the conflict
+/// surfaced.
 ///
 /// Filed under [`CalculationErrorKind::ThetaError`] because a vanished theta is
 /// the cause; there is no alpha-specific variant, and this matches how
 /// `greeks::numerical` reports the same family of failures.
 #[cold]
 #[inline(never)]
-fn alpha_sentinel_error(option: &Options, index: usize) -> GreeksError {
+fn alpha_sentinel_error(index: usize, description: &str) -> GreeksError {
     GreeksError::CalculationError(CalculationErrorKind::ThetaError {
         reason: format!(
-            "leg {index} ({symbol} {strike} {style:?} {side:?}) has a vanished theta, \
-             so its alpha is the Decimal::MAX sentinel and cannot be summed into an \
-             aggregate; read the leg's own alpha instead",
-            symbol = option.underlying_symbol,
-            strike = option.strike_price,
-            style = option.option_style,
-            side = option.side,
+            "leg {index} ({description}) has a vanished theta, so its alpha is the \
+             Decimal::MAX sentinel and cannot be summed into an aggregate; read the \
+             leg's own alpha instead"
         ),
     })
 }
@@ -5844,6 +5872,60 @@ mod tests_checked_aggregation {
             Side::Long,
             positive(SENTINEL_QUANTITY),
         )
+    }
+
+    /// The refusal must name the leg whose theta vanished, which is not the
+    /// leg that was arriving when the conflict surfaced. With the sentinel
+    /// first, the ordinary leg is the one being refused, and naming *it*
+    /// would report a vanished theta for a leg whose theta is fine.
+    ///
+    /// The two legs differ by style rather than by strike, so the fixture
+    /// keeps the at-the-money position both of them need — the sentinel to
+    /// have a theta that rounds away while its gamma does not, the ordinary
+    /// leg to carry a real alpha.
+    #[test]
+    fn test_alpha_sentinel_refusal_names_the_sentinel_leg_in_either_order() {
+        let sentinel = sentinel_leg();
+        let ordinary = leg(
+            OptionType::European,
+            Positive::HUNDRED,
+            pos_or_panic!(30.0),
+            pos_or_panic!(0.8),
+            OptionStyle::Put,
+            Side::Long,
+            Positive::ONE,
+        );
+        assert!(
+            ok(alpha(&ordinary), "alpha") != Decimal::ZERO,
+            "the ordinary leg must contribute, or nothing is being refused"
+        );
+
+        for (legs, sentinel_index, what) in [
+            (
+                vec![sentinel.clone(), ordinary.clone()],
+                "leg 0",
+                "sentinel first",
+            ),
+            (
+                vec![ordinary.clone(), sentinel.clone()],
+                "leg 1",
+                "sentinel last",
+            ),
+        ] {
+            match Legs(legs).alpha() {
+                Err(GreeksError::CalculationError(CalculationErrorKind::ThetaError { reason })) => {
+                    assert!(
+                        reason.contains(sentinel_index) && reason.contains("Call"),
+                        "{what}: the refusal must name the sentinel leg, got {reason}"
+                    );
+                    assert!(
+                        !reason.contains("Put"),
+                        "{what}: the refusal must not blame the ordinary leg, got {reason}"
+                    );
+                }
+                other => panic!("{what}: expected the sentinel refusal, got {other:?}"),
+            }
+        }
     }
 
     fn ok(result: Result<Decimal, GreeksError>, what: &str) -> Decimal {

--- a/src/model/decimal.rs
+++ b/src/model/decimal.rs
@@ -750,6 +750,50 @@ mod checked_helpers_tests {
         }
     }
 
+    /// A checked add that reports `Ok` has not necessarily moved the value.
+    ///
+    /// `Decimal::MAX` has scale 0 and a mantissa filling all 96 bits. Adding a
+    /// fractional addend needs a 29th significant digit, which does not exist,
+    /// so `rust_decimal` rescales the addend down to scale 0 instead of failing:
+    /// anything below half a unit rounds to zero, the addition succeeds, and the
+    /// result is `Decimal::MAX` again. The overflow path is never reached. The
+    /// silent window is `|x| < 0.5`, not `|x| < 1` — at `0.5` the addend rounds
+    /// away from zero to `1` and the sum does overflow, which is why the two
+    /// halves of this test sit three hundredths apart.
+    ///
+    /// This has already broken two call sites in this crate:
+    ///
+    /// - `chains::optiondata::unlock` lifted a locked quote by one tick and read
+    ///   `Ok` as "lifted", so it re-emitted the very quote it existed to remove.
+    /// - `greeks::equations::alpha_from` returns `Decimal::MAX` as its
+    ///   "theta vanished" sentinel. Summing one such leg with an ordinary one
+    ///   returned `Ok` with the running total standing still and the ordinary
+    ///   leg's alpha silently dropped, so that aggregation needs an explicit
+    ///   guard on the operand; no arithmetic check can catch it.
+    ///
+    /// The rule this implies: when you nudge a value and need to know it moved,
+    /// compare the result against the input. `checked_*` returning `Ok` is not
+    /// that check — it only says the result was representable.
+    #[test]
+    fn checked_add_near_max_reports_ok_without_moving_the_value() {
+        // Below half a unit: rounds to zero, succeeds, and stands still.
+        assert_eq!(
+            Decimal::MAX.checked_add(dec!(0.01)),
+            Some(Decimal::MAX),
+            "a fractional addend rescales away instead of overflowing"
+        );
+        assert_eq!(
+            d_add(Decimal::MAX, dec!(0.47), "test::add").unwrap(),
+            Decimal::MAX,
+            "the crate helper inherits the same behaviour"
+        );
+
+        // At half a unit and above: rounds away from zero and does overflow, so
+        // the boundary is visible rather than implied.
+        assert_eq!(Decimal::MAX.checked_add(dec!(0.5)), None);
+        assert!(d_add(Decimal::MAX, dec!(0.5), "test::add").is_err());
+    }
+
     #[test]
     fn d_sub_happy_path() {
         let result = d_sub(dec!(10), dec!(3.5), "test::sub");

--- a/tests/property/strategies_panic_freedom_test.rs
+++ b/tests/property/strategies_panic_freedom_test.rs
@@ -271,11 +271,7 @@ where
     let _ = strategy.get_positions();
     let _ = strategy.delta();
     let _ = strategy.gamma();
-    // `Greeks::greeks` is deliberately absent. Its aggregation loop in
-    // `greeks::equations` adds the per-option `alpha`, and `alpha_from`
-    // returns `Decimal::MAX` as a sentinel when theta vanishes, so two legs at
-    // a sub-contract quantity abort on `Decimal::MAX + Decimal::MAX`. That is
-    // in `src/greeks`, outside this sweep, and is reported separately.
+    let _ = strategy.greeks();
     let _ = strategy.delta_neutrality();
     let _ = strategy.is_delta_neutral();
     let _ = strategy.get_atm_strike();


### PR DESCRIPTION
## Summary

The greek aggregators summed eleven greeks across a strategy's legs with
unchecked `Decimal` addition. The plain overflow was the lesser problem:
`alpha_from` returns `Decimal::MAX` as a **documented sentinel** when theta
vanishes but gamma does not, so a strategy with two legs at a sub-contract
quantity aborted on `Decimal::MAX + Decimal::MAX`.

Fixing that surfaced a second defect in the same place, and it is the one worth
reading this PR for.

## 24 accumulations, not 23

12 in `Greeks::greeks` (the twelve-field aggregate) and 12 in the per-greek
aggregators — the issue says eleven of the latter; there are twelve. All go
through `d_add` now. No new plumbing: `GreeksError: From<DecimalError>` already
existed and both entry points already returned `Result`.

## The second defect: `checked_add` cannot see this one

**One sentinel leg beside an ordinary one never aborted — it silently dropped
the ordinary leg.** `Decimal::MAX` has scale 0 with a mantissa filling all 96
bits, so a fractional addend would need a 29th significant digit; `rust_decimal`
rescales the addend to scale 0 instead of failing, and anything below half a
unit rounds to zero. The addition *succeeds*, the running total stands still,
and the other leg's alpha is gone without a trace.

Converting to `d_add` does not fix that, because nothing overflows. So the two
alpha accumulation paths — and **only** those two, no other greek has a
sentinel — carry an explicit guard that refuses a sentinel operand and names the
leg:

```
leg {index} ({symbol} {strike} {style} {side}) has a vanished theta, so its
alpha is the Decimal::MAX sentinel and cannot be summed into an aggregate;
read the leg's own alpha instead
```

### The guard refuses exactly when a contribution would be lost

This is narrower than "a sentinel can never be aggregated", deliberately:

- **Refused** — a sentinel meeting a total that already carries a contribution,
  or a contribution meeting a total that is already the sentinel. Covers
  sentinel + ordinary in either order, and two sentinels, caught before the
  range limit.
- **Allowed** — a lone sentinel, and a sentinel beside legs whose own alpha is
  zero (`alpha` returns zero for a vanished gamma, so nothing is dropped).

The looser rule would have broken `OptionData::greeks_snapshot`
(`src/chains/optiondata.rs:1229`), which calls `greeks()` on a **single** option
and maps `alpha == Decimal::MAX` to `None`. Refusing a lone sentinel there
would discard eleven good greeks to report one bad one, and falsify that
module's doc comment. **A lone sentinel still returns the sentinel; chain
snapshots behave exactly as before.**

No silent drop survives either way.

## The mechanism is now pinned once, where the next person will look

`Decimal::MAX.checked_add(x)` returning `Ok(Decimal::MAX)` is a property of
`rust_decimal`, not of this sentinel, and it has cost **three** separate
diagnoses in this programme — it also made `chains::optiondata::unlock` re-emit
the locked quote it existed to remove (#459, merged as #472).

`checked_add_near_max_reports_ok_without_moving_the_value` now sits beside the
`d_add` family in `src/model/decimal.rs`, names both call sites it has broken,
and states the rule: **when you nudge a value and need to know it moved, compare
the result against the input; `checked_*` returning `Ok` only says the result
was representable.**

It also pins the boundary, which is narrower than first diagnosed: the silent
window is `|x| < 0.5`, not `|x| < 1`. At half a unit the addend rounds away from
zero to 1 and the sum genuinely overflows. Both sides are asserted so the
boundary is visible rather than implied.

## The sentinel stays `Decimal::MAX`

The issue asks whether it is still the right sentinel. It is: it was a hazard
only because the aggregators added it with the raw operator, and reporting that
sum was the whole of the danger. Replacing it would change the documented return
of the public `alpha` and ripple into `OptionData::calculate_greeks` for no
added safety. `alpha_from`'s doc comment carries that reasoning, states that
nothing prevents a caller reaching the sentinel — with the concrete reachable
case, rather than a claim of impossibility — and points at the pinned test.

The error variant reuses `CalculationErrorKind::ThetaError`: a vanished theta is
the cause, `numerical.rs:147` already uses it that way, and inventing an
`AlphaError` would be a public-API change to buy a better label.

## Aggregated greeks are unchanged — two independent checks

1. **Source-level.** `Decimal::checked_add` and `impl Add for Decimal` both
   dispatch to the same `ops::add_impl`; they differ only in whether a non-`Ok`
   result panics or yields `None`. For any sum the old code did not abort on,
   `d_add` returns the identical value — bit-identically, not approximately.
2. **Differential test.** `test_checked_aggregation_matches_the_unchecked_sum`
   builds a 24-leg matrix (both styles × both sides × three strikes × two
   maturity/vol/quantity regimes), accumulates a reference with the raw `+`
   operator greek by greek, and asserts the whole `Greek` struct equals it
   across all twelve fields, plus each of the twelve `Greeks::*` methods against
   the corresponding reference field.

The fixture for the sentinel tests was verified to be the real defect rather
than a construction: reverting only the two alpha accumulations to `+=` makes
both two-sentinel tests fail with `Addition overflowed` while the other five
still pass.

## The proptest exclusion is gone

`Greeks::greeks` was deliberately absent from the strategies panic-freedom
property, with a comment explaining why. Both are removed and the call is
driven with the rest. 67 property tests pass.

## Tests

4019 lib + 67 property + 423 integration + 207 doctests, 0 failed. `cargo fmt
--all --check`, `cargo clippy --all-targets --all-features --workspace -- -D
warnings`, `make scan-banned` and `make public-api-check` clean — re-run after
the rebase onto `main` rather than trusting the pre-rebase run.

Public API unchanged: both entry points already returned `Result<_,
GreeksError>` and no error variant was added. `CHANGELOG.md` carries the
behaviour change under `### Fixed`, including the note that a lone sentinel is
unaffected.

## Stack

Chain A, second of four.

- Stack: #470 → **#469** (this one) → #463 → #471. Independent of chain B
  (#466 → #451 → #453), chain C (#462), #459, and the #442 capstone.
- Base branch: `main`. #470 merged as #475, so this branch is rebased onto
  `main` and the diff is its own work alone.

Closes #469
