### PR TITLE
Give the infallible signatures that could abort an error channel (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,95 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Twenty public methods whose return type had no error channel are now
+  fallible, which is a breaking change** (#471). Each aborted the process on
+  arithmetic over `pub` fields. #460 closed everything reachable through the
+  public constructors, and what remained was reachable only by writing a
+  field directly, by deserializing a document that carries one, or through a
+  trait whose signature forbade failure — so none of them could be fixed
+  without changing the signature, which is why they were reported rather than
+  fixed at the time. The values returned are unchanged for every input the
+  panicking forms accepted. To migrate, add `?` where the value feeds a
+  fallible function, or handle the `Result` at a boundary that cannot
+  propagate.
+
+  **`LegAble` gains an error channel on three methods.** `pnl_at_price`
+  returns `Result<Decimal, PricingError>` instead of `Decimal`, and
+  `total_cost` and `fees` return `Result<Positive, PositionError>` instead of
+  `Positive`. `pnl_at_price` computes `(price - cost_basis) * quantity` and
+  aborted with `Subtraction overflowed`; `total_cost` multiplies size by cost
+  basis before adding two fees, and aborted with `Positive arithmetic overflow
+  in add`. The four implementors — `SpotPosition`, `FuturePosition`,
+  `PerpetualPosition` and the `Leg` enum — are updated, and every one of the
+  three now uses the checked helpers. `Leg::pnl_at_price` and
+  `Leg::total_cost` propagate the option leg's failure instead of swallowing
+  it as `unwrap_or(Decimal::ZERO)` / `unwrap_or(Positive::ZERO)`; both
+  fallbacks were values a legitimate leg can also return, so neither could be
+  told apart from an answer. `Position::total_cost` and `Position::fees` have
+  returned `Result` since #470, so the leg trait was the last infallible
+  wrapper over the same sums.
+
+  **Five `PerpetualPosition` and `FuturePosition` methods follow.**
+  `FuturePosition::unrealized_pnl` and `PerpetualPosition::unrealized_pnl`
+  return `Result<Decimal, PricingError>`, and with them
+  `PerpetualPosition::roe_percentage`, `margin_ratio` and
+  `effective_leverage`. `unrealized_pnl` is the entire body of
+  `pnl_at_price` on those two types, so leaving it infallible would have
+  moved the abort one frame down rather than removed it. The three ratios
+  keep their existing degenerate answers — `Decimal::ZERO` for a zero margin
+  or a zero notional, `Decimal::MAX` for wiped-out equity — rather than
+  turning those into errors; only the overflow is new.
+
+  **`PnL::try_add` is now public, and the operator impls are documented as
+  superseded.** `impl Add for PnL` and `impl Sum for PnL` add `initial_costs:
+  Positive + Positive` with the raw operator. `Add::add` and `Sum::sum` are
+  fixed by `std` to return `Self`, so no fallible form of either exists and no
+  signature change makes them safe. #460 routed every accumulation inside the
+  library through a `pub(crate) try_add`; it is `pub` now so callers have the
+  same route. The four operator impls are kept, because removing them would
+  break every `a + b` and `.sum()` at a call site with nothing to overflow.
+  They carry a `# Deprecated in favour of PnL::try_add` doc section rather
+  than a `#[deprecated]` attribute: Rust rejects that attribute on a trait
+  `impl` block and on a trait method inside one (`error: #[deprecated]
+  attribute cannot be used on trait impl blocks`), so the compiler cannot
+  emit this warning at all.
+
+  **Three `Collar` methods.** `net_premium` returns `Result<Decimal,
+  PricingError>` instead of `Decimal`, and `is_zero_cost` and `is_credit`
+  return `Result<bool, PricingError>` instead of `bool`. `net_premium`
+  multiplies each leg's `premium` by its `quantity`, both `pub` fields, and
+  aborted on overflow; the two predicates read it. They report the same
+  failure rather than collapsing it into `false`, which would have read as a
+  definite classification.
+
+  **`CoveredCall::effective_cost_basis` and
+  `ProtectivePut::effective_cost_basis`** return `Result<Positive,
+  PositiveError>` instead of `Positive`. Both divide the premium by
+  `spot_leg.quantity`. Both constructors reject a zero share count, but a
+  strategy deserialized from JSON or mutated in place can carry one, and
+  `Positive` has no value meaning "undefined per-share figure".
+
+  **Four `PortfolioGreeks` methods.** `delta_gap` and `gamma_gap` return
+  `Result<Decimal, GreeksError>`, `combined` returns
+  `Result<PortfolioGreeks, GreeksError>`, and `add` returns `Result<(),
+  GreeksError>` instead of nothing. All five Greek fields are `pub` and are
+  written directly by callers aggregating from their own sources, so
+  `from_positions` guarantees nothing about them. `add` now writes through
+  `combined`, so a failure on the fourth of five sums leaves the receiver
+  exactly as it was rather than committing the first three.
+
+  No error enum and no error variant was added, so nothing that matches
+  exhaustively on a public error type needs a new arm. The property suite's
+  `test_spot_leg_strategies_never_panic` drops the bounded `spot_leg_money`
+  generator that existed only for these signatures and runs against the
+  unbounded `extreme_money`, so `Positive::MAX` is back in range for the
+  three spot-leg strategies.
+
+  Two siblings with the same defect are deliberately out of scope and remain
+  infallible: `AdjustmentTarget::delta_gap` / `gamma_gap` / `vega_gap` /
+  `is_satisfied`, which subtract the same `pub` Greeks a `PortfolioGreeks`
+  carries.
+
 - **`Curve::bilinear_interpolate` now answers across the whole interior
   domain, and its exact-match branch fails on a repeated abscissa** (#451).
   The method read a four-sample window starting at the bracket index, which

--- a/examples/examples_strategies_delta/src/bin/strategy_bull_call_spread_extended_delta.rs
+++ b/examples/examples_strategies_delta/src/bin/strategy_bull_call_spread_extended_delta.rs
@@ -76,7 +76,10 @@ fn main() -> Result<(), Error> {
             info!("Portfolio Rho: {:.4}", greeks.rho);
             info!("Is Delta Neutral: {}", greeks.is_delta_neutral(dec!(0.1)));
             info!("Is Gamma Neutral: {}", greeks.is_gamma_neutral(dec!(0.01)));
-            info!("Delta Gap from 0: {:.4}", greeks.delta_gap(Decimal::ZERO));
+            match greeks.delta_gap(Decimal::ZERO) {
+                Ok(gap) => info!("Delta Gap from 0: {:.4}", gap),
+                Err(e) => warn!("Could not calculate the portfolio delta gap: {}", e),
+            }
         }
         Err(e) => warn!("Could not calculate portfolio Greeks: {}", e),
     }

--- a/public-api/optionstratlib.txt
+++ b/public-api/optionstratlib.txt
@@ -3573,7 +3573,7 @@ pub fn optionstratlib::model::leg::PerpetualPosition::funding_payment(&self, pos
 pub fn optionstratlib::model::leg::PerpetualPosition::funding_rate(&self) -> rust_decimal::decimal::Decimal
 pub trait optionstratlib::model::leg::traits::LegAble
 pub fn optionstratlib::model::leg::traits::LegAble::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::traits::LegAble::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::traits::LegAble::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::traits::LegAble::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::traits::LegAble::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::traits::LegAble::get_side(&self) -> financial_types::Side
@@ -3581,14 +3581,14 @@ pub fn optionstratlib::model::leg::traits::LegAble::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::traits::LegAble::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::traits::LegAble::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::traits::LegAble::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::traits::LegAble::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::traits::LegAble::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::traits::LegAble::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::traits::LegAble::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::traits::LegAble::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::traits::LegAble::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::traits::LegAble::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::FuturePosition
 pub fn optionstratlib::model::leg::FuturePosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::FuturePosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::FuturePosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::FuturePosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::FuturePosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::FuturePosition::get_side(&self) -> financial_types::Side
@@ -3596,14 +3596,14 @@ pub fn optionstratlib::model::leg::FuturePosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::FuturePosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::FuturePosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::FuturePosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::FuturePosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::FuturePosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::FuturePosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::FuturePosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::FuturePosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::FuturePosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::FuturePosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::Leg
 pub fn optionstratlib::model::leg::Leg::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::Leg::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::Leg::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::Leg::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::Leg::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::Leg::get_side(&self) -> financial_types::Side
@@ -3611,14 +3611,14 @@ pub fn optionstratlib::model::leg::Leg::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::Leg::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::Leg::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::Leg::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::Leg::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::Leg::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::Leg::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::Leg::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::Leg::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::Leg::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::Leg::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::PerpetualPosition
 pub fn optionstratlib::model::leg::PerpetualPosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::PerpetualPosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::PerpetualPosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::PerpetualPosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::PerpetualPosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::PerpetualPosition::get_side(&self) -> financial_types::Side
@@ -3626,14 +3626,14 @@ pub fn optionstratlib::model::leg::PerpetualPosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::PerpetualPosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::PerpetualPosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::PerpetualPosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::PerpetualPosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::PerpetualPosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::PerpetualPosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::PerpetualPosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::PerpetualPosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::PerpetualPosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::PerpetualPosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::SpotPosition
 pub fn optionstratlib::model::leg::SpotPosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::SpotPosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::SpotPosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::SpotPosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::SpotPosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::SpotPosition::get_side(&self) -> financial_types::Side
@@ -3641,10 +3641,10 @@ pub fn optionstratlib::model::leg::SpotPosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::SpotPosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::SpotPosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::SpotPosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::SpotPosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::SpotPosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::SpotPosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::SpotPosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::SpotPosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::SpotPosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::SpotPosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub trait optionstratlib::model::leg::traits::Marginable: optionstratlib::model::leg::traits::LegAble
 pub fn optionstratlib::model::leg::traits::Marginable::initial_margin(&self) -> positive::positive::Positive
@@ -3703,7 +3703,7 @@ impl core::fmt::Display for optionstratlib::model::leg::Leg
 pub fn optionstratlib::model::leg::Leg::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::Leg
 pub fn optionstratlib::model::leg::Leg::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::Leg::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::Leg::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::Leg::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::Leg::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::Leg::get_side(&self) -> financial_types::Side
@@ -3711,10 +3711,10 @@ pub fn optionstratlib::model::leg::Leg::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::Leg::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::Leg::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::Leg::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::Leg::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::Leg::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::Leg::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::Leg::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::Leg::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::Leg::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::Leg::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl utoipa::ToSchema for optionstratlib::model::leg::Leg
 pub fn optionstratlib::model::leg::Leg::name() -> alloc::borrow::Cow<'static, str>
@@ -3752,7 +3752,7 @@ pub fn optionstratlib::model::leg::FuturePosition::notional_value_at_price(&self
 pub fn optionstratlib::model::leg::FuturePosition::short(alloc::string::String, positive::positive::Positive, positive::positive::Positive, expiration_date::ExpirationDate, positive::positive::Positive, positive::positive::Positive) -> Self
 pub fn optionstratlib::model::leg::FuturePosition::tick_value(&self, positive::positive::Positive) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::FuturePosition::total_margin_required(&self) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::FuturePosition::unrealized_pnl(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::FuturePosition::unrealized_pnl(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 impl core::convert::From<optionstratlib::model::leg::FuturePosition> for optionstratlib::model::leg::Leg
 pub fn optionstratlib::model::leg::Leg::from(optionstratlib::model::leg::FuturePosition) -> Self
 impl core::default::Default for optionstratlib::model::leg::FuturePosition
@@ -3766,7 +3766,7 @@ pub fn optionstratlib::model::leg::FuturePosition::is_expired(&self) -> bool
 pub fn optionstratlib::model::leg::FuturePosition::time_to_expiration_years(&self) -> rust_decimal::decimal::Decimal
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::FuturePosition
 pub fn optionstratlib::model::leg::FuturePosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::FuturePosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::FuturePosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::FuturePosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::FuturePosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::FuturePosition::get_side(&self) -> financial_types::Side
@@ -3774,10 +3774,10 @@ pub fn optionstratlib::model::leg::FuturePosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::FuturePosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::FuturePosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::FuturePosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::FuturePosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::FuturePosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::FuturePosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::FuturePosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::FuturePosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::FuturePosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::FuturePosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::Marginable for optionstratlib::model::leg::FuturePosition
 pub fn optionstratlib::model::leg::FuturePosition::initial_margin(&self) -> positive::positive::Positive
@@ -3804,15 +3804,15 @@ pub optionstratlib::model::leg::PerpetualPosition::symbol: alloc::string::String
 impl optionstratlib::model::leg::PerpetualPosition
 pub const optionstratlib::model::leg::PerpetualPosition::DEFAULT_FUNDING_INTERVAL_HOURS: u32
 pub const optionstratlib::model::leg::PerpetualPosition::DEFAULT_MAINTENANCE_MARGIN_RATIO: rust_decimal::decimal::Decimal
-pub fn optionstratlib::model::leg::PerpetualPosition::effective_leverage(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::PerpetualPosition::effective_leverage(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::PerpetualPosition::long(alloc::string::String, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> Self
-pub fn optionstratlib::model::leg::PerpetualPosition::margin_ratio(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::PerpetualPosition::margin_ratio(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::PerpetualPosition::new(alloc::string::String, positive::positive::Positive, positive::positive::Positive, financial_types::Side, positive::positive::Positive, positive::positive::Positive, optionstratlib::model::leg::MarginType, rust_decimal::decimal::Decimal, chrono::datetime::DateTime<chrono::offset::utc::Utc>, positive::positive::Positive) -> Self
 pub fn optionstratlib::model::leg::PerpetualPosition::notional_value_at_entry(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::PerpetualPosition::notional_value_at_price(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::PerpetualPosition::roe_percentage(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::PerpetualPosition::roe_percentage(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::PerpetualPosition::short(alloc::string::String, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> Self
-pub fn optionstratlib::model::leg::PerpetualPosition::unrealized_pnl(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::PerpetualPosition::unrealized_pnl(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::PerpetualPosition::update_funding_rate(&mut self, rust_decimal::decimal::Decimal)
 impl core::convert::From<optionstratlib::model::leg::PerpetualPosition> for optionstratlib::model::leg::Leg
 pub fn optionstratlib::model::leg::Leg::from(optionstratlib::model::leg::PerpetualPosition) -> Self
@@ -3827,7 +3827,7 @@ pub fn optionstratlib::model::leg::PerpetualPosition::funding_payment(&self, pos
 pub fn optionstratlib::model::leg::PerpetualPosition::funding_rate(&self) -> rust_decimal::decimal::Decimal
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::PerpetualPosition
 pub fn optionstratlib::model::leg::PerpetualPosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::PerpetualPosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::PerpetualPosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::PerpetualPosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::PerpetualPosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::PerpetualPosition::get_side(&self) -> financial_types::Side
@@ -3835,10 +3835,10 @@ pub fn optionstratlib::model::leg::PerpetualPosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::PerpetualPosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::PerpetualPosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::PerpetualPosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::PerpetualPosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::PerpetualPosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::PerpetualPosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::PerpetualPosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::PerpetualPosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::PerpetualPosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::PerpetualPosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::Marginable for optionstratlib::model::leg::PerpetualPosition
 pub fn optionstratlib::model::leg::PerpetualPosition::initial_margin(&self) -> positive::positive::Positive
@@ -3875,7 +3875,7 @@ impl core::fmt::Display for optionstratlib::model::leg::SpotPosition
 pub fn optionstratlib::model::leg::SpotPosition::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::SpotPosition
 pub fn optionstratlib::model::leg::SpotPosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::SpotPosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::SpotPosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::SpotPosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::SpotPosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::SpotPosition::get_side(&self) -> financial_types::Side
@@ -3883,10 +3883,10 @@ pub fn optionstratlib::model::leg::SpotPosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::SpotPosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::SpotPosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::SpotPosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::SpotPosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::SpotPosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::SpotPosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::SpotPosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::SpotPosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::SpotPosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::SpotPosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl utoipa::ToSchema for optionstratlib::model::leg::SpotPosition
 pub fn optionstratlib::model::leg::SpotPosition::name() -> alloc::borrow::Cow<'static, str>
@@ -3915,7 +3915,7 @@ pub fn optionstratlib::model::leg::PerpetualPosition::funding_payment(&self, pos
 pub fn optionstratlib::model::leg::PerpetualPosition::funding_rate(&self) -> rust_decimal::decimal::Decimal
 pub trait optionstratlib::model::leg::LegAble
 pub fn optionstratlib::model::leg::LegAble::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::LegAble::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::LegAble::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::LegAble::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::LegAble::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::LegAble::get_side(&self) -> financial_types::Side
@@ -3923,14 +3923,14 @@ pub fn optionstratlib::model::leg::LegAble::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::LegAble::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::LegAble::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::LegAble::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::LegAble::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::LegAble::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::LegAble::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::LegAble::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::LegAble::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::LegAble::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::LegAble::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::FuturePosition
 pub fn optionstratlib::model::leg::FuturePosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::FuturePosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::FuturePosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::FuturePosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::FuturePosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::FuturePosition::get_side(&self) -> financial_types::Side
@@ -3938,14 +3938,14 @@ pub fn optionstratlib::model::leg::FuturePosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::FuturePosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::FuturePosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::FuturePosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::FuturePosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::FuturePosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::FuturePosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::FuturePosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::FuturePosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::FuturePosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::FuturePosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::Leg
 pub fn optionstratlib::model::leg::Leg::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::Leg::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::Leg::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::Leg::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::Leg::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::Leg::get_side(&self) -> financial_types::Side
@@ -3953,14 +3953,14 @@ pub fn optionstratlib::model::leg::Leg::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::Leg::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::Leg::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::Leg::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::Leg::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::Leg::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::Leg::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::Leg::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::Leg::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::Leg::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::Leg::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::PerpetualPosition
 pub fn optionstratlib::model::leg::PerpetualPosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::PerpetualPosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::PerpetualPosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::PerpetualPosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::PerpetualPosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::PerpetualPosition::get_side(&self) -> financial_types::Side
@@ -3968,14 +3968,14 @@ pub fn optionstratlib::model::leg::PerpetualPosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::PerpetualPosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::PerpetualPosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::PerpetualPosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::PerpetualPosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::PerpetualPosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::PerpetualPosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::PerpetualPosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::PerpetualPosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::PerpetualPosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::PerpetualPosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 impl optionstratlib::model::leg::traits::LegAble for optionstratlib::model::leg::SpotPosition
 pub fn optionstratlib::model::leg::SpotPosition::delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::SpotPosition::fees(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::SpotPosition::fees(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::SpotPosition::gamma(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::SpotPosition::get_quantity(&self) -> positive::positive::Positive
 pub fn optionstratlib::model::leg::SpotPosition::get_side(&self) -> financial_types::Side
@@ -3983,10 +3983,10 @@ pub fn optionstratlib::model::leg::SpotPosition::get_symbol(&self) -> &str
 pub fn optionstratlib::model::leg::SpotPosition::is_long(&self) -> bool
 pub fn optionstratlib::model::leg::SpotPosition::is_short(&self) -> bool
 pub fn optionstratlib::model::leg::SpotPosition::notional_value(&self, positive::positive::Positive) -> positive::positive::Positive
-pub fn optionstratlib::model::leg::SpotPosition::pnl_at_price(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::leg::SpotPosition::pnl_at_price(&self, positive::positive::Positive) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::model::leg::SpotPosition::rho(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::model::leg::SpotPosition::theta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::model::leg::SpotPosition::total_cost(&self) -> positive::positive::Positive
+pub fn optionstratlib::model::leg::SpotPosition::total_cost(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::position::PositionError>
 pub fn optionstratlib::model::leg::SpotPosition::vega(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub trait optionstratlib::model::leg::Marginable: optionstratlib::model::leg::traits::LegAble
 pub fn optionstratlib::model::leg::Marginable::initial_margin(&self) -> positive::positive::Positive
@@ -4660,6 +4660,7 @@ pub optionstratlib::pnl::utils::PnL::unrealized: core::option::Option<rust_decim
 impl optionstratlib::pnl::utils::PnL
 pub fn optionstratlib::pnl::utils::PnL::new(core::option::Option<rust_decimal::decimal::Decimal>, core::option::Option<rust_decimal::decimal::Decimal>, positive::positive::Positive, positive::positive::Positive, chrono::datetime::DateTime<chrono::offset::utc::Utc>) -> Self
 pub fn optionstratlib::pnl::utils::PnL::total_pnl(&self) -> core::option::Option<rust_decimal::decimal::Decimal>
+pub fn optionstratlib::pnl::utils::PnL::try_add(&self, &optionstratlib::pnl::utils::PnL) -> core::result::Result<optionstratlib::pnl::utils::PnL, optionstratlib::error::pricing::PricingError>
 impl core::convert::From<&optionstratlib::model::Trade> for optionstratlib::pnl::utils::PnL
 pub fn optionstratlib::pnl::utils::PnL::from(&optionstratlib::model::Trade) -> Self
 impl core::convert::From<optionstratlib::model::Trade> for optionstratlib::pnl::utils::PnL
@@ -4817,6 +4818,7 @@ pub optionstratlib::pnl::PnL::unrealized: core::option::Option<rust_decimal::dec
 impl optionstratlib::pnl::utils::PnL
 pub fn optionstratlib::pnl::utils::PnL::new(core::option::Option<rust_decimal::decimal::Decimal>, core::option::Option<rust_decimal::decimal::Decimal>, positive::positive::Positive, positive::positive::Positive, chrono::datetime::DateTime<chrono::offset::utc::Utc>) -> Self
 pub fn optionstratlib::pnl::utils::PnL::total_pnl(&self) -> core::option::Option<rust_decimal::decimal::Decimal>
+pub fn optionstratlib::pnl::utils::PnL::try_add(&self, &optionstratlib::pnl::utils::PnL) -> core::result::Result<optionstratlib::pnl::utils::PnL, optionstratlib::error::pricing::PricingError>
 impl core::convert::From<&optionstratlib::model::Trade> for optionstratlib::pnl::utils::PnL
 pub fn optionstratlib::pnl::utils::PnL::from(&optionstratlib::model::Trade) -> Self
 impl core::convert::From<optionstratlib::model::Trade> for optionstratlib::pnl::utils::PnL
@@ -7299,13 +7301,13 @@ pub fn optionstratlib::strategies::collar::Collar::get_legs(&self) -> alloc::vec
 pub fn optionstratlib::strategies::collar::Collar::get_put_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::collar::Collar::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::collar::Collar::is_call_itm(&self, positive::positive::Positive) -> bool
-pub fn optionstratlib::strategies::collar::Collar::is_credit(&self) -> bool
+pub fn optionstratlib::strategies::collar::Collar::is_credit(&self) -> core::result::Result<bool, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::is_put_itm(&self, positive::positive::Positive) -> bool
-pub fn optionstratlib::strategies::collar::Collar::is_zero_cost(&self) -> bool
+pub fn optionstratlib::strategies::collar::Collar::is_zero_cost(&self) -> core::result::Result<bool, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::max_loss_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::max_profit_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::net_delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::strategies::collar::Collar::net_premium(&self) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::collar::Collar::net_premium(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::new(alloc::string::String, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, expiration_date::ExpirationDate, positive::positive::Positive, rust_decimal::decimal::Decimal, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> core::result::Result<Self, optionstratlib::error::strategies::StrategyError>
 pub fn optionstratlib::strategies::collar::Collar::put_strike(&self) -> positive::positive::Positive
 pub fn optionstratlib::strategies::collar::Collar::quantity(&self) -> positive::positive::Positive
@@ -7450,7 +7452,7 @@ pub optionstratlib::prelude::CoveredCall::spot_leg: optionstratlib::model::leg::
 impl optionstratlib::strategies::covered_call::CoveredCall
 pub fn optionstratlib::strategies::covered_call::CoveredCall::assignment_probability(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
 pub fn optionstratlib::strategies::covered_call::CoveredCall::call_strike(&self) -> positive::positive::Positive
-pub fn optionstratlib::strategies::covered_call::CoveredCall::effective_cost_basis(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::covered_call::CoveredCall::effective_cost_basis(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_legs(&self) -> alloc::vec::Vec<optionstratlib::model::leg::Leg>
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_option_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
@@ -9399,6 +9401,7 @@ pub optionstratlib::prelude::PnL::unrealized: core::option::Option<rust_decimal:
 impl optionstratlib::pnl::utils::PnL
 pub fn optionstratlib::pnl::utils::PnL::new(core::option::Option<rust_decimal::decimal::Decimal>, core::option::Option<rust_decimal::decimal::Decimal>, positive::positive::Positive, positive::positive::Positive, chrono::datetime::DateTime<chrono::offset::utc::Utc>) -> Self
 pub fn optionstratlib::pnl::utils::PnL::total_pnl(&self) -> core::option::Option<rust_decimal::decimal::Decimal>
+pub fn optionstratlib::pnl::utils::PnL::try_add(&self, &optionstratlib::pnl::utils::PnL) -> core::result::Result<optionstratlib::pnl::utils::PnL, optionstratlib::error::pricing::PricingError>
 impl core::convert::From<&optionstratlib::model::Trade> for optionstratlib::pnl::utils::PnL
 pub fn optionstratlib::pnl::utils::PnL::from(&optionstratlib::model::Trade) -> Self
 impl core::convert::From<optionstratlib::model::Trade> for optionstratlib::pnl::utils::PnL
@@ -9736,12 +9739,12 @@ pub optionstratlib::prelude::PortfolioGreeks::rho: rust_decimal::decimal::Decima
 pub optionstratlib::prelude::PortfolioGreeks::theta: rust_decimal::decimal::Decimal
 pub optionstratlib::prelude::PortfolioGreeks::vega: rust_decimal::decimal::Decimal
 impl optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks)
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<(), optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks, optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions(&[optionstratlib::model::position::Position]) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions_with_underlying(&[optionstratlib::model::position::Position], rust_decimal::decimal::Decimal) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_delta_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_gamma_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_vega_neutral(&self, rust_decimal::decimal::Decimal) -> bool
@@ -9864,7 +9867,7 @@ pub optionstratlib::prelude::ProtectivePut::long_put: optionstratlib::model::pos
 pub optionstratlib::prelude::ProtectivePut::name: alloc::string::String
 pub optionstratlib::prelude::ProtectivePut::spot_leg: optionstratlib::model::leg::SpotPosition
 impl optionstratlib::strategies::protective_put::ProtectivePut
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::effective_cost_basis(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::effective_cost_basis(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_legs(&self) -> alloc::vec::Vec<optionstratlib::model::leg::Leg>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_put_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
@@ -17729,13 +17732,13 @@ pub fn optionstratlib::strategies::collar::Collar::get_legs(&self) -> alloc::vec
 pub fn optionstratlib::strategies::collar::Collar::get_put_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::collar::Collar::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::collar::Collar::is_call_itm(&self, positive::positive::Positive) -> bool
-pub fn optionstratlib::strategies::collar::Collar::is_credit(&self) -> bool
+pub fn optionstratlib::strategies::collar::Collar::is_credit(&self) -> core::result::Result<bool, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::is_put_itm(&self, positive::positive::Positive) -> bool
-pub fn optionstratlib::strategies::collar::Collar::is_zero_cost(&self) -> bool
+pub fn optionstratlib::strategies::collar::Collar::is_zero_cost(&self) -> core::result::Result<bool, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::max_loss_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::max_profit_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::net_delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::strategies::collar::Collar::net_premium(&self) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::collar::Collar::net_premium(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::new(alloc::string::String, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, expiration_date::ExpirationDate, positive::positive::Positive, rust_decimal::decimal::Decimal, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> core::result::Result<Self, optionstratlib::error::strategies::StrategyError>
 pub fn optionstratlib::strategies::collar::Collar::put_strike(&self) -> positive::positive::Positive
 pub fn optionstratlib::strategies::collar::Collar::quantity(&self) -> positive::positive::Positive
@@ -17882,7 +17885,7 @@ pub optionstratlib::strategies::covered_call::CoveredCall::spot_leg: optionstrat
 impl optionstratlib::strategies::covered_call::CoveredCall
 pub fn optionstratlib::strategies::covered_call::CoveredCall::assignment_probability(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
 pub fn optionstratlib::strategies::covered_call::CoveredCall::call_strike(&self) -> positive::positive::Positive
-pub fn optionstratlib::strategies::covered_call::CoveredCall::effective_cost_basis(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::covered_call::CoveredCall::effective_cost_basis(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_legs(&self) -> alloc::vec::Vec<optionstratlib::model::leg::Leg>
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_option_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
@@ -18292,12 +18295,12 @@ pub optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::rho: 
 pub optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::theta: rust_decimal::decimal::Decimal
 pub optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::vega: rust_decimal::decimal::Decimal
 impl optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks)
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<(), optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks, optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions(&[optionstratlib::model::position::Position]) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions_with_underlying(&[optionstratlib::model::position::Position], rust_decimal::decimal::Decimal) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_delta_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_gamma_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_vega_neutral(&self, rust_decimal::decimal::Decimal) -> bool
@@ -18490,12 +18493,12 @@ pub optionstratlib::strategies::delta_neutral::PortfolioGreeks::rho: rust_decima
 pub optionstratlib::strategies::delta_neutral::PortfolioGreeks::theta: rust_decimal::decimal::Decimal
 pub optionstratlib::strategies::delta_neutral::PortfolioGreeks::vega: rust_decimal::decimal::Decimal
 impl optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks)
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<(), optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks, optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions(&[optionstratlib::model::position::Position]) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions_with_underlying(&[optionstratlib::model::position::Position], rust_decimal::decimal::Decimal) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_delta_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_gamma_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_vega_neutral(&self, rust_decimal::decimal::Decimal) -> bool
@@ -20248,7 +20251,7 @@ pub optionstratlib::strategies::protective_put::ProtectivePut::long_put: options
 pub optionstratlib::strategies::protective_put::ProtectivePut::name: alloc::string::String
 pub optionstratlib::strategies::protective_put::ProtectivePut::spot_leg: optionstratlib::model::leg::SpotPosition
 impl optionstratlib::strategies::protective_put::ProtectivePut
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::effective_cost_basis(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::effective_cost_basis(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_legs(&self) -> alloc::vec::Vec<optionstratlib::model::leg::Leg>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_put_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
@@ -22165,13 +22168,13 @@ pub fn optionstratlib::strategies::collar::Collar::get_legs(&self) -> alloc::vec
 pub fn optionstratlib::strategies::collar::Collar::get_put_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::collar::Collar::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::collar::Collar::is_call_itm(&self, positive::positive::Positive) -> bool
-pub fn optionstratlib::strategies::collar::Collar::is_credit(&self) -> bool
+pub fn optionstratlib::strategies::collar::Collar::is_credit(&self) -> core::result::Result<bool, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::is_put_itm(&self, positive::positive::Positive) -> bool
-pub fn optionstratlib::strategies::collar::Collar::is_zero_cost(&self) -> bool
+pub fn optionstratlib::strategies::collar::Collar::is_zero_cost(&self) -> core::result::Result<bool, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::max_loss_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::max_profit_potential(&self) -> core::result::Result<positive::positive::Positive, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::net_delta(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::strategies::collar::Collar::net_premium(&self) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::collar::Collar::net_premium(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::pricing::PricingError>
 pub fn optionstratlib::strategies::collar::Collar::new(alloc::string::String, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, expiration_date::ExpirationDate, positive::positive::Positive, rust_decimal::decimal::Decimal, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive, positive::positive::Positive) -> core::result::Result<Self, optionstratlib::error::strategies::StrategyError>
 pub fn optionstratlib::strategies::collar::Collar::put_strike(&self) -> positive::positive::Positive
 pub fn optionstratlib::strategies::collar::Collar::quantity(&self) -> positive::positive::Positive
@@ -22316,7 +22319,7 @@ pub optionstratlib::strategies::CoveredCall::spot_leg: optionstratlib::model::le
 impl optionstratlib::strategies::covered_call::CoveredCall
 pub fn optionstratlib::strategies::covered_call::CoveredCall::assignment_probability(&self, positive::positive::Positive) -> rust_decimal::decimal::Decimal
 pub fn optionstratlib::strategies::covered_call::CoveredCall::call_strike(&self) -> positive::positive::Positive
-pub fn optionstratlib::strategies::covered_call::CoveredCall::effective_cost_basis(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::covered_call::CoveredCall::effective_cost_basis(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_legs(&self) -> alloc::vec::Vec<optionstratlib::model::leg::Leg>
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_option_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::covered_call::CoveredCall::get_spot_leg(&self) -> optionstratlib::model::leg::Leg
@@ -23649,12 +23652,12 @@ pub optionstratlib::strategies::PortfolioGreeks::rho: rust_decimal::decimal::Dec
 pub optionstratlib::strategies::PortfolioGreeks::theta: rust_decimal::decimal::Decimal
 pub optionstratlib::strategies::PortfolioGreeks::vega: rust_decimal::decimal::Decimal
 impl optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks)
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::add(&mut self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<(), optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::combined(&self, &optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks) -> core::result::Result<optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks, optionstratlib::error::greeks::GreeksError>
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::delta_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions(&[optionstratlib::model::position::Position]) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::from_positions_with_underlying(&[optionstratlib::model::position::Position], rust_decimal::decimal::Decimal) -> core::result::Result<Self, optionstratlib::error::greeks::GreeksError>
-pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::gamma_gap(&self, rust_decimal::decimal::Decimal) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::greeks::GreeksError>
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_delta_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_gamma_neutral(&self, rust_decimal::decimal::Decimal) -> bool
 pub fn optionstratlib::strategies::delta_neutral::portfolio::PortfolioGreeks::is_vega_neutral(&self, rust_decimal::decimal::Decimal) -> bool
@@ -23674,7 +23677,7 @@ pub optionstratlib::strategies::ProtectivePut::long_put: optionstratlib::model::
 pub optionstratlib::strategies::ProtectivePut::name: alloc::string::String
 pub optionstratlib::strategies::ProtectivePut::spot_leg: optionstratlib::model::leg::SpotPosition
 impl optionstratlib::strategies::protective_put::ProtectivePut
-pub fn optionstratlib::strategies::protective_put::ProtectivePut::effective_cost_basis(&self) -> positive::positive::Positive
+pub fn optionstratlib::strategies::protective_put::ProtectivePut::effective_cost_basis(&self) -> core::result::Result<positive::positive::Positive, positive::error::PositiveError>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_legs(&self) -> alloc::vec::Vec<optionstratlib::model::leg::Leg>
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_put_leg(&self) -> optionstratlib::model::leg::Leg
 pub fn optionstratlib::strategies::protective_put::ProtectivePut::get_spot_leg(&self) -> optionstratlib::model::leg::Leg

--- a/src/model/leg/future.rs
+++ b/src/model/leg/future.rs
@@ -40,8 +40,9 @@
 //! );
 //! ```
 
-use crate::error::GreeksError;
+use crate::error::{GreeksError, PositionError, PricingError};
 use crate::model::ExpirationDate;
+use crate::model::decimal::{d_mul, d_sub};
 use crate::model::expiration::resolve_expiration_date;
 use crate::model::leg::traits::{Expirable, LegAble, Marginable};
 use crate::model::types::Side;
@@ -235,15 +236,40 @@ impl FuturePosition {
     /// # Arguments
     ///
     /// * `current_price` - Current market price
-    #[must_use]
-    pub fn unrealized_pnl(&self, current_price: Positive) -> Decimal {
-        let price_change = current_price.to_dec() - self.entry_price.to_dec();
-        let pnl = price_change * self.quantity.to_dec() * self.contract_size.to_dec();
+    ///
+    /// # Decision (issue #471): fallible because `pnl_at_price` is
+    ///
+    /// This is the whole body of [`LegAble::pnl_at_price`] for a future, so
+    /// leaving it infallible would have moved that method's abort one frame
+    /// down rather than removing it. `entry_price`, `quantity` and
+    /// `contract_size` are `pub`, so no constructor guard bounds the product.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Decimal`] when the price difference, the
+    /// quantity scaling or the contract-size scaling leaves the representable
+    /// `Decimal` range.
+    pub fn unrealized_pnl(&self, current_price: Positive) -> Result<Decimal, PricingError> {
+        let price_change = d_sub(
+            current_price.to_dec(),
+            self.entry_price.to_dec(),
+            "FuturePosition::unrealized_pnl/price_change",
+        )?;
+        let pnl = d_mul(
+            d_mul(
+                price_change,
+                self.quantity.to_dec(),
+                "FuturePosition::unrealized_pnl/quantity",
+            )?,
+            self.contract_size.to_dec(),
+            "FuturePosition::unrealized_pnl/contract_size",
+        )?;
 
-        match self.side {
+        Ok(match self.side {
             Side::Long => pnl,
+            // Negating a representable `Decimal` is always representable.
             Side::Short => -pnl,
-        }
+        })
     }
 
     /// Calculates the tick value (value of one minimum price movement).
@@ -299,16 +325,20 @@ impl LegAble for FuturePosition {
         self.side
     }
 
-    fn pnl_at_price(&self, price: Positive) -> Decimal {
-        self.unrealized_pnl(price) - self.fees.to_dec()
+    fn pnl_at_price(&self, price: Positive) -> Result<Decimal, PricingError> {
+        Ok(d_sub(
+            self.unrealized_pnl(price)?,
+            self.fees.to_dec(),
+            "FuturePosition::pnl_at_price/net",
+        )?)
     }
 
-    fn total_cost(&self) -> Positive {
-        self.total_margin_required() + self.fees
+    fn total_cost(&self) -> Result<Positive, PositionError> {
+        Ok(self.total_margin_required().checked_add(&self.fees)?)
     }
 
-    fn fees(&self) -> Positive {
-        self.fees
+    fn fees(&self) -> Result<Positive, PositionError> {
+        Ok(self.fees)
     }
 
     fn delta(&self) -> Result<Decimal, GreeksError> {
@@ -514,10 +544,10 @@ mod tests {
         );
 
         let pnl = future.unrealized_pnl(pos_or_panic!(4510.0));
-        assert_eq!(pnl, Decimal::from(500));
+        assert_eq!(pnl.ok(), Some(Decimal::from(500)));
 
         let pnl_loss = future.unrealized_pnl(pos_or_panic!(4490.0));
-        assert_eq!(pnl_loss, Decimal::from(-500));
+        assert_eq!(pnl_loss.ok(), Some(Decimal::from(-500)));
     }
 
     #[test]
@@ -532,10 +562,10 @@ mod tests {
         );
 
         let pnl = future.unrealized_pnl(pos_or_panic!(4490.0));
-        assert_eq!(pnl, Decimal::from(500));
+        assert_eq!(pnl.ok(), Some(Decimal::from(500)));
 
         let pnl_loss = future.unrealized_pnl(pos_or_panic!(4510.0));
-        assert_eq!(pnl_loss, Decimal::from(-500));
+        assert_eq!(pnl_loss.ok(), Some(Decimal::from(-500)));
     }
 
     #[test]

--- a/src/model/leg/future.rs
+++ b/src/model/leg/future.rs
@@ -334,7 +334,17 @@ impl LegAble for FuturePosition {
     }
 
     fn total_cost(&self) -> Result<Positive, PositionError> {
-        Ok(self.total_margin_required().checked_add(&self.fees)?)
+        // The product is formed here rather than read from
+        // `total_margin_required`, which multiplies raw and would abort on
+        // `initial_margin_req = Positive::MAX` before this `Result` could
+        // carry the failure. The infallible helper keeps its signature; what
+        // this fixes is the error channel promising something it could not
+        // deliver.
+        let margin = self
+            .initial_margin_req
+            .checked_mul(&self.quantity)
+            .map_err(PositionError::from)?;
+        Ok(margin.checked_add(&self.fees)?)
     }
 
     fn fees(&self) -> Result<Positive, PositionError> {
@@ -466,6 +476,28 @@ impl Default for FuturePosition {
 mod tests {
     use super::*;
     use positive::pos_or_panic;
+
+    /// A margin requirement at the top of the range with more than one
+    /// contract overflows the product `total_cost` needs. The signature
+    /// promises a `Result`, so it has to arrive as one rather than as an
+    /// abort inside the raw multiplication `total_margin_required` performs.
+    #[test]
+    fn test_future_total_cost_reports_a_margin_product_that_overflows() {
+        let future = FuturePosition::new(
+            "ES".to_string(),
+            Positive::TWO,
+            pos_or_panic!(4500.0),
+            Side::Long,
+            ExpirationDate::Days(pos_or_panic!(30.0)),
+            pos_or_panic!(50.0),
+            Positive::MAX,
+            pos_or_panic!(12000.0),
+            Utc::now(),
+            pos_or_panic!(5.0),
+        );
+
+        assert!(future.total_cost().is_err());
+    }
 
     #[test]
     fn test_future_position_new() {

--- a/src/model/leg/leg_enum.rs
+++ b/src/model/leg/leg_enum.rs
@@ -33,7 +33,7 @@
 //! assert!(spot_leg.is_spot());
 //! ```
 
-use crate::error::GreeksError;
+use crate::error::{GreeksError, PositionError, PricingError};
 use crate::model::leg::future::FuturePosition;
 use crate::model::leg::perpetual::PerpetualPosition;
 use crate::model::leg::spot::SpotPosition;
@@ -260,29 +260,39 @@ impl LegAble for Leg {
         }
     }
 
-    fn pnl_at_price(&self, price: Positive) -> Decimal {
+    fn pnl_at_price(&self, price: Positive) -> Result<Decimal, PricingError> {
         match self {
-            Self::Option(pos) => pos
-                .pnl_at_expiration(&Some(&price))
-                .unwrap_or(Decimal::ZERO),
+            // The option arm used to swallow the failure as
+            // `unwrap_or(Decimal::ZERO)`, which reported a break-even where
+            // the payoff had in fact not been computed. Now that the trait
+            // has an error channel it reports the failure instead.
+            Self::Option(pos) => pos.pnl_at_expiration(&Some(&price)),
             Self::Spot(pos) => pos.pnl_at_price(price),
             Self::Future(pos) => pos.pnl_at_price(price),
             Self::Perpetual(pos) => pos.pnl_at_price(price),
         }
     }
 
-    fn total_cost(&self) -> Positive {
+    fn total_cost(&self) -> Result<Positive, PositionError> {
         match self {
-            Self::Option(pos) => pos.total_cost().unwrap_or(Positive::ZERO),
+            // The option arm used to swallow the failure as
+            // `unwrap_or(Positive::ZERO)`, which is also the honest cost of a
+            // short leg and so could not be told apart from a real answer.
+            Self::Option(pos) => pos.total_cost(),
             Self::Spot(pos) => pos.total_cost(),
             Self::Future(pos) => pos.total_cost(),
             Self::Perpetual(pos) => pos.total_cost(),
         }
     }
 
-    fn fees(&self) -> Positive {
+    fn fees(&self) -> Result<Positive, PositionError> {
         match self {
-            Self::Option(pos) => pos.open_fee + pos.close_fee,
+            // Deliberately not `Position::fees()`, which scales the sum by
+            // the contract quantity. This arm has always returned the two
+            // fees unscaled, and #471 is about giving the method an error
+            // channel, not about changing what it reports. The discrepancy
+            // between the two conventions predates this change.
+            Self::Option(pos) => Ok(pos.open_fee.checked_add(&pos.close_fee)?),
             Self::Spot(pos) => pos.fees(),
             Self::Future(pos) => pos.fees(),
             Self::Perpetual(pos) => pos.fees(),
@@ -607,7 +617,7 @@ mod tests {
         let leg = Leg::spot(spot);
 
         let pnl = leg.pnl_at_price(pos_or_panic!(160.0));
-        assert_eq!(pnl, Decimal::from(1000));
+        assert_eq!(pnl.ok(), Some(Decimal::from(1000)));
     }
 
     #[test]
@@ -646,7 +656,7 @@ mod tests {
             pos_or_panic!(10.0),
         );
         let leg = Leg::spot(spot);
-        assert_eq!(leg.total_cost(), pos_or_panic!(15020.0));
+        assert_eq!(leg.total_cost().ok(), Some(pos_or_panic!(15020.0)));
     }
 
     #[test]
@@ -661,6 +671,6 @@ mod tests {
             pos_or_panic!(15.0),
         );
         let leg = Leg::spot(spot);
-        assert_eq!(leg.fees(), pos_or_panic!(25.0));
+        assert_eq!(leg.fees().ok(), Some(pos_or_panic!(25.0)));
     }
 }

--- a/src/model/leg/perpetual.rs
+++ b/src/model/leg/perpetual.rs
@@ -40,7 +40,8 @@
 //! );
 //! ```
 
-use crate::error::GreeksError;
+use crate::error::{GreeksError, PositionError, PricingError};
+use crate::model::decimal::{d_add, d_div, d_mul, d_sub};
 use crate::model::leg::traits::{Fundable, LegAble, Marginable};
 use crate::model::types::Side;
 use chrono::{DateTime, Utc};
@@ -256,50 +257,105 @@ impl PerpetualPosition {
     /// # Arguments
     ///
     /// * `current_price` - Current market price
-    #[must_use]
-    pub fn unrealized_pnl(&self, current_price: Positive) -> Decimal {
-        let price_change = current_price.to_dec() - self.entry_price.to_dec();
-        let pnl = price_change * self.quantity.to_dec();
+    ///
+    /// # Decision (issue #471): fallible because `pnl_at_price` is
+    ///
+    /// This is the whole body of [`LegAble::pnl_at_price`] for a perpetual,
+    /// so leaving it infallible would have moved that method's abort one
+    /// frame down rather than removing it. `entry_price` and `quantity` are
+    /// `pub`, so no constructor guard bounds the product.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Decimal`] when the price difference or the
+    /// quantity scaling leaves the representable `Decimal` range.
+    pub fn unrealized_pnl(&self, current_price: Positive) -> Result<Decimal, PricingError> {
+        let price_change = d_sub(
+            current_price.to_dec(),
+            self.entry_price.to_dec(),
+            "PerpetualPosition::unrealized_pnl/price_change",
+        )?;
+        let pnl = d_mul(
+            price_change,
+            self.quantity.to_dec(),
+            "PerpetualPosition::unrealized_pnl/quantity",
+        )?;
 
-        match self.side {
+        Ok(match self.side {
             Side::Long => pnl,
+            // Negating a representable `Decimal` is always representable.
             Side::Short => -pnl,
-        }
+        })
     }
 
     /// Calculates the ROE (Return on Equity) percentage.
     ///
     /// ROE = (Unrealized P&L / Margin) × 100
     ///
+    /// A zero margin has no return on equity to report, and the function
+    /// keeps its existing answer of `Decimal::ZERO` for that case rather than
+    /// turning it into an error.
+    ///
     /// # Arguments
     ///
     /// * `current_price` - Current market price
-    #[must_use]
-    pub fn roe_percentage(&self, current_price: Positive) -> Decimal {
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`PerpetualPosition::unrealized_pnl`], and returns
+    /// [`PricingError::Decimal`] when the ratio or its percentage scaling
+    /// leaves the representable `Decimal` range.
+    pub fn roe_percentage(&self, current_price: Positive) -> Result<Decimal, PricingError> {
         if self.margin == Positive::ZERO {
-            return Decimal::ZERO;
+            return Ok(Decimal::ZERO);
         }
 
-        let pnl = self.unrealized_pnl(current_price);
-        (pnl / self.margin.to_dec()) * Decimal::ONE_HUNDRED
+        let pnl = self.unrealized_pnl(current_price)?;
+        let ratio = d_div(
+            pnl,
+            self.margin.to_dec(),
+            "PerpetualPosition::roe_percentage/ratio",
+        )?;
+        Ok(d_mul(
+            ratio,
+            Decimal::ONE_HUNDRED,
+            "PerpetualPosition::roe_percentage/percent",
+        )?)
     }
 
     /// Calculates the margin ratio at a given price.
     ///
     /// Margin Ratio = (Margin + Unrealized P&L) / Notional Value
     ///
+    /// A zero notional has no margin ratio to report, and the function keeps
+    /// its existing answer of `Decimal::ZERO` for that case rather than
+    /// turning it into an error.
+    ///
     /// # Arguments
     ///
     /// * `current_price` - Current market price
-    #[must_use]
-    pub fn margin_ratio(&self, current_price: Positive) -> Decimal {
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`PerpetualPosition::unrealized_pnl`], and returns
+    /// [`PricingError::Decimal`] when the equity sum or the ratio leaves the
+    /// representable `Decimal` range.
+    pub fn margin_ratio(&self, current_price: Positive) -> Result<Decimal, PricingError> {
         let notional = self.notional_value_at_price(current_price);
         if notional == Positive::ZERO {
-            return Decimal::ZERO;
+            return Ok(Decimal::ZERO);
         }
 
-        let equity = self.margin.to_dec() + self.unrealized_pnl(current_price);
-        equity / notional.to_dec()
+        let equity = d_add(
+            self.margin.to_dec(),
+            self.unrealized_pnl(current_price)?,
+            "PerpetualPosition::margin_ratio/equity",
+        )?;
+        Ok(d_div(
+            equity,
+            notional.to_dec(),
+            "PerpetualPosition::margin_ratio/ratio",
+        )?)
     }
 
     /// Updates the funding rate.
@@ -315,18 +371,35 @@ impl PerpetualPosition {
     ///
     /// Effective Leverage = Notional Value / (Margin + Unrealized P&L)
     ///
+    /// A position whose equity has been wiped out is infinitely levered, and
+    /// the function keeps its existing answer of `Decimal::MAX` for that case
+    /// rather than turning it into an error.
+    ///
     /// # Arguments
     ///
     /// * `current_price` - Current market price
-    #[must_use]
-    pub fn effective_leverage(&self, current_price: Positive) -> Decimal {
-        let equity = self.margin.to_dec() + self.unrealized_pnl(current_price);
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`PerpetualPosition::unrealized_pnl`], and returns
+    /// [`PricingError::Decimal`] when the equity sum or the quotient leaves
+    /// the representable `Decimal` range.
+    pub fn effective_leverage(&self, current_price: Positive) -> Result<Decimal, PricingError> {
+        let equity = d_add(
+            self.margin.to_dec(),
+            self.unrealized_pnl(current_price)?,
+            "PerpetualPosition::effective_leverage/equity",
+        )?;
         if equity <= Decimal::ZERO {
-            return Decimal::MAX;
+            return Ok(Decimal::MAX);
         }
 
         let notional = self.notional_value_at_price(current_price);
-        notional.to_dec() / equity
+        Ok(d_div(
+            notional.to_dec(),
+            equity,
+            "PerpetualPosition::effective_leverage/leverage",
+        )?)
     }
 }
 
@@ -343,16 +416,20 @@ impl LegAble for PerpetualPosition {
         self.side
     }
 
-    fn pnl_at_price(&self, price: Positive) -> Decimal {
-        self.unrealized_pnl(price) - self.fees.to_dec()
+    fn pnl_at_price(&self, price: Positive) -> Result<Decimal, PricingError> {
+        Ok(d_sub(
+            self.unrealized_pnl(price)?,
+            self.fees.to_dec(),
+            "PerpetualPosition::pnl_at_price/net",
+        )?)
     }
 
-    fn total_cost(&self) -> Positive {
-        self.margin + self.fees
+    fn total_cost(&self) -> Result<Positive, PositionError> {
+        Ok(self.margin.checked_add(&self.fees)?)
     }
 
-    fn fees(&self) -> Positive {
-        self.fees
+    fn fees(&self) -> Result<Positive, PositionError> {
+        Ok(self.fees)
     }
 
     fn delta(&self) -> Result<Decimal, GreeksError> {
@@ -549,8 +626,14 @@ mod tests {
             pos_or_panic!(5000.0),
         );
 
-        assert_eq!(perp.unrealized_pnl(pos_or_panic!(55000.0)), dec!(5000));
-        assert_eq!(perp.unrealized_pnl(pos_or_panic!(45000.0)), dec!(-5000));
+        assert_eq!(
+            perp.unrealized_pnl(pos_or_panic!(55000.0)).ok(),
+            Some(dec!(5000))
+        );
+        assert_eq!(
+            perp.unrealized_pnl(pos_or_panic!(45000.0)).ok(),
+            Some(dec!(-5000))
+        );
     }
 
     #[test]
@@ -563,8 +646,14 @@ mod tests {
             pos_or_panic!(5000.0),
         );
 
-        assert_eq!(perp.unrealized_pnl(pos_or_panic!(45000.0)), dec!(5000));
-        assert_eq!(perp.unrealized_pnl(pos_or_panic!(55000.0)), dec!(-5000));
+        assert_eq!(
+            perp.unrealized_pnl(pos_or_panic!(45000.0)).ok(),
+            Some(dec!(5000))
+        );
+        assert_eq!(
+            perp.unrealized_pnl(pos_or_panic!(55000.0)).ok(),
+            Some(dec!(-5000))
+        );
     }
 
     #[test]
@@ -578,7 +667,7 @@ mod tests {
         );
 
         let roe = perp.roe_percentage(pos_or_panic!(55000.0));
-        assert_eq!(roe, dec!(100));
+        assert_eq!(roe.ok(), Some(dec!(100)));
     }
 
     #[test]
@@ -685,7 +774,7 @@ mod tests {
         );
 
         let eff_lev = perp.effective_leverage(pos_or_panic!(50000.0));
-        assert_eq!(eff_lev, dec!(10));
+        assert_eq!(eff_lev.ok(), Some(dec!(10)));
     }
 
     #[test]

--- a/src/model/leg/perpetual.rs
+++ b/src/model/leg/perpetual.rs
@@ -341,7 +341,10 @@ impl PerpetualPosition {
     /// [`PricingError::Decimal`] when the equity sum or the ratio leaves the
     /// representable `Decimal` range.
     pub fn margin_ratio(&self, current_price: Positive) -> Result<Decimal, PricingError> {
-        let notional = self.notional_value_at_price(current_price);
+        // Formed here rather than read from `notional_value_at_price`, whose
+        // raw product aborts for a quantity and price whose product leaves
+        // the `Positive` range — before this `Result` could report it.
+        let notional = self.quantity.checked_mul(&current_price)?;
         if notional == Positive::ZERO {
             return Ok(Decimal::ZERO);
         }
@@ -394,7 +397,7 @@ impl PerpetualPosition {
             return Ok(Decimal::MAX);
         }
 
-        let notional = self.notional_value_at_price(current_price);
+        let notional = self.quantity.checked_mul(&current_price)?;
         Ok(d_div(
             notional.to_dec(),
             equity,
@@ -546,6 +549,29 @@ mod tests {
     use positive::pos_or_panic;
 
     use rust_decimal_macros::dec;
+
+    /// Both ratios divide by a notional whose product leaves the `Positive`
+    /// range for a large quantity at a large price. Both signatures promise a
+    /// `Result`, so both have to report it rather than abort inside the raw
+    /// multiplication `notional_value_at_price` performs.
+    #[test]
+    fn test_perpetual_ratios_report_a_notional_that_overflows() {
+        let perp = PerpetualPosition::new(
+            "BTC-USDT-PERP".to_string(),
+            Positive::MAX,
+            pos_or_panic!(50000.0),
+            Side::Long,
+            pos_or_panic!(10.0),
+            pos_or_panic!(5000.0),
+            MarginType::Isolated,
+            dec!(0.0001),
+            Utc::now(),
+            pos_or_panic!(5.0),
+        );
+
+        assert!(perp.margin_ratio(pos_or_panic!(50000.0)).is_err());
+        assert!(perp.effective_leverage(pos_or_panic!(50000.0)).is_err());
+    }
 
     #[test]
     fn test_perpetual_position_new() {

--- a/src/model/leg/spot.rs
+++ b/src/model/leg/spot.rs
@@ -35,7 +35,8 @@
 //! );
 //! ```
 
-use crate::error::GreeksError;
+use crate::error::{GreeksError, PositionError, PricingError};
+use crate::model::decimal::{d_mul, d_sub};
 use crate::model::leg::traits::LegAble;
 use crate::model::types::Side;
 use chrono::{DateTime, Utc};
@@ -248,26 +249,45 @@ impl LegAble for SpotPosition {
         self.side
     }
 
-    fn pnl_at_price(&self, price: Positive) -> Decimal {
-        let price_change = price.to_dec() - self.cost_basis.to_dec();
-        let gross_pnl = price_change * self.quantity.to_dec();
-        let total_fees = self.open_fee.to_dec() + self.close_fee.to_dec();
+    fn pnl_at_price(&self, price: Positive) -> Result<Decimal, PricingError> {
+        let price_change = d_sub(
+            price.to_dec(),
+            self.cost_basis.to_dec(),
+            "SpotPosition::pnl_at_price/price_change",
+        )?;
+        let gross_pnl = d_mul(
+            price_change,
+            self.quantity.to_dec(),
+            "SpotPosition::pnl_at_price/gross",
+        )?;
+        let total_fees = self.open_fee.checked_add(&self.close_fee)?;
 
-        match self.side {
-            Side::Long => gross_pnl - total_fees,
-            Side::Short => -gross_pnl - total_fees,
-        }
+        let signed_gross = match self.side {
+            Side::Long => gross_pnl,
+            // `Decimal` is symmetric, so negating a representable value is
+            // itself representable and needs no check.
+            Side::Short => -gross_pnl,
+        };
+        Ok(d_sub(
+            signed_gross,
+            total_fees.to_dec(),
+            "SpotPosition::pnl_at_price/net",
+        )?)
     }
 
-    fn total_cost(&self) -> Positive {
-        match self.side {
-            Side::Long => self.quantity * self.cost_basis + self.open_fee + self.close_fee,
-            Side::Short => self.open_fee + self.close_fee,
-        }
+    fn total_cost(&self) -> Result<Positive, PositionError> {
+        Ok(match self.side {
+            Side::Long => self
+                .quantity
+                .checked_mul(&self.cost_basis)?
+                .checked_add(&self.open_fee)?
+                .checked_add(&self.close_fee)?,
+            Side::Short => self.open_fee.checked_add(&self.close_fee)?,
+        })
     }
 
-    fn fees(&self) -> Positive {
-        self.open_fee + self.close_fee
+    fn fees(&self) -> Result<Positive, PositionError> {
+        Ok(self.open_fee.checked_add(&self.close_fee)?)
     }
 
     fn delta(&self) -> Result<Decimal, GreeksError> {
@@ -376,28 +396,28 @@ mod tests {
     fn test_long_pnl_profit() {
         let spot = SpotPosition::long("AAPL".to_string(), Positive::HUNDRED, pos_or_panic!(150.0));
         let pnl = spot.pnl_at_price(pos_or_panic!(160.0));
-        assert_eq!(pnl, Decimal::from(1000)); // (160-150) * 100
+        assert_eq!(pnl.ok(), Some(Decimal::from(1000))); // (160-150) * 100
     }
 
     #[test]
     fn test_long_pnl_loss() {
         let spot = SpotPosition::long("AAPL".to_string(), Positive::HUNDRED, pos_or_panic!(150.0));
         let pnl = spot.pnl_at_price(pos_or_panic!(140.0));
-        assert_eq!(pnl, Decimal::from(-1000)); // (140-150) * 100
+        assert_eq!(pnl.ok(), Some(Decimal::from(-1000))); // (140-150) * 100
     }
 
     #[test]
     fn test_short_pnl_profit() {
         let spot = SpotPosition::short("AAPL".to_string(), Positive::HUNDRED, pos_or_panic!(150.0));
         let pnl = spot.pnl_at_price(pos_or_panic!(140.0));
-        assert_eq!(pnl, Decimal::from(1000)); // Short profits when price drops
+        assert_eq!(pnl.ok(), Some(Decimal::from(1000))); // Short profits when price drops
     }
 
     #[test]
     fn test_short_pnl_loss() {
         let spot = SpotPosition::short("AAPL".to_string(), Positive::HUNDRED, pos_or_panic!(150.0));
         let pnl = spot.pnl_at_price(pos_or_panic!(160.0));
-        assert_eq!(pnl, Decimal::from(-1000)); // Short loses when price rises
+        assert_eq!(pnl.ok(), Some(Decimal::from(-1000))); // Short loses when price rises
     }
 
     #[test]
@@ -412,7 +432,42 @@ mod tests {
             pos_or_panic!(10.0),
         );
         let pnl = spot.pnl_at_price(pos_or_panic!(160.0));
-        assert_eq!(pnl, Decimal::from(980)); // 1000 profit - 20 fees
+        assert_eq!(pnl.ok(), Some(Decimal::from(980))); // 1000 profit - 20 fees
+    }
+
+    /// `cost_basis` and `quantity` are `pub`, so a spot leg can hold a
+    /// price difference the `Decimal` range cannot express. Before #471 the
+    /// trait signature had nowhere to say so and the process aborted with
+    /// `Subtraction overflowed`.
+    #[test]
+    fn test_spot_position_pnl_at_price_overflowing_notional_is_reported() {
+        let mut spot =
+            SpotPosition::long("AAPL".to_string(), Positive::HUNDRED, pos_or_panic!(150.0));
+        spot.quantity = Positive::MAX;
+
+        assert!(spot.pnl_at_price(Positive::MAX).is_err());
+    }
+
+    /// A long spot leg's `total_cost` multiplies size by cost basis before
+    /// adding the two fees, so both steps can leave the `Positive` range.
+    #[test]
+    fn test_spot_position_total_cost_overflowing_notional_is_reported() {
+        let mut spot = SpotPosition::long("AAPL".to_string(), Positive::MAX, Positive::MAX);
+        spot.open_fee = Positive::ONE;
+
+        assert!(spot.total_cost().is_err());
+    }
+
+    /// A short leg pays only the fees, and those still have to sum.
+    #[test]
+    fn test_spot_position_total_cost_overflowing_fees_is_reported() {
+        let mut spot =
+            SpotPosition::short("AAPL".to_string(), Positive::HUNDRED, pos_or_panic!(150.0));
+        spot.open_fee = Positive::MAX;
+        spot.close_fee = Positive::MAX;
+
+        assert!(spot.total_cost().is_err());
+        assert!(spot.fees().is_err());
     }
 
     #[test]
@@ -438,7 +493,7 @@ mod tests {
             pos_or_panic!(10.0),
             pos_or_panic!(10.0),
         );
-        assert_eq!(spot.total_cost(), pos_or_panic!(15020.0)); // 15000 + 20 fees
+        assert_eq!(spot.total_cost().ok(), Some(pos_or_panic!(15020.0))); // 15000 + 20 fees
     }
 
     #[test]
@@ -452,7 +507,7 @@ mod tests {
             pos_or_panic!(10.0),
             pos_or_panic!(10.0),
         );
-        assert_eq!(spot.total_cost(), pos_or_panic!(20.0)); // Only fees for short
+        assert_eq!(spot.total_cost().ok(), Some(pos_or_panic!(20.0))); // Only fees for short
     }
 
     #[test]

--- a/src/model/leg/traits.rs
+++ b/src/model/leg/traits.rs
@@ -13,7 +13,7 @@
 //! retrieving position information, and computing Greeks across different
 //! instrument types.
 
-use crate::error::GreeksError;
+use crate::error::{GreeksError, PositionError, PricingError};
 use crate::model::types::Side;
 use positive::Positive;
 use rust_decimal::Decimal;
@@ -49,16 +49,55 @@ pub trait LegAble {
     /// # Returns
     ///
     /// The profit (positive) or loss (negative) as a Decimal value.
-    fn pnl_at_price(&self, price: Positive) -> Decimal;
+    ///
+    /// # Decision (issue #471): the error channel is part of the signature
+    ///
+    /// This method used to return a bare `Decimal`. Every implementor computes
+    /// some form of `(price - basis) * quantity - fees`, and each of those
+    /// operators aborts the process on overflow. The inputs are `pub` fields
+    /// on the leg structs, so no constructor guard can bound them, and a
+    /// `Decimal` has no value that means "this does not fit". The trait
+    /// signature was the thing forbidding the report, so the trait signature
+    /// is what changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Decimal`] when the price difference, the
+    /// quantity scaling or the fee deduction leaves the representable
+    /// `Decimal` range, and [`PricingError::Positive`] when a fee total
+    /// leaves the `Positive` range. Option legs additionally propagate
+    /// whatever [`crate::model::position::Position::pnl_at_expiration`]
+    /// reports.
+    fn pnl_at_price(&self, price: Positive) -> Result<Decimal, PricingError>;
 
     /// Returns the total cost to establish this position.
     ///
     /// For long positions, this includes the purchase price plus fees.
     /// For short positions, this typically includes only fees.
-    fn total_cost(&self) -> Positive;
+    ///
+    /// # Decision (issue #471): fallible, alongside `pnl_at_price`
+    ///
+    /// `Position::total_cost` has returned `Result<Positive, PositionError>`
+    /// since the position layer was made panic-free; the leg trait was the
+    /// remaining infallible wrapper over the same sum, and `Leg::Option` had
+    /// to swallow the position's error as `unwrap_or(Positive::ZERO)` to fit
+    /// this signature. A cost of zero is a legitimate answer for a short
+    /// leg, so that fallback was indistinguishable from a real result.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PositionError`] when the size, premium or fee sum leaves the
+    /// `Positive` range.
+    fn total_cost(&self) -> Result<Positive, PositionError>;
 
     /// Returns the total fees associated with this position.
-    fn fees(&self) -> Positive;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PositionError`] when the open and close fees do not sum
+    /// within the `Positive` range. See [`LegAble::total_cost`] for why this
+    /// gained an error channel.
+    fn fees(&self) -> Result<Positive, PositionError>;
 
     /// Returns the delta of this position.
     ///
@@ -288,20 +327,23 @@ mod tests {
             self.side
         }
 
-        fn pnl_at_price(&self, price: Positive) -> Decimal {
+        fn pnl_at_price(&self, price: Positive) -> Result<Decimal, PricingError> {
             let value_change = (price.to_dec() - self.cost_basis.to_dec()) * self.quantity.to_dec();
-            match self.side {
+            Ok(match self.side {
                 Side::Long => value_change,
                 Side::Short => -value_change,
-            }
+            })
         }
 
-        fn total_cost(&self) -> Positive {
-            self.cost_basis * self.quantity + self.fees
+        fn total_cost(&self) -> Result<Positive, PositionError> {
+            Ok(self
+                .cost_basis
+                .checked_mul(&self.quantity)?
+                .checked_add(&self.fees)?)
         }
 
-        fn fees(&self) -> Positive {
-            self.fees
+        fn fees(&self) -> Result<Positive, PositionError> {
+            Ok(self.fees)
         }
 
         fn delta(&self) -> Result<Decimal, GreeksError> {
@@ -325,11 +367,11 @@ mod tests {
 
         // Price goes up - profit
         let pnl = leg.pnl_at_price(positive::pos_or_panic!(55000.0));
-        assert_eq!(pnl, Decimal::from(5000));
+        assert_eq!(pnl.ok(), Some(Decimal::from(5000)));
 
         // Price goes down - loss
         let pnl = leg.pnl_at_price(positive::pos_or_panic!(45000.0));
-        assert_eq!(pnl, Decimal::from(-5000));
+        assert_eq!(pnl.ok(), Some(Decimal::from(-5000)));
     }
 
     #[test]
@@ -344,11 +386,11 @@ mod tests {
 
         // Price goes up - loss for short
         let pnl = leg.pnl_at_price(positive::pos_or_panic!(55000.0));
-        assert_eq!(pnl, Decimal::from(-5000));
+        assert_eq!(pnl.ok(), Some(Decimal::from(-5000)));
 
         // Price goes down - profit for short
         let pnl = leg.pnl_at_price(positive::pos_or_panic!(45000.0));
-        assert_eq!(pnl, Decimal::from(5000));
+        assert_eq!(pnl.ok(), Some(Decimal::from(5000)));
     }
 
     #[test]

--- a/src/pnl/utils.rs
+++ b/src/pnl/utils.rs
@@ -159,12 +159,44 @@ impl PnL {
     /// overflow and aborts instead. Every accumulation inside the library goes
     /// through this method, which reports it.
     ///
+    /// # Decision (issue #471): public, and the operator stays
+    ///
+    /// `Add::add` and `Sum::sum` are fixed by `std` to return `Self`, so no
+    /// fallible form of either exists — there is no signature change that
+    /// makes the operator safe. This method was already the crate-internal
+    /// accumulation path; making it `pub` gives callers the same route.
+    ///
+    /// The operator impls are kept rather than removed: deleting them would
+    /// break every `a + b` and `.sum()` at a call site that has no overflow
+    /// to worry about. Rust does not accept `#[deprecated]` on a trait `impl`
+    /// block or on a trait method inside one (`error: #[deprecated]
+    /// attribute cannot be used on trait impl blocks`), so the redirection
+    /// is documented on the impls themselves rather than emitted by the
+    /// compiler.
+    ///
     /// # Errors
     ///
     /// Returns [`PricingError::Positive`] when either running cost total
     /// leaves the `Positive` range, and [`PricingError::Decimal`] when a
     /// realized or unrealized total leaves the `Decimal` range.
-    pub(crate) fn try_add(&self, other: &PnL) -> Result<PnL, PricingError> {
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrono::Utc;
+    /// use rust_decimal_macros::dec;
+    /// use optionstratlib::pnl::utils::PnL;
+    /// use positive::Positive;
+    ///
+    /// let now = Utc::now();
+    /// let a = PnL::new(Some(dec!(500.0)), None, Positive::HUNDRED, Positive::ZERO, now);
+    /// let b = PnL::new(Some(dec!(250.0)), None, Positive::HUNDRED, Positive::ZERO, now);
+    ///
+    /// let total = a.try_add(&b)?;
+    /// assert_eq!(total.realized, Some(dec!(750.0)));
+    /// # Ok::<(), optionstratlib::error::PricingError>(())
+    /// ```
+    pub fn try_add(&self, other: &PnL) -> Result<PnL, PricingError> {
         fn add_leg(
             a: Option<Decimal>,
             b: Option<Decimal>,
@@ -192,6 +224,28 @@ impl PnL {
     }
 }
 
+/// Sums a sequence of `PnL` values.
+///
+/// # Deprecated in favour of [`PnL::try_add`]
+///
+/// `initial_costs` and `initial_income` are `Positive`, and this fold adds
+/// them with the raw `+` operator, which aborts on overflow. `Sum::sum` is
+/// fixed by `std` to return `Self`, so there is no fallible form of it and
+/// the abort cannot be removed from this signature. Fold with
+/// [`PnL::try_add`] instead:
+///
+/// ```rust
+/// use optionstratlib::pnl::utils::PnL;
+/// # let items: Vec<PnL> = Vec::new();
+/// let total = items
+///     .iter()
+///     .try_fold(PnL::default(), |acc, item| acc.try_add(item))?;
+/// # Ok::<(), optionstratlib::error::PricingError>(())
+/// ```
+///
+/// The impl is retained because removing it would break every call site that
+/// sums values it already knows to be in range. Rust rejects `#[deprecated]`
+/// on a trait `impl` block, so this notice is the only marker available.
 impl Sum for PnL {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(PnL::default(), |acc, x| PnL {
@@ -214,6 +268,13 @@ impl Sum for PnL {
     }
 }
 
+/// Sums a sequence of `&PnL` values.
+///
+/// # Deprecated in favour of [`PnL::try_add`]
+///
+/// Same defect and same reasoning as [`Sum::sum`] for owned `PnL`: the
+/// `Positive` accumulation uses the raw `+` operator and `std` gives
+/// `Sum::sum` no error channel. Fold with [`PnL::try_add`] instead.
 impl<'a> Sum<&'a PnL> for PnL {
     fn sum<I: Iterator<Item = &'a PnL>>(iter: I) -> Self {
         iter.fold(PnL::default(), |acc, x| PnL {
@@ -236,6 +297,33 @@ impl<'a> Sum<&'a PnL> for PnL {
     }
 }
 
+/// Adds two `PnL` values.
+///
+/// # Deprecated in favour of [`PnL::try_add`]
+///
+/// `initial_costs: Positive + Positive` uses the raw `+` operator, which
+/// aborts on overflow. `Add::add` is fixed by `std` to return `Self`, so
+/// there is no fallible form of it. Use [`PnL::try_add`], which returns
+/// `Result<PnL, PricingError>`:
+///
+/// ```rust
+/// use chrono::Utc;
+/// use optionstratlib::pnl::utils::PnL;
+/// use positive::Positive;
+/// use rust_decimal_macros::dec;
+///
+/// let now = Utc::now();
+/// let a = PnL::new(Some(dec!(1.0)), None, Positive::ONE, Positive::ZERO, now);
+/// let b = PnL::new(Some(dec!(2.0)), None, Positive::ONE, Positive::ZERO, now);
+///
+/// let total = a.try_add(&b)?;      // instead of `a + b`
+/// assert_eq!(total.realized, Some(dec!(3.0)));
+/// # Ok::<(), optionstratlib::error::PricingError>(())
+/// ```
+///
+/// The impl is retained because removing it would break every call site that
+/// adds values it already knows to be in range. Rust rejects `#[deprecated]`
+/// on a trait `impl` block, so this notice is the only marker available.
 impl Add for PnL {
     type Output = Self;
 
@@ -264,6 +352,14 @@ impl Add for PnL {
     }
 }
 
+/// Adds two `&PnL` values.
+///
+/// # Deprecated in favour of [`PnL::try_add`]
+///
+/// Same defect and same reasoning as [`Add::add`] for owned `PnL`: the
+/// `Positive` accumulation uses the raw `+` operator and `std` gives
+/// `Add::add` no error channel. Use [`PnL::try_add`], which already takes
+/// both operands by reference.
 impl Add for &PnL {
     type Output = PnL;
 
@@ -483,6 +579,55 @@ mod tests_add {
         assert_eq!(sum.unrealized, Some(dec!(15.0)));
         assert_eq!(sum.initial_costs, pos_or_panic!(5.0));
         assert_eq!(sum.initial_income, pos_or_panic!(3.0));
+    }
+
+    /// `try_add` is the public replacement for the operator: on values the
+    /// operator handles it gives the same answer.
+    #[test]
+    fn test_pnl_try_add_matches_the_operator_in_range() {
+        let now = Utc::now();
+        let pnl1 = PnL {
+            realized: Some(dec!(10.0)),
+            unrealized: Some(dec!(5.0)),
+            initial_costs: Positive::TWO,
+            initial_income: Positive::ONE,
+            date_time: now,
+        };
+        let pnl2 = PnL {
+            realized: Some(dec!(20.0)),
+            unrealized: Some(dec!(10.0)),
+            initial_costs: pos_or_panic!(3.0),
+            initial_income: Positive::TWO,
+            date_time: now,
+        };
+
+        let Ok(sum) = pnl1.try_add(&pnl2) else {
+            unreachable!("both operands are well inside the Decimal range")
+        };
+        assert_eq!(sum, pnl1 + pnl2);
+    }
+
+    /// Where the operator aborts, `try_add` reports. This is the whole point
+    /// of making it public in #471.
+    #[test]
+    fn test_pnl_try_add_reports_what_the_operator_aborts_on() {
+        let now = Utc::now();
+        let pnl1 = PnL {
+            realized: None,
+            unrealized: None,
+            initial_costs: Positive::MAX,
+            initial_income: Positive::ZERO,
+            date_time: now,
+        };
+        let pnl2 = PnL {
+            realized: None,
+            unrealized: None,
+            initial_costs: Positive::MAX,
+            initial_income: Positive::ZERO,
+            date_time: now,
+        };
+
+        assert!(pnl1.try_add(&pnl2).is_err());
     }
 }
 

--- a/src/strategies/collar.rs
+++ b/src/strategies/collar.rs
@@ -356,23 +356,58 @@ impl Collar {
     /// Calculates the net premium (credit if positive, debit if negative).
     ///
     /// Net Premium = Call Premium Received - Put Premium Paid
-    #[must_use]
-    pub fn net_premium(&self) -> Decimal {
-        let call_premium = self.short_call.premium * self.short_call.option.quantity;
-        let put_premium = self.long_put.premium * self.long_put.option.quantity;
-        call_premium.to_dec() - put_premium.to_dec()
+    ///
+    /// # Decision (issue #471): return `Result`, do not privatise the fields
+    ///
+    /// This used to return a bare `Decimal` over `premium * quantity` on both
+    /// legs. `Position::premium` and `Options::quantity` are `pub`, so
+    /// [`Collar::new`] cannot bound either product, and a signed premium has
+    /// no sentinel that means "did not fit". Hiding the fields would have
+    /// been a larger break than adding the error channel and would still
+    /// leave `Collar` deserializable from arbitrary JSON, so the channel is
+    /// what was added.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PricingError::Positive`] when either leg's `premium ×
+    /// quantity` leaves the `Positive` range, and [`PricingError::Decimal`]
+    /// when their difference leaves the representable `Decimal` range.
+    pub fn net_premium(&self) -> Result<Decimal, PricingError> {
+        let call_premium = self
+            .short_call
+            .premium
+            .checked_mul(&self.short_call.option.quantity)?;
+        let put_premium = self
+            .long_put
+            .premium
+            .checked_mul(&self.long_put.option.quantity)?;
+        Ok(d_sub(
+            call_premium.to_dec(),
+            put_premium.to_dec(),
+            "Collar::net_premium",
+        )?)
     }
 
     /// Returns true if this is a zero-cost collar (net premium is approximately zero).
-    #[must_use]
-    pub fn is_zero_cost(&self) -> bool {
-        self.net_premium().abs() < Decimal::new(1, 2) // Less than $0.01
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`Collar::net_premium`]: a premium total that does not fit
+    /// is not a collar this predicate can classify, and `false` would read as
+    /// "not zero-cost" rather than "not known".
+    pub fn is_zero_cost(&self) -> Result<bool, PricingError> {
+        Ok(self.net_premium()?.abs() < Decimal::new(1, 2)) // Less than $0.01
     }
 
     /// Returns true if this is a credit collar (net premium received).
-    #[must_use]
-    pub fn is_credit(&self) -> bool {
-        self.net_premium() > Decimal::ZERO
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`Collar::net_premium`]: a premium total that does not fit
+    /// is not a collar this predicate can classify, and `false` would read as
+    /// "a debit collar" rather than "not known".
+    pub fn is_credit(&self) -> Result<bool, PricingError> {
+        Ok(self.net_premium()? > Decimal::ZERO)
     }
 
     /// Calculates the net delta of the collar.
@@ -412,7 +447,7 @@ impl Collar {
         let call_strike = self.call_strike();
         let cost_basis = self.spot_leg.cost_basis;
         let quantity = self.spot_leg.quantity;
-        let net_premium = self.net_premium();
+        let net_premium = self.net_premium()?;
         let total_fees = self.total_fees()?;
 
         if call_strike >= cost_basis {
@@ -453,7 +488,7 @@ impl Collar {
         let put_strike = self.put_strike();
         let cost_basis = self.spot_leg.cost_basis;
         let quantity = self.spot_leg.quantity;
-        let net_premium = self.net_premium();
+        let net_premium = self.net_premium()?;
         let total_fees = self.total_fees()?;
 
         if cost_basis >= put_strike {
@@ -561,7 +596,7 @@ impl BreakEvenable for Collar {
 
         // Break-even = Cost Basis - Net Premium per Share
         let net_premium_per_share = d_div(
-            self.net_premium(),
+            self.net_premium()?,
             self.spot_leg.quantity.to_dec(),
             "Collar::update_break_even_points",
         )?;
@@ -791,7 +826,7 @@ impl Strategies for Collar {
 impl Profit for Collar {
     fn calculate_profit_at(&self, price: &Positive) -> Result<Decimal, PricingError> {
         // Spot P&L
-        let spot_pnl = self.spot_leg.pnl_at_price(*price);
+        let spot_pnl = self.spot_leg.pnl_at_price(*price)?;
 
         // Put P&L at expiration
         let put_pnl = self
@@ -838,7 +873,7 @@ impl PnLCalculator for Collar {
         underlying_price: &Positive,
     ) -> Result<crate::pnl::utils::PnL, PricingError> {
         let profit = self.calculate_profit_at(underlying_price)?;
-        let spot_cost = self.spot_leg.total_cost();
+        let spot_cost = self.spot_leg.total_cost()?;
         let put_cost = self
             .long_put
             .premium
@@ -1017,13 +1052,38 @@ mod tests {
 
         // Call premium (3.00) - Put premium (2.50) = 0.50 credit per share
         // With 1 contract (100 shares / 100 = 1), net = 0.50
-        assert!(net_premium > Decimal::ZERO); // Credit collar
+        assert!(net_premium.is_ok_and(|p| p > Decimal::ZERO)); // Credit collar
+    }
+
+    /// `net_premium` reads two `pub` premium fields. Setting one past the
+    /// range `Collar::new` produced makes the product unrepresentable, and
+    /// the getter reports it instead of aborting.
+    #[test]
+    fn test_collar_net_premium_overflowing_premium_is_reported() {
+        let mut collar = create_test_collar();
+        collar.short_call.premium = Positive::MAX;
+        collar.short_call.option.quantity = Positive::TWO;
+
+        assert!(collar.net_premium().is_err());
+    }
+
+    /// The two predicates over `net_premium` report the same failure rather
+    /// than collapsing it into `false`, which would read as a definite
+    /// classification.
+    #[test]
+    fn test_collar_credit_predicates_propagate_the_premium_overflow() {
+        let mut collar = create_test_collar();
+        collar.long_put.premium = Positive::MAX;
+        collar.long_put.option.quantity = Positive::TWO;
+
+        assert!(collar.is_zero_cost().is_err());
+        assert!(collar.is_credit().is_err());
     }
 
     #[test]
     fn test_is_credit() {
         let collar = create_test_collar();
-        assert!(collar.is_credit());
+        assert_eq!(collar.is_credit().ok(), Some(true));
     }
 
     #[test]

--- a/src/strategies/covered_call.rs
+++ b/src/strategies/covered_call.rs
@@ -73,7 +73,7 @@ use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::{BasicAble, Strategies};
 use chrono::Utc;
 use positive::{Positive, PositiveError};
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, RoundingStrategy};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
@@ -315,7 +315,16 @@ impl CoveredCall {
             .short_call
             .premium
             .checked_mul(&self.short_call.option.quantity)?
-            .checked_div(&self.spot_leg.quantity)?;
+            // A per-share figure rarely divides exactly — one contract of
+            // premium over three shares repeats — so the rounding is chosen
+            // here rather than taken from the dependency's default.
+            // `MidpointNearestEven` is what `d_div` already applies to every
+            // `Decimal` division in this crate, so a per-share value rounds
+            // the same way whichever path computes it.
+            .checked_div_with_strategy(
+                &self.spot_leg.quantity,
+                RoundingStrategy::MidpointNearestEven,
+            )?;
         if self.spot_leg.cost_basis > premium_per_share {
             self.spot_leg.cost_basis.checked_sub(&premium_per_share)
         } else {
@@ -463,12 +472,20 @@ impl BreakEvenable for CoveredCall {
             .short_call
             .premium
             .checked_mul(&self.short_call.option.quantity)?
-            .checked_div(&self.spot_leg.quantity)?;
+            // Same rounding choice as the per-share premium above.
+            .checked_div_with_strategy(
+                &self.spot_leg.quantity,
+                RoundingStrategy::MidpointNearestEven,
+            )?;
         let fees_per_share = self
             .spot_leg
             .open_fee
             .checked_add(&self.spot_leg.close_fee)?
-            .checked_div(&self.spot_leg.quantity)?;
+            // Same rounding choice as the per-share premium above.
+            .checked_div_with_strategy(
+                &self.spot_leg.quantity,
+                RoundingStrategy::MidpointNearestEven,
+            )?;
 
         // Net credit per share, which is negative when the fees swallow the
         // premium. `lower_break_even` floors the result at zero, the sentinel
@@ -805,6 +822,26 @@ mod tests {
             pos_or_panic!(0.65),
         )
         .unwrap()
+    }
+
+    /// A per-share premium that does not divide exactly: one contract of
+    /// 3.50 spread over three shares is 1.1666… repeating. The rounding is
+    /// this crate's choice rather than the dependency's default, so the
+    /// quotient is pinned here — if the strategy ever changes, the last digit
+    /// moves and this test says so.
+    #[test]
+    fn test_covered_call_per_share_premium_rounds_to_nearest_even() {
+        let mut cc = create_test_covered_call();
+        cc.spot_leg.quantity = pos_or_panic!(3.0);
+        cc.spot_leg.cost_basis = Positive::HUNDRED;
+
+        // 100 - 3.50/3. The quotient repeats, so it is rounded, and the
+        // literal is written as a `Decimal` rather than through the `f64`
+        // path of `pos_or_panic!`, which cannot carry these digits.
+        assert_eq!(
+            cc.effective_cost_basis().unwrap().to_dec(),
+            dec!(98.83333333333333333333333333)
+        );
     }
 
     #[test]

--- a/src/strategies/covered_call.rs
+++ b/src/strategies/covered_call.rs
@@ -72,7 +72,7 @@ use crate::strategies::probabilities::core::ProbabilityAnalysis;
 use crate::strategies::probabilities::utils::VolatilityAdjustment;
 use crate::strategies::{BasicAble, Strategies};
 use chrono::Utc;
-use positive::Positive;
+use positive::{Positive, PositiveError};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -292,14 +292,34 @@ impl CoveredCall {
     /// Calculates the effective cost basis after receiving premium.
     ///
     /// Effective Cost Basis = Original Cost Basis - Premium Received per Share
-    #[must_use]
-    pub fn effective_cost_basis(&self) -> Positive {
-        let premium_per_share =
-            self.short_call.premium * self.short_call.option.quantity / self.spot_leg.quantity;
+    ///
+    /// A credit larger than the cost basis leaves nothing at risk per share,
+    /// and the function keeps its existing answer of `Positive::ZERO` for
+    /// that case rather than turning it into an error.
+    ///
+    /// # Decision (issue #471): return `Result`
+    ///
+    /// The divisor is `spot_leg.quantity`, a `pub` field. [`CoveredCall::new`]
+    /// rejects a zero share count, but a `CoveredCall` deserialized from JSON
+    /// or mutated in place can carry one, and `Positive` has no value that
+    /// means "undefined per-share figure". The product above the division can
+    /// also leave the `Positive` range on its own.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PositiveError::ArithmeticError`] when the spot leg holds
+    /// zero shares, so there is no per-share premium to divide out, and when
+    /// `premium × quantity` overflows.
+    pub fn effective_cost_basis(&self) -> Result<Positive, PositiveError> {
+        let premium_per_share = self
+            .short_call
+            .premium
+            .checked_mul(&self.short_call.option.quantity)?
+            .checked_div(&self.spot_leg.quantity)?;
         if self.spot_leg.cost_basis > premium_per_share {
-            self.spot_leg.cost_basis - premium_per_share
+            self.spot_leg.cost_basis.checked_sub(&premium_per_share)
         } else {
-            Positive::ZERO
+            Ok(Positive::ZERO)
         }
     }
 
@@ -616,7 +636,7 @@ impl Strategies for CoveredCall {
 impl Profit for CoveredCall {
     fn calculate_profit_at(&self, price: &Positive) -> Result<Decimal, PricingError> {
         // Spot P&L
-        let spot_pnl = self.spot_leg.pnl_at_price(*price);
+        let spot_pnl = self.spot_leg.pnl_at_price(*price)?;
 
         // Option P&L at expiration
         let option_pnl = self
@@ -657,7 +677,7 @@ impl PnLCalculator for CoveredCall {
         underlying_price: &Positive,
     ) -> Result<crate::pnl::utils::PnL, PricingError> {
         let profit = self.calculate_profit_at(underlying_price)?;
-        let spot_cost = self.spot_leg.total_cost();
+        let spot_cost = self.spot_leg.total_cost()?;
         let premium_received = self
             .short_call
             .premium
@@ -823,7 +843,19 @@ mod tests {
         let effective = cc.effective_cost_basis();
 
         // Effective cost basis should be lower than original
-        assert!(effective < cc.spot_leg.cost_basis);
+        assert!(effective.is_ok_and(|e| e < cc.spot_leg.cost_basis));
+    }
+
+    /// `effective_cost_basis` divides by `spot_leg.quantity`, a `pub` field.
+    /// `CoveredCall::new` rejects a zero share count, but a covered call
+    /// mutated in place or deserialized from JSON can carry one, and there is
+    /// no per-share cost basis to report for it.
+    #[test]
+    fn test_covered_call_effective_cost_basis_zero_shares_is_reported() {
+        let mut cc = create_test_covered_call();
+        cc.spot_leg.quantity = Positive::ZERO;
+
+        assert!(cc.effective_cost_basis().is_err());
     }
 
     #[test]

--- a/src/strategies/delta_neutral/portfolio.rs
+++ b/src/strategies/delta_neutral/portfolio.rs
@@ -29,7 +29,7 @@
 
 use crate::error::GreeksError;
 use crate::greeks::Greeks;
-use crate::model::decimal::d_add;
+use crate::model::decimal::{d_add, d_sub};
 use crate::model::position::Position;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -207,10 +207,23 @@ impl PortfolioGreeks {
     /// # Returns
     ///
     /// The difference between current delta and target
+    ///
+    /// # Decision (issue #471): return `Result`
+    ///
+    /// All five Greek fields on this struct are `pub` and are written
+    /// directly by callers that aggregate Greeks from their own sources, so
+    /// [`PortfolioGreeks::from_positions`] guarantees nothing about the value
+    /// this subtracts from. A `Decimal` gap has no sentinel for "did not
+    /// fit", so the error channel is the only place the overflow can be
+    /// reported.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GreeksError::CalculationError`] when the difference leaves the
+    /// representable `Decimal` range.
     #[inline]
-    #[must_use]
-    pub fn delta_gap(&self, target: Decimal) -> Decimal {
-        target - self.delta
+    pub fn delta_gap(&self, target: Decimal) -> Result<Decimal, GreeksError> {
+        Ok(d_sub(target, self.delta, "PortfolioGreeks::delta_gap")?)
     }
 
     /// Returns the gamma gap from a target value.
@@ -222,35 +235,52 @@ impl PortfolioGreeks {
     /// # Returns
     ///
     /// The difference between current gamma and target
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GreeksError::CalculationError`] when the difference leaves the
+    /// representable `Decimal` range. See [`PortfolioGreeks::delta_gap`] for
+    /// why the `pub` fields make that reachable.
     #[inline]
-    #[must_use]
-    pub fn gamma_gap(&self, target: Decimal) -> Decimal {
-        target - self.gamma
+    pub fn gamma_gap(&self, target: Decimal) -> Result<Decimal, GreeksError> {
+        Ok(d_sub(target, self.gamma, "PortfolioGreeks::gamma_gap")?)
     }
 
     /// Adds another PortfolioGreeks to this one.
     ///
     /// Useful for combining Greeks from multiple sources.
+    ///
+    /// On failure `self` is left unchanged: the five sums are computed into
+    /// a temporary before any field is written, so a portfolio is never left
+    /// holding a partially applied aggregation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GreeksError::CalculationError`] when any of the five sums leaves the
+    /// representable `Decimal` range. See [`PortfolioGreeks::delta_gap`] for
+    /// why the `pub` fields make that reachable.
     #[inline]
-    pub fn add(&mut self, other: &PortfolioGreeks) {
-        self.delta += other.delta;
-        self.gamma += other.gamma;
-        self.theta += other.theta;
-        self.vega += other.vega;
-        self.rho += other.rho;
+    pub fn add(&mut self, other: &PortfolioGreeks) -> Result<(), GreeksError> {
+        *self = self.combined(other)?;
+        Ok(())
     }
 
     /// Returns a new PortfolioGreeks that is the sum of this and another.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GreeksError::CalculationError`] when any of the five sums leaves the
+    /// representable `Decimal` range. See [`PortfolioGreeks::delta_gap`] for
+    /// why the `pub` fields make that reachable.
     #[inline]
-    #[must_use]
-    pub fn combined(&self, other: &PortfolioGreeks) -> PortfolioGreeks {
-        PortfolioGreeks {
-            delta: self.delta + other.delta,
-            gamma: self.gamma + other.gamma,
-            theta: self.theta + other.theta,
-            vega: self.vega + other.vega,
-            rho: self.rho + other.rho,
-        }
+    pub fn combined(&self, other: &PortfolioGreeks) -> Result<PortfolioGreeks, GreeksError> {
+        Ok(PortfolioGreeks {
+            delta: d_add(self.delta, other.delta, "PortfolioGreeks::combined/delta")?,
+            gamma: d_add(self.gamma, other.gamma, "PortfolioGreeks::combined/gamma")?,
+            theta: d_add(self.theta, other.theta, "PortfolioGreeks::combined/theta")?,
+            vega: d_add(self.vega, other.vega, "PortfolioGreeks::combined/vega")?,
+            rho: d_add(self.rho, other.rho, "PortfolioGreeks::combined/rho")?,
+        })
     }
 }
 
@@ -623,8 +653,8 @@ mod tests_portfolio_greeks {
     fn test_delta_gap() {
         let greeks =
             PortfolioGreeks::new(dec!(0.3), dec!(0.02), dec!(-0.05), dec!(0.15), dec!(0.01));
-        assert_eq!(greeks.delta_gap(Decimal::ZERO), dec!(-0.3));
-        assert_eq!(greeks.delta_gap(dec!(0.5)), dec!(0.2));
+        assert_eq!(greeks.delta_gap(Decimal::ZERO).ok(), Some(dec!(-0.3)));
+        assert_eq!(greeks.delta_gap(dec!(0.5)).ok(), Some(dec!(0.2)));
     }
 
     #[test]
@@ -633,7 +663,9 @@ mod tests_portfolio_greeks {
             PortfolioGreeks::new(dec!(0.3), dec!(0.02), dec!(-0.05), dec!(0.15), dec!(0.01));
         let greeks2 =
             PortfolioGreeks::new(dec!(0.2), dec!(0.01), dec!(-0.03), dec!(0.10), dec!(0.005));
-        let combined = greeks1.combined(&greeks2);
+        let Ok(combined) = greeks1.combined(&greeks2) else {
+            unreachable!("hand-written Greeks well inside the Decimal range")
+        };
 
         assert_eq!(combined.delta, dec!(0.5));
         assert_eq!(combined.gamma, dec!(0.03));
@@ -648,10 +680,52 @@ mod tests_portfolio_greeks {
             PortfolioGreeks::new(dec!(0.3), dec!(0.02), dec!(-0.05), dec!(0.15), dec!(0.01));
         let greeks2 =
             PortfolioGreeks::new(dec!(0.2), dec!(0.01), dec!(-0.03), dec!(0.10), dec!(0.005));
-        greeks1.add(&greeks2);
+        assert!(greeks1.add(&greeks2).is_ok());
 
         assert_eq!(greeks1.delta, dec!(0.5));
         assert_eq!(greeks1.gamma, dec!(0.03));
+    }
+
+    /// `add` writes through `combined`, so an overflow on any one of the five
+    /// Greeks has to leave all five as they were rather than commit the ones
+    /// that happened to be summed first.
+    #[test]
+    fn test_portfolio_greeks_add_overflow_leaves_the_receiver_untouched() {
+        let mut greeks = PortfolioGreeks::new(
+            Decimal::MAX,
+            dec!(0.02),
+            dec!(-0.05),
+            dec!(0.15),
+            dec!(0.01),
+        );
+        let other = PortfolioGreeks::new(
+            Decimal::MAX,
+            dec!(0.01),
+            dec!(-0.03),
+            dec!(0.10),
+            dec!(0.005),
+        );
+
+        assert!(greeks.add(&other).is_err());
+        assert_eq!(greeks.delta, Decimal::MAX);
+        assert_eq!(greeks.gamma, dec!(0.02));
+        assert_eq!(greeks.theta, dec!(-0.05));
+        assert_eq!(greeks.vega, dec!(0.15));
+        assert_eq!(greeks.rho, dec!(0.01));
+    }
+
+    /// A gap against a target at the far end of the range is not a number
+    /// this type can report, and the `Result` says so instead of aborting.
+    #[test]
+    fn test_portfolio_greeks_delta_gap_overflow_is_reported() {
+        let greeks = PortfolioGreeks::new(
+            -Decimal::MAX,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+        );
+        assert!(greeks.delta_gap(Decimal::MAX).is_err());
     }
 }
 

--- a/src/strategies/protective_put.rs
+++ b/src/strategies/protective_put.rs
@@ -40,7 +40,7 @@ use crate::strategies::{BasicAble, Strategies};
 use chrono::Utc;
 use positive::Positive;
 use positive::PositiveError;
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, RoundingStrategy};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
@@ -328,7 +328,16 @@ impl ProtectivePut {
             .long_put
             .premium
             .checked_mul(&self.long_put.option.quantity)?
-            .checked_div(&self.spot_leg.quantity)?;
+            // A per-share figure rarely divides exactly — one contract of
+            // premium over three shares repeats — so the rounding is chosen
+            // here rather than taken from the dependency's default.
+            // `MidpointNearestEven` is what `d_div` already applies to every
+            // `Decimal` division in this crate, so a per-share value rounds
+            // the same way whichever path computes it.
+            .checked_div_with_strategy(
+                &self.spot_leg.quantity,
+                RoundingStrategy::MidpointNearestEven,
+            )?;
         self.spot_leg.cost_basis.checked_add(&premium_per_share)
     }
 

--- a/src/strategies/protective_put.rs
+++ b/src/strategies/protective_put.rs
@@ -308,11 +308,28 @@ impl ProtectivePut {
     }
 
     /// Calculates the effective cost basis (Price paid for spot + Premium paid for put).
-    #[must_use]
-    pub fn effective_cost_basis(&self) -> Positive {
-        let premium_per_share =
-            self.long_put.premium * self.long_put.option.quantity / self.spot_leg.quantity;
-        self.spot_leg.cost_basis + premium_per_share
+    ///
+    /// # Decision (issue #471): return `Result`
+    ///
+    /// The divisor is `spot_leg.quantity`, a `pub` field.
+    /// [`ProtectivePut::new`] rejects a zero share count, but a
+    /// `ProtectivePut` deserialized from JSON or mutated in place can carry
+    /// one, and `Positive` has no value that means "undefined per-share
+    /// figure". The product above the division and the sum below it can also
+    /// leave the `Positive` range on their own.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PositiveError::ArithmeticError`] when the spot leg holds
+    /// zero shares, so there is no per-share premium to divide out, and when
+    /// `premium × quantity` or the final sum overflows.
+    pub fn effective_cost_basis(&self) -> Result<Positive, PositiveError> {
+        let premium_per_share = self
+            .long_put
+            .premium
+            .checked_mul(&self.long_put.option.quantity)?
+            .checked_div(&self.spot_leg.quantity)?;
+        self.spot_leg.cost_basis.checked_add(&premium_per_share)
     }
 
     /// Checks if the put is out-of-the-money.
@@ -510,7 +527,7 @@ impl Strategies for ProtectivePut {
 
 impl Profit for ProtectivePut {
     fn calculate_profit_at(&self, price: &Positive) -> Result<Decimal, PricingError> {
-        let spot_pnl = self.spot_leg.pnl_at_price(*price);
+        let spot_pnl = self.spot_leg.pnl_at_price(*price)?;
         let put_pnl = self
             .long_put
             .pnl_at_expiration(&Some(price))
@@ -548,7 +565,7 @@ impl PnLCalculator for ProtectivePut {
         underlying_price: &Positive,
     ) -> Result<crate::pnl::utils::PnL, PricingError> {
         let profit = self.calculate_profit_at(underlying_price)?;
-        let spot_cost = self.spot_leg.total_cost();
+        let spot_cost = self.spot_leg.total_cost()?;
         let put_cost = self
             .long_put
             .premium
@@ -686,6 +703,29 @@ mod tests {
         assert_eq!(pp.spot_leg.symbol, "AAPL");
         assert_eq!(pp.spot_leg.cost_basis, pos_or_panic!(150.0));
         assert_eq!(pp.long_put.option.strike_price, pos_or_panic!(145.0));
+    }
+
+    /// `effective_cost_basis` divides by `spot_leg.quantity`, a `pub` field.
+    /// `ProtectivePut::new` rejects a zero share count, but a protective put
+    /// mutated in place or deserialized from JSON can carry one, and there is
+    /// no per-share cost basis to report for it.
+    #[test]
+    fn test_protective_put_effective_cost_basis_zero_shares_is_reported() {
+        let mut pp = create_test_protective_put();
+        pp.spot_leg.quantity = Positive::ZERO;
+
+        assert!(pp.effective_cost_basis().is_err());
+    }
+
+    /// The premium leg is `pub` too, so the numerator can leave the
+    /// `Positive` range before the division is reached.
+    #[test]
+    fn test_protective_put_effective_cost_basis_overflowing_premium_is_reported() {
+        let mut pp = create_test_protective_put();
+        pp.long_put.premium = Positive::MAX;
+        pp.long_put.option.quantity = Positive::TWO;
+
+        assert!(pp.effective_cost_basis().is_err());
     }
 
     #[test]

--- a/tests/property/strategies_panic_freedom_test.rs
+++ b/tests/property/strategies_panic_freedom_test.rs
@@ -84,28 +84,6 @@ fn extreme_money() -> impl Strategy<Value = Positive> {
     ]
 }
 
-/// Premia, fees and spot prices for the spot-leg strategies, bounded below the
-/// magnitude at which the *infallible* signatures they run through overflow.
-///
-/// `LegAble::pnl_at_price`, `LegAble::total_cost` and `LegAble::fees` return a
-/// bare `Decimal` or `Positive` (`src/model/leg/spot.rs:251`, `:262` and
-/// `:269`) and `Collar::net_premium` returns a bare `Decimal`
-/// (`src/strategies/collar.rs:361`). All four multiply and add with the raw
-/// operators and have nowhere to report an overflow, so they abort. Lifting
-/// this bound needs those signatures to gain an error channel, which is a
-/// change to the `LegAble` trait and to the spot-leg strategies, both outside
-/// the model-layer sweep that unbounded the generators above.
-fn spot_leg_money() -> impl Strategy<Value = Positive> {
-    prop_oneof![
-        Just(Positive::ZERO),
-        Just(pos(TINY)),
-        Just(pos(dec!(0.01))),
-        Just(Positive::ONE),
-        Just(Positive::HUNDRED),
-        Just(pos(dec!(100000000000000))),
-    ]
-}
-
 /// Contract and share counts. Zero is kept: it is the divisor of every
 /// per-contract and per-share figure in this layer.
 fn extreme_quantity() -> impl Strategy<Value = Positive> {
@@ -375,19 +353,24 @@ proptest! {
     /// basis net of a credit that the fees can turn into a debit.
     #[test]
     fn test_spot_leg_strategies_never_panic(
-        // Every monetary argument of this test goes through an infallible
-        // signature in the spot leg; see [`spot_leg_money`] for the four sites
-        // and why they are not this sweep's to fix.
-        underlying in spot_leg_money(),
+        // Every monetary argument of this test goes through the spot leg.
+        // Until #471 these arguments ran through a bounded `spot_leg_money`
+        // generator, because `LegAble::pnl_at_price`, `LegAble::total_cost`
+        // and `LegAble::fees` returned a bare `Decimal` or `Positive` and
+        // `Collar::net_premium` returned a bare `Decimal`: all four added and
+        // multiplied with the raw operators and had nowhere to report an
+        // overflow. All four now return `Result`, so the generator is the
+        // unbounded `extreme_money` and `Positive::MAX` is back in range.
+        underlying in extreme_money(),
         put_strike in extreme_positive(),
         call_strike in extreme_positive(),
         volatility in extreme_volatility(),
         quantity in extreme_quantity(),
-        premium in spot_leg_money(),
-        fee in spot_leg_money(),
+        premium in extreme_money(),
+        fee in extreme_money(),
         rate in extreme_decimal(),
         expiration in extreme_expiration(),
-        probe in spot_leg_money(),
+        probe in extreme_money(),
     ) {
         if let Ok(mut strategy) = Collar::new(
             "PROP".to_string(), underlying, put_strike, call_strike, expiration,

--- a/tests/unit/strategies/protective_put_test.rs
+++ b/tests/unit/strategies/protective_put_test.rs
@@ -171,7 +171,7 @@ fn test_protective_put_effective_cost_basis() {
     let pp = create_test_protective_put();
     let effective = pp.effective_cost_basis();
     // 150 + 3.5 = 153.5
-    assert_eq!(effective, Positive::new(153.5).unwrap());
+    assert_eq!(effective.ok(), Positive::new(153.5).ok());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The last group from the panic-freedom programme: **public methods whose return
type has no error channel and whose bodies can abort.** After #460 closed
everything reachable through the public constructors, each of these is reachable
only by mutating a `pub` field directly, or through a trait whose signature
forbids failure. None can be fixed without a public signature change, which is
why #460 reported them instead of fixing them.

`Cargo.toml` stays at `0.21.0`: `main` has not published since that bump, so
this cycle's break is already covered. `cargo semver-checks --all-features`
reads `0.20.0 -> 0.21.0 (major change)`, `no semver update required`.

## Decisions, one per item

| item | decision | error type |
|---|---|---|
| `LegAble::pnl_at_price` | `Result<Decimal, _>` — the trait signature was the thing forbidding the report | `PricingError` (matches `Position::pnl_at_expiration`) |
| `LegAble::total_cost`, `LegAble::fees` | `Result<_, _>` — **added, see scope below** | `PositionError` (matches `Position::total_cost` / `fees`) |
| `FuturePosition::unrealized_pnl`, `PerpetualPosition::unrealized_pnl` | `Result` — **added**; they *are* the body of `pnl_at_price` on those types | `PricingError` |
| `PerpetualPosition::roe_percentage`, `margin_ratio`, `effective_leverage` | `Result` — **added**, mechanical consequence | `PricingError` |
| `PnL::try_add` | now `pub`; operator impls kept and documented as superseded | `PricingError` (unchanged) |
| `Collar::net_premium` | `Result<Decimal, _>`; fields stay `pub` | `PricingError` |
| `Collar::is_zero_cost`, `is_credit` | `Result<bool, _>` — `false` would read as a definite classification | `PricingError` |
| `CoveredCall::effective_cost_basis` | `Result<Positive, _>` | `PositiveError` |
| `ProtectivePut::effective_cost_basis` | `Result<Positive, _>` | `PositiveError` |
| `ProtectivePut::total_fees`, `protection_level` | **already fallible** — #460 fixed them; the issue's list was stale | — |
| `PortfolioGreeks::delta_gap`, `gamma_gap` | `Result<Decimal, _>` | `GreeksError` |
| `PortfolioGreeks::add`, `combined` | `Result<(), _>` / `Result<Self, _>`; `add` writes through `combined`, so a failure on the fourth of five sums leaves the receiver untouched | `GreeksError` |

Each decision is recorded in the doc comment, which is what the issue asks for —
not just the fix.

**No error enum and no variant was added**, deliberately: a variant on an
exhaustive public enum trips `enum_variant_added` and would cost a second
version bump this cycle. Every error type here already existed with the `From`
impls needed.

## Scope: six items beyond the issue's list

`LegAble` has three infallible methods with the same defect, all named in the
same property-test doc comment. Fixing one would have forced a **second break of
the same public trait** in a later PR. A trait break should happen once, so all
three go together, and the two `unrealized_pnl` implementations go with them
because they are the body `pnl_at_price` calls — leaving them infallible moves
the abort one frame down rather than removing it. The three `PerpetualPosition`
ratios follow mechanically from `unrealized_pnl`; their degenerate answers are
preserved (`ZERO` for a zero margin or notional, `MAX` for wiped equity), and
only the overflow is new.

## `#[deprecated]` on `Add`/`Sum` is not expressible

The plan called for deprecating the operator impls in favour of `try_add`.
**rustc rejects that outright**, verified with a standalone `--edition 2024`
reproduction before deciding:

```
error: `#[deprecated]` attribute cannot be used on trait impl blocks
error: `#[deprecated]` attribute cannot be used on trait methods in impl blocks
  = note: `#[deny(useless_deprecated)]` on by default
```

So all four impls (`Sum for PnL`, `Sum<&PnL> for PnL`, `Add for PnL`,
`Add for &PnL`) carry a `# Deprecated in favour of PnL::try_add` doc section
instead, stating the defect, why no fallible form of the std traits exists, the
`try_fold(PnL::default(), |acc, x| acc.try_add(x))` replacement, and the
compiler limitation itself so the next person does not retry it.

It warns nowhere in the crate, and would not have: #460 already routed every
in-library accumulation through `try_add`, which is why the operator is reachable
only from caller code.

## Public API

`public-api/optionstratlib.txt`: 81 insertions, 78 deletions, regenerated with
`make public-api-update` and committed here. Deduplicated across re-export
paths, the distinct changes are the signature moves in the table above.
`CHANGELOG.md` carries the breaking-change entry with the migration.

## Tests and gates

4049 lib + 71 property + 423 integration + 210 doctests, 0 failed.

```
cargo test --all-features --workspace                            0 failed
LOGLEVEL=WARN cargo test          (default feature set)          0 failed
cargo fmt --all --check                                          clean
cargo clippy --all-targets --all-features --workspace -- -D warnings   clean
cargo build --release                                            no warnings
cargo doc --all-features --no-deps                               clean
make scan-banned                                                 OK
make public-api-check                                            OK
cargo semver-checks --all-features                               no update required
```

## Stack

Chain A, last of four — and the last implementation PR of the programme.

- Stack: #470 → #469 → #463 → **#471** (this one). #442 is the capstone that
  follows once every chain has landed.
- Base branch: `main`. The three below it are merged, so this diff is its own
  work alone.

Closes #471
