### PR TITLE
Fold the merge product in order instead of in parallel (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entry exists. Every merge test in the crate compares within `1e-3` or
   `1e-4`, so none of them moved.
 
-  **The parallelism it removes was worth nothing.** Pooling 500 samples a side
-  over five alternating Criterion runs, the sequential fold is 2% to 12%
+  **The parallelism it removes was worth nothing.** Over five alternating
+  Criterion runs — 500 samples a side on the curve group, 50 on the surface
+  group, whose `sample_size(10)` keeps a 51 x 51 grid affordable — the
+  sequential fold is 2% to 12%
   faster at the least-contended end of the distribution and indistinguishable
   from the reducer at the median, against a noise floor on the measuring
   machine of roughly 30%. What it removes is a rayon dispatch per grid point

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the direction and size are stated here so the claim can be checked rather
   than taken.
 
+- **`Curve::merge` and `Surface::merge` return the same digits on every run,
+  on every machine** (#453). The `Multiply` arm of both types reduced the
+  interpolated values with a rayon `reduce`, and `Curve`'s `Divide` arm folded
+  its reciprocals with the same reducer. `Decimal` multiplication rounds once
+  a product needs more than the 28 decimal places it stores, so it is not
+  associative: over a sweep of 205,379 reciprocal triples, 628 of them, 0.31%,
+  regroup to a different last digit.
+
+  Rayon takes the grouping from its length splitter, whose threshold is the
+  length of the input divided by eight times the number of threads in the
+  ambient pool. So the result moved two ways. Run to run, from work stealing:
+  merging forty curves returned **1996 distinct results in 2000 runs of one
+  binary over one input** on an eight-thread pool, 809 in 2000 at four threads
+  and 52 in 2000 at two. And machine to machine, from the pool size: on one
+  thread and on sixteen it returned one result across 2000 runs each, and
+  those two results disagreed with each other. The second is the worse of the
+  two, because two services on differently sized machines then disagree on one
+  input while each looks perfectly stable where it runs.
+
+  Both arms now fold left to right, `Multiply` through the new
+  `d_product_iter` placed beside the `d_sum_iter` the `Add` arm already used.
+
+  **Both `Multiply` and `Divide` move in their last digits, and they are
+  separate changes.** `Multiply` moves on both types. Three constant curves at
+  `0.010989010989010989010989011`, `0.010752688172043010752688172` and
+  `0.0094339622641509433962264151` merged to
+  `0.0000011147302687168785768907` before, the reducer having bracketed them
+  as `a * (b * c)`, and merge to `0.0000011147302687168785768908` now, which
+  is `(a * b) * c`: one unit in the last of the 28 decimal places, `9e-23`
+  relative to a value of that size. `Divide` moves on `Curve` only. #452 made
+  `Surface`'s `Divide` a sequential chain of divisions and it is untouched
+  here; `Curve`'s was still a parallel product of reciprocals, so it took its
+  bracketing from the same splitter and had to change with `Multiply`. Three
+  constant curves at 97, 91 and 93 merged to
+  `0.0114616566229469455275906915` before and merge to
+  `0.0114616566229469455275906888` now, a move of 27 units in the last
+  decimal place, `2.4e-25` relative. The `Divide` move is the larger of the
+  two because each reciprocal is separately rounded to 28 decimal places
+  before it is multiplied in.
+
+  Both are more than twenty orders of magnitude below a tick, so no quoted
+  price, greek or premium changes; the values are given so the claim can be
+  checked rather than taken. A downstream consumer holding a golden file at
+  full `Decimal` precision will see the difference, which is the reason this
+  entry exists. Every merge test in the crate compares within `1e-3` or
+  `1e-4`, so none of them moved.
+
+  **The parallelism it removes was worth nothing.** Pooling 500 samples a side
+  over five alternating Criterion runs, the sequential fold is 2% to 12%
+  faster at the least-contended end of the distribution and indistinguishable
+  from the reducer at the median, against a noise floor on the measuring
+  machine of roughly 30%. What it removes is a rayon dispatch per grid point
+  to multiply between two and ten numbers; measured on its own that dispatch
+  costs 17 µs against 22 ns for the fold at two operands, and 28 µs against
+  794 ns at ten. `benches/geometrics/merge.rs` is new and carries all three
+  measurements.
+
+  `Max` and `Min` keep their parallel reducers: they select a value instead of
+  accumulating one, so no rounding enters and the extremum does not depend on
+  the grouping.
+
 ### Changed
 
 - **`Curve::bilinear_interpolate` now answers across the whole interior

--- a/benches/geometrics/merge.rs
+++ b/benches/geometrics/merge.rs
@@ -1,0 +1,192 @@
+use criterion::{BenchmarkId, Criterion, Throughput};
+use optionstratlib::curves::{Curve, Point2D};
+use optionstratlib::geometrics::{Arithmetic, GeometricObject, MergeOperation};
+use optionstratlib::surfaces::{Point3D, Surface};
+use rayon::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::hint::black_box;
+
+/// Operand counts the merge is measured at.
+///
+/// Two operands is the `merge_with` case and cannot expose an ordering
+/// difference; three is the smallest count that can. Five and ten stand for
+/// the multi-leg strategy surfaces this crate actually multiplies together.
+const OPERAND_COUNTS: [usize; 4] = [2, 3, 5, 10];
+
+/// Point counts per curve, in the range an option chain produces: a few tens
+/// of strikes for a weekly, a few hundred for a full-term underlying.
+const CURVE_SIZES: [usize; 3] = [32, 128, 512];
+
+/// Side length of the square grid backing each surface fixture, so the
+/// surfaces carry 64 and 256 points respectively.
+///
+/// `Surface::merge` resamples onto a fixed 51 x 51 grid whatever the operands
+/// hold, so a denser fixture buys more interpolation cost per call and not one
+/// extra invocation of the fold under test. Two sizes are enough to show how
+/// far interpolation dilutes it.
+const SURFACE_SIDES: [usize; 2] = [8, 16];
+
+/// Builds a `Decimal` with a long mantissa from two small integers.
+///
+/// The quotient by 970 is a repeating decimal, so every fixture ordinate
+/// fills the 28-digit scale. That is what makes a product of three or more of
+/// them round, which is the whole subject of the measurement: on short
+/// mantissas the fold would be exact and the ordering of the reduction would
+/// not matter.
+fn long_mantissa(n: u64, offset: u64) -> Decimal {
+    let numerator = Decimal::from(n.wrapping_mul(7).wrapping_add(offset) % 89 + 11);
+    // Kept near 1 so a ten-operand product neither overflows nor collapses
+    // to zero, which would make the benchmark measure a degenerate case.
+    dec!(0.5) + numerator / dec!(970)
+}
+
+/// Builds a curve of `points` samples spanning `[0, 10]`.
+///
+/// `index` shifts the ordinates so the operands of a merge are distinct;
+/// merging a curve with itself would let the compiler share interpolation
+/// work that a real merge cannot.
+fn curve_fixture(points: usize, index: u64) -> Curve {
+    let step = dec!(10) / Decimal::from(points.max(2) - 1);
+    let samples: Vec<Point2D> = (0..points)
+        .map(|i| {
+            let x = step * Decimal::from(i);
+            Point2D::new(x, long_mantissa(i as u64, index * 31))
+        })
+        .collect();
+    Curve::from_vector(samples)
+}
+
+/// Builds a `side * side` surface spanning `[0, 10] x [0, 10]`.
+fn surface_fixture(side: usize, index: u64) -> Surface {
+    let step = dec!(10) / Decimal::from(side.max(2) - 1);
+    let samples: Vec<Point3D> = (0..side)
+        .flat_map(|i| {
+            (0..side).map(move |j| {
+                let x = step * Decimal::from(i);
+                let y = step * Decimal::from(j);
+                Point3D::new(x, y, long_mantissa((i * side + j) as u64, index * 31))
+            })
+        })
+        .collect();
+    Surface::from_vector(samples)
+}
+
+/// End-to-end cost of `Curve::merge` under `Multiply`, per operand count and
+/// curve size.
+///
+/// This is the number a caller sees. It includes the cubic interpolation of
+/// every operand onto the shared grid, which dominates; the fold under test
+/// is a small share of it, so the isolated fold is measured separately by
+/// [`benchmark_decimal_product_fold`].
+pub fn benchmark_curve_merge_multiply(c: &mut Criterion) {
+    let mut group = c.benchmark_group("curve_merge_multiply");
+
+    for &size in CURVE_SIZES.iter() {
+        for &operands in OPERAND_COUNTS.iter() {
+            let curves: Vec<Curve> = (0..operands)
+                .map(|i| curve_fixture(size, i as u64))
+                .collect();
+            let refs: Vec<&Curve> = curves.iter().collect();
+
+            group.throughput(Throughput::Elements(operands as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("size_{size}"), operands),
+                &refs,
+                |b, refs| {
+                    b.iter(|| {
+                        let merged = Curve::merge(black_box(refs), MergeOperation::Multiply);
+                        black_box(merged.is_ok())
+                    })
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+/// End-to-end cost of `Surface::merge` under `Multiply`.
+///
+/// `Surface::merge` samples a 51 x 51 grid, so it runs the fold 2601 times
+/// per call against `Curve::merge`'s 101: if the reduction strategy were
+/// ever going to show up end to end, it would show up here first.
+pub fn benchmark_surface_merge_multiply(c: &mut Criterion) {
+    let mut group = c.benchmark_group("surface_merge_multiply");
+    group.sample_size(10);
+
+    for &side in SURFACE_SIDES.iter() {
+        for &operands in OPERAND_COUNTS.iter() {
+            let surfaces: Vec<Surface> = (0..operands)
+                .map(|i| surface_fixture(side, i as u64))
+                .collect();
+            let refs: Vec<&Surface> = surfaces.iter().collect();
+
+            group.throughput(Throughput::Elements(operands as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("side_{side}"), operands),
+                &refs,
+                |b, refs| {
+                    b.iter(|| {
+                        let merged = Surface::merge(black_box(refs), MergeOperation::Multiply);
+                        black_box(merged.is_ok())
+                    })
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+/// Isolated cost of the two candidate reductions, on exactly the input the
+/// merge hands them: one `Vec<Decimal>` holding one interpolated ordinate per
+/// operand.
+///
+/// The end-to-end merge benchmarks bury this behind interpolation. Here the
+/// rayon `reduce` and the sequential `try_fold` are measured against each
+/// other with nothing else in the frame, so the price of determinism is
+/// visible rather than inferred.
+pub fn benchmark_decimal_product_fold(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decimal_product_fold");
+
+    for &operands in OPERAND_COUNTS.iter() {
+        let values: Vec<Decimal> = (0..operands)
+            .map(|i| long_mantissa(i as u64, i as u64 * 31))
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("parallel_reduce", operands),
+            &values,
+            |b, values| {
+                b.iter(|| {
+                    let product: Option<Decimal> =
+                        black_box(values).par_iter().copied().map(Some).reduce(
+                            || Some(Decimal::ONE),
+                            |a, b| match (a, b) {
+                                (Some(a), Some(b)) => a.checked_mul(b),
+                                _ => None,
+                            },
+                        );
+                    black_box(product)
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("sequential_fold", operands),
+            &values,
+            |b, values| {
+                b.iter(|| {
+                    let product = black_box(values)
+                        .iter()
+                        .copied()
+                        .try_fold(Decimal::ONE, |acc, v| acc.checked_mul(v));
+                    black_box(product)
+                })
+            },
+        );
+    }
+
+    group.finish();
+}

--- a/benches/geometrics/merge.rs
+++ b/benches/geometrics/merge.rs
@@ -30,7 +30,7 @@ const SURFACE_SIDES: [usize; 2] = [8, 16];
 /// Builds a `Decimal` with a long mantissa from two small integers.
 ///
 /// The quotient by 970 is a repeating decimal, so every fixture ordinate
-/// fills the 28-digit scale. That is what makes a product of three or more of
+/// fills the 28-place scale. That is what makes a product of three or more of
 /// them round, which is the whole subject of the measurement: on short
 /// mantissas the fold would be exact and the ordering of the reduction would
 /// not matter.

--- a/benches/geometrics/mod.rs
+++ b/benches/geometrics/mod.rs
@@ -1,0 +1,1 @@
+pub mod merge;

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,10 +1,15 @@
 use criterion::{criterion_group, criterion_main};
 
 mod chains;
+mod geometrics;
 mod model;
 
 use chains::generators::benchmark_chain_generators;
 use chains::optiondata::benchmark_option_data;
+use geometrics::merge::{
+    benchmark_curve_merge_multiply, benchmark_decimal_product_fold,
+    benchmark_surface_merge_multiply,
+};
 use model::positive::{
     benchmark_arithmetic, benchmark_comparisons, benchmark_conversions, benchmark_creation,
     benchmark_math_operations,
@@ -39,6 +44,9 @@ criterion_group!(
     benchmark_profit_calculations,
     benchmark_time_calculations,
     benchmark_validations,
-    benchmark_strategies
+    benchmark_strategies,
+    benchmark_curve_merge_multiply,
+    benchmark_surface_merge_multiply,
+    benchmark_decimal_product_fold
 );
 criterion_main!(benches);

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -1928,7 +1928,7 @@ impl Arithmetic<Curve> for Curve {
     /// passed in, never in an order chosen by the thread pool.
     ///
     /// This matters for `Multiply` and `Divide` in particular. `Decimal`
-    /// multiplication rounds once a product needs more than 28 significant
+    /// multiplication rounds once a product needs more than 28 decimal
     /// digits, so it is not associative, and a parallel reducer would take
     /// its bracketing from whatever chunking rayon picked on the day: three
     /// or more curves could then merge to different last digits on
@@ -3426,7 +3426,7 @@ mod tests_curve_arithmetic {
 
     /// Builds `CROSS_POOL_OPERANDS` constant curves just under one.
     ///
-    /// Each ordinate is `1 - 1/n` for a distinct `n`, which fills the 28-digit
+    /// Each ordinate is `1 - 1/n` for a distinct `n`, which fills the 28-place
     /// scale so the running product rounds at every step, and stays near one
     /// so forty of them neither overflow nor collapse toward zero.
     fn cross_pool_operands() -> Vec<Curve> {
@@ -3558,7 +3558,7 @@ mod tests_curve_arithmetic {
     /// value, so it rounds as often as `Multiply` does and needs the same
     /// fixed order.
     ///
-    /// The divisors are chosen so their reciprocals fill the 28-digit scale;
+    /// The divisors are chosen so their reciprocals fill the 28-place scale;
     /// the quotient is not pinned to a literal here because the operand
     /// ordering is already pinned by
     /// [`test_merge_curves_multiply_is_reproducible`], and reproducing the

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -14,7 +14,7 @@ use crate::geometrics::{
     InterpolationType, LinearInterpolation, MergeAxisInterpolate, MergeOperation, MetricsExtractor,
     RangeMetrics, RiskMetrics, ShapeMetrics, SplineInterpolation, TrendMetrics, powu_checked,
 };
-use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
+use crate::model::decimal::{d_add, d_div, d_mul, d_product_iter, d_sub, d_sum_iter};
 use crate::utils::Len;
 use crate::visualization::{Graph, GraphData};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -1912,12 +1912,36 @@ impl Arithmetic<Curve> for Curve {
     ///   - Applies the specified `operation` to the aggregated y-values at each x-point.
     ///
     /// 5. **Parallel Processing**:
-    ///   - Uses parallel iteration to perform interpolation and value combination
-    ///     efficiently, leveraging the Rayon library.
+    ///   - Uses parallel iteration over the grid to interpolate the operands
+    ///     efficiently, leveraging the Rayon library. The grid points are
+    ///     independent of one another and are collected back in x order.
     ///
     /// 6. **Error Handling**:
     ///   - Any errors during interpolation or arithmetic operations are propagated
     ///     back to the caller.
+    ///
+    /// # Determinism
+    ///
+    /// The same operands in the same order give the same result, digit for
+    /// digit, with the one exception noted for `Max` and `Min` below. Within
+    /// a grid point the operands are accumulated in the order they were
+    /// passed in, never in an order chosen by the thread pool.
+    ///
+    /// This matters for `Multiply` and `Divide` in particular. `Decimal`
+    /// multiplication rounds once a product needs more than 28 significant
+    /// digits, so it is not associative, and a parallel reducer would take
+    /// its bracketing from whatever chunking rayon picked on the day: three
+    /// or more curves could then merge to different last digits on
+    /// consecutive runs of one binary over one input. `Add` and `Subtract`
+    /// fold in order for the same reason.
+    ///
+    /// `Max` and `Min` still reduce in parallel. They select an operand
+    /// instead of accumulating one, so no rounding enters and the extremum
+    /// is the same whatever the grouping. What is not pinned is which of
+    /// several operands that compare equal is the one returned, and two
+    /// `Decimal` values comparing equal can still carry different scales, so
+    /// a tie between `2.0` and `2.00` is the one case where the stored digits
+    /// are left to the reducer.
     ///
     /// # Errors
     ///
@@ -2019,28 +2043,36 @@ impl Arithmetic<Curve> for Curve {
                             .map(|(i, &val)| if i == 0 { val } else { -val });
                         d_sum_iter(signed, op).map_err(construction_err)?
                     }
-                    MergeOperation::Multiply => y_values.par_iter().copied().map(Ok).reduce(
-                        || Ok(Decimal::ONE),
-                        |a, b| d_mul(a?, b?, op).map_err(construction_err),
-                    )?,
-                    MergeOperation::Divide => y_values
-                        .par_iter()
-                        .enumerate()
-                        .map(|(i, &val)| {
-                            // `Decimal::MAX` is the pre-existing sentinel for a
-                            // zero divisor; only the arithmetic is made checked.
-                            if i == 0 {
-                                Ok(val)
-                            } else if val == Decimal::ZERO {
-                                Ok(Decimal::MAX)
-                            } else {
-                                d_div(Decimal::ONE, val, op).map_err(construction_err)
-                            }
-                        })
-                        .reduce(
-                            || Ok(Decimal::ONE),
-                            |a, b| d_mul(a?, b?, op).map_err(construction_err),
-                        )?,
+                    MergeOperation::Multiply => {
+                        d_product_iter(y_values.iter().copied(), op).map_err(construction_err)?
+                    }
+                    MergeOperation::Divide => {
+                        // Division is neither associative nor commutative, so
+                        // every element after the first enters as its
+                        // reciprocal and the whole set is folded in sequence
+                        // from the leftmost value, leaving no partial to
+                        // discard. The fold is sequential for the same reason
+                        // `Multiply` is: `Decimal` multiplication rounds at 28
+                        // digits and is not associative either, so a parallel
+                        // reducer would take its bracketing from rayon's
+                        // chunking and move the last digits with it.
+                        y_values.iter().copied().enumerate().try_fold(
+                            Decimal::ONE,
+                            |acc, (i, val)| {
+                                // `Decimal::MAX` is the pre-existing sentinel
+                                // for a zero divisor; only the arithmetic is
+                                // made checked.
+                                let factor = if i == 0 {
+                                    val
+                                } else if val == Decimal::ZERO {
+                                    Decimal::MAX
+                                } else {
+                                    d_div(Decimal::ONE, val, op).map_err(construction_err)?
+                                };
+                                d_mul(acc, factor, op).map_err(construction_err)
+                            },
+                        )?
+                    }
                     MergeOperation::Max => y_values
                         .par_iter()
                         .cloned()
@@ -3329,6 +3361,224 @@ mod tests_curve_arithmetic {
             assert!(
                 (y - dec!(2)).abs() < dec!(0.0001),
                 "expected 8 / 2 / 2 = 2 at x = {x}, got {y}"
+            );
+        }
+    }
+
+    /// Number of times a single-pool determinism test repeats the same merge.
+    ///
+    /// This is the weaker of the two guards here, and the count says so.
+    /// Repeating on one pool only reaches the work-stealing component of the
+    /// old defect: measured against the reducer this replaces, a forty-operand
+    /// merge returned 52 distinct results in 2000 runs on a two-thread pool,
+    /// 809 in 2000 on four threads and 1996 in 2000 on eight, but exactly one
+    /// result in 2000 on one thread and one in 2000 on sixteen. Taking the
+    /// weakest rate that did flap, about 2.6% per run, 512 repeats leave
+    /// roughly one chance in a million of missing it.
+    ///
+    /// At the three operands the issue names, the old reducer was stable on
+    /// every pool size probed: 5000 runs, one result. Repetition alone would
+    /// not have caught it there at any count, which is why
+    /// [`test_merge_curves_multiply_is_reproducible`] also pins the exact
+    /// product, and why the property that actually broke is pinned by
+    /// [`test_merge_curves_multiply_is_reproducible_across_pool_sizes`].
+    const DETERMINISM_REPEATS: usize = 512;
+
+    /// The ordinates of a curve as `(mantissa, scale)` pairs.
+    ///
+    /// `Decimal` compares equal across scales, so `dec!(2.0) == dec!(2.00)`
+    /// and a plain equality check would not notice a fold that moved the
+    /// scale. The mantissa and the scale together are the stored value.
+    fn ordinate_fingerprint(curve: &Curve) -> Vec<(i128, u32)> {
+        curve
+            .points
+            .iter()
+            .map(|point| (point.y.mantissa(), point.y.scale()))
+            .collect()
+    }
+
+    /// Rayon pool sizes a cross-pool determinism test merges on.
+    ///
+    /// Rayon sets the splitting threshold of a parallel reduction to the
+    /// length of the input divided by eight times the number of threads in
+    /// the pool, so the pool size is one of the inputs to the grouping the
+    /// old reducer chose. One, two and four are the sizes at which the
+    /// threshold lands above one for a forty-operand merge, and eight and
+    /// sixteen bracket the count of a typical machine.
+    const POOL_SIZES: [usize; 5] = [1, 2, 4, 8, 16];
+
+    /// Merges per pool size in a cross-pool determinism test.
+    ///
+    /// The pool size is the variable that moved the result deterministically;
+    /// the repeats on top of it catch the work-stealing component, which on
+    /// eight threads made 1996 of 2000 runs of the old reducer distinct from
+    /// one another. Four is enough at that rate for the odds of missing it to
+    /// be negligible, and keeps the whole test inside a second.
+    const RUNS_PER_POOL: usize = 4;
+
+    /// Number of operands a cross-pool determinism test merges.
+    ///
+    /// Forty rather than three. At three operands the splitting threshold is
+    /// one whatever the pool size, so rayon built the same balanced tree
+    /// everywhere and the old reducer looked stable; the divergence needs an
+    /// input long enough for the threshold to exceed one on a small pool.
+    const CROSS_POOL_OPERANDS: u32 = 40;
+
+    /// Builds `CROSS_POOL_OPERANDS` constant curves just under one.
+    ///
+    /// Each ordinate is `1 - 1/n` for a distinct `n`, which fills the 28-digit
+    /// scale so the running product rounds at every step, and stays near one
+    /// so forty of them neither overflow nor collapse toward zero.
+    fn cross_pool_operands() -> Vec<Curve> {
+        (0..CROSS_POOL_OPERANDS)
+            .map(|i| {
+                let value = Decimal::ONE - Decimal::ONE / Decimal::from(1000 + i * 7);
+                create_constant_curve(dec!(0), dec!(10), value)
+                    .expect("constant curve fixture must build")
+            })
+            .collect()
+    }
+
+    /// Asserts that merging `curves` under `operation` gives one set of digits
+    /// across every pool size in [`POOL_SIZES`].
+    fn assert_reproducible_across_pools(curves: &[&Curve], operation: MergeOperation) {
+        let mut reference: Option<Vec<(i128, u32)>> = None;
+
+        for threads in POOL_SIZES {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("rayon must build a pool of a fixed size");
+
+            for run in 0..RUNS_PER_POOL {
+                let merged = pool
+                    .install(|| Curve::merge(curves, operation))
+                    .expect("the fixture merge must succeed");
+                let fingerprint = ordinate_fingerprint(&merged);
+
+                match &reference {
+                    None => reference = Some(fingerprint),
+                    Some(reference) => assert_eq!(
+                        &fingerprint, reference,
+                        "run {run} on a {threads}-thread pool produced different digits \
+                         from the first merge, under {operation:?}"
+                    ),
+                }
+            }
+        }
+    }
+
+    /// The same operands in the same order give the same digits whatever the
+    /// size of the rayon pool the merge runs on.
+    ///
+    /// This is the defect of #453 at its root, and the property repetition on
+    /// one pool does not reach. Rayon takes the grouping of a parallel
+    /// reduction from a threshold keyed to the pool size, so the old reducer
+    /// bracketed a forty-curve product one way on one thread and another way
+    /// on sixteen: 2000 runs on each, one result each, and the two results
+    /// disagreed. Two services on differently sized machines would have
+    /// disagreed on one input while each looked perfectly stable where it
+    /// ran, which is harder to notice than run-to-run noise.
+    ///
+    /// The pool is built explicitly rather than read from the environment
+    /// because `RAYON_NUM_THREADS` is consulted once, when the global pool is
+    /// first used, and a test cannot rely on being the first to touch it.
+    /// `rayon` is already a direct dependency, so this needs nothing new.
+    #[test]
+    fn test_merge_curves_multiply_is_reproducible_across_pool_sizes() {
+        let curves = cross_pool_operands();
+        let refs: Vec<&Curve> = curves.iter().collect();
+        assert_reproducible_across_pools(&refs, MergeOperation::Multiply);
+    }
+
+    /// `Divide` folds the reciprocals of its divisors into the leftmost value
+    /// with the same multiplication, so it took its bracketing from the same
+    /// splitter and moves under the same fix.
+    ///
+    /// `Surface`'s `Divide` was made sequential in #452; `Curve`'s was not,
+    /// and was still a parallel product of reciprocals until #453.
+    #[test]
+    fn test_merge_curves_divide_is_reproducible_across_pool_sizes() {
+        let curves = cross_pool_operands();
+        let refs: Vec<&Curve> = curves.iter().collect();
+        assert_reproducible_across_pools(&refs, MergeOperation::Divide);
+    }
+
+    /// Merging three curves under `Multiply` gives the same digits on every
+    /// run, and gives the digits of a left-to-right fold.
+    ///
+    /// The three ordinates are picked so the triple product overruns the 28
+    /// significant digits a `Decimal` holds and has to round twice: they
+    /// multiply to `...768908` grouped from the left and to `...768907`
+    /// grouped from the right, so the bracketing shows up in the result
+    /// instead of being hidden by exact arithmetic. Most triples do not
+    /// behave that way, which is why these are not arbitrary: over a sweep of
+    /// 205,379 reciprocal triples only 628, 0.31%, regrouped to a different
+    /// last digit.
+    ///
+    /// The exact product is what fails the old reducer here: it returned the
+    /// right-grouped value on every pool size probed, so at three operands
+    /// the repetition is a guard against a future regression rather than a
+    /// reproduction of this one. See [`DETERMINISM_REPEATS`] for the count,
+    /// and [`test_merge_curves_multiply_is_reproducible_across_pool_sizes`]
+    /// for the property that did break.
+    #[test]
+    fn test_merge_curves_multiply_is_reproducible() {
+        let a =
+            create_constant_curve(dec!(0), dec!(10), dec!(0.010989010989010989010989011)).unwrap();
+        let b =
+            create_constant_curve(dec!(0), dec!(10), dec!(0.010752688172043010752688172)).unwrap();
+        let c =
+            create_constant_curve(dec!(0), dec!(10), dec!(0.0094339622641509433962264151)).unwrap();
+
+        let expected = dec!(0.0000011147302687168785768908);
+        let first = Curve::merge(&[&a, &b, &c], MergeOperation::Multiply).unwrap();
+        for point in first.points.iter() {
+            assert_eq!(
+                (point.y.mantissa(), point.y.scale()),
+                (expected.mantissa(), expected.scale()),
+                "expected the left-to-right product {expected} at x = {}, got {}",
+                point.x,
+                point.y
+            );
+        }
+
+        let reference = ordinate_fingerprint(&first);
+        for run in 1..DETERMINISM_REPEATS {
+            let again = Curve::merge(&[&a, &b, &c], MergeOperation::Multiply).unwrap();
+            assert_eq!(
+                ordinate_fingerprint(&again),
+                reference,
+                "run {run} of {DETERMINISM_REPEATS} produced different digits from the first"
+            );
+        }
+    }
+
+    /// `Divide` folds the reciprocals of every divisor into the leftmost
+    /// value, so it rounds as often as `Multiply` does and needs the same
+    /// fixed order.
+    ///
+    /// The divisors are chosen so their reciprocals fill the 28-digit scale;
+    /// the quotient is not pinned to a literal here because the operand
+    /// ordering is already pinned by
+    /// [`test_merge_curves_multiply_is_reproducible`], and reproducing the
+    /// reciprocal rounding rule inside the assertion would only restate the
+    /// implementation. What is asserted is the property the issue names:
+    /// same operands, same digits, every run.
+    #[test]
+    fn test_merge_curves_divide_is_reproducible() {
+        let a = create_constant_curve(dec!(0), dec!(10), dec!(97)).unwrap();
+        let b = create_constant_curve(dec!(0), dec!(10), dec!(91)).unwrap();
+        let c = create_constant_curve(dec!(0), dec!(10), dec!(93)).unwrap();
+
+        let first = Curve::merge(&[&a, &b, &c], MergeOperation::Divide).unwrap();
+        let reference = ordinate_fingerprint(&first);
+        for run in 1..DETERMINISM_REPEATS {
+            let again = Curve::merge(&[&a, &b, &c], MergeOperation::Divide).unwrap();
+            assert_eq!(
+                ordinate_fingerprint(&again),
+                reference,
+                "run {run} of {DETERMINISM_REPEATS} produced different digits from the first"
             );
         }
     }

--- a/src/model/decimal.rs
+++ b/src/model/decimal.rs
@@ -396,6 +396,45 @@ pub(crate) fn d_mul(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Deci
         .ok_or_else(|| DecimalError::overflow(op, lhs, rhs))
 }
 
+/// Checked product over any `IntoIterator` of `Decimal` values.
+///
+/// Multiplicative counterpart to [`d_sum_iter`], with the same
+/// overflow-tagging semantics and the same zero-allocation shape. Returns
+/// [`Decimal::ONE`] on an empty iterator, so an empty product is the
+/// multiplicative identity just as an empty sum is [`Decimal::ZERO`].
+///
+/// # Ordering
+///
+/// The fold runs strictly left to right, and that order is part of the
+/// contract rather than an implementation detail. `Decimal` multiplication
+/// rounds as soon as a product needs more than the 28 significant digits the
+/// backing 96-bit mantissa holds, which makes it non-associative: `(a * b) *
+/// c` and `a * (b * c)` can differ in their last digit. A parallel reducer
+/// picks its bracketing from the chunking rayon happens to choose on the day,
+/// so the same binary on the same input can return different last digits from
+/// one run to the next. Callers that have to reconcile, cache or
+/// regression-test a result at full precision need the fixed order this
+/// gives them.
+///
+/// # Errors
+///
+/// Returns [`DecimalError::Overflow`] on the first accumulation that
+/// exceeds the representable `Decimal` range, tagged with the supplied `op`
+/// string so the call-site can be identified without a stack trace.
+#[inline]
+pub(crate) fn d_product_iter<I>(iter: I, op: &'static str) -> Result<Decimal, DecimalError>
+where
+    I: IntoIterator<Item = Decimal>,
+{
+    let mut acc = Decimal::ONE;
+    for v in iter {
+        acc = acc
+            .checked_mul(v)
+            .ok_or_else(|| DecimalError::overflow(op, acc, v))?;
+    }
+    Ok(acc)
+}
+
 /// Checked `Decimal` division with banker's rounding at scale 28.
 ///
 /// Crate-private helper used by every monetary-flow kernel in place of the

--- a/src/model/decimal.rs
+++ b/src/model/decimal.rs
@@ -407,8 +407,8 @@ pub(crate) fn d_mul(lhs: Decimal, rhs: Decimal, op: &'static str) -> Result<Deci
 ///
 /// The fold runs strictly left to right, and that order is part of the
 /// contract rather than an implementation detail. `Decimal` multiplication
-/// rounds as soon as a product needs more than the 28 significant digits the
-/// backing 96-bit mantissa holds, which makes it non-associative: `(a * b) *
+/// rounds as soon as a product needs more decimal places than `Decimal`'s
+/// scale limit of 28, which makes it non-associative: `(a * b) *
 /// c` and `a * (b * c)` can differ in their last digit. A parallel reducer
 /// picks its bracketing from the chunking rayon happens to choose on the day,
 /// so the same binary on the same input can return different last digits from

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -30,7 +30,7 @@ use crate::geometrics::{
     InterpolationType, LinearInterpolation, MergeAxisInterpolate, MergeOperation, MetricsExtractor,
     RangeMetrics, RiskMetrics, ShapeMetrics, SplineInterpolation, TrendMetrics, powu_checked,
 };
-use crate::model::decimal::{d_add, d_div, d_mul, d_sub, d_sum_iter};
+use crate::model::decimal::{d_add, d_div, d_mul, d_product_iter, d_sub, d_sum_iter};
 use crate::surfaces::Point3D;
 use crate::surfaces::types::Axis;
 use crate::utils::Len;
@@ -1649,6 +1649,34 @@ impl MetricsExtractor for Surface {
 impl Arithmetic<Surface> for Surface {
     type Error = SurfaceError;
 
+    /// Merges a collection of surfaces into one, resampled onto a 51 x 51
+    /// grid over the intersection of their ranges.
+    ///
+    /// Each cell of the grid interpolates every operand and combines the
+    /// heights with `operation`. An empty slice is an error; a single surface
+    /// is returned as a clone.
+    ///
+    /// # Determinism
+    ///
+    /// The same operands in the same order give the same result, digit for
+    /// digit. Within a cell the heights are accumulated in the order they
+    /// were passed in, never in an order chosen by the thread pool: `Decimal`
+    /// multiplication rounds once a product needs more than 28 significant
+    /// digits and is therefore not associative, so a parallel reducer would
+    /// take its bracketing from rayon's chunking and could return different
+    /// last digits on consecutive runs of one binary over one input.
+    ///
+    /// `Max` and `Min` still reduce in parallel; they select a height rather
+    /// than accumulating one, so no rounding enters, and the same caveat
+    /// about ties between equal `Decimal` values at different scales applies
+    /// as it does to `Curve::merge`.
+    ///
+    /// # Errors
+    ///
+    /// - [`SurfaceError::OperationError`] when no surfaces are supplied or
+    ///   their ranges do not intersect.
+    /// - The interpolation error of the operand that failed, and any
+    ///   checked-arithmetic failure raised while combining the heights.
     fn merge(surfaces: &[&Surface], operation: MergeOperation) -> Result<Surface, Self::Error> {
         if surfaces.is_empty() {
             return Err(SurfaceError::invalid_parameters(
@@ -1733,10 +1761,8 @@ impl Arithmetic<Surface> for Surface {
                                 .map_err(construction_err)?;
                             d_sub(first, remaining_sum, op).map_err(construction_err)?
                         }
-                        MergeOperation::Multiply => z_values.par_iter().copied().map(Ok).reduce(
-                            || Ok(Decimal::ONE),
-                            |a, b| d_mul(a?, b?, op).map_err(construction_err),
-                        )?,
+                        MergeOperation::Multiply => d_product_iter(z_values.iter().copied(), op)
+                            .map_err(construction_err)?,
                         MergeOperation::Divide => {
                             // Division is neither associative nor commutative,
                             // so the divisors are folded in sequence from the
@@ -3389,6 +3415,67 @@ mod tests_surface_arithmetic {
             "expected 8 / 2 / 2 = 2, got {}",
             mid_point.z
         );
+    }
+
+    /// Number of times a determinism test repeats the same merge.
+    ///
+    /// `Surface::merge` resamples a 51 x 51 grid and runs the fold once per
+    /// cell, so one call already exercises the fold 2601 times against
+    /// `Curve::merge`'s 101. That buys the same confidence from far fewer
+    /// repeats, which matters because each call is three orders of magnitude
+    /// dearer than a curve merge; see `DETERMINISM_REPEATS` in
+    /// `curves::curve` for how the rate this is sized against was measured.
+    const DETERMINISM_REPEATS: usize = 24;
+
+    /// The heights of a surface as `(mantissa, scale)` pairs.
+    ///
+    /// `Decimal` compares equal across scales, so `dec!(2.0) == dec!(2.00)`
+    /// and a plain equality check would not notice a fold that moved the
+    /// scale. The mantissa and the scale together are the stored value.
+    fn height_fingerprint(surface: &Surface) -> Vec<(i128, u32)> {
+        surface
+            .points
+            .iter()
+            .map(|point| (point.z.mantissa(), point.z.scale()))
+            .collect()
+    }
+
+    /// Merging three surfaces under `Multiply` gives the same digits on every
+    /// run, and gives the digits of a left-to-right fold.
+    ///
+    /// The three heights are the ones used by the curve test of the same
+    /// name: their triple product overruns the 28 significant digits a
+    /// `Decimal` holds and has to round twice, ending `...768908` grouped
+    /// from the left and `...768907` grouped from the right. The parallel
+    /// reducer this replaces returned the second.
+    #[test]
+    fn test_merge_surfaces_multiply_is_reproducible() {
+        let a = constant_surface(dec!(0.010989010989010989010989011));
+        let b = constant_surface(dec!(0.010752688172043010752688172));
+        let c = constant_surface(dec!(0.0094339622641509433962264151));
+
+        let expected = dec!(0.0000011147302687168785768908);
+        let first = Surface::merge(&[&a, &b, &c], MergeOperation::Multiply).unwrap();
+        for point in first.points.iter() {
+            assert_eq!(
+                (point.z.mantissa(), point.z.scale()),
+                (expected.mantissa(), expected.scale()),
+                "expected the left-to-right product {expected} at ({}, {}), got {}",
+                point.x,
+                point.y,
+                point.z
+            );
+        }
+
+        let reference = height_fingerprint(&first);
+        for run in 1..DETERMINISM_REPEATS {
+            let again = Surface::merge(&[&a, &b, &c], MergeOperation::Multiply).unwrap();
+            assert_eq!(
+                height_fingerprint(&again),
+                reference,
+                "run {run} of {DETERMINISM_REPEATS} produced different digits from the first"
+            );
+        }
     }
 
     /// A divisor that fails the checked division has to surface as an error

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -1661,7 +1661,7 @@ impl Arithmetic<Surface> for Surface {
     /// The same operands in the same order give the same result, digit for
     /// digit. Within a cell the heights are accumulated in the order they
     /// were passed in, never in an order chosen by the thread pool: `Decimal`
-    /// multiplication rounds once a product needs more than 28 significant
+    /// multiplication rounds once a product needs more than 28 decimal
     /// digits and is therefore not associative, so a parallel reducer would
     /// take its bracketing from rayon's chunking and could return different
     /// last digits on consecutive runs of one binary over one input.
@@ -3444,7 +3444,7 @@ mod tests_surface_arithmetic {
     /// run, and gives the digits of a left-to-right fold.
     ///
     /// The three heights are the ones used by the curve test of the same
-    /// name: their triple product overruns the 28 significant digits a
+    /// name: their triple product overruns the 28 decimal places a
     /// `Decimal` holds and has to round twice, ending `...768908` grouped
     /// from the left and `...768907` grouped from the right. The parallel
     /// reducer this replaces returned the second.


### PR DESCRIPTION
## Summary

`Curve::merge` and `Surface::merge` reduced their `Multiply` arm with a rayon
`reduce`. `Decimal` multiplication rounds past 28 significant digits, so it is
**not associative**, and rayon picks the grouping from its length splitter —
which is keyed to the input length *and the ambient pool size*.

The premise is confirmed and it is worse than "different last digits". Merging
40 curves, same binary, same input:

| rayon threads | distinct results in 2000 runs |
|---|---|
| 1 | 1 |
| 2 | **52** |
| 4 | **809** |
| 8 | **1996** |
| 16 | 1 |

Two machines with different core counts disagree on the same input while each
looks perfectly stable locally. Over a sweep of 205,379 reciprocal triples,
**628 (0.31%) regroup to a different last digit**.

## `Curve`'s Divide was still parallel

The issue and my own brief said Divide went sequential in #452. **That was
`Surface` only.** `Curve`'s Divide was still a parallel product of reciprocals,
taking its bracketing from the same splitter, so "merging three or more curves
is bit-reproducible" would have been false without fixing it too. Semantics are
unchanged, including the `Decimal::MAX` zero-divisor sentinel.

## Criterion

The first attempt — a 12-configuration single-shot A/B — was thrown away rather
than reported: the machine was at load 79 on 16 cores, and running the
*identical* code pair three times gave deltas from −32% to +114%. Replaced with
five alternating old/new rounds, 500 samples a side, comparing minima as the
best estimator of uncontended cost.

**End to end, `Multiply` (min over 5 paired rounds):**

| benchmark | parallel | sequential | ratio |
|---|---|---|---|
| curve size_32 / 2 operands | 93.68 µs | 89.24 µs | **0.953** |
| curve size_32 / 3 | 100.78 µs | 93.09 µs | **0.924** |
| curve size_32 / 5 | 126.91 µs | 119.98 µs | **0.945** |
| curve size_32 / 10 | 185.06 µs | 177.14 µs | **0.957** |
| curve size_512 / 10 | 692.19 µs | 608.75 µs | **0.879** |
| surface side_8 / 3 | 10.986 ms | 10.733 ms | **0.977** |

Sequential is 2–12% faster at the uncontended end and never slower; at the
median it is inside the noise floor.

**The two folds in isolation:**

| operands | rayon `reduce` | sequential fold | factor |
|---|---|---|---|
| 2 | 16.695–17.282 µs | 22.254–22.363 ns | **761×** |
| 3 | 16.282–16.801 µs | 69.709–70.576 ns | **236×** |
| 5 | 27.690–32.905 µs | 158.98–160.76 ns | **189×** |
| 10 | 26.996–29.055 µs | 702.28–888.80 ns | **35×** |

Stated plainly: that isolated figure is a *cold* dispatch from the main thread,
and in-merge the reduce is nested inside the outer grid `par_iter`, which is why
end-to-end is a few percent rather than 100×.

**Decision: sequential**, and the number that drove it is the isolated fold. The
code was dispatching a rayon job per grid point to multiply 2–10 numbers. There
was no speed to trade away for the determinism.

Reproduce: `cargo bench --bench benches -- 'decimal_product_fold'`.

## The determinism tests pin what actually broke

Repeating a merge on one pool reaches only the **work-stealing** component. The
pool size is itself an input to the grouping — rayon sets a reduction's
splitting threshold to the input length over eight times the thread count — and
the old reducer was perfectly stable on 1 and on 16 threads while flapping on
1996 of 2000 runs on 8. A test that never varied the pool would have called the
worst case stable.

So there are two guards, and their doc comments say which is which:

- `..._is_reproducible_across_pool_sizes` merges on 1, 2, 4, 8 and 16 threads.
  This is the property that actually broke.
- `..._is_reproducible` repeats 512 times on one pool, sized from the weakest
  rate that flapped (~2.6%/run) to leave about one chance in a million of
  missing a reintroduced parallel fold.

Both compare ordinates as `(mantissa, scale)` pairs: `Decimal` compares equal
across scales, so `dec!(2.0) == dec!(2.00)` and a plain equality check would not
notice a fold that moved the scale.

At the three operands the issue names, the old reducer was stable on every pool
size probed — 5000 runs, one result — but returned the `a*(b*c)` grouping. So
the tests also pin the exact product; that is what fails the old code, on the
first iteration.

## Numerical change

`Multiply` and `Divide` move in their last decimal places: old `a*(b*c)`, new
`(a*b)*c`. Any fix repins the bracketing, so a last-digit move is unavoidable in
either direction; the sequential fold at least pins the value a reader would
predict.

Measured rather than estimated — `Decimal`'s 28 is decimal *places*, not
significant digits, so the relative size depends on the value's exponent:

| arm | operands | before | after | move |
|---|---|---|---|---|
| Multiply | `0.010989010989…`, `0.010752688172…`, `0.009433962264…` | `0.0000011147302687168785768907` | `…908` | 1 unit in the last place, **9e-23** relative |
| Divide (`Curve`) | 97, 91, 93 | `0.0114616566229469455275906915` | `…888` | 27 units in the last place, **2.4e-25** relative |

`Curve`'s Divide moves further because each reciprocal is separately rounded to
28 places by `d_div` before being multiplied in. `Surface`'s Divide is untouched
and does not move.

Signed off on the grounds that a move twenty orders of magnitude below a tick is
below any price, greek or premium this crate represents, while a value that
changes with the machine's core count
cannot be reconciled, cached or regression-tested at all. Every existing merge
test compares within 1e-3/1e-4, so none moved — which protects us, not a
downstream consumer holding a golden at full precision, and the `CHANGELOG.md`
entry gives the concrete triple and both values so they can check.

## Tests and gates

4038 lib + 67 property + 423 integration + 207 doctests, 0 failed.

```
cargo fmt --all --check                                          clean
cargo clippy --all-targets --all-features --workspace -- -D warnings   clean
cargo test --all-features --workspace                            0 failed
LOGLEVEL=WARN cargo test          (default feature set)          0 failed
cargo build --release                                            no warnings
cargo doc --all-features --no-deps                               clean
make scan-banned                                                 OK
make public-api-check                                            OK
```

`d_product_iter` lands beside `d_sum_iter` in `src/model/decimal.rs` with
left-to-right order documented as its contract. `Surface::merge` also gained a
doc comment; it had none.

## Stack

Chain B, third of three — the last of that chain.

- Stack: #466 → #451 → **#453** (this one). Independent of chain A (#470 →
  #469 → #463 → #471), chain C (#462), #459, and the #442 capstone.
- Base branch: `main`. #466 and #451 are merged, so this is rebased onto `main`
  and the diff is its own work alone.

Closes #453
