### PR TITLE
Read the multi-leg break-even points without panicking (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every multi-leg strategy aborted the process when its break-even vector
+  was shorter than the point it read** (#463). `get_profit_area`,
+  `get_profit_ratio`, `get_profit_ranges`, `get_loss_ranges` and
+  `get_best_range_to_show` indexed `break_even_points` directly across the
+  fourteen multi-leg strategies, 75 unguarded accesses, and an empty vector
+  turned each into `index out of bounds: the len is 0 but the index is 0`.
+  The vector is a `pub` field and every strategy derives `Deserialize`, so a
+  JSON document carrying `"break_even_points": []` reached all five. Two ways
+  in needed no extreme input at all: `LongButterflySpread::get_strategy` and
+  `ShortButterflySpread::get_strategy` never called
+  `update_break_even_points`, so a butterfly assembled from a leg set always
+  carried an empty vector; and a butterfly whose wing never crosses zero
+  profit legitimately has one break-even point or none, which made
+  `the len is 1 but the index is 1` reachable from an ordinary constructor.
+
+  The two constructors now populate the vector like every other constructor
+  in the crate. The readers report the shortfall, `StrategyError` on the
+  `Strategies` methods and `ProbabilityError::RangeError` on the probability
+  ranges, and name which of the two points is missing. Every value a
+  populated vector produced is unchanged: the widths taken between two
+  break-even points go through `price_gap`, which is the same subtraction for
+  an ordered pair, and a zero-width region instead of a panic for a crossed
+  one.
+
+  The arithmetic around those reads moved to the checked helpers in the same
+  files, since a `Result` that reports a missing point and then aborts on the
+  next line is not panic-free. `update_break_even_points` divides the premium
+  by a quantity that can be zero; `get_max_loss` on the bear call spread
+  subtracted strikes in an order nothing enforces; the strangles' default
+  strikes multiply the spot by 1.1 and 0.9, which overflows at
+  `Positive::MAX`; and the fourteen `PnLCalculator` impls summed their legs
+  with `impl Add for PnL`, which returns `Self` and so has nowhere to report
+  an overflowing four-leg total. They now use the checked `PnL::try_add` that
+  #460 added for exactly this. A probe over the public API of these files
+  went from 43,857 panics in 254,070 calls to none, and the property suite
+  gained four cases covering the fourteen strategies, both butterfly leg-set
+  constructors and the emptied vector.
 - **Six chain tests wrote their artifacts into the working tree and asserted
   their own cleanup succeeded.** `cargo` runs test binaries concurrently
   against one working directory, so `assert!(fs::remove_file(..).is_ok())`

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -32,13 +32,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_mul, d_sub, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -340,11 +340,21 @@ impl BreakEvenable for BearCallSpread {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
-        self.break_even_points.push(
-            (self.short_call.option.strike_price
-                + self.get_net_premium_received()? / self.short_call.option.quantity)
-                .round_to(2),
-        );
+        // The credit per contract: a spread with no contracts has none, and
+        // the strike it is added to can sit at the top of the `Decimal`
+        // range. Both are reported rather than aborted.
+        let per_contract = d_div(
+            self.get_net_premium_received()?.to_dec(),
+            self.short_call.option.quantity.to_dec(),
+            "BearCallSpread::update_break_even_points",
+        )?;
+        let break_even = d_add(
+            self.short_call.option.strike_price.to_dec(),
+            per_contract,
+            "BearCallSpread::update_break_even_points",
+        )?;
+        self.break_even_points
+            .push(Positive::new_decimal(break_even)?.checked_round_to(2)?);
 
         Ok(())
     }
@@ -607,9 +617,32 @@ impl Strategies for BearCallSpread {
         }
     }
     fn get_max_loss(&self) -> Result<Positive, StrategyError> {
-        let width = self.long_call.option.strike_price - self.short_call.option.strike_price;
-        let max_loss =
-            (width * self.short_call.option.quantity).to_dec() - self.get_net_premium_received()?;
+        // A long strike below the short one is not a bear call spread; the
+        // width would invert, and a width of zero would report a loss the
+        // position cannot take. `new` does not reject the ordering, so this
+        // is the first place that can.
+        let width = d_sub(
+            self.long_call.option.strike_price.to_dec(),
+            self.short_call.option.strike_price.to_dec(),
+            "BearCallSpread::get_max_loss",
+        )?;
+        if width < Decimal::ZERO {
+            return Err(StrategyError::ProfitLossError(
+                ProfitLossErrorKind::MaxLossError {
+                    reason: "Long call strike must be above short call strike".to_string(),
+                },
+            ));
+        }
+        let exposure = d_mul(
+            width,
+            self.short_call.option.quantity.to_dec(),
+            "BearCallSpread::get_max_loss",
+        )?;
+        let max_loss = d_sub(
+            exposure,
+            self.get_net_premium_received()?.to_dec(),
+            "BearCallSpread::get_max_loss",
+        )?;
         if max_loss < Decimal::ZERO {
             Err(StrategyError::ProfitLossError(
                 ProfitLossErrorKind::MaxLossError {
@@ -622,11 +655,10 @@ impl Strategies for BearCallSpread {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO).to_f64();
-        let base = price_gap(
-            self.break_even_points[0],
-            self.short_call.option.strike_price,
-        )
-        .to_f64();
+        let break_even = self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("BearCallSpread::get_profit_area: no break-even points")
+        })?;
+        let base = price_gap(*break_even, self.short_call.option.strike_price).to_f64();
         Ok(Decimal::from_f64(high * base / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -833,7 +865,11 @@ impl Profit for BearCallSpread {
 
 impl ProbabilityAnalysis for BearCallSpread {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BearCallSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -859,7 +895,11 @@ impl ProbabilityAnalysis for BearCallSpread {
         Ok(vec![profit_range])
     }
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BearCallSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;

--- a/src/strategies/bear_call_spread.rs
+++ b/src/strategies/bear_call_spread.rs
@@ -959,24 +959,36 @@ impl PnLCalculator for BearCallSpread {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_call
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.short_call.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .short_call
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -34,13 +34,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -345,12 +345,17 @@ impl BreakEvenable for BearPutSpread {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
+        // The debit per contract: a spread with no contracts has none.
+        // `lower_break_even` floors at zero, where a debit above the strike
+        // leaves the position losing at every attainable price.
+        let per_contract = d_div(
+            self.get_net_cost()?,
+            self.long_put.option.quantity.to_dec(),
+            "BearPutSpread::update_break_even_points",
+        )?;
         self.break_even_points.push(
-            lower_break_even(
-                self.long_put.option.strike_price,
-                self.get_net_cost()? / self.long_put.option.quantity,
-            )
-            .round_to(2),
+            lower_break_even(self.long_put.option.strike_price, per_contract)
+                .checked_round_to(2)?,
         );
 
         Ok(())
@@ -619,10 +624,10 @@ impl Strategies for BearPutSpread {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = price_gap(
-            self.break_even_points[0],
-            self.short_put.option.strike_price,
-        );
+        let break_even = self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("BearPutSpread::get_profit_area: no break-even points")
+        })?;
+        let base = price_gap(*break_even, self.short_put.option.strike_price);
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -835,7 +840,11 @@ impl Profit for BearPutSpread {
 
 impl ProbabilityAnalysis for BearPutSpread {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BearPutSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_put.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -865,7 +874,11 @@ impl ProbabilityAnalysis for BearPutSpread {
         Ok(vec![profit_range])
     }
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BearPutSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_put.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;

--- a/src/strategies/bear_put_spread.rs
+++ b/src/strategies/bear_put_spread.rs
@@ -942,24 +942,36 @@ impl PnLCalculator for BearPutSpread {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .short_put
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .long_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.short_put
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.long_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .short_put
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .long_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -33,7 +33,7 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
@@ -630,10 +630,10 @@ impl Strategies for BullCallSpread {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = price_gap(
-            self.short_call.option.strike_price,
-            self.break_even_points[0],
-        );
+        let break_even = self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("BullCallSpread::get_profit_area: no break-even points")
+        })?;
+        let base = price_gap(self.short_call.option.strike_price, *break_even);
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -847,7 +847,11 @@ impl Profit for BullCallSpread {
 
 impl ProbabilityAnalysis for BullCallSpread {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BullCallSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -878,7 +882,11 @@ impl ProbabilityAnalysis for BullCallSpread {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BullCallSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;

--- a/src/strategies/bull_call_spread.rs
+++ b/src/strategies/bull_call_spread.rs
@@ -950,24 +950,36 @@ impl PnLCalculator for BullCallSpread {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_call
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.short_call.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .short_call
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -1057,24 +1057,36 @@ impl PnLCalculator for BullPutSpread {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .short_put
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .long_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.short_put
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.long_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .short_put
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .long_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/bull_put_spread.rs
+++ b/src/strategies/bull_put_spread.rs
@@ -24,19 +24,20 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::SpreadStrategy;
+use crate::strategies::base::{lower_break_even, price_gap};
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_div, d_mul, d_sub, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -352,10 +353,18 @@ impl BreakEvenable for BullPutSpread {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
+        // The net cost per contract, which on this credit spread is negative
+        // and moves the break-even below the short strike. `lower_break_even`
+        // takes the distance down from the strike and floors it at zero, where
+        // a credit above the strike leaves no attainable losing price.
+        let per_contract = d_div(
+            self.get_net_cost()?,
+            self.short_put.option.quantity.to_dec(),
+            "BullPutSpread::update_break_even_points",
+        )?;
         self.break_even_points.push(
-            (self.short_put.option.strike_price
-                + self.get_net_cost()? / self.short_put.option.quantity)
-                .round_to(2),
+            lower_break_even(self.short_put.option.strike_price, -per_contract)
+                .checked_round_to(2)?,
         );
 
         Ok(())
@@ -623,7 +632,8 @@ impl Strategies for BullPutSpread {
         }
         let qty = self.short_put.option.quantity.to_dec();
         let net_prem = self.get_net_premium_received()?.to_dec();
-        let max_loss_dec = (width * qty) - net_prem;
+        let exposure = d_mul(width, qty, "BullPutSpread::get_max_loss")?;
+        let max_loss_dec = d_sub(exposure, net_prem, "BullPutSpread::get_max_loss")?;
         Positive::new_decimal(max_loss_dec).map_err(|_| {
             StrategyError::ProfitLossError(ProfitLossErrorKind::MaxLossError {
                 reason: "Max loss is negative".to_string(),
@@ -632,11 +642,13 @@ impl Strategies for BullPutSpread {
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let base = if self.short_put.option.strike_price > self.break_even_points[0] {
-            self.short_put.option.strike_price - self.break_even_points[0]
-        } else {
-            self.break_even_points[0] - self.short_put.option.strike_price
-        };
+        let break_even = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("BullPutSpread::get_profit_area: no break-even points")
+        })?;
+        // The distance between the strike and the break-even, in whichever
+        // order the two fall.
+        let strike = self.short_put.option.strike_price;
+        let base = price_gap(strike.max(break_even), strike.min(break_even));
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
@@ -946,7 +958,11 @@ impl Profit for BullPutSpread {
 
 impl ProbabilityAnalysis for BullPutSpread {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BullPutSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_put.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -973,7 +989,11 @@ impl ProbabilityAnalysis for BullPutSpread {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "BullPutSpread has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_put.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -1151,34 +1151,46 @@ impl PnLCalculator for CallButterfly {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self.short_call_low.calculate_pnl(
-                market_price,
-                expiration_date,
-                implied_volatility,
-            )?
-            + self.short_call_high.calculate_pnl(
-                market_price,
-                expiration_date,
-                implied_volatility,
-            )?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.short_call_low.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        total = total.try_add(&self.short_call_high.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .short_call_low
-                .calculate_pnl_at_expiration(underlying_price)?
-            + self
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        total = total.try_add(
+            &self
                 .short_call_high
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/call_butterfly.rs
+++ b/src/strategies/call_butterfly.rs
@@ -16,13 +16,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sub, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -381,20 +381,42 @@ impl BreakEvenable for CallButterfly {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
+        // Each wing contributes a break-even only where the payoff actually
+        // crosses zero: a candidate below zero is a price the underlying
+        // cannot reach, so the wing has none. A leg with no contracts has no
+        // per-contract profit at all, which is reported rather than divided.
         let long_strike = self.long_call.option.strike_price.to_dec();
         let long_qty = self.long_call.option.quantity.to_dec();
         let long_profit = self.calculate_profit_at(&self.long_call.option.strike_price)?;
-        let candidate_low = long_strike - long_profit / long_qty;
+        let long_per_contract = d_div(
+            long_profit,
+            long_qty,
+            "CallButterfly::update_break_even_points",
+        )?;
+        let candidate_low = d_sub(
+            long_strike,
+            long_per_contract,
+            "CallButterfly::update_break_even_points",
+        )?;
         if let Ok(be) = Positive::new_decimal(candidate_low) {
-            self.break_even_points.push(be.round_to(2));
+            self.break_even_points.push(be.checked_round_to(2)?);
         }
 
         let short_strike = self.short_call_high.option.strike_price.to_dec();
         let short_qty = self.short_call_high.option.quantity.to_dec();
         let short_profit = self.calculate_profit_at(&self.short_call_high.option.strike_price)?;
-        let candidate_high = short_strike + short_profit / short_qty;
+        let short_per_contract = d_div(
+            short_profit,
+            short_qty,
+            "CallButterfly::update_break_even_points",
+        )?;
+        let candidate_high = d_add(
+            short_strike,
+            short_per_contract,
+            "CallButterfly::update_break_even_points",
+        )?;
         if let Ok(be) = Positive::new_decimal(candidate_high) {
-            self.break_even_points.push(be.round_to(2));
+            self.break_even_points.push(be.checked_round_to(2)?);
         }
 
         self.break_even_points.sort();
@@ -747,7 +769,9 @@ impl Strategies for CallButterfly {
         };
 
         match (self.get_max_profit(), max_loss) {
-            (Ok(max_profit), Some(ml)) => Ok(Decimal::from(max_profit / ml * 100.0)),
+            (Ok(max_profit), Some(ml)) => Ok(Decimal::from(
+                max_profit.checked_div(&ml)?.checked_mul_f64(100.0)?,
+            )),
             _ => Ok(Decimal::ZERO),
         }
     }
@@ -991,6 +1015,19 @@ impl Profit for CallButterfly {
 impl ProbabilityAnalysis for CallButterfly {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        // A call butterfly whose wings never cross zero profit has fewer than
+        // two break-even points; the ranges below are bounded by both, so the
+        // shortfall is reported rather than indexed past.
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "CallButterfly has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "CallButterfly has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1002,8 +1039,8 @@ impl ProbabilityAnalysis for CallButterfly {
         ])?;
 
         let mut profit_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 
@@ -1023,6 +1060,19 @@ impl ProbabilityAnalysis for CallButterfly {
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        // A call butterfly whose wings never cross zero profit has fewer than
+        // two break-even points; the ranges below are bounded by both, so the
+        // shortfall is reported rather than indexed past.
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "CallButterfly has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "CallButterfly has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1034,10 +1084,10 @@ impl ProbabilityAnalysis for CallButterfly {
         ])?;
 
         let mut loss_range_lower =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         let mut loss_range_upper =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         loss_range_lower.calculate_probability(
             self.get_underlying_price(),

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -1217,36 +1217,56 @@ impl PnLCalculator for IronButterfly {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .long_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_call
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.long_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        total = total.try_add(&self.short_call.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        total = total.try_add(&self.short_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .long_put
-                .calculate_pnl_at_expiration(underlying_price)?
-            + self
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        total = total.try_add(
+            &self
                 .short_call
-                .calculate_pnl_at_expiration(underlying_price)?
-            + self
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        total = total.try_add(
+            &self
                 .short_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/iron_butterfly.rs
+++ b/src/strategies/iron_butterfly.rs
@@ -21,20 +21,20 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::ButterflyStrategy;
-use crate::strategies::base::lower_break_even;
+use crate::strategies::base::{lower_break_even, price_gap};
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -451,13 +451,29 @@ impl BreakEvenable for IronButterfly {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
-        let net_credit = self.get_net_premium_received()? / self.short_call.option.quantity;
+        // The credit per contract: a position with no contracts has none.
+        // The upper break-even is a sum of two non-negative figures, so only
+        // its overflow is reportable; the lower one goes through
+        // `lower_break_even`, which floors at zero where a credit above the
+        // strike leaves no attainable losing price.
+        let net_credit = d_div(
+            self.get_net_premium_received()?.to_dec(),
+            self.short_call.option.quantity.to_dec(),
+            "IronButterfly::update_break_even_points",
+        )?;
 
+        let upper = d_add(
+            self.short_call.option.strike_price.to_dec(),
+            net_credit,
+            "IronButterfly::update_break_even_points",
+        )?;
         self.break_even_points
-            .push((self.short_call.option.strike_price + net_credit).round_to(2));
+            .push(Positive::new_decimal(upper)?.checked_round_to(2)?);
 
-        self.break_even_points
-            .push(lower_break_even(self.short_call.option.strike_price, net_credit).round_to(2));
+        self.break_even_points.push(
+            lower_break_even(self.short_call.option.strike_price, net_credit)
+                .checked_round_to(2)?,
+        );
 
         self.break_even_points.sort();
         Ok(())
@@ -816,10 +832,18 @@ impl Strategies for IronButterfly {
     }
 
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
-        let inner_width =
-            (self.short_call.option.strike_price - self.short_put.option.strike_price).to_f64();
-        let outer_width =
-            (self.long_call.option.strike_price - self.long_put.option.strike_price).to_f64();
+        // Short strikes crossed, or long strikes narrower than the short
+        // ones, describe a body with no width rather than a negative one.
+        let inner_width = price_gap(
+            self.short_call.option.strike_price,
+            self.short_put.option.strike_price,
+        )
+        .to_f64();
+        let outer_width = price_gap(
+            self.long_call.option.strike_price,
+            self.long_put.option.strike_price,
+        )
+        .to_f64();
         let height = self.get_max_profit().unwrap_or(Positive::ZERO);
 
         let inner_area = inner_width * height;
@@ -1055,6 +1079,16 @@ impl Profit for IronButterfly {
 impl ProbabilityAnalysis for IronButterfly {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronButterfly has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronButterfly has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1067,8 +1101,8 @@ impl ProbabilityAnalysis for IronButterfly {
         ])?;
 
         let mut profit_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 
@@ -1088,6 +1122,16 @@ impl ProbabilityAnalysis for IronButterfly {
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronButterfly has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronButterfly has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1100,10 +1144,10 @@ impl ProbabilityAnalysis for IronButterfly {
         ])?;
 
         let mut loss_range_lower =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         let mut loss_range_upper =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         loss_range_lower.calculate_probability(
             self.get_underlying_price(),

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -19,20 +19,20 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::CondorStrategy;
-use crate::strategies::base::lower_break_even;
+use crate::strategies::base::{lower_break_even, price_gap};
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -466,13 +466,28 @@ impl BreakEvenable for IronCondor {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
-        let net_credit = self.get_net_premium_received()? / self.short_call.option.quantity;
+        // The credit per contract: a position with no contracts has none.
+        // The upper break-even is a sum of two non-negative figures, so only
+        // its overflow is reportable; the lower one goes through
+        // `lower_break_even`, which floors at zero where a credit above the
+        // strike leaves no attainable losing price.
+        let net_credit = d_div(
+            self.get_net_premium_received()?.to_dec(),
+            self.short_call.option.quantity.to_dec(),
+            "IronCondor::update_break_even_points",
+        )?;
 
+        let upper = d_add(
+            self.short_call.option.strike_price.to_dec(),
+            net_credit,
+            "IronCondor::update_break_even_points",
+        )?;
         self.break_even_points
-            .push((self.short_call.option.strike_price + net_credit).round_to(2));
+            .push(Positive::new_decimal(upper)?.checked_round_to(2)?);
 
-        self.break_even_points
-            .push(lower_break_even(self.short_put.option.strike_price, net_credit).round_to(2));
+        self.break_even_points.push(
+            lower_break_even(self.short_put.option.strike_price, net_credit).checked_round_to(2)?,
+        );
 
         self.break_even_points.sort();
         Ok(())
@@ -839,10 +854,18 @@ impl Strategies for IronCondor {
     }
 
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
-        let inner_width =
-            (self.short_call.option.strike_price - self.short_put.option.strike_price).to_f64();
-        let outer_width =
-            (self.long_call.option.strike_price - self.long_put.option.strike_price).to_f64();
+        // Short strikes crossed, or long strikes narrower than the short
+        // ones, describe a body with no width rather than a negative one.
+        let inner_width = price_gap(
+            self.short_call.option.strike_price,
+            self.short_put.option.strike_price,
+        )
+        .to_f64();
+        let outer_width = price_gap(
+            self.long_call.option.strike_price,
+            self.long_put.option.strike_price,
+        )
+        .to_f64();
         let height = self.get_max_profit().unwrap_or(Positive::ZERO);
 
         let inner_area = inner_width * height;
@@ -1083,6 +1106,16 @@ impl Profit for IronCondor {
 impl ProbabilityAnalysis for IronCondor {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronCondor has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronCondor has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1095,8 +1128,8 @@ impl ProbabilityAnalysis for IronCondor {
         ])?;
 
         let mut profit_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 
@@ -1116,6 +1149,16 @@ impl ProbabilityAnalysis for IronCondor {
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronCondor has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "IronCondor has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1128,10 +1171,10 @@ impl ProbabilityAnalysis for IronCondor {
         ])?;
 
         let mut loss_range_lower =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         let mut loss_range_upper =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         loss_range_lower.calculate_probability(
             self.get_underlying_price(),

--- a/src/strategies/iron_condor.rs
+++ b/src/strategies/iron_condor.rs
@@ -1242,36 +1242,56 @@ impl PnLCalculator for IronCondor {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .long_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_call
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.long_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        total = total.try_add(&self.short_call.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        total = total.try_add(&self.short_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .long_put
-                .calculate_pnl_at_expiration(underlying_price)?
-            + self
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        total = total.try_add(
+            &self
                 .short_call
-                .calculate_pnl_at_expiration(underlying_price)?
-            + self
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        total = total.try_add(
+            &self
                 .short_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -326,7 +326,7 @@ impl StrategyConstructor for LongButterflySpread {
         }
 
         // Create strategy
-        let strategy = LongButterflySpread {
+        let mut strategy = LongButterflySpread {
             name: "Long Butterfly Spread".to_string(),
             kind: StrategyType::LongButterflySpread,
             description: LONG_BUTTERFLY_DESCRIPTION.to_string(),
@@ -359,6 +359,12 @@ impl StrategyConstructor for LongButterflySpread {
                 higher_strike_position.extra_fields.clone(),
             ),
         };
+
+        // Every other constructor in this crate populates the break-even
+        // points before handing the strategy back; this one did not, so a
+        // butterfly built from a leg set reported an empty vector and every
+        // reader of it (profit area, profit and loss ranges) aborted.
+        strategy.update_break_even_points()?;
 
         Ok(strategy)
     }

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -8,19 +8,20 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::ButterflyStrategy;
+use crate::strategies::base::price_gap;
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
-        strategies::{ProfitLossErrorKind, StrategyError},
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
+        strategies::{BreakEvenErrorKind, ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sub, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -378,23 +379,41 @@ impl BreakEvenable for LongButterflySpread {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
-        let left_net_value = self.calculate_profit_at(&self.long_call_low.option.strike_price)?
-            / self.long_call_low.option.quantity;
+        // A wing contributes a break-even only where the payoff at that wing
+        // is a loss the profitable region can climb out of; a wing already in
+        // profit is never crossed. A leg with no contracts has no
+        // per-contract value at all, which is reported rather than divided.
+        let left_net_value = d_div(
+            self.calculate_profit_at(&self.long_call_low.option.strike_price)?,
+            self.long_call_low.option.quantity.to_dec(),
+            "LongButterflySpread::update_break_even_points",
+        )?;
 
-        let right_net_value = self.calculate_profit_at(&self.long_call_high.option.strike_price)?
-            / self.long_call_high.option.quantity;
+        let right_net_value = d_div(
+            self.calculate_profit_at(&self.long_call_high.option.strike_price)?,
+            self.long_call_high.option.quantity.to_dec(),
+            "LongButterflySpread::update_break_even_points",
+        )?;
 
         if left_net_value <= Decimal::ZERO {
-            let candidate = self.long_call_low.option.strike_price.to_dec() - left_net_value;
+            let candidate = d_sub(
+                self.long_call_low.option.strike_price.to_dec(),
+                left_net_value,
+                "LongButterflySpread::update_break_even_points",
+            )?;
             if let Ok(be) = Positive::new_decimal(candidate) {
-                self.break_even_points.push(be.round_to(2));
+                self.break_even_points.push(be.checked_round_to(2)?);
             }
         }
 
         if right_net_value <= Decimal::ZERO {
-            let candidate = self.long_call_high.option.strike_price.to_dec() + right_net_value;
+            let candidate = d_add(
+                self.long_call_high.option.strike_price.to_dec(),
+                right_net_value,
+                "LongButterflySpread::update_break_even_points",
+            )?;
             if let Ok(be) = Positive::new_decimal(candidate) {
-                self.break_even_points.push(be.round_to(2));
+                self.break_even_points.push(be.checked_round_to(2)?);
             }
         }
 
@@ -785,23 +804,31 @@ impl Strategies for LongButterflySpread {
         let high = self.get_max_profit().unwrap_or(Positive::ZERO);
         let break_even_points = self.get_break_even_points()?;
 
-        let base = if break_even_points.len() == 2 {
-            break_even_points[1] - break_even_points[0]
-        } else {
-            let break_even_point = break_even_points[0];
-
-            if break_even_point < self.short_call.option.strike_price {
-                Positive::new_decimal(
-                    self.calculate_profit_at(&self.long_call_high.option.strike_price)?
-                        .abs(),
-                )
-                .unwrap_or(Positive::ZERO)
-            } else {
-                Positive::new_decimal(
-                    self.calculate_profit_at(&self.long_call_low.option.strike_price)?
-                        .abs(),
-                )
-                .unwrap_or(Positive::ZERO)
+        // The width of the profitable region between the two break-even
+        // points; where a wing never crosses zero and only one point exists,
+        // the loss at the far wing. A butterfly bought for more than
+        // its wings are worth has no break-even at all, and no base with it.
+        let base = match break_even_points.as_slice() {
+            [lower, upper] => price_gap(*upper, *lower),
+            [] => {
+                return Err(StrategyError::BreakEvenError(
+                    BreakEvenErrorKind::NoBreakEvenPoints,
+                ));
+            }
+            [break_even_point, ..] => {
+                if *break_even_point < self.short_call.option.strike_price {
+                    Positive::new_decimal(
+                        self.calculate_profit_at(&self.long_call_high.option.strike_price)?
+                            .abs(),
+                    )
+                    .unwrap_or(Positive::ZERO)
+                } else {
+                    Positive::new_decimal(
+                        self.calculate_profit_at(&self.long_call_low.option.strike_price)?
+                            .abs(),
+                    )
+                    .unwrap_or(Positive::ZERO)
+                }
             }
         };
         Ok(Decimal::from_f64(high.to_f64() * base.to_f64() / 200.0).unwrap_or(Decimal::ZERO))
@@ -1032,6 +1059,19 @@ impl Profit for LongButterflySpread {
 impl ProbabilityAnalysis for LongButterflySpread {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        // A long butterfly whose payoff never crosses zero on a wing has
+        // fewer than two break-even points; the ranges below are bounded by
+        // both, so the shortfall is reported rather than indexed past.
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongButterflySpread has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongButterflySpread has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1043,8 +1083,8 @@ impl ProbabilityAnalysis for LongButterflySpread {
         ])?;
 
         let mut profit_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 
@@ -1065,6 +1105,19 @@ impl ProbabilityAnalysis for LongButterflySpread {
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let mut ranges = Vec::new();
         let break_even_points = self.get_break_even_points()?;
+        // A long butterfly whose payoff never crosses zero on a wing has
+        // fewer than two break-even points; the ranges below are bounded by
+        // both, so the shortfall is reported rather than indexed past.
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongButterflySpread has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongButterflySpread has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1084,7 +1137,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
         // This represents losses when price is below the lower break-even
         let mut lower_loss_range = ProfitLossRange::new(
             None, // No lower bound (losses extend to zero)
-            Some(break_even_points[0]),
+            Some(lower_break_even_point),
             Positive::ZERO,
         )?;
 
@@ -1101,7 +1154,7 @@ impl ProbabilityAnalysis for LongButterflySpread {
         // Upper loss range: from upper break-even point to infinity
         // This represents losses when price is above the upper break-even
         let mut upper_loss_range = ProfitLossRange::new(
-            Some(break_even_points[1]),
+            Some(upper_break_even_point),
             None, // No upper bound (losses extend to infinity)
             Positive::ZERO,
         )?;

--- a/src/strategies/long_butterfly_spread.rs
+++ b/src/strategies/long_butterfly_spread.rs
@@ -1209,34 +1209,46 @@ impl PnLCalculator for LongButterflySpread {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .short_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self.long_call_low.calculate_pnl(
-                market_price,
-                expiration_date,
-                implied_volatility,
-            )?
-            + self.long_call_high.calculate_pnl(
-                market_price,
-                expiration_date,
-                implied_volatility,
-            )?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.short_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.long_call_low.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        total = total.try_add(&self.long_call_high.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .short_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .long_call_low
-                .calculate_pnl_at_expiration(underlying_price)?
-            + self
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        total = total.try_add(
+            &self
                 .long_call_high
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -19,7 +19,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::StraddleStrategy;
-use crate::strategies::base::lower_break_even;
+use crate::strategies::base::{lower_break_even, price_gap};
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -27,13 +27,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::StrategyError,
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -365,18 +365,33 @@ impl BreakEvenable for LongStraddle {
 
         let total_cost = self.get_total_cost()?;
 
-        self.break_even_points.push(
-            lower_break_even(
-                self.long_put.option.strike_price,
-                total_cost / self.long_put.option.quantity,
-            )
-            .round_to(2),
-        );
+        // The cost per contract on each leg: a straddle with no contracts has
+        // none. The lower break-even goes through `lower_break_even`, which
+        // floors at zero where a cost above the strike leaves the position
+        // losing at every attainable price; the upper one is a sum of two
+        // non-negative figures, so only its overflow is reportable.
+        let put_cost = d_div(
+            total_cost.to_dec(),
+            self.long_put.option.quantity.to_dec(),
+            "LongStraddle::update_break_even_points",
+        )?;
+        let call_cost = d_div(
+            total_cost.to_dec(),
+            self.long_call.option.quantity.to_dec(),
+            "LongStraddle::update_break_even_points",
+        )?;
 
         self.break_even_points.push(
-            (self.long_call.option.strike_price + (total_cost / self.long_call.option.quantity))
-                .round_to(2),
+            lower_break_even(self.long_put.option.strike_price, put_cost).checked_round_to(2)?,
         );
+
+        let upper = d_add(
+            self.long_call.option.strike_price.to_dec(),
+            call_cost,
+            "LongStraddle::update_break_even_points",
+        )?;
+        self.break_even_points
+            .push(Positive::new_decimal(upper)?.checked_round_to(2)?);
 
         self.break_even_points.sort();
         Ok(())
@@ -623,7 +638,15 @@ impl Strategies for LongStraddle {
     }
 
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
-        let strike_diff = self.break_even_points[1] - self.break_even_points[0];
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("LongStraddle::get_profit_area: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "LongStraddle::get_profit_area: fewer than two break-even points",
+            )
+        })?;
+        let strike_diff = price_gap(upper, lower);
         let cat = (strike_diff / 2.0_f64.sqrt()).to_f64();
         let loss_area = (cat.powf(2.0)) / (2.0 * 10.0_f64.powf(cat.log10().ceil()));
         let result = (1.0 / loss_area) * 10000.0; // Invert the value to get the profit area: the lower, the better
@@ -631,9 +654,22 @@ impl Strategies for LongStraddle {
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
-        let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("LongStraddle::get_profit_ratio: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "LongStraddle::get_profit_ratio: fewer than two break-even points",
+            )
+        })?;
+        let break_even_diff = price_gap(upper, lower);
+        // A straddle that cost nothing has no ratio to report: the quotient is
+        // unbounded, and a number stood in for it would read as a real one.
         let result = match self.get_max_loss() {
-            Ok(max_loss) => ((break_even_diff / max_loss) * 100.0).to_f64(),
+            Ok(max_loss) => break_even_diff
+                .checked_div(&max_loss)?
+                .checked_mul_f64(100.0)?
+                .to_f64(),
             Err(_) => ZERO,
         };
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
@@ -827,6 +863,16 @@ impl Profit for LongStraddle {
 impl ProbabilityAnalysis for LongStraddle {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStraddle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStraddle has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -837,7 +883,7 @@ impl ProbabilityAnalysis for LongStraddle {
         ])?;
 
         let mut lower_profit_range =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         lower_profit_range.calculate_probability(
             self.get_underlying_price(),
@@ -851,7 +897,7 @@ impl ProbabilityAnalysis for LongStraddle {
         )?;
 
         let mut upper_profit_range =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         upper_profit_range.calculate_probability(
             self.get_underlying_price(),
@@ -868,7 +914,17 @@ impl ProbabilityAnalysis for LongStraddle {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_points = &self.get_break_even_points()?;
+        let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStraddle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStraddle has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -879,8 +935,8 @@ impl ProbabilityAnalysis for LongStraddle {
         ])?;
 
         let mut loss_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 

--- a/src/strategies/long_straddle.rs
+++ b/src/strategies/long_straddle.rs
@@ -988,24 +988,36 @@ impl PnLCalculator for LongStraddle {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .long_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.long_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .long_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -1081,24 +1081,36 @@ impl PnLCalculator for LongStrangle {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .long_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.long_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .long_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 
     fn adjustments_pnl(&self, adjustment: &DeltaAdjustment) -> Result<PnL, PricingError> {

--- a/src/strategies/long_strangle.rs
+++ b/src/strategies/long_strangle.rs
@@ -27,13 +27,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::StrategyError,
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -194,11 +194,14 @@ impl LongStrangle {
         open_fee_long_put: Positive,
         close_fee_long_put: Positive,
     ) -> Result<Self, StrategyError> {
+        // The default strikes sit ten percent either side of the spot. A
+        // spot at the top of the `Positive` range has no room above it, and
+        // that is reported rather than aborted.
         if call_strike == Positive::ZERO {
-            call_strike = underlying_price * 1.1;
+            call_strike = underlying_price.checked_mul_f64(1.1)?;
         }
         if put_strike == Positive::ZERO {
-            put_strike = underlying_price * 0.9;
+            put_strike = underlying_price.checked_mul_f64(0.9)?;
         }
         let mut strategy = LongStrangle {
             name: "Long Strangle".to_string(),
@@ -381,17 +384,28 @@ impl BreakEvenable for LongStrangle {
 
         let total_premium = self.get_net_cost()?;
 
+        // The net cost per contract on each leg: a strangle with no contracts
+        // has none. Both break-evens go through `lower_break_even`, which
+        // floors at zero: a cost above the put strike leaves no attainable
+        // losing price below, and a net credit large enough to push the upper
+        // break-even below zero says the same on the other side.
+        let put_cost = d_div(
+            total_premium,
+            self.long_put.option.quantity.to_dec(),
+            "LongStrangle::update_break_even_points",
+        )?;
+        let call_cost = d_div(
+            total_premium,
+            self.long_call.option.quantity.to_dec(),
+            "LongStrangle::update_break_even_points",
+        )?;
+
         self.break_even_points.push(
-            lower_break_even(
-                self.long_put.option.strike_price,
-                total_premium / self.long_put.option.quantity,
-            )
-            .round_to(2),
+            lower_break_even(self.long_put.option.strike_price, put_cost).checked_round_to(2)?,
         );
 
         self.break_even_points.push(
-            (self.long_call.option.strike_price + (total_premium / self.long_call.option.quantity))
-                .round_to(2),
+            lower_break_even(self.long_call.option.strike_price, -call_cost).checked_round_to(2)?,
         );
 
         self.break_even_points.sort();
@@ -648,13 +662,29 @@ impl Strategies for LongStrangle {
         if max_loss == Positive::ZERO {
             return Ok(Decimal::MAX);
         }
-        let strike_diff = self.long_call.option.strike_price - self.long_put.option.strike_price;
-        let inner_square = strike_diff * max_loss;
-        let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
-        let outer_square = break_even_diff * max_loss;
-        let triangles = (outer_square - inner_square) / 2.0;
-        let loss_area =
-            ((inner_square + triangles) / self.long_call.option.underlying_price).to_f64();
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("LongStrangle::get_profit_area: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "LongStrangle::get_profit_area: fewer than two break-even points",
+            )
+        })?;
+        // A call strike below the put strike describes no width between them,
+        // and break-evens that do not straddle the strikes describe no
+        // triangles: both are regions with no area, not negative ones.
+        let strike_diff = price_gap(
+            self.long_call.option.strike_price,
+            self.long_put.option.strike_price,
+        );
+        let inner_square = strike_diff.checked_mul(&max_loss)?;
+        let break_even_diff = price_gap(upper, lower);
+        let outer_square = break_even_diff.checked_mul(&max_loss)?;
+        let triangles = price_gap(outer_square, inner_square) / 2.0;
+        let loss_area = inner_square
+            .checked_add(&triangles)?
+            .checked_div(&self.long_call.option.underlying_price)?
+            .to_f64();
         let result = 1.0 / loss_area; // Invert the value to get the profit area: the lower, the better
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
@@ -663,13 +693,33 @@ impl Strategies for LongStrangle {
         if max_loss == Positive::ZERO {
             return Ok(Decimal::MAX);
         }
-        let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
-        let ratio = max_loss / break_even_diff * 100.0;
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("LongStrangle::get_profit_ratio: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "LongStrangle::get_profit_ratio: fewer than two break-even points",
+            )
+        })?;
+        // Break-evens that coincide leave no width to divide the loss by.
+        let break_even_diff = price_gap(upper, lower);
+        let ratio = max_loss
+            .checked_div(&break_even_diff)?
+            .checked_mul_f64(100.0)?;
         let result = 1.0 / ratio; // Invert the value to get the profit ratio: the lower, the better
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
     fn get_best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
-        let (first_option, last_option) = (self.break_even_points[0], self.break_even_points[1]);
+        let first_option = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection(
+                "LongStrangle::get_best_range_to_show: no break-even points",
+            )
+        })?;
+        let last_option = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "LongStrangle::get_best_range_to_show: fewer than two break-even points",
+            )
+        })?;
         debug!("First: {} Last: {}", first_option, last_option);
         if first_option >= last_option {
             return Err(StrategyError::invalid_parameters(
@@ -686,7 +736,7 @@ impl Strategies for LongStrangle {
         // cannot start below it.
         let start_price = price_gap(first_option, diff);
         debug!("Start price: {}", start_price);
-        let end_price = last_option + diff;
+        let end_price = last_option.checked_add(&diff)?;
         debug!("End price: {}", end_price);
         calculate_price_range(start_price, end_price, step)
     }
@@ -901,7 +951,17 @@ impl Profit for LongStrangle {
 
 impl ProbabilityAnalysis for LongStrangle {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_points = &self.get_break_even_points()?;
+        let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStrangle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStrangle has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -912,7 +972,7 @@ impl ProbabilityAnalysis for LongStrangle {
         ])?;
 
         let mut lower_profit_range =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         lower_profit_range.calculate_probability(
             self.get_underlying_price(),
@@ -926,7 +986,7 @@ impl ProbabilityAnalysis for LongStrangle {
         )?;
 
         let mut upper_profit_range =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         upper_profit_range.calculate_probability(
             self.get_underlying_price(),
@@ -943,7 +1003,17 @@ impl ProbabilityAnalysis for LongStrangle {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_points = &self.get_break_even_points()?;
+        let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStrangle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "LongStrangle has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -954,8 +1024,8 @@ impl ProbabilityAnalysis for LongStrangle {
         ])?;
 
         let mut loss_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -919,24 +919,36 @@ impl PnLCalculator for PoorMansCoveredCall {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_call
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.short_call.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .short_call
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/poor_mans_covered_call.rs
+++ b/src/strategies/poor_mans_covered_call.rs
@@ -34,6 +34,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use crate::chains::OptionData;
+use crate::strategies::base::{lower_break_even, price_gap};
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain},
@@ -41,13 +42,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -360,10 +361,18 @@ impl BreakEvenable for PoorMansCoveredCall {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
-        let net_debit = self.get_net_cost()? / self.long_call.option.quantity;
+        // The debit per contract: a position with no contracts has none.
+        // `lower_break_even` measures a distance below the strike and floors
+        // it at zero, hence the negated debit, which sits above the strike.
+        let net_debit = d_div(
+            self.get_net_cost()?,
+            self.long_call.option.quantity.to_dec(),
+            "PoorMansCoveredCall::update_break_even_points",
+        )?;
 
-        self.break_even_points
-            .push((self.long_call.option.strike_price + net_debit).round_to(2));
+        self.break_even_points.push(
+            lower_break_even(self.long_call.option.strike_price, -net_debit).checked_round_to(2)?,
+        );
 
         Ok(())
     }
@@ -650,18 +659,21 @@ impl Strategies for PoorMansCoveredCall {
     }
 
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
-        let base = (self.short_call.option.strike_price
-            - (self.short_call.option.strike_price
-                - self.get_max_profit().unwrap_or(Positive::ZERO)))
-        .to_f64();
-        let high = self.get_max_profit().unwrap_or(Positive::ZERO).to_f64();
+        // The base is the maximum profit measured back from the short strike,
+        // so it is the profit itself while the profit fits under the strike.
+        // A profit above the strike leaves no room below it, and the base
+        // stops at the strike rather than inverting the subtraction.
+        let strike = self.short_call.option.strike_price;
+        let max_profit = self.get_max_profit().unwrap_or(Positive::ZERO);
+        let base = price_gap(strike, price_gap(strike, max_profit)).to_f64();
+        let high = max_profit.to_f64();
         let result = base * high / 200.0;
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
         let result = match (self.get_max_profit(), self.get_max_loss()) {
-            (Ok(profit), Ok(loss)) => (profit / loss).to_f64() * 100.0,
+            (Ok(profit), Ok(loss)) => profit.checked_div(&loss)?.to_f64() * 100.0,
             _ => ZERO,
         };
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
@@ -830,7 +842,11 @@ impl Profit for PoorMansCoveredCall {
 
 impl ProbabilityAnalysis for PoorMansCoveredCall {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "PoorMansCoveredCall has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -857,7 +873,11 @@ impl ProbabilityAnalysis for PoorMansCoveredCall {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_point = self.get_break_even_points()?[0];
+        let break_even_point = *self.get_break_even_points()?.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "PoorMansCoveredCall has no break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -1157,34 +1157,46 @@ impl PnLCalculator for ShortButterflySpread {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .long_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self.short_call_low.calculate_pnl(
-                market_price,
-                expiration_date,
-                implied_volatility,
-            )?
-            + self.short_call_high.calculate_pnl(
-                market_price,
-                expiration_date,
-                implied_volatility,
-            )?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.long_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.short_call_low.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        total = total.try_add(&self.short_call_high.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .long_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .short_call_low
-                .calculate_pnl_at_expiration(underlying_price)?
-            + self
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        total = total.try_add(
+            &self
                 .short_call_high
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -319,7 +319,7 @@ impl StrategyConstructor for ShortButterflySpread {
         }
 
         // Create strategy
-        let strategy = ShortButterflySpread {
+        let mut strategy = ShortButterflySpread {
             name: "Short Butterfly Spread".to_string(),
             kind: StrategyType::ShortButterflySpread,
             description: SHORT_BUTTERFLY_DESCRIPTION.to_string(),
@@ -352,6 +352,12 @@ impl StrategyConstructor for ShortButterflySpread {
                 higher_strike_position.extra_fields.clone(),
             ),
         };
+
+        // Every other constructor in this crate populates the break-even
+        // points before handing the strategy back; this one did not, so a
+        // butterfly built from a leg set reported an empty vector and every
+        // reader of it (profit area, profit and loss ranges) aborted.
+        strategy.update_break_even_points()?;
 
         Ok(strategy)
     }

--- a/src/strategies/short_butterfly_spread.rs
+++ b/src/strategies/short_butterfly_spread.rs
@@ -15,13 +15,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -371,22 +371,36 @@ impl BreakEvenable for ShortButterflySpread {
     fn update_break_even_points(&mut self) -> Result<(), StrategyError> {
         self.break_even_points = Vec::new();
 
-        let left_net_value = self.calculate_profit_at(&self.short_call_low.option.strike_price)?
-            / self.short_call_low.option.quantity;
+        // A wing contributes a break-even only where the payoff at that wing
+        // is a profit the losing region falls back through; a wing already at
+        // a loss is never crossed. A leg with no contracts has no
+        // per-contract value at all, which is reported rather than divided.
+        let left_net_value = d_div(
+            self.calculate_profit_at(&self.short_call_low.option.strike_price)?,
+            self.short_call_low.option.quantity.to_dec(),
+            "ShortButterflySpread::update_break_even_points",
+        )?;
 
-        let right_net_value = self
-            .calculate_profit_at(&self.short_call_high.option.strike_price)?
-            / self.short_call_high.option.quantity;
+        let right_net_value = d_div(
+            self.calculate_profit_at(&self.short_call_high.option.strike_price)?,
+            self.short_call_high.option.quantity.to_dec(),
+            "ShortButterflySpread::update_break_even_points",
+        )?;
 
         if left_net_value >= Decimal::ZERO {
+            let candidate = d_add(
+                self.short_call_low.option.strike_price.to_dec(),
+                left_net_value,
+                "ShortButterflySpread::update_break_even_points",
+            )?;
             self.break_even_points
-                .push((self.short_call_low.option.strike_price + left_net_value).round_to(2));
+                .push(Positive::new_decimal(candidate)?.checked_round_to(2)?);
         }
 
         if right_net_value >= Decimal::ZERO {
             self.break_even_points.push(
                 lower_break_even(self.short_call_high.option.strike_price, right_net_value)
-                    .round_to(2),
+                    .checked_round_to(2)?,
             );
         }
 
@@ -1004,6 +1018,19 @@ impl ProbabilityAnalysis for ShortButterflySpread {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let mut ranges = Vec::new();
         let break_even_points = self.get_break_even_points()?;
+        // A short butterfly whose payoff never crosses zero on a wing has
+        // fewer than two break-even points; the ranges below are bounded by
+        // both, so the shortfall is reported rather than indexed past.
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortButterflySpread has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortButterflySpread has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1020,7 +1047,7 @@ impl ProbabilityAnalysis for ShortButterflySpread {
         });
 
         let mut lower_profit_range =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         lower_profit_range.calculate_probability(
             self.get_underlying_price(),
@@ -1033,7 +1060,7 @@ impl ProbabilityAnalysis for ShortButterflySpread {
         ranges.push(lower_profit_range);
 
         let mut upper_profit_range =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         upper_profit_range.calculate_probability(
             self.get_underlying_price(),
@@ -1050,6 +1077,19 @@ impl ProbabilityAnalysis for ShortButterflySpread {
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let break_even_points = self.get_break_even_points()?;
+        // A short butterfly whose payoff never crosses zero on a wing has
+        // fewer than two break-even points; the ranges below are bounded by
+        // both, so the shortfall is reported rather than indexed past.
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortButterflySpread has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortButterflySpread has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.long_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1061,8 +1101,8 @@ impl ProbabilityAnalysis for ShortButterflySpread {
         ])?;
 
         let mut loss_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -19,7 +19,7 @@ use super::base::{
     BreakEvenable, Optimizable, Positionable, Strategable, StrategyBasics, StrategyType, Validable,
 };
 use super::shared::StraddleStrategy;
-use crate::strategies::base::lower_break_even;
+use crate::strategies::base::{lower_break_even, price_gap};
 use crate::{
     ExpirationDate, Options,
     chains::{StrategyLegs, chain::OptionChain, utils::OptionDataGroup},
@@ -27,13 +27,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sum},
         position::Position,
         types::{OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -377,19 +377,33 @@ impl BreakEvenable for ShortStraddle {
 
         let total_premium = self.get_net_premium_received()?;
 
-        self.break_even_points.push(
-            lower_break_even(
-                self.short_put.option.strike_price,
-                total_premium / self.short_put.option.quantity,
-            )
-            .round_to(2),
-        );
+        // The credit per contract on each leg: a straddle with no contracts
+        // has none. The lower break-even goes through `lower_break_even`,
+        // which floors at zero where a credit above the strike leaves no
+        // attainable losing price; the upper one is a sum of two non-negative
+        // figures, so only its overflow is reportable.
+        let put_credit = d_div(
+            total_premium.to_dec(),
+            self.short_put.option.quantity.to_dec(),
+            "ShortStraddle::update_break_even_points",
+        )?;
+        let call_credit = d_div(
+            total_premium.to_dec(),
+            self.short_call.option.quantity.to_dec(),
+            "ShortStraddle::update_break_even_points",
+        )?;
 
         self.break_even_points.push(
-            (self.short_call.option.strike_price
-                + (total_premium / self.short_call.option.quantity))
-                .round_to(2),
+            lower_break_even(self.short_put.option.strike_price, put_credit).checked_round_to(2)?,
         );
+
+        let upper = d_add(
+            self.short_call.option.strike_price.to_dec(),
+            call_credit,
+            "ShortStraddle::update_break_even_points",
+        )?;
+        self.break_even_points
+            .push(Positive::new_decimal(upper)?.checked_round_to(2)?);
 
         self.break_even_points.sort();
         Ok(())
@@ -651,13 +665,29 @@ impl Strategies for ShortStraddle {
         Ok(Positive::MAX)
     }
     fn get_profit_area(&self) -> Result<Decimal, StrategyError> {
-        let strike_diff = self.break_even_points[1] - self.break_even_points[0];
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("ShortStraddle::get_profit_area: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "ShortStraddle::get_profit_area: fewer than two break-even points",
+            )
+        })?;
+        let strike_diff = price_gap(upper, lower);
         let cat = (strike_diff / 2.0_f64.sqrt()).to_f64();
         let result = (cat.powf(2.0)) / (2.0 * 10.0_f64.powf(cat.log10().ceil()));
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
-        let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("ShortStraddle::get_profit_ratio: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "ShortStraddle::get_profit_ratio: fewer than two break-even points",
+            )
+        })?;
+        let break_even_diff = price_gap(upper, lower);
         let result =
             self.get_max_profit().unwrap_or(Positive::ZERO).to_f64() / break_even_diff * 100.0;
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
@@ -877,7 +907,17 @@ impl Profit for ShortStraddle {
 
 impl ProbabilityAnalysis for ShortStraddle {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_points = &self.get_break_even_points()?;
+        let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStraddle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStraddle has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -888,8 +928,8 @@ impl ProbabilityAnalysis for ShortStraddle {
         ])?;
 
         let mut profit_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 
@@ -908,7 +948,17 @@ impl ProbabilityAnalysis for ShortStraddle {
     }
 
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_points = &self.get_break_even_points()?;
+        let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStraddle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStraddle has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.short_call.option;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -919,7 +969,7 @@ impl ProbabilityAnalysis for ShortStraddle {
         ])?;
 
         let mut lower_loss_range =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         lower_loss_range.calculate_probability(
             self.get_underlying_price(),
@@ -933,7 +983,7 @@ impl ProbabilityAnalysis for ShortStraddle {
         )?;
 
         let mut upper_loss_range =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         upper_loss_range.calculate_probability(
             self.get_underlying_price(),

--- a/src/strategies/short_straddle.rs
+++ b/src/strategies/short_straddle.rs
@@ -1033,24 +1033,36 @@ impl PnLCalculator for ShortStraddle {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .short_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.short_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.short_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .short_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .short_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 }
 

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -1352,24 +1352,36 @@ impl PnLCalculator for ShortStrangle {
         expiration_date: ExpirationDate,
         implied_volatility: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
-            .short_call
-            .calculate_pnl(market_price, expiration_date, implied_volatility)?
-            + self
-                .short_put
-                .calculate_pnl(market_price, expiration_date, implied_volatility)?)
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total =
+            self.short_call
+                .calculate_pnl(market_price, expiration_date, implied_volatility)?;
+        total = total.try_add(&self.short_put.calculate_pnl(
+            market_price,
+            expiration_date,
+            implied_volatility,
+        )?)?;
+        Ok(total)
     }
 
     fn calculate_pnl_at_expiration(
         &self,
         underlying_price: &Positive,
     ) -> Result<PnL, PricingError> {
-        Ok(self
+        // `impl Add for PnL` returns `Self`, so a leg total that leaves the
+        // `Positive` range has nowhere to be reported and aborts instead.
+        // `PnL::try_add` adds the same fields and reports it.
+        let mut total = self
             .short_call
-            .calculate_pnl_at_expiration(underlying_price)?
-            + self
+            .calculate_pnl_at_expiration(underlying_price)?;
+        total = total.try_add(
+            &self
                 .short_put
-                .calculate_pnl_at_expiration(underlying_price)?)
+                .calculate_pnl_at_expiration(underlying_price)?,
+        )?;
+        Ok(total)
     }
 
     fn adjustments_pnl(&self, adjustment: &DeltaAdjustment) -> Result<PnL, PricingError> {

--- a/src/strategies/short_strangle.rs
+++ b/src/strategies/short_strangle.rs
@@ -29,13 +29,13 @@ use crate::{
     error::{
         GreeksError, OperationErrorKind, PricingError,
         position::{PositionError, PositionValidationErrorKind},
-        probability::ProbabilityError,
+        probability::{ProbabilityError, ProfitLossRangeErrorKind},
         strategies::{ProfitLossErrorKind, StrategyError},
     },
     greeks::Greeks,
     model::{
         ProfitLossRange, Trade, TradeStatusAble,
-        decimal::d_sum,
+        decimal::{d_add, d_div, d_sum},
         position::Position,
         types::{Action, OptionBasicType, OptionStyle, OptionType, Side},
         utils::mean_and_std,
@@ -182,11 +182,14 @@ impl ShortStrangle {
         open_fee_short_put: Positive,
         close_fee_short_put: Positive,
     ) -> Result<Self, StrategyError> {
+        // The default strikes sit ten percent either side of the spot. A
+        // spot at the top of the `Positive` range has no room above it, and
+        // that is reported rather than aborted.
         if call_strike == Positive::ZERO {
-            call_strike = underlying_price * 1.1;
+            call_strike = underlying_price.checked_mul_f64(1.1)?;
         }
         if put_strike == Positive::ZERO {
-            put_strike = underlying_price * 0.9;
+            put_strike = underlying_price.checked_mul_f64(0.9)?;
         }
         let mut strategy = ShortStrangle {
             name: "Short Strangle".to_string(),
@@ -368,18 +371,33 @@ impl BreakEvenable for ShortStrangle {
 
         let total_premium = self.get_net_premium_received()?;
 
-        self.break_even_points.push(
-            lower_break_even(
-                self.short_put.option.strike_price,
-                total_premium / self.short_put.option.quantity,
-            )
-            .round_to(2),
-        );
+        // The credit per contract on each leg: a strangle with no contracts
+        // has none. The lower break-even goes through `lower_break_even`,
+        // which floors at zero where a credit above the strike leaves no
+        // attainable losing price; the upper one is a sum of two non-negative
+        // figures, so only its overflow is reportable.
+        let put_credit = d_div(
+            total_premium.to_dec(),
+            self.short_put.option.quantity.to_dec(),
+            "ShortStrangle::update_break_even_points",
+        )?;
+        let call_credit = d_div(
+            total_premium.to_dec(),
+            self.one_option().quantity.to_dec(),
+            "ShortStrangle::update_break_even_points",
+        )?;
 
         self.break_even_points.push(
-            (self.one_option().strike_price + (total_premium / self.one_option().quantity))
-                .round_to(2),
+            lower_break_even(self.short_put.option.strike_price, put_credit).checked_round_to(2)?,
         );
+
+        let upper = d_add(
+            self.one_option().strike_price.to_dec(),
+            call_credit,
+            "ShortStrangle::update_break_even_points",
+        )?;
+        self.break_even_points
+            .push(Positive::new_decimal(upper)?.checked_round_to(2)?);
 
         self.break_even_points.sort();
         Ok(())
@@ -720,17 +738,42 @@ impl Strategies for ShortStrangle {
         if max_profit == Positive::ZERO {
             return Ok(Decimal::ZERO);
         }
-        let strike_diff = self.one_option().strike_price - self.short_put.option.strike_price;
-        let inner_square = strike_diff * max_profit;
-        let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
-        let outer_square = break_even_diff * max_profit;
-        let triangles = (outer_square - inner_square) / 2.0;
-        let result = ((inner_square + triangles) / self.one_option().underlying_price).to_f64();
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("ShortStrangle::get_profit_area: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "ShortStrangle::get_profit_area: fewer than two break-even points",
+            )
+        })?;
+        // A call strike below the put strike describes no width between them,
+        // and break-evens that do not straddle the strikes describe no
+        // triangles: both are regions with no area, not negative ones.
+        let strike_diff = price_gap(
+            self.one_option().strike_price,
+            self.short_put.option.strike_price,
+        );
+        let inner_square = strike_diff.checked_mul(&max_profit)?;
+        let break_even_diff = price_gap(upper, lower);
+        let outer_square = break_even_diff.checked_mul(&max_profit)?;
+        let triangles = price_gap(outer_square, inner_square) / 2.0;
+        let result = inner_square
+            .checked_add(&triangles)?
+            .checked_div(&self.one_option().underlying_price)?
+            .to_f64();
         Decimal::from_f64(result).ok_or_else(|| StrategyError::numeric_conversion(result))
     }
 
     fn get_profit_ratio(&self) -> Result<Decimal, StrategyError> {
-        let break_even_diff = self.break_even_points[1] - self.break_even_points[0];
+        let lower = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection("ShortStrangle::get_profit_ratio: no break-even points")
+        })?;
+        let upper = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "ShortStrangle::get_profit_ratio: fewer than two break-even points",
+            )
+        })?;
+        let break_even_diff = price_gap(upper, lower);
         let result = match self.get_max_profit() {
             Ok(max_profit) => max_profit.to_f64() / break_even_diff * 100.0,
             Err(_) => ZERO,
@@ -740,11 +783,20 @@ impl Strategies for ShortStrangle {
 
     fn get_best_range_to_show(&self, step: Positive) -> Result<Vec<Positive>, StrategyError> {
         let max_profit = self.get_max_profit().unwrap_or(Positive::ZERO);
-        let (first_option, last_option) = (self.break_even_points[0], self.break_even_points[1]);
+        let first_option = *self.break_even_points.first().ok_or_else(|| {
+            StrategyError::empty_collection(
+                "ShortStrangle::get_best_range_to_show: no break-even points",
+            )
+        })?;
+        let last_option = *self.break_even_points.get(1).ok_or_else(|| {
+            StrategyError::empty_collection(
+                "ShortStrangle::get_best_range_to_show: fewer than two break-even points",
+            )
+        })?;
         // No lower break-even puts `first_option` at zero, and the plot range
         // cannot start below it.
         let start_price = price_gap(first_option, max_profit);
-        let end_price = last_option + max_profit;
+        let end_price = last_option.checked_add(&max_profit)?;
         calculate_price_range(start_price, end_price, step)
     }
 
@@ -1170,7 +1222,17 @@ impl Profit for ShortStrangle {
 
 impl ProbabilityAnalysis for ShortStrangle {
     fn get_profit_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
-        let break_even_points = &self.get_break_even_points()?;
+        let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStrangle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStrangle has no upper break-even point".to_string(),
+            })
+        })?;
         let option = &self.one_option();
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
@@ -1181,8 +1243,8 @@ impl ProbabilityAnalysis for ShortStrangle {
         ])?;
 
         let mut profit_range = ProfitLossRange::new(
-            Some(break_even_points[0]),
-            Some(break_even_points[1]),
+            Some(lower_break_even_point),
+            Some(upper_break_even_point),
             Positive::ZERO,
         )?;
 
@@ -1203,6 +1265,16 @@ impl ProbabilityAnalysis for ShortStrangle {
     fn get_loss_ranges(&self) -> Result<Vec<ProfitLossRange>, ProbabilityError> {
         let option = &self.one_option();
         let break_even_points = self.get_break_even_points()?;
+        let lower_break_even_point = *break_even_points.first().ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStrangle has no lower break-even point".to_string(),
+            })
+        })?;
+        let upper_break_even_point = *break_even_points.get(1).ok_or_else(|| {
+            ProbabilityError::RangeError(ProfitLossRangeErrorKind::InvalidBreakEvenPoints {
+                reason: "ShortStrangle has no upper break-even point".to_string(),
+            })
+        })?;
         let expiration_date = &option.expiration_date;
         let risk_free_rate = option.risk_free_rate;
 
@@ -1212,7 +1284,7 @@ impl ProbabilityAnalysis for ShortStrangle {
         ])?;
 
         let mut lower_loss_range =
-            ProfitLossRange::new(None, Some(break_even_points[0]), Positive::ZERO)?;
+            ProfitLossRange::new(None, Some(lower_break_even_point), Positive::ZERO)?;
 
         lower_loss_range.calculate_probability(
             self.get_underlying_price(),
@@ -1226,7 +1298,7 @@ impl ProbabilityAnalysis for ShortStrangle {
         )?;
 
         let mut upper_loss_range =
-            ProfitLossRange::new(Some(break_even_points[1]), None, Positive::ZERO)?;
+            ProfitLossRange::new(Some(upper_break_even_point), None, Positive::ZERO)?;
 
         upper_loss_range.calculate_probability(
             self.get_underlying_price(),

--- a/tests/property/strategies_panic_freedom_test.rs
+++ b/tests/property/strategies_panic_freedom_test.rs
@@ -35,7 +35,10 @@ use optionstratlib::strategies::probabilities::{
     calculate_single_point_probability,
 };
 use optionstratlib::strategies::{
-    BullCallSpread, Collar, CoveredCall, LongCall, ProtectivePut, ShortPut,
+    BearCallSpread, BearPutSpread, BullCallSpread, BullPutSpread, CallButterfly, Collar,
+    CoveredCall, IronButterfly, IronCondor, LongButterflySpread, LongCall, LongStraddle,
+    LongStrangle, PoorMansCoveredCall, ProtectivePut, ShortButterflySpread, ShortPut,
+    ShortStraddle, ShortStrangle, StrategyConstructor,
 };
 use optionstratlib::visualization::Graph;
 use positive::Positive;
@@ -567,6 +570,229 @@ proptest! {
             exercise(&strategy, underlying);
             let _ = strategy.get_best_range_to_show(Positive::HUNDRED);
             let _ = strategy.update_break_even_points();
+        }
+    }
+}
+
+/// Drives a multi-leg strategy twice: as its constructor left it, and again
+/// with its break-even vector emptied.
+///
+/// The second pass is the point. `break_even_points` is a `pub` field on every
+/// strategy in this crate and every strategy derives `Deserialize`, so a JSON
+/// document carrying `"break_even_points": []`, or a struct literal written
+/// downstream, reaches the profit area, the profit ratio and the two
+/// probability ranges with nothing to read. Until #463 each of those indexed
+/// the vector directly and aborted the process.
+macro_rules! exercise_with_and_without_break_evens {
+    ($strategy:expr, $probe:expr) => {{
+        let mut strategy = $strategy;
+        exercise(&strategy, $probe);
+        let _ = strategy.update_break_even_points();
+        exercise(&strategy, $probe);
+        strategy.break_even_points = Vec::new();
+        exercise(&strategy, $probe);
+    }};
+}
+
+proptest! {
+    // Fourteen strategies over eight generators is a wide product, so these
+    // properties run fewer cases each than the single-leg ones above; the
+    // magnitudes they draw from are the same.
+    #![proptest_config(ProptestConfig::with_cases(96))]
+
+    /// The four vertical spreads and the poor man's covered call. Each carries
+    /// a single break-even point computed as a strike offset by a
+    /// per-contract premium, so a zero quantity, a premium above the strike
+    /// and a strike at the top of the `Decimal` range all land in
+    /// `update_break_even_points`; the readers of that point land in
+    /// `get_profit_area` and in the probability ranges.
+    #[test]
+    fn test_vertical_spread_strategies_never_panic(
+        underlying in extreme_positive(),
+        low_strike in extreme_positive(),
+        high_strike in extreme_positive(),
+        volatility in extreme_volatility(),
+        quantity in extreme_quantity(),
+        premium in extreme_money(),
+        fee in extreme_money(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_positive(),
+    ) {
+        if let Ok(strategy) = BearCallSpread::new(
+            "PROP".to_string(), underlying, low_strike, high_strike, expiration,
+            volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = BullPutSpread::new(
+            "PROP".to_string(), underlying, low_strike, high_strike, expiration,
+            volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = BearPutSpread::new(
+            "PROP".to_string(), underlying, high_strike, low_strike, expiration,
+            volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = PoorMansCoveredCall::new(
+            "PROP".to_string(), underlying, low_strike, high_strike, expiration,
+            expiration, volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+    }
+
+    /// The straddles and the strangles. They carry two break-even points and
+    /// measure widths between them, so a pair that coincides (a premium of
+    /// zero) and a pair whose order the strikes invert both reach the
+    /// subtraction and the division in `get_profit_area` and
+    /// `get_profit_ratio`.
+    #[test]
+    fn test_straddle_and_strangle_strategies_never_panic(
+        underlying in extreme_positive(),
+        put_strike in extreme_positive(),
+        call_strike in extreme_positive(),
+        volatility in extreme_volatility(),
+        quantity in extreme_quantity(),
+        premium in extreme_money(),
+        fee in extreme_money(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_positive(),
+    ) {
+        if let Ok(strategy) = LongStraddle::new(
+            "PROP".to_string(), underlying, call_strike, expiration, volatility,
+            rate, Positive::ZERO, quantity, premium, premium, fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = ShortStraddle::new(
+            "PROP".to_string(), underlying, call_strike, expiration, volatility,
+            rate, Positive::ZERO, quantity, premium, premium, fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = LongStrangle::new(
+            "PROP".to_string(), underlying, call_strike, put_strike, expiration,
+            volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = ShortStrangle::new(
+            "PROP".to_string(), underlying, call_strike, put_strike, expiration,
+            volatility, volatility, rate, Positive::ZERO, quantity, premium, premium,
+            fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+    }
+
+    /// The four-leg structures and the butterflies. The butterflies push a
+    /// break-even point only where a wing actually crosses zero profit, so
+    /// one point, or none at all, is an ordinary outcome here rather than a
+    /// broken constructor, and the readers of the second point have to say
+    /// so instead of indexing past it.
+    #[test]
+    fn test_condor_and_butterfly_strategies_never_panic(
+        underlying in extreme_positive(),
+        low_strike in extreme_positive(),
+        high_strike in extreme_positive(),
+        volatility in extreme_volatility(),
+        quantity in extreme_quantity(),
+        premium in extreme_money(),
+        fee in extreme_money(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_positive(),
+    ) {
+        let middle_strike = low_strike.checked_add(&high_strike).unwrap_or(high_strike);
+        if let Ok(strategy) = IronCondor::new(
+            "PROP".to_string(), underlying, high_strike, low_strike, high_strike, low_strike,
+            expiration, volatility, rate, Positive::ZERO, quantity, premium, premium,
+            premium, premium, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = IronButterfly::new(
+            "PROP".to_string(), underlying, middle_strike, high_strike, low_strike,
+            expiration, volatility, rate, Positive::ZERO, quantity, premium, premium,
+            premium, premium, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = LongButterflySpread::new(
+            "PROP".to_string(), underlying, low_strike, middle_strike, high_strike,
+            expiration, volatility, rate, Positive::ZERO, quantity, premium, premium,
+            premium, fee, fee, fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = ShortButterflySpread::new(
+            "PROP".to_string(), underlying, low_strike, middle_strike, high_strike,
+            expiration, volatility, rate, Positive::ZERO, quantity, premium, premium,
+            premium, fee, fee, fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = CallButterfly::new(
+            "PROP".to_string(), underlying, low_strike, middle_strike, high_strike,
+            expiration, volatility, rate, Positive::ZERO, quantity, premium, premium,
+            premium, fee, fee, fee, fee, fee, fee,
+        ) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+    }
+
+    /// The leg-set construction path of the two butterfly spreads. Until #463
+    /// neither populated the break-even points, so a butterfly assembled from
+    /// positions (the route a chain or a persisted strategy takes) reported
+    /// an empty vector on a well-formed structure.
+    #[test]
+    fn test_butterfly_leg_set_construction_never_panics(
+        underlying in extreme_positive(),
+        strike in extreme_positive(),
+        volatility in extreme_volatility(),
+        quantity in extreme_quantity(),
+        premium in extreme_money(),
+        rate in extreme_decimal(),
+        expiration in extreme_expiration(),
+        probe in extreme_positive(),
+    ) {
+        // The strikes have to be symmetric for `get_strategy` to accept them.
+        let middle = strike.checked_add(&Positive::TEN).unwrap_or(strike);
+        let high = middle.checked_add(&Positive::TEN).unwrap_or(middle);
+        let body = quantity.checked_add(&quantity).unwrap_or(quantity);
+        let leg = |side: Side, strike: Positive, quantity: Positive| {
+            Position::new(
+                Options::new(
+                    OptionType::European, side, "PROP".to_string(), strike, expiration,
+                    volatility, quantity, underlying, rate, OptionStyle::Call,
+                    Positive::ZERO, None,
+                ),
+                premium, chrono::Utc::now(), premium, premium, None, None,
+            )
+        };
+        if let Ok(strategy) = LongButterflySpread::get_strategy(&[
+            leg(Side::Long, strike, quantity),
+            leg(Side::Short, middle, body),
+            leg(Side::Long, high, quantity),
+        ]) {
+            exercise_with_and_without_break_evens!(strategy, probe);
+        }
+        if let Ok(strategy) = ShortButterflySpread::get_strategy(&[
+            leg(Side::Short, strike, quantity),
+            leg(Side::Long, middle, body),
+            leg(Side::Short, high, quantity),
+        ]) {
+            exercise_with_and_without_break_evens!(strategy, probe);
         }
     }
 }


### PR DESCRIPTION
## Summary

The mechanical half of the strategies sweep: **unguarded `break_even_points`
indexing across the fourteen multi-leg strategies**, in `get_profit_area`,
`get_profit_ratio`, `get_profit_ranges`, `get_loss_ranges` and
`get_best_range_to_show`. An empty vector turned each into `index out of
bounds: the len is 0 but the index is 0`.

A probe over these files' public API, run against the parent commit and against
this branch:

| | panics | calls |
|---|---|---|
| before | **43,857** | 254,070 |
| after | **0** | 244,962 |

Breakdown of the 43,857: 36,234 index-out-of-bounds (31,806 `len 0 index 0`,
4,014 `len 0 index 1`, 414 `len 1 index 1`), 7,281 `Positive` invariant or
overflow, 342 division by zero. The call count drops because `get_strategy` now
rejects a zero-quantity leg set instead of building an unusable strategy.

## 75 accesses, not 65

The issue counted `break_even_points[i]`. A second form,
`self.get_break_even_points()?[0]`, sits in the same functions in five of the
files and the issue's grep missed it: **10 more**.

| file | converted | file | converted |
|---|---|---|---|
| `long_strangle.rs` | 10 | `iron_condor.rs` | 4 |
| `short_strangle.rs` | 10 | `iron_butterfly.rs` | 4 |
| `long_straddle.rs` | 8 | `call_butterfly.rs` | 4 |
| `short_straddle.rs` | 8 | `short_butterfly_spread.rs` | 4 |
| `long_butterfly_spread.rs` | 7 | `bear_call_spread.rs` | 3 |
| `bull_put_spread.rs` | 5 | `bear_put_spread.rs` | 3 |
| | | `bull_call_spread.rs` | 3 |
| | | `poor_mans_covered_call.rs` | 2 |

`base.rs` and `custom.rs` keep theirs — they are #460's and already
length-guarded.

## Per strategy: constructor bug, or legitimate state?

The issue asks for this decision per strategy, and the two answers are
different fixes. Conflating them is how a silent wrong value gets in.

| strategy | empty vector is | why |
|---|---|---|
| `LongButterflySpread` | **constructor bug** (+ legitimate short vector) | `get_strategy` never called `update_break_even_points`; separately a wing that never crosses zero yields 1 point or none |
| `ShortButterflySpread` | **constructor bug** (+ legitimate short vector) | same missing call, same conditional push |
| `CallButterfly` | legitimate state | its push is conditional on `Positive::new_decimal(candidate)`; the probe hit `len 1 index 1` from a plain `new` |
| `BearCallSpread`, `BearPutSpread`, `BullCallSpread`, `BullPutSpread`, `PoorMansCoveredCall` | legitimate state | the constructor always pushes exactly 1 |
| `LongStraddle`, `ShortStraddle`, `LongStrangle`, `ShortStrangle`, `IronCondor`, `IronButterfly` | legitimate state | the constructor always pushes exactly 2 |

Where it is a constructor bug it is fixed at the constructor (`1c835106`);
everywhere else the readers report the shortfall and name which point is
missing — `StrategyError` on the `Strategies` methods,
`ProbabilityError::RangeError` on the probability ranges.

**Two public routes reach an empty vector on every strategy in the table**, so
"legitimate state" is not hypothetical: `break_even_points` is a `pub` field
and every strategy derives `Deserialize`, so `"break_even_points": []` in a
JSON document reached all five readers.

## Unchanged behaviour, and the five places it is not

For every vector long enough to answer the read, **every value is identical in
all fourteen files**. The substitutions are value-preserving by construction:
`price_gap(hi, lo)` is the same subtraction for an ordered pair; `d_div` rounds
banker's at scale 28 and `positive`'s `DIV_SCALE` is also 28 with the same
strategy, so quotients are bit-identical; `d_add` / `d_sub` / `d_mul` and the
`checked_*` twins differ from the operators only in the overflow arm.

Five sites change what happens where the old code **panicked**, never where it
returned: `BearCallSpread::get_max_loss` on inverted strikes, now
`MaxLossError`; `PoorMansCoveredCall::get_profit_area` for a profit above the
strike; the two straddle/strangle ratios on a zero divisor; and
`CallButterfly::get_profit_ratio` on an overflowing product.

**One behaviour change beyond that**, called out because it is a constructor
that used to succeed: `LongButterflySpread::get_strategy` and
`ShortButterflySpread::get_strategy` now return `Err` for a zero-quantity leg
set, where they returned `Ok` with an empty vector.

It reads as a new refusal and it is not — it is the two outliers rejoining the
convention. Counting call sites of `strategy.update_break_even_points()?` on
`889004b7`, across the fourteen multi-leg strategies:

| call sites | files |
|---|---|
| 2 — from `new` **and** from `get_strategy` | the other twelve |
| 1 — from `new` only | `long_butterfly_spread.rs`, `short_butterfly_spread.rs` |

So twelve constructors already propagate that failure rather than hand back a
strategy whose break-even vector they could not fill. **The butterflies' `Ok`
was the absence of the call, not a decision to tolerate a degenerate leg set.**
Restoring it restores the convention; the `Err` is a consequence of that, not a
new policy.

The substance agrees: `update_break_even_points` divides the net cost by the
leg quantity, and a leg set with no contracts has no per-contract break-even to
compute. Returning `Ok` moved that failure to whichever reader touched it
first, which is this sweep's own thesis inverted — report at the boundary, not
at the abort site.

## Tests

The strategies panic-freedom property now covers the multi-leg strategies
(+228 lines). 4032 lib + 71 property + 423 integration + 207 doctests, 0
failed.

Gates, all run on the rebased head:

```
cargo fmt --all --check                                          clean
cargo clippy --all-targets --all-features --workspace -- -D warnings   clean
cargo test --all-features --workspace                            0 failed
LOGLEVEL=WARN cargo test          (default feature set)          0 failed
cargo build --release                                            no warnings
cargo doc --all-features --no-deps                               clean
make scan-banned                                                 OK
make public-api-check                                            OK
```

The last three are in `rules/global_rules.md`'s pre-submission checklist and
are not covered by `make pre-push`: `create-doc` has no `--all-features`, and
`--all-features` is not the default feature set.

## Stack

Chain A, third of four.

- Stack: #470 → #469 → **#463** (this one) → #471. Independent of chain B
  (#466 → #451 → #453), chain C (#462), #459, and the #442 capstone.
- Base branch: `main`. #470 and #469 are merged, so this branch is rebased onto
  `main` and the diff is its own work alone.

Closes #463
