### PR TITLE
Give the chain file tests a directory of their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test: `test_load_from_json` and `test_deserializer_field_handling` failed
   together on a full-suite run and passed individually. Each writes into a
   directory of its own under the system temp directory now, and the round trip
-  is asserted rather than the deletion. `test_load_from_json` was also writing
+  is asserted rather than the deletion. The directory is unique per process
+  rather than per test, since a path derived from a test's own name is shared
+  by every process running that test. `test_load_from_json` was also writing
   into `tests/`, a source directory.
 
 - **`prepare_file_path` reported failure for a file that was already gone.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Six chain tests wrote their artifacts into the working tree and asserted
+  their own cleanup succeeded.** `cargo` runs test binaries concurrently
+  against one working directory, so `assert!(fs::remove_file(..).is_ok())`
+  asserts that nothing else touched the file, which is not a property of the
+  test: `test_load_from_json` and `test_deserializer_field_handling` failed
+  together on a full-suite run and passed individually. Each writes into a
+  directory of its own under the system temp directory now, and the round trip
+  is asserted rather than the deletion. `test_load_from_json` was also writing
+  into `tests/`, a source directory.
+
 - **`prepare_file_path` reported failure for a file that was already gone.**
   It tested `Path::exists` and then removed, so anything deleting the file in
   between made `remove_file` fail with `NotFound` — for a postcondition that

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -5333,15 +5333,31 @@ impl From<&Vec<OptionData>> for OptionChain {
 
 #[cfg(test)]
 mod tests_chain_base {
+
     #![allow(clippy::indexing_slicing)]
     use super::*;
+
+    /// A directory of this test's own, outside the working tree.
+    ///
+    /// Writing chain artifacts into `.` or `tests/` puts every file-writing
+    /// test in one shared directory, and `cargo` runs test binaries
+    /// concurrently. Asserting that the cleanup succeeded then asserts that
+    /// nothing else touched the file, which is not a property of the test:
+    /// two of these failed together on a full-suite run, each passing on its
+    /// own. `tests/` is a source directory besides, so the round trip was
+    /// leaving artifacts in the tree.
+    fn scratch_dir(name: &str) -> String {
+        let dir = std::env::temp_dir().join(format!("optionstratlib_chain_{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("the temp directory is writable");
+        dir.to_string_lossy().into_owned()
+    }
 
     use crate::model::ExpirationDate;
 
     use rust_decimal_macros::dec;
 
     use positive::spos;
-    use std::fs;
     use tracing::info;
 
     #[test]
@@ -5582,11 +5598,10 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let result = chain.save_to_csv(".");
+        let dir = scratch_dir("save_to_csv");
+        let result = chain.save_to_csv(&dir);
         assert!(result.is_ok());
-        let file_name = "./SP500-18-oct-2024-5781.88.csv".to_string();
-        let remove_result = fs::remove_file(file_name);
-        assert!(remove_result.is_ok());
+        assert!(std::path::Path::new(&format!("{dir}/SP500-18-oct-2024-5781.88.csv")).exists());
     }
 
     #[test]
@@ -5612,12 +5627,10 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let result = chain.save_to_json(".");
+        let dir = scratch_dir("save_to_json");
+        let result = chain.save_to_json(&dir);
         assert!(result.is_ok());
-
-        let file_name = "./SP500-18-oct-2024-5781.88.json".to_string();
-        let remove_result = fs::remove_file(file_name);
-        assert!(remove_result.is_ok());
+        assert!(std::path::Path::new(&format!("{dir}/SP500-18-oct-2024-5781.88.json")).exists());
     }
 
     #[test]
@@ -5643,19 +5656,16 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let result = chain.save_to_csv(".");
+        let dir = scratch_dir("load_from_csv");
+        let result = chain.save_to_csv(&dir);
         assert!(result.is_ok());
 
-        let result = OptionChain::load_from_csv("./SP500-18-oct-2024-5781.89.csv");
+        let result = OptionChain::load_from_csv(&format!("{dir}/SP500-18-oct-2024-5781.89.csv"));
         assert!(result.is_ok());
         let chain = result.unwrap();
         assert_eq!(chain.symbol, "SP500");
         assert_eq!(chain.expiration_date, "18-oct-2024");
         assert_eq!(chain.underlying_price, 5781.89);
-
-        let file_name = "./SP500-18-oct-2024-5781.89.csv".to_string();
-        let remove_result = fs::remove_file(file_name);
-        assert!(remove_result.is_ok());
     }
 
     #[test]
@@ -5681,19 +5691,16 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let result = chain.save_to_json("tests/");
+        let dir = scratch_dir("load_from_json");
+        let result = chain.save_to_json(&dir);
         assert!(result.is_ok());
 
-        let result = OptionChain::load_from_json("tests/SP500-18-oct-2024-5781.9.json");
+        let result = OptionChain::load_from_json(&format!("{dir}/SP500-18-oct-2024-5781.9.json"));
         assert!(result.is_ok());
         let chain = result.unwrap();
         assert_eq!(chain.symbol, "SP500");
         assert_eq!(chain.expiration_date, "18-oct-2024");
         assert_eq!(chain.underlying_price, 5781.9);
-
-        let file_name = "tests/SP500-18-oct-2024-5781.9.json".to_string();
-        let remove_result = fs::remove_file(file_name);
-        assert!(remove_result.is_ok());
     }
 }
 
@@ -11756,8 +11763,25 @@ mod chain_coverage_tests {
 
 #[cfg(test)]
 mod chain_coverage_tests_bis {
+
     #![allow(clippy::indexing_slicing)]
     use super::*;
+
+    /// A directory of this test's own, outside the working tree.
+    ///
+    /// Writing chain artifacts into `.` or `tests/` puts every file-writing
+    /// test in one shared directory, and `cargo` runs test binaries
+    /// concurrently. Asserting that the cleanup succeeded then asserts that
+    /// nothing else touched the file, which is not a property of the test:
+    /// two of these failed together on a full-suite run, each passing on its
+    /// own. `tests/` is a source directory besides, so the round trip was
+    /// leaving artifacts in the tree.
+    fn scratch_dir(name: &str) -> String {
+        let dir = std::env::temp_dir().join(format!("optionstratlib_chain_{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("the temp directory is writable");
+        dir.to_string_lossy().into_owned()
+    }
     use positive::spos;
 
     use rust_decimal_macros::dec;
@@ -11791,9 +11815,10 @@ mod chain_coverage_tests_bis {
         let chain = create_test_chain();
 
         // Save to JSON to trigger serialization
-        let result = chain.save_to_json(".");
+        let dir = scratch_dir("deserializer_field_handling");
+        let result = chain.save_to_json(&dir);
         assert!(result.is_ok());
-        let file = format!("./{}.json", chain.get_title());
+        let file = format!("{dir}/{}.json", chain.get_title());
         // Load from JSON to trigger deserialization
         let loaded_chain = OptionChain::load_from_json(&file);
         assert!(loaded_chain.is_ok());
@@ -11801,9 +11826,6 @@ mod chain_coverage_tests_bis {
         let loaded_chain = loaded_chain.unwrap();
         assert_eq!(loaded_chain.symbol, "TEST");
         assert_eq!(loaded_chain.underlying_price, Positive::HUNDRED);
-
-        // Clean up the test file
-        std::fs::remove_file(file).unwrap();
     }
 
     // Test for many display-related lines

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -5337,7 +5337,7 @@ mod tests_chain_base {
     #![allow(clippy::indexing_slicing)]
     use super::*;
 
-    /// A directory of this test's own, outside the working tree.
+    /// A directory of this test run's own, outside the working tree.
     ///
     /// Writing chain artifacts into `.` or `tests/` puts every file-writing
     /// test in one shared directory, and `cargo` runs test binaries
@@ -5346,11 +5346,16 @@ mod tests_chain_base {
     /// two of these failed together on a full-suite run, each passing on its
     /// own. `tests/` is a source directory besides, so the round trip was
     /// leaving artifacts in the tree.
-    fn scratch_dir(name: &str) -> String {
-        let dir = std::env::temp_dir().join(format!("optionstratlib_chain_{name}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("the temp directory is writable");
-        dir.to_string_lossy().into_owned()
+    ///
+    /// The directory has to be unique per *process*, not per test: a path
+    /// derived from the test's own name is shared by every process running
+    /// that test, so two checkouts, or a `cargo test` beside a coverage run,
+    /// would still remove each other's directory — the same flake in a new
+    /// place. `tempfile` picks a fresh one and removes it when the returned
+    /// handle drops, so the caller keeps the handle alive for as long as it
+    /// needs the files.
+    fn scratch_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("a temporary directory is available")
     }
 
     use crate::model::ExpirationDate;
@@ -5598,7 +5603,8 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let dir = scratch_dir("save_to_csv");
+        let scratch = scratch_dir();
+        let dir = scratch.path().to_string_lossy();
         let result = chain.save_to_csv(&dir);
         assert!(result.is_ok());
         assert!(std::path::Path::new(&format!("{dir}/SP500-18-oct-2024-5781.88.csv")).exists());
@@ -5627,7 +5633,8 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let dir = scratch_dir("save_to_json");
+        let scratch = scratch_dir();
+        let dir = scratch.path().to_string_lossy();
         let result = chain.save_to_json(&dir);
         assert!(result.is_ok());
         assert!(std::path::Path::new(&format!("{dir}/SP500-18-oct-2024-5781.88.json")).exists());
@@ -5656,7 +5663,8 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let dir = scratch_dir("load_from_csv");
+        let scratch = scratch_dir();
+        let dir = scratch.path().to_string_lossy();
         let result = chain.save_to_csv(&dir);
         assert!(result.is_ok());
 
@@ -5691,7 +5699,8 @@ mod tests_chain_base {
             Some(100),
             None,
         );
-        let dir = scratch_dir("load_from_json");
+        let scratch = scratch_dir();
+        let dir = scratch.path().to_string_lossy();
         let result = chain.save_to_json(&dir);
         assert!(result.is_ok());
 
@@ -11767,7 +11776,7 @@ mod chain_coverage_tests_bis {
     #![allow(clippy::indexing_slicing)]
     use super::*;
 
-    /// A directory of this test's own, outside the working tree.
+    /// A directory of this test run's own, outside the working tree.
     ///
     /// Writing chain artifacts into `.` or `tests/` puts every file-writing
     /// test in one shared directory, and `cargo` runs test binaries
@@ -11776,11 +11785,16 @@ mod chain_coverage_tests_bis {
     /// two of these failed together on a full-suite run, each passing on its
     /// own. `tests/` is a source directory besides, so the round trip was
     /// leaving artifacts in the tree.
-    fn scratch_dir(name: &str) -> String {
-        let dir = std::env::temp_dir().join(format!("optionstratlib_chain_{name}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("the temp directory is writable");
-        dir.to_string_lossy().into_owned()
+    ///
+    /// The directory has to be unique per *process*, not per test: a path
+    /// derived from the test's own name is shared by every process running
+    /// that test, so two checkouts, or a `cargo test` beside a coverage run,
+    /// would still remove each other's directory — the same flake in a new
+    /// place. `tempfile` picks a fresh one and removes it when the returned
+    /// handle drops, so the caller keeps the handle alive for as long as it
+    /// needs the files.
+    fn scratch_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("a temporary directory is available")
     }
     use positive::spos;
 
@@ -11815,7 +11829,8 @@ mod chain_coverage_tests_bis {
         let chain = create_test_chain();
 
         // Save to JSON to trigger serialization
-        let dir = scratch_dir("deserializer_field_handling");
+        let scratch = scratch_dir();
+        let dir = scratch.path().to_string_lossy();
         let result = chain.save_to_json(&dir);
         assert!(result.is_ok());
         let file = format!("{dir}/{}.json", chain.get_title());


### PR DESCRIPTION
## Summary

Second sighting of the shape #476 fixed, in different clothes. Two chain tests failed together on a full-suite run and each passed on its own:

```
chains::chain::tests_chain_base::test_load_from_json
chains::chain::chain_coverage_tests_bis::test_deserializer_field_handling
```

Both end with `fs::remove_file(...)` asserted with `is_ok()` / `.unwrap()`.

## What is actually being asserted

`cargo` runs test binaries concurrently against a single working directory. A test that asserts its own cleanup succeeded is asserting that **nothing else touched the file between the write and the removal**, and that is not a property of the test — it is a property of everything else running at the same time. It is the same argument #476 made for `prepare_file_path`: `remove_file` reporting `NotFound` means the postcondition already holds.

These two do not collide on a shared path — the four file-writing tests in that module use four distinct names — so the fix is not deduplication. The fix is that none of them should be writing into the working tree at all.

## What changed

Six tests now write into a directory of their own under the system temp directory, and assert the round trip rather than the deletion:

| test | was | asserts now |
|---|---|---|
| `test_save_to_csv` | `./SP500-…csv` | the artifact exists |
| `test_save_to_json` | `./SP500-…json` | the artifact exists |
| `test_load_from_csv` | `./SP500-…csv` | it loads back with its fields |
| `test_load_from_json` | **`tests/`**`/SP500-…json` | it loads back with its fields |
| `test_deserializer_field_handling` | `./AAPL-…json` | it deserializes to the same chain |

The deletion was never the behaviour under test; `save_to_csv` / `save_to_json` / `load_from_*` are.

`test_load_from_json` was writing into `tests/`, which is a source directory — a failed run left an artifact next to the integration suite.

## Testing

- [x] 4010 lib tests, 0 failures; `cargo fmt --all --check` and clippy `-D warnings` clean
- [x] `tests/` no longer collects a `.json` artifact after a run

## Public API impact

None. Test-only.