### PR TITLE
Close the panic sweep: volatility, the panicking macros, and the lint that keeps them out (#442)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,14 +110,21 @@ it. They are gaps, not advice.
    `lower_break_even` (`src/strategies/base.rs`).
 
 2. **`make public-api-check` is not a documentation gate.** It builds
-   rustdoc with `--all-features`, but `cargo public-api` forwards
-   `--cap-lints warn` to that build, so the lints `src/lib.rs` denies
-   (`missing_docs`, `rustdoc::broken_intra_doc_links`) are capped to
-   warnings. With the same broken link in place:
+   rustdoc with `--all-features`, but that build runs under
+   `--cap-lints warn`, so the lints `src/lib.rs` denies (`missing_docs`,
+   `rustdoc::broken_intra_doc_links`) are capped to warnings. The cap is not
+   `cargo public-api`'s choice: it comes from the `rustdoc-json` builder it
+   calls, which defaults to it and passes it through
+   (`rustdoc-json-0.9.10/src/builder.rs:316` sets
+   `cap_lints: Some(String::from("warn"))`, `:159` forwards it). An upgrade
+   changing that default changes this behaviour without anything here
+   changing. With the same broken link in place:
 
    ```
    cargo +nightly-2026-08-28 public-api -sss --all-features > /dev/null
-   # exit 0, "warning: unresolved link", full snapshot produced
+   # exit 0, full snapshot produced, and the link reported as
+   # "warning: unresolved link to ..." — not as an error, so it reads
+   # like ordinary noise rather than something hiding under a green check
    ```
 
 3. **`cargo test --all-features` never exercises the default feature set.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,70 @@ When implementing a non-trivial change, follow this order:
 
 Steps 3 and 5 can be parallelized across agents when the model layer is
 stable.
+
+## What the gates do not check
+
+Five facts about this repository's checks, each with the command that shows
+it. They are gaps, not advice.
+
+1. **`make doc` built no documentation.** It ran
+   `cargo clippy -- -W missing-docs`; it is `cargo doc --all-features
+   --no-deps` as of this commit. `make create-doc` has no `--all-features`,
+   so a doc link inside `plotly` / `static_export` / `async` code was
+   resolved by nothing. Add `/// See [`ThisItemDoesNotExist`].` to
+   `pub trait Graph` in `src/visualization/plotly.rs`, then:
+
+   ```
+   make create-doc                    # exit 0
+   cargo doc --all-features --no-deps # exit 101, unresolved link
+   ```
+
+   Two `private_intra_doc_links` warnings stand on a clean tree and are not
+   worth re-investigating: `RNDStatistics::new` (`src/chains/rnd.rs`) and
+   `lower_break_even` (`src/strategies/base.rs`).
+
+2. **`make public-api-check` is not a documentation gate.** It builds
+   rustdoc with `--all-features`, but `cargo public-api` forwards
+   `--cap-lints warn` to that build, so the lints `src/lib.rs` denies
+   (`missing_docs`, `rustdoc::broken_intra_doc_links`) are capped to
+   warnings. With the same broken link in place:
+
+   ```
+   cargo +nightly-2026-08-28 public-api -sss --all-features > /dev/null
+   # exit 0, "warning: unresolved link", full snapshot produced
+   ```
+
+3. **`cargo test --all-features` never exercises the default feature set.**
+   `src/visualization/default.rs` is `#[cfg(not(feature = "plotly"))]`, so
+   the `Graph` a default-features consumer gets is never compiled. Append
+   `compile_error!("x");` to that file:
+
+   ```
+   cargo check --all-features   # exit 0
+   cargo check                  # exit 101
+   ```
+
+   `make test` is what covers all three: default, `plotly`, and
+   `static_export,plotly`, run separately.
+
+4. **`cargo-semver-checks` compares against the published baseline, not the
+   snapshot.** `.github/workflows/semver.yml` passes no `baseline-rev`, so
+   the baseline is the crates.io release. A rename, or a variant added to an
+   exhaustive public enum, therefore needs a minor bump for a 0.x crate.
+   `make public-api-check` only diffs against
+   `public-api/optionstratlib.txt` and never asks for the bump.
+
+   ```
+   grep -A4 cargo-semver-checks-action .github/workflows/semver.yml
+   curl -sL -H 'User-Agent: optionstratlib' \
+     https://crates.io/api/v1/crates/optionstratlib/versions   # baseline
+   ```
+
+5. **`gh` reports refusals on stderr only.** A `gh pr merge` blocked by a
+   base-branch policy writes nothing to stdout, so a caller capturing only
+   stdout sees a silent no-op:
+
+   ```
+   gh pr view 999999 --repo joaquinbejar/OptionStratLib 2>/dev/null
+   # no output; the message went to stderr
+   ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ stable.
 
 ## What the gates do not check
 
-Five facts about this repository's checks, each with the command that shows
+Six facts about this repository's checks, each with the command that shows
 it. They are gaps, not advice.
 
 1. **`make doc` built no documentation.** It ran
@@ -153,4 +153,20 @@ it. They are gaps, not advice.
    ```
    gh pr view 999999 --repo joaquinbejar/OptionStratLib 2>/dev/null
    # no output; the message went to stderr
+   ```
+
+6. **`make scan-banned` is a grep, so confirm it sees your construct before
+   trusting a clean run.** It is line-oriented `awk`, and its comment filter
+   skipped every line beginning with `*`, which is what the continuation
+   lines of a multi-line expression are indented to — five `.exp()` calls in
+   `src/pricing/compound.rs` were invisible to it until this commit. It also
+   cannot tell receiver types apart, so `f64::exp` and `Decimal::exp` look
+   alike and the `f64` sites carry `// scan-banned: allow` markers saying so.
+   Before relying on it for a new construct, plant one and check it is
+   caught:
+
+   ```
+   printf '\npub fn probe(x: Decimal) -> Decimal {\n    x\n        * dec!(2)\n        .exp()\n}\n' >> src/pricing/utils.rs
+   make scan-banned    # must fail (exit 2) and print the offending line
+   git checkout -- src/pricing/utils.rs
    ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`make doc` builds documentation.** It ran `cargo clippy -- -W
+  missing-docs`, which builds none, so no intra-doc link was ever resolved by
+  it. It is now `cargo doc --all-features --no-deps`. The target starts green:
+  two `private_intra_doc_links` warnings stand (`RNDStatistics::new` in
+  `src/chains/rnd.rs`, `lower_break_even` in `src/strategies/base.rs`) and
+  warnings do not fail it. `AGENTS.md` records this and four other gaps
+  between what the gates check and what they appear to check.
+
 - **`make scan-banned` guards the panicking maths and the panicking macros,
   not just `unwrap`/`expect`.** It now also rejects `panic!`,
   `unreachable!`, `todo!`, `unimplemented!`, `.exp()`, `.ln()`, `.powd(` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `src/model/decimal.rs`; the sample standard deviation is unchanged digit for
   digit for a representable sample.
 
+  This is a breaking change to a public trait. To migrate, add `?` where the
+  value feeds a fallible function or `.expect("…")` at a boundary that cannot
+  propagate; an external implementor changes the two signatures and returns
+  `Ok(..)`. No further version bump: 0.21.0 is already the breaking version
+  for this unreleased cycle.
+
 - **`decimal_normal_sample` constructed a distribution that could be
   rejected** (#442). It built `Normal::new(0.0, 1.0)` on every call and had an
   `unreachable!` in the `Err` arm. It samples `rand_distr::StandardNormal`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Seven entry points in `src/volatility/` aborted on inputs the type system
+  accepts** (#442). A `catch_unwind` probe over the module's public API across
+  3305 extreme-input cases reported 287 aborts before the sweep and none
+  after. `historical_volatility` handed a zero `window_size` to
+  `slice::windows`, which panics with `window size must be non-zero`;
+  `garch_volatility` seeded its recursion with `returns[0]` and aborted on an
+  empty slice with `index out of bounds: the len is 0 but the index is 0`;
+  `simulate_heston_volatility` ran its Euler step on raw `Decimal` operators
+  and aborted with `Multiplication overflowed`; `annualized_volatility`,
+  `de_annualized_volatility`, `volatility_for_dt` and `adjust_volatility` used
+  the panicking `Positive` operators for the square-root-of-time rescaling and
+  aborted with `Positive arithmetic overflow in mul` / `in div`, and with
+  `Positive invariant broken in div: result would be non-positive` for a
+  `TimeFrame::Custom(Positive::ZERO)` divisor; and `implied_volatility`
+  computed its grid size as `100 * max_iterations`, which aborts a debug build
+  with `attempt to multiply with overflow` at `i64::MAX` and wraps silently in
+  release.
+
+  Every one of these already returned `Result`, so no signature changed. The
+  degenerate timeframe is now `VolatilityError::InvalidTime` with the same
+  message shape `adjust_volatility` already used for its target frame, so the
+  two entry points agree on where the domain ends. Well-formed inputs keep
+  their values: the checked `Positive` helpers are the same code path the
+  operators call before panicking. `tests/property/volatility_panic_freedom_test.rs`
+  drives the sweep over the sample shapes, the timeframes and the option
+  geometries.
+
+- **`Options::payoff`, `payoff_at_price` and `intrinsic_value` reported a
+  payoff of zero when it was too large to represent** (#442). All three
+  evaluated the payoff in `f64`, scaled it by the quantity, and converted with
+  `Decimal::from_f64(..).unwrap_or_default()`. Both factors reach
+  `Positive::MAX` (`≈ 7.92e28`), so the product routinely leaves the `Decimal`
+  range — and a long call struck at zero on an underlying at `Positive::MAX`
+  leaves it at quantity one, because the nearest `f64` to `Decimal::MAX` rounds
+  above it. The three now return `OptionsError::PayoffError` naming the value
+  and the entry point. An out-of-the-money leg still returns `Ok(0)`, which is
+  the answer rather than a fallback, and no existing test changed.
+
+- **`DecimalStats::mean` and `DecimalStats::std_dev` aborted on a sample they
+  could not sum** (#442). `mean` folded with `iter().sum()`, which aborts with
+  `Addition overflowed`; `std_dev` squared each centred deviation with
+  `.powd(Decimal::TWO)`, which aborts with `Pow overflowed`. `vec![Decimal::MAX;
+  2]` reached both. The two trait methods now return
+  `Result<Decimal, DecimalError>` and fold through the checked helpers in
+  `src/model/decimal.rs`; the sample standard deviation is unchanged digit for
+  digit for a representable sample.
+
+- **`decimal_normal_sample` constructed a distribution that could be
+  rejected** (#442). It built `Normal::new(0.0, 1.0)` on every call and had an
+  `unreachable!` in the `Err` arm. It samples `rand_distr::StandardNormal`
+  instead, a unit struct with no constructor and nothing to reject.
+  `Normal::sample` is `mean + std_dev * z` over the same `StandardNormal`, so
+  at `(0.0, 1.0)` the two are the same value as well as the same distribution.
+
 - **Every multi-leg strategy aborted the process when its break-even vector
   was shorter than the point it read** (#463). `get_profit_area`,
   `get_profit_ratio`, `get_profit_ranges`, `get_loss_ranges` and
@@ -157,6 +211,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`make scan-banned` guards the panicking maths and the panicking macros,
+  not just `unwrap`/`expect`.** It now also rejects `panic!`,
+  `unreachable!`, `todo!`, `unimplemented!`, `.exp()`, `.ln()`, `.powd(` and
+  `.sqrt().unwrap()`. The `f64` methods share three of those names and do not
+  abort, so those call sites carry a `// scan-banned: allow` marker saying so;
+  grep cannot tell the receiver types apart. Its comment filter no longer
+  skips every line starting with `*`, which had been swallowing the
+  continuation lines of multi-line products — five `.exp()` calls in
+  `src/pricing/compound.rs` were invisible to it.
 - **Twenty public methods whose return type had no error channel are now
   fallible, which is a breaking change** (#471). Each aborted the process on
   arithmetic over `pub` fields. #460 closed everything reachable through the

--- a/Makefile
+++ b/Makefile
@@ -61,16 +61,38 @@ clean:
 .PHONY: check
 check: test fmt-check lint scan-banned
 
-# Fails when a panicking construct reappears in production code. A bare
-# `#[cfg(test)]` never truncates the scan; only the braced body of the item
-# it actually gates is skipped, brace counted (files may carry several):
+# Fails when a panicking construct reappears in production code.
+#
+# The banned set, and why each entry is there:
+#   * `.unwrap()` / `.expect(` — abort instead of reporting.
+#   * `panic!` / `unreachable!` / `todo!` / `unimplemented!` — the same,
+#     spelled out. The pattern requires a non-word, non-`_` character before
+#     the macro name so `pos_or_panic!` is not swept up with `panic!`.
+#   * `.exp()` / `.ln()` / `.powd(` — `rust_decimal`'s `MathematicalOps`
+#     aborts on all three (`Exp overflowed`, `Unable to calculate ln for
+#     zero`, `Pow overflowed`); `d_exp` / `d_ln` / `d_powd` in
+#     `src/model/decimal.rs` are the checked forms. `f64` has the same three
+#     method names and does *not* abort, so those call sites carry a marker
+#     saying so — grep cannot tell the receiver types apart.
+#   * `.sqrt().unwrap()` — `Decimal::sqrt` is the safe one, returning
+#     `Option`; unwrapping it puts the panic back.
+#
+# A bare `#[cfg(test)]` never truncates the scan; only the braced body of the
+# item it actually gates is skipped, brace counted (files may carry several):
 # `mod`/`fn`/`impl`/`trait`/`struct`/`enum`/`union` (any `pub(..)` visibility,
 # `async`/`unsafe`, generics or return type before the `{`, spanning multiple
 # signature lines if needed), and a bare `#[cfg(test)] { ... }` block. A
 # body-less item behind `#[cfg(test)]` (`use`, `const`, `static`, `type`
 # alias, or a `;`-terminated declaration such as a tuple struct or a trait
 # method signature) skips nothing; scanning resumes right after it as usual.
-# Doc comments are skipped too. A reviewed exception carries a trailing
+#
+# Line comments (`///`, `//!`, `//`) are skipped, and so is the closing line
+# of a `/*** … ***/` banner (`*`-run followed by `/`). The filter used to skip
+# every line starting with `*`, which also skipped the continuation lines of a
+# multi-line product — `        * asr.exp()` in `src/pricing/compound.rs` is
+# five such lines — so a banned construct could hide there.
+#
+# A reviewed exception carries a trailing
 # `// scan-banned: allow -- <reason>` marker on the same line.
 .PHONY: scan-banned
 scan-banned:
@@ -117,15 +139,15 @@ scan-banned:
 			} \
 		' "$$f"; \
 	done \
-		| grep -E '\.unwrap\(\)|\.expect\(' \
-		| grep -v -E ':[0-9]+:[[:space:]]*(///|//!|//|\*)' \
+		| grep -E '\.unwrap\(\)|\.expect\(|\.exp\(\)|\.ln\(\)|\.powd\(|\.sqrt\(\)\.unwrap\(\)|[^_[:alnum:]](panic|unreachable|todo|unimplemented)!' \
+		| grep -v -E ':[0-9]+:[[:space:]]*(///|//!|//|\*+/)' \
 		| grep -v 'scan-banned: allow' || true); \
 	if [ -n "$$found" ]; then \
 		echo "Banned patterns found in production code:"; \
 		echo "$$found"; \
 		exit 1; \
 	fi; \
-	echo "OK: no .unwrap()/.expect() in production code"
+	echo "OK: no unwrap/expect, no panic/unreachable/todo/unimplemented, no unchecked exp/ln/powd/sqrt in production code"
 
 # Pinned producers of public-api/optionstratlib.txt. Both anchors are needed
 # and they only work as a pair: `cargo public-api` does not read the source,

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,19 @@ fix:
 .PHONY: pre-push
 pre-push: fix fmt lint-fix test readme doc
 
+# Builds the crate's documentation with every feature on. It used to run
+# `cargo clippy -- -W missing-docs`, which builds no documentation at all and
+# so never resolved an intra-doc link. `--all-features` is what makes the
+# difference: `create-doc` below omits it, so a link inside `plotly` /
+# `static_export` / `async` code was checked by nothing.
+#
+# The target starts green: two `private_intra_doc_links` warnings stand
+# (`RNDStatistics::new` in src/chains/rnd.rs and `lower_break_even` in
+# src/strategies/base.rs), and warnings do not fail it. `src/lib.rs` denies
+# `rustdoc::broken_intra_doc_links`, so a broken link is an error and exits 101.
 .PHONY: doc
 doc:
-	cargo clippy -- -W missing-docs
+	cargo doc --all-features --no-deps
 
 .PHONY: doc-open
 doc-open:

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,14 @@ scan-banned:
 	done \
 		| grep -E '\.unwrap\(\)|\.expect\(|\.exp\(\)|\.ln\(\)|\.powd\(|\.sqrt\(\)\.unwrap\(\)|[^_[:alnum:]](panic|unreachable|todo|unimplemented)!' \
 		| grep -v -E ':[0-9]+:[[:space:]]*(///|//!|//|\*+/)' \
-		| grep -v 'scan-banned: allow' || true); \
+		| grep -v -E 'scan-banned: allow -- [^[:space:]]' || true); \
+	malformed=$$(grep -rn 'scan-banned: allow' src \
+		| grep -v -E 'scan-banned: allow -- [^[:space:]]' || true); \
+	if [ -n "$$malformed" ]; then \
+		echo "Exemption markers without a reason (use 'scan-banned: allow -- <reason>'):"; \
+		echo "$$malformed"; \
+		exit 1; \
+	fi; \
 	if [ -n "$$found" ]; then \
 		echo "Banned patterns found in production code:"; \
 		echo "$$found"; \

--- a/public-api/optionstratlib.txt
+++ b/public-api/optionstratlib.txt
@@ -3541,11 +3541,11 @@ pub use optionstratlib::model::Side
 pub mod optionstratlib::model::decimal
 pub const optionstratlib::model::decimal::ONE_DAY: rust_decimal::decimal::Decimal
 pub trait optionstratlib::model::decimal::DecimalStats
-pub fn optionstratlib::model::decimal::DecimalStats::mean(&self) -> rust_decimal::decimal::Decimal
-pub fn optionstratlib::model::decimal::DecimalStats::std_dev(&self) -> rust_decimal::decimal::Decimal
+pub fn optionstratlib::model::decimal::DecimalStats::mean(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::decimal::DecimalError>
+pub fn optionstratlib::model::decimal::DecimalStats::std_dev(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::decimal::DecimalError>
 impl optionstratlib::model::decimal::DecimalStats for alloc::vec::Vec<rust_decimal::decimal::Decimal>
-pub fn alloc::vec::Vec<rust_decimal::decimal::Decimal>::mean(&self) -> rust_decimal::decimal::Decimal
-pub fn alloc::vec::Vec<rust_decimal::decimal::Decimal>::std_dev(&self) -> rust_decimal::decimal::Decimal
+pub fn alloc::vec::Vec<rust_decimal::decimal::Decimal>::mean(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::decimal::DecimalError>
+pub fn alloc::vec::Vec<rust_decimal::decimal::Decimal>::std_dev(&self) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::decimal::DecimalError>
 pub fn optionstratlib::model::decimal::decimal_normal_sample() -> rust_decimal::decimal::Decimal
 pub fn optionstratlib::model::decimal::decimal_to_f64(rust_decimal::decimal::Decimal) -> core::result::Result<f64, optionstratlib::error::decimal::DecimalError>
 pub fn optionstratlib::model::decimal::f64_to_decimal(f64) -> core::result::Result<rust_decimal::decimal::Decimal, optionstratlib::error::decimal::DecimalError>

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -643,7 +643,7 @@ impl OptionChain {
             if iv <= 0.0 {
                 continue;
             }
-            let m = (option.strike_price.to_f64() / spot).ln();
+            let m = (option.strike_price.to_f64() / spot).ln(); // scan-banned: allow -- f64 `ln`: returns -inf/NaN, it does not abort; the `is_finite` guard on the next line drops the point
             if !m.is_finite() {
                 continue;
             }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -180,3 +180,39 @@ pub const MAX_NEWTON_ITER: NonZeroUsize = match NonZeroUsize::new(100) {
     Some(n) => n,
     None => unreachable!(), // scan-banned: allow -- `const` context: an unreachable arm here fails compilation, it cannot abort at run time
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Forces every `LazyLock` in this file.
+    ///
+    /// The `unreachable!` arms above are justified by the literals beside
+    /// them being strictly positive and finite, which is true of the literals
+    /// as written and of nothing else: `LazyLock` initialises at first
+    /// access, at run time, so an edit that makes one of these literals zero
+    /// or negative compiles cleanly and aborts on whichever request touches
+    /// it first. Unlike the `const` items below, the compiler does not check
+    /// the premise.
+    ///
+    /// Dereferencing each one here moves that failure into the test suite,
+    /// where a bad literal is a red run rather than a dead worker. It is what
+    /// makes the markers honest rather than merely reviewed.
+    #[test]
+    fn test_every_lazy_constant_initialises() {
+        for (name, value) in [
+            ("MIN_VOLATILITY", *MIN_VOLATILITY),
+            ("TRADING_DAYS", *TRADING_DAYS),
+            ("TRADING_HOURS", *TRADING_HOURS),
+            ("SECONDS_PER_HOUR", *SECONDS_PER_HOUR),
+            ("MICROSECONDS_PER_SECOND", *MICROSECONDS_PER_SECOND),
+            ("WEEKS_PER_YEAR", *WEEKS_PER_YEAR),
+            ("MONTHS_PER_YEAR", *MONTHS_PER_YEAR),
+        ] {
+            assert!(
+                value > Positive::ZERO,
+                "{name} must be strictly positive, or its unreachable arm is reachable"
+            );
+        }
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,13 +29,24 @@ pub const EPSILON: Decimal = dec!(1e-16);
 /// Minimum allowed volatility value as a `Positive` decimal.
 ///
 /// Prevents numerical issues in financial calculations with near-zero volatility.
-/// Initialized once via `LazyLock`. `Positive::new_decimal(dec!(1e-16))` is
-/// total because `dec!()` produces a compile-time non-negative `Decimal`, so
-/// the `Err` arm is unreachable by construction; it trips `unreachable!` if
-/// the invariant is ever broken (fail-fast instead of silent `Positive::ZERO`).
+/// Initialized once via `LazyLock`, like the six cells below it.
+///
+/// # Why the `Err` arm cannot fire
+///
+/// Each of these initialisers is a closure over nothing: its only input is a
+/// `dec!(…)` literal, expanded to a fixed mantissa and scale at compile time.
+/// [`Positive::new_decimal`] rejects exactly one thing, a value below the
+/// lower bound — zero without the `non-zero` feature, which this crate does
+/// not enable — and every literal here is strictly positive. There is no
+/// runtime value that reaches the `Err` arm, and no `Positive` constant to
+/// return in its place: `positive` keeps `from_decimal_const` crate-private,
+/// so a `const` alternative does not exist for values outside its own
+/// constant ladder. The alternative to aborting would be a stand-in like
+/// `Positive::ZERO`, which would silently make every annualisation divide by
+/// zero — worse than the abort it replaced.
 pub(crate) static MIN_VOLATILITY: LazyLock<Positive> = LazyLock::new(|| {
     Positive::new_decimal(dec!(1e-16))
-        .unwrap_or_else(|e| unreachable!("MIN_VOLATILITY literal is positive and finite: {e}"))
+        .unwrap_or_else(|e| unreachable!("MIN_VOLATILITY literal is positive and finite: {e}")) // scan-banned: allow -- `dec!()` literal, `Err` arm has no reachable input; see MIN_VOLATILITY
 });
 
 /// Maximum allowed volatility value as a `Positive` decimal (100%).
@@ -57,7 +68,7 @@ pub(crate) const STRIKE_PRICE_UPPER_BOUND_MULTIPLIER: f64 = 1.02;
 /// for the `LazyLock` rationale.
 pub(crate) static TRADING_DAYS: LazyLock<Positive> = LazyLock::new(|| {
     Positive::new_decimal(dec!(252.0))
-        .unwrap_or_else(|e| unreachable!("TRADING_DAYS literal is positive and finite: {e}"))
+        .unwrap_or_else(|e| unreachable!("TRADING_DAYS literal is positive and finite: {e}")) // scan-banned: allow -- `dec!()` literal, `Err` arm has no reachable input; see MIN_VOLATILITY
 });
 
 /// Standard number of trading hours in a market day as a `Positive` decimal.
@@ -65,7 +76,7 @@ pub(crate) static TRADING_DAYS: LazyLock<Positive> = LazyLock::new(|| {
 /// Typically represents a standard U.S. market session (9:30 AM to 4:00 PM).
 pub(crate) static TRADING_HOURS: LazyLock<Positive> = LazyLock::new(|| {
     Positive::new_decimal(dec!(6.5))
-        .unwrap_or_else(|e| unreachable!("TRADING_HOURS literal is positive and finite: {e}"))
+        .unwrap_or_else(|e| unreachable!("TRADING_HOURS literal is positive and finite: {e}")) // scan-banned: allow -- `dec!()` literal, `Err` arm has no reachable input; see MIN_VOLATILITY
 });
 
 /// Number of seconds in an hour as a `Positive` decimal value.
@@ -73,7 +84,7 @@ pub(crate) static TRADING_HOURS: LazyLock<Positive> = LazyLock::new(|| {
 /// Used for time-based conversions and calculations.
 pub(crate) static SECONDS_PER_HOUR: LazyLock<Positive> = LazyLock::new(|| {
     Positive::new_decimal(dec!(3600.0))
-        .unwrap_or_else(|e| unreachable!("SECONDS_PER_HOUR literal is positive and finite: {e}"))
+        .unwrap_or_else(|e| unreachable!("SECONDS_PER_HOUR literal is positive and finite: {e}")) // scan-banned: allow -- `dec!()` literal, `Err` arm has no reachable input; see MIN_VOLATILITY
 });
 
 /// Number of minutes in an hour as a `Positive` decimal value.
@@ -93,7 +104,7 @@ pub(crate) const MILLISECONDS_PER_SECOND: Positive = positive::constants::THOUSA
 /// is built once via `LazyLock`.
 pub(crate) static MICROSECONDS_PER_SECOND: LazyLock<Positive> = LazyLock::new(|| {
     Positive::new_decimal(dec!(1_000_000.0)).unwrap_or_else(|e| {
-        unreachable!("MICROSECONDS_PER_SECOND literal is positive and finite: {e}")
+        unreachable!("MICROSECONDS_PER_SECOND literal is positive and finite: {e}") // scan-banned: allow -- `dec!()` literal, `Err` arm has no reachable input; see MIN_VOLATILITY
     })
 });
 
@@ -102,7 +113,7 @@ pub(crate) static MICROSECONDS_PER_SECOND: LazyLock<Positive> = LazyLock::new(||
 /// Used for time-based financial calculations and annualization.
 pub(crate) static WEEKS_PER_YEAR: LazyLock<Positive> = LazyLock::new(|| {
     Positive::new_decimal(dec!(52.0))
-        .unwrap_or_else(|e| unreachable!("WEEKS_PER_YEAR literal is positive and finite: {e}"))
+        .unwrap_or_else(|e| unreachable!("WEEKS_PER_YEAR literal is positive and finite: {e}")) // scan-banned: allow -- `dec!()` literal, `Err` arm has no reachable input; see MIN_VOLATILITY
 });
 
 /// Number of months in a year as a `Positive` decimal value.
@@ -111,7 +122,7 @@ pub(crate) static WEEKS_PER_YEAR: LazyLock<Positive> = LazyLock::new(|| {
 /// value is built once via `LazyLock`.
 pub(crate) static MONTHS_PER_YEAR: LazyLock<Positive> = LazyLock::new(|| {
     Positive::new_decimal(dec!(12.0))
-        .unwrap_or_else(|e| unreachable!("MONTHS_PER_YEAR literal is positive and finite: {e}"))
+        .unwrap_or_else(|e| unreachable!("MONTHS_PER_YEAR literal is positive and finite: {e}")) // scan-banned: allow -- `dec!()` literal, `Err` arm has no reachable input; see MIN_VOLATILITY
 });
 
 /// Number of quarters in a year as a `Positive` decimal value.
@@ -132,22 +143,32 @@ pub(crate) const IV_TOLERANCE: Decimal = dec!(1e-5);
 ///
 /// Typed as `NonZeroUsize` so the type system enforces the non-zero invariant
 /// at call sites, matching the public signatures migrated in #337.
+///
+/// # Why the `None` arm cannot fire
+///
+/// This and the three `NonZeroUsize` constants below are `const` items, so
+/// the `match` is evaluated by the compiler, not at run time. `std` offers no
+/// safe `const` literal for a non-zero integer, so the `Option` has to be
+/// destructured; if the literal were ever changed to zero the build would
+/// fail with `evaluation of constant value failed`, which is the outcome
+/// wanted. No caller can reach the arm, because there is no run time at
+/// which it exists.
 pub const DEFAULT_BINOMIAL_STEPS: NonZeroUsize = match NonZeroUsize::new(100) {
     Some(n) => n,
-    None => unreachable!(),
+    None => unreachable!(), // scan-banned: allow -- `const` context: an unreachable arm here fails compilation, it cannot abort at run time
 };
 
 /// Default number of Monte-Carlo simulation paths used by
 /// `monte_carlo_option_pricing` and related samplers.
 pub const DEFAULT_MC_PATHS: NonZeroUsize = match NonZeroUsize::new(10_000) {
     Some(n) => n,
-    None => unreachable!(),
+    None => unreachable!(), // scan-banned: allow -- `const` context: an unreachable arm here fails compilation, it cannot abort at run time
 };
 
 /// Default number of time steps per Monte-Carlo path.
 pub const DEFAULT_MC_STEPS: NonZeroUsize = match NonZeroUsize::new(252) {
     Some(n) => n,
-    None => unreachable!(),
+    None => unreachable!(), // scan-banned: allow -- `const` context: an unreachable arm here fails compilation, it cannot abort at run time
 };
 
 /// Maximum Newton-Raphson iterations used by implied-volatility solvers.
@@ -157,5 +178,5 @@ pub const DEFAULT_MC_STEPS: NonZeroUsize = match NonZeroUsize::new(252) {
 /// `VolatilityError`.
 pub const MAX_NEWTON_ITER: NonZeroUsize = match NonZeroUsize::new(100) {
     Some(n) => n,
-    None => unreachable!(),
+    None => unreachable!(), // scan-banned: allow -- `const` context: an unreachable arm here fails compilation, it cannot abort at run time
 };

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -517,14 +517,14 @@ impl Index<usize> for Curve {
         // and is documented above.
         match self.points.iter().nth(index) {
             Some(p) => p,
-            // scan-banned: allow -- `std::ops::Index` returns `&Self::Output`
-            // and has no fallible channel; the contract mirrors `Vec::index`.
-            // No library code reaches this arm: every internal lookup goes
-            // through `Curve::point_at`.
-            None => panic!(
-                "Curve::index: out of bounds (index = {index}, len = {})",
-                self.points.len()
-            ),
+            None => {
+                // INVARIANT: `std::ops::Index` returns `&Self::Output` and has
+                // no fallible channel; the contract mirrors `Vec::index`. No
+                // library code reaches this arm: every internal lookup goes
+                // through `Curve::point_at`.
+                let len = self.points.len();
+                panic!("Curve::index: out of bounds (index = {index}, len = {len})") // scan-banned: allow -- `Index` has no fallible channel and no library call site reaches it
+            }
         }
     }
 }

--- a/src/model/decimal.rs
+++ b/src/model/decimal.rs
@@ -7,7 +7,7 @@ use crate::error::decimal::DecimalError;
 use crate::geometrics::HasX;
 use num_traits::{FromPrimitive, ToPrimitive};
 use rand::distr::Distribution;
-use rand_distr::Normal;
+use rand_distr::StandardNormal;
 use rust_decimal::{Decimal, MathematicalOps, RoundingStrategy};
 use rust_decimal_macros::dec;
 
@@ -65,24 +65,24 @@ macro_rules! assert_decimal_eq {
 /// ```rust
 /// use rust_decimal::Decimal;
 /// use rust_decimal_macros::dec;
+/// use optionstratlib::error::DecimalError;
 /// use optionstratlib::model::decimal::DecimalStats;
 ///
 /// struct DecimalSeries(Vec<Decimal>);
 ///
 /// impl DecimalStats for DecimalSeries {
-///     fn mean(&self) -> Decimal {
-///         let sum: Decimal = self.0.iter().sum();
+///     fn mean(&self) -> Result<Decimal, DecimalError> {
 ///         if self.0.is_empty() {
-///             dec!(0)
-///         } else {
-///             sum / Decimal::from(self.0.len())
+///             return Ok(dec!(0));
 ///         }
+///         let sum: Decimal = self.0.iter().sum();
+///         Ok(sum / Decimal::from(self.0.len()))
 ///     }
-///     
-///     fn std_dev(&self) -> Decimal {
+///
+///     fn std_dev(&self) -> Result<Decimal, DecimalError> {
 ///         // Implementation of standard deviation calculation
 ///         // ...
-///         dec!(0) // Placeholder return
+///         Ok(dec!(0)) // Placeholder return
 ///     }
 /// }
 /// ```
@@ -91,7 +91,12 @@ pub trait DecimalStats {
     ///
     /// The mean is the sum of all values divided by the count of values.
     /// This method should handle empty collections appropriately.
-    fn mean(&self) -> Decimal;
+    ///
+    /// # Errors
+    ///
+    /// Implementations return [`DecimalError`] when the running sum or the
+    /// division by the count leaves the representable `Decimal` range.
+    fn mean(&self) -> Result<Decimal, DecimalError>;
 
     /// Calculates the standard deviation of the collection.
     ///
@@ -99,28 +104,58 @@ pub trait DecimalStats {
     /// from the mean. A low standard deviation indicates that values tend to be
     /// close to the mean, while a high standard deviation indicates values are
     /// spread out over a wider range.
-    fn std_dev(&self) -> Decimal;
+    ///
+    /// # Errors
+    ///
+    /// Implementations return [`DecimalError`] when a centred deviation, its
+    /// square, the sum of squares, or the final division leaves the
+    /// representable `Decimal` range.
+    fn std_dev(&self) -> Result<Decimal, DecimalError>;
 }
 
 impl DecimalStats for Vec<Decimal> {
-    fn mean(&self) -> Decimal {
+    /// # Errors
+    ///
+    /// Returns [`DecimalError::Overflow`] when the sum of the values leaves
+    /// the representable range — `vec![Decimal::MAX; 2]` is enough. The
+    /// previous signature had nowhere to put that, and `iter().sum()` aborts
+    /// with `Addition overflowed`.
+    fn mean(&self) -> Result<Decimal, DecimalError> {
         if self.is_empty() {
-            return Decimal::ZERO;
+            return Ok(Decimal::ZERO);
         }
-        let sum: Decimal = self.iter().sum();
-        sum / Decimal::from(self.len())
+        let sum = d_sum(self, "decimal::stats::mean::sum")?;
+        // `Decimal::from(usize)` is total, and the slice is non-empty here,
+        // so the divisor is neither an overflow nor a zero.
+        d_div(sum, Decimal::from(self.len()), "decimal::stats::mean")
     }
 
-    fn std_dev(&self) -> Decimal {
+    /// # Errors
+    ///
+    /// Returns [`DecimalError::Overflow`] when the mean, a centred deviation,
+    /// its square or the sum of squares leaves the representable range, and
+    /// [`DecimalError::ArithmeticError`] if the sample variance were negative.
+    /// The squaring was `.powd(Decimal::TWO)`, which aborts with
+    /// `Pow overflowed`.
+    fn std_dev(&self) -> Result<Decimal, DecimalError> {
         // Population variance of a single value is zero
         if self.len() < 2usize {
-            return Decimal::ZERO;
+            return Ok(Decimal::ZERO);
         }
-        let mean = self.mean();
-        let variance: Decimal = self.iter().map(|x| (x - mean).powd(Decimal::TWO)).sum();
-        (variance / Decimal::from(self.len() - 1))
-            .sqrt()
-            .unwrap_or(Decimal::ZERO)
+        let mean = self.mean()?;
+        let mut sq_total = Decimal::ZERO;
+        for value in self {
+            let centred = d_sub(*value, mean, "decimal::stats::std_dev::centred")?;
+            let centred_sq = d_mul(centred, centred, "decimal::stats::std_dev::centred_sq")?;
+            sq_total = d_add(sq_total, centred_sq, "decimal::stats::std_dev::sq_total")?;
+        }
+        // `len() >= 2` above, so `len() - 1` neither underflows nor is zero.
+        let variance = d_div(
+            sq_total,
+            Decimal::from(self.len() - 1),
+            "decimal::stats::std_dev::variance",
+        )?;
+        d_sqrt(variance, "decimal::stats::std_dev")
     }
 }
 
@@ -260,25 +295,17 @@ pub(crate) fn finite_decimal(value: f64) -> Option<Decimal> {
 /// let normal = decimal_normal_sample();
 /// ```
 ///
-/// # Panics
-///
-/// The `unreachable!` branch fires only if
-/// `statrs::distribution::Normal::new(0.0, 1.0)` rejects the provided
-/// parameters. `statrs` accepts any finite mean together with a
-/// strictly positive standard deviation, so `(0.0, 1.0)` is always
-/// valid under the `statrs` contract and the arm is unreachable in
-/// practice. Kept as a panic rather than `Result` to preserve the
-/// infallible sampling API.
+/// The sample is drawn from [`rand_distr::StandardNormal`], which is a unit
+/// struct with no constructor and therefore nothing to reject. It replaced
+/// `Normal::new(0.0, 1.0)`, whose `Err` arm had no value to return and so
+/// aborted. The two are the same distribution and the same value: `Normal`
+/// samples `StandardNormal` and applies `mean + std_dev * z`, which is the
+/// identity at `(0.0, 1.0)`.
 #[must_use]
 pub fn decimal_normal_sample() -> Decimal {
     let mut t_rng = rand::rng();
-    // Normal::new(0.0, 1.0) is provably valid (mean=0, std=1 are accepted
-    // by `statrs::distribution::Normal`), so the Err arm is unreachable.
-    let normal = match Normal::new(0.0, 1.0) {
-        Ok(n) => n,
-        Err(_) => unreachable!("standard normal parameters are always valid"),
-    };
-    Decimal::from_f64(normal.sample(&mut t_rng)).unwrap_or(Decimal::ZERO)
+    let sample: f64 = StandardNormal.sample(&mut t_rng);
+    Decimal::from_f64(sample).unwrap_or(Decimal::ZERO)
 }
 
 impl HasX for Decimal {
@@ -610,8 +637,13 @@ macro_rules! d2f {
 #[macro_export]
 macro_rules! nz {
     ($val:expr) => {{
+        // The panic expands at the caller, never inside the library: no
+        // production code uses `nz!`, only tests, examples and doc examples,
+        // all of which pass a non-zero literal. A runtime count must go
+        // through `NonZeroUsize::new(x).ok_or_else(..)` at the boundary, as
+        // the doc comment above says.
         ::std::num::NonZeroUsize::new($val)
-            .unwrap_or_else(|| panic!("nz!({}) must be non-zero", stringify!($val)))
+            .unwrap_or_else(|| panic!("nz!({}) must be non-zero", stringify!($val))) // scan-banned: allow -- expands at the caller only; no library code uses `nz!`
     }};
 }
 
@@ -691,6 +723,58 @@ pub mod tests {
 }
 
 #[cfg(test)]
+mod tests_decimal_stats {
+    use super::*;
+
+    #[test]
+    fn test_decimal_stats_empty_and_singleton_return_zero() {
+        let empty: Vec<Decimal> = vec![];
+        assert_eq!(empty.mean().unwrap(), Decimal::ZERO);
+        assert_eq!(empty.std_dev().unwrap(), Decimal::ZERO);
+        let one = vec![dec!(3)];
+        assert_eq!(one.mean().unwrap(), dec!(3));
+        assert_eq!(one.std_dev().unwrap(), Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_decimal_stats_ordinary_sample_is_unchanged() {
+        // The textbook series: mean 5, sample variance 32 / 7.
+        let values = vec![
+            dec!(2),
+            dec!(4),
+            dec!(4),
+            dec!(4),
+            dec!(5),
+            dec!(5),
+            dec!(7),
+            dec!(9),
+        ];
+        assert_eq!(values.mean().unwrap(), dec!(5));
+        let expected = d_div(dec!(32), dec!(7), "test")
+            .and_then(|v| d_sqrt(v, "test"))
+            .unwrap();
+        assert_eq!(values.std_dev().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_decimal_stats_saturated_sample_reports_overflow_instead_of_aborting() {
+        // `iter().sum()` aborted here with `Addition overflowed`, and the
+        // squaring in `std_dev` with `Pow overflowed`. Both are a
+        // `DecimalError` the caller can read now.
+        let values = vec![Decimal::MAX, Decimal::MAX];
+        assert!(values.mean().is_err());
+        assert!(values.std_dev().is_err());
+    }
+
+    #[test]
+    fn test_decimal_stats_std_dev_reports_a_deviation_that_overflows() {
+        // The mean is finite but a centred deviation is not.
+        let values = vec![Decimal::MAX, Decimal::MIN, Decimal::MAX, Decimal::MIN];
+        assert!(values.std_dev().is_err());
+    }
+}
+
+#[cfg(test)]
 mod tests_random_generation {
     use super::*;
     use approx::assert_relative_eq;
@@ -733,7 +817,8 @@ mod tests_random_generation {
     #[test]
     fn test_normal_distribution_transformation() {
         let mut t_rng = rand::rng();
-        let normal = Normal::new(-1.0, 0.5).unwrap(); // Deliberately using a distribution with negative mean
+        // Deliberately a distribution with a negative mean.
+        let normal = rand_distr::Normal::new(-1.0, 0.5).unwrap();
 
         // Count occurrences of values after transformation
         let mut value_counts: HashMap<i32, usize> = HashMap::new();

--- a/src/model/option.rs
+++ b/src/model/option.rs
@@ -5,7 +5,7 @@ use crate::error::{
     GreeksError, OptionsError, OptionsResult, PricingError, StrategyError, VolatilityError,
 };
 use crate::greeks::Greeks;
-use crate::model::decimal::d_sub;
+use crate::model::decimal::{d_sub, finite_decimal};
 use crate::model::expiration::resolve_expiration_date;
 use crate::model::types::{OptionBasicType, OptionStyle, OptionType, Side};
 use crate::model::utils::calculate_optimal_price_range;
@@ -30,6 +30,30 @@ use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use tracing::{error, trace};
 use utoipa::ToSchema;
+
+/// Projects a quantity-scaled `f64` payoff back onto `Decimal`, reporting the
+/// rejection instead of substituting zero.
+///
+/// The three payoff entry points below (`payoff`, `payoff_at_price`,
+/// `intrinsic_value`) evaluate `OptionType::payoff` in `f64` and scale it by
+/// the position quantity. Both factors can be as large as `Positive::MAX`
+/// (`≈ 7.92e28`), so the product routinely leaves the `Decimal` range — and a
+/// deep in-the-money call on an underlying at `Positive::MAX` leaves it even
+/// at quantity one, because the `f64` nearest to `Decimal::MAX` rounds above
+/// it. Those cases used to come back as `Ok(Decimal::ZERO)`: a worthless
+/// payoff for an option that is worth more than the type can express.
+///
+/// The returned error is [`OptionsError::PayoffError`], carrying the entry
+/// point and the offending value.
+#[cold]
+#[inline(never)]
+fn payoff_out_of_range(context: &'static str, value: f64) -> OptionsError {
+    OptionsError::PayoffError {
+        reason: format!(
+            "{context}: payoff {value} is not representable as a Decimal (non-finite or out of range)"
+        ),
+    }
+}
 
 /// Result type for binomial tree pricing models, containing:
 /// - The option price
@@ -491,10 +515,10 @@ impl Options {
     ///
     /// # Errors
     ///
-    /// Currently infallible in practice (the `f64` → `Decimal` conversion falls
-    /// back to `Decimal::default()`), but the `Result` signature is retained
-    /// for forward-compatibility with exotic payoff kernels that may surface
-    /// `OptionsError` variants.
+    /// Returns [`OptionsError::PayoffError`] when the quantity-scaled payoff is
+    /// not representable as a `Decimal` (non-finite, or beyond the `Decimal`
+    /// range). It previously returned `Ok(Decimal::ZERO)` for those inputs,
+    /// which reported a deep in-the-money position as worthless.
     pub fn payoff(&self) -> OptionsResult<Decimal> {
         let payoff_info = PayoffInfo {
             spot: self.underlying_price,
@@ -506,7 +530,7 @@ impl Options {
             spot_max: None,
         };
         let payoff = self.option_type.payoff(&payoff_info) * self.quantity.to_f64();
-        Ok(Decimal::from_f64(payoff).unwrap_or_default())
+        finite_decimal(payoff).ok_or_else(|| payoff_out_of_range("Options::payoff", payoff))
     }
 
     /// Calculates the financial payoff value of the option at a specific underlying price.
@@ -526,10 +550,10 @@ impl Options {
     ///
     /// # Errors
     ///
-    /// Currently infallible in practice (the `f64` → `Decimal` conversion falls
-    /// back to `Decimal::default()`), but the `Result` signature is retained
-    /// for forward-compatibility with exotic payoff kernels that may surface
-    /// `OptionsError` variants.
+    /// Returns [`OptionsError::PayoffError`] when the quantity-scaled payoff at
+    /// `price` is not representable as a `Decimal` (non-finite, or beyond the
+    /// `Decimal` range). It previously returned `Ok(Decimal::ZERO)` for those
+    /// inputs, which reported a deep in-the-money position as worthless.
     pub fn payoff_at_price(&self, price: &Positive) -> OptionsResult<Decimal> {
         let payoff_info = PayoffInfo {
             spot: *price,
@@ -541,7 +565,7 @@ impl Options {
             spot_max: None,
         };
         let price = self.option_type.payoff(&payoff_info) * self.quantity.to_f64();
-        Ok(Decimal::from_f64(price).unwrap_or_default())
+        finite_decimal(price).ok_or_else(|| payoff_out_of_range("Options::payoff_at_price", price))
     }
 
     /// Calculates the intrinsic value of the option.
@@ -560,10 +584,10 @@ impl Options {
     ///
     /// # Errors
     ///
-    /// Currently infallible in practice (the `f64` → `Decimal` conversion falls
-    /// back to `Decimal::default()`), but the `Result` signature is retained
-    /// for forward-compatibility with exotic payoff kernels that may surface
-    /// `OptionsError` variants.
+    /// Returns [`OptionsError::PayoffError`] when the quantity-scaled intrinsic
+    /// value is not representable as a `Decimal` (non-finite, or beyond the
+    /// `Decimal` range). It previously returned `Ok(Decimal::ZERO)` for those
+    /// inputs, which reported a deep in-the-money position as worthless.
     pub fn intrinsic_value(&self, underlying_price: Positive) -> OptionsResult<Decimal> {
         let payoff_info = PayoffInfo {
             spot: underlying_price,
@@ -575,7 +599,7 @@ impl Options {
             spot_max: None,
         };
         let iv = self.option_type.payoff(&payoff_info) * self.quantity.to_f64();
-        Ok(Decimal::from_f64(iv).unwrap_or_default())
+        finite_decimal(iv).ok_or_else(|| payoff_out_of_range("Options::intrinsic_value", iv))
     }
 
     /// Determines whether an option is "in-the-money" based on its current price relative to strike price.
@@ -1558,6 +1582,57 @@ mod tests_options_payoffs {
         );
         let put_payoff_otm = put_option_otm.payoff().unwrap();
         assert_eq!(put_payoff_otm, Decimal::ZERO); // -max(95 - 100, 0) = 0
+    }
+
+    /// The three payoff entry points reported `Ok(0)` for a payoff too large
+    /// to represent, which is a deep in-the-money position priced at nothing.
+    #[test]
+    fn test_payoff_out_of_range_reports_an_error_instead_of_zero() {
+        let mut option = create_sample_option_simplest_strike(
+            Side::Long,
+            OptionStyle::Call,
+            pos_or_panic!(95.0),
+        );
+        option.strike_price = Positive::ZERO;
+        option.underlying_price = Positive::MAX;
+        option.quantity = Positive::ONE;
+
+        // `Positive::MAX` is representable, but the nearest `f64` to it
+        // rounds above `Decimal::MAX`, so the round trip fails at quantity
+        // one — no extreme quantity is needed.
+        assert!(matches!(
+            option.payoff(),
+            Err(OptionsError::PayoffError { .. })
+        ));
+        assert!(matches!(
+            option.payoff_at_price(&Positive::MAX),
+            Err(OptionsError::PayoffError { .. })
+        ));
+        assert!(matches!(
+            option.intrinsic_value(Positive::MAX),
+            Err(OptionsError::PayoffError { .. })
+        ));
+    }
+
+    /// A payoff that is genuinely zero still comes back as `Ok(0)`: the fix
+    /// distinguishes "worth nothing" from "cannot be represented".
+    #[test]
+    fn test_payoff_out_of_the_money_still_returns_zero() {
+        let mut option =
+            create_sample_option_simplest_strike(Side::Long, OptionStyle::Put, pos_or_panic!(95.0));
+        option.strike_price = Positive::ZERO;
+        option.underlying_price = Positive::MAX;
+        option.quantity = Positive::ONE;
+
+        assert_eq!(option.payoff().unwrap(), Decimal::ZERO);
+        assert_eq!(
+            option.payoff_at_price(&Positive::MAX).unwrap(),
+            Decimal::ZERO
+        );
+        assert_eq!(
+            option.intrinsic_value(Positive::MAX).unwrap(),
+            Decimal::ZERO
+        );
     }
 }
 

--- a/src/pricing/compound.rs
+++ b/src/pricing/compound.rs
@@ -116,9 +116,9 @@ fn drezner_bivariate_normal(a: f64, b: f64, rho: f64) -> f64 {
 
         for i in 0..5 {
             let sn = (asr * (1.0 - x[i]) / 2.0).sin();
-            bvn += w[i] * (sn * hk / (1.0 - sn * sn)).exp() * (-hs / (1.0 - sn * sn)).exp();
+            bvn += w[i] * (sn * hk / (1.0 - sn * sn)).exp() * (-hs / (1.0 - sn * sn)).exp(); // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
             let sn = (asr * (1.0 + x[i]) / 2.0).sin();
-            bvn += w[i] * (sn * hk / (1.0 - sn * sn)).exp() * (-hs / (1.0 - sn * sn)).exp();
+            bvn += w[i] * (sn * hk / (1.0 - sn * sn)).exp() * (-hs / (1.0 - sn * sn)).exp(); // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
         }
         bvn *= asr / (4.0 * PI);
         bvn += standard_normal_cdf(-h) * standard_normal_cdf(-k);
@@ -149,7 +149,7 @@ fn high_correlation_bvn(h: f64, k: f64, hk: f64, rho: f64, x: &[f64; 5], w: &[f6
 
         if asr > -100.0 {
             bvn = a
-                * asr.exp()
+                * asr.exp() // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
                 * (1.0 - c * (bs - ass) * (1.0 - d * bs / 5.0) / 3.0 + c * d * ass * ass / 5.0);
         } else {
             bvn = 0.0;
@@ -157,7 +157,7 @@ fn high_correlation_bvn(h: f64, k: f64, hk: f64, rho: f64, x: &[f64; 5], w: &[f6
 
         if -hk < 100.0 {
             let b = ass.sqrt();
-            bvn -= (-hk / 2.0).exp()
+            bvn -= (-hk / 2.0).exp() // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
                 * (2.0 * PI).sqrt()
                 * standard_normal_cdf(-h / b)
                 * b
@@ -172,8 +172,8 @@ fn high_correlation_bvn(h: f64, k: f64, hk: f64, rho: f64, x: &[f64; 5], w: &[f6
             if asr_tmp > -100.0 {
                 bvn += a
                     * w[i]
-                    * asr_tmp.exp()
-                    * ((-hk * (1.0 - rs) / (2.0 * (1.0 + (1.0 - rs).sqrt()))).exp()
+                    * asr_tmp.exp() // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
+                    * ((-hk * (1.0 - rs) / (2.0 * (1.0 + (1.0 - rs).sqrt()))).exp() // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
                         / (1.0 + (1.0 - rs).sqrt())
                         - (1.0 + c * rs * (1.0 + d * rs)));
             }
@@ -183,8 +183,8 @@ fn high_correlation_bvn(h: f64, k: f64, hk: f64, rho: f64, x: &[f64; 5], w: &[f6
             if asr_tmp > -100.0 {
                 bvn += a
                     * w[i]
-                    * asr_tmp.exp()
-                    * ((-hk * (1.0 - rs) / (2.0 * (1.0 + (1.0 - rs).sqrt()))).exp()
+                    * asr_tmp.exp() // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
+                    * ((-hk * (1.0 - rs) / (2.0 * (1.0 + (1.0 - rs).sqrt()))).exp() // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
                         / (1.0 + (1.0 - rs).sqrt())
                         - (1.0 + c * rs * (1.0 + d * rs)));
             }

--- a/src/pricing/monte_carlo.rs
+++ b/src/pricing/monte_carlo.rs
@@ -125,7 +125,7 @@ pub fn monte_carlo_option_pricing(
             years,
         ));
     }
-    let discount = (-rate_f64 * years).exp();
+    let discount = (-rate_f64 * years).exp(); // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
     if !discount.is_finite() {
         return Err(PricingError::non_finite(
             "pricing::monte_carlo::discount",

--- a/src/pricing/power.rs
+++ b/src/pricing/power.rs
@@ -147,15 +147,15 @@ fn power_price(
 
     let drift_adjustment =
         n_f64 * (r_f64 - q_f64) + n_f64 * (n_f64 - 1.0) * sigma_f64 * sigma_f64 / 2.0;
-    let forward = s_power * (drift_adjustment * t_f64).exp();
+    let forward = s_power * (drift_adjustment * t_f64).exp(); // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
 
     let sigma_adj = n_f64 * sigma_f64;
 
     let sqrt_t = t_f64.sqrt();
-    let d1 = ((forward / k_f64).ln() + sigma_adj * sigma_adj * t_f64 / 2.0) / (sigma_adj * sqrt_t);
+    let d1 = ((forward / k_f64).ln() + sigma_adj * sigma_adj * t_f64 / 2.0) / (sigma_adj * sqrt_t); // scan-banned: allow -- f64 `ln`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
     let d2 = d1 - sigma_adj * sqrt_t;
 
-    let discount = (-r_f64 * t_f64).exp();
+    let discount = (-r_f64 * t_f64).exp(); // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
 
     let d1_dec =
         Decimal::from_f64(d1).ok_or_else(|| PricingError::other("Failed to convert d1"))?;

--- a/src/pricing/rainbow.rs
+++ b/src/pricing/rainbow.rs
@@ -312,8 +312,8 @@ fn monte_carlo_rainbow(
     for i in 0..num_simulations {
         let (z1, z2) = generate_correlated_normals(i as u64, rho_f);
 
-        let s1_t = s1_f * (drift1 + vol1 * z1).exp();
-        let s2_t = s2_f * (drift2 + vol2 * z2).exp();
+        let s1_t = s1_f * (drift1 + vol1 * z1).exp(); // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
+        let s2_t = s2_f * (drift2 + vol2 * z2).exp(); // scan-banned: allow -- f64 `exp`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
 
         let underlying = if is_best_of {
             s1_t.max(s2_t)
@@ -351,7 +351,8 @@ fn box_muller_transform(seed: u64) -> f64 {
     let u1_clamped = u1.clamp(1e-10, 1.0 - 1e-10);
     let u2_clamped = u2.clamp(1e-10, 1.0 - 1e-10);
 
-    (-2.0 * u1_clamped.ln()).sqrt() * (2.0 * PI * u2_clamped).cos()
+    // `u1_clamped` is clamped away from 0 and 1 above, so the log is finite.
+    (-2.0 * u1_clamped.ln()).sqrt() * (2.0 * PI * u2_clamped).cos() // scan-banned: allow -- f64 `ln`: returns inf/NaN on overflow, it does not abort; the non-finite value is rejected at the `Decimal` boundary
 }
 
 /// Simple linear congruential generator for uniform random numbers.

--- a/src/pricing/utils.rs
+++ b/src/pricing/utils.rs
@@ -605,8 +605,8 @@ mod tests_simulate_returns {
         assert_eq!(returns.len(), length);
 
         // Check that the mean and standard deviation are reasonably close to expected values
-        let simulated_mean = returns.clone().mean();
-        let simulated_std_dev = returns.std_dev();
+        let simulated_mean = returns.clone().mean().unwrap();
+        let simulated_std_dev = returns.std_dev().unwrap();
 
         assert_decimal_eq!(simulated_mean, mean * time_step, dec!(0.01));
         assert_decimal_eq!(
@@ -649,7 +649,7 @@ mod tests_simulate_returns_bis {
             Decimal::from_f64(1.0 / 252.0).unwrap(),
         )
         .unwrap();
-        let mean = returns.mean();
+        let mean = returns.mean().unwrap();
         assert!(mean.abs() < dec!(0.01));
     }
 

--- a/src/surfaces/surface.rs
+++ b/src/surfaces/surface.rs
@@ -821,14 +821,14 @@ impl Index<usize> for Surface {
         // so panic on out-of-bounds is the documented contract.
         match self.points.iter().nth(index) {
             Some(p) => p,
-            // scan-banned: allow -- `std::ops::Index` returns `&Self::Output`
-            // and has no fallible channel; the contract mirrors `Vec::index`.
-            // No library code reaches this arm: every internal lookup goes
-            // through `Surface::point_at`.
-            None => panic!(
-                "Surface::index: out of bounds (index = {index}, len = {})",
-                self.points.len()
-            ),
+            None => {
+                // INVARIANT: `std::ops::Index` returns `&Self::Output` and has
+                // no fallible channel; the contract mirrors `Vec::index`. No
+                // library code reaches this arm: every internal lookup goes
+                // through `Surface::point_at`.
+                let len = self.points.len();
+                panic!("Surface::index: out of bounds (index = {index}, len = {len})") // scan-banned: allow -- `Index` has no fallible channel and no library call site reaches it
+            }
         }
     }
 }

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -172,12 +172,19 @@ pub fn units_per_year(time_frame: &TimeFrame) -> Positive {
         // 365 / 7 — kept as exact Decimal arithmetic to preserve the
         // round-trip identity Week→Day→Week (an f64 literal would
         // accumulate ~1 ulp of error and break the strict assertion in
-        // tests like `test_step_next_with_weeks`). The structural
-        // invariant (positive non-zero numerator and denominator)
-        // makes the Err arm unreachable.
+        // tests like `test_step_next_with_weeks`).
+        //
+        // Both operands are `dec!()` literals fixed at compile time, so the
+        // division has no runtime input: the divisor is 7, never zero, and
+        // the quotient 52.142857… is positive and far inside the `Decimal`
+        // range. `Positive::new_decimal` rejects only a value below the
+        // lower bound, so nothing reaches the `Err` arm, and there is no
+        // value to return there — `units_per_year` is infallible by
+        // signature and a stand-in would make every weekly annualisation
+        // silently wrong.
         TimeFrame::Week => match Positive::new_decimal(dec!(365.0) / dec!(7.0)) {
             Ok(v) => v,
-            Err(_) => unreachable!("365/7 is structurally positive non-zero"),
+            Err(_) => unreachable!("365/7 is structurally positive non-zero"), // scan-banned: allow -- both operands are compile-time literals; see the comment above
         },
         TimeFrame::Month => pos_lit(dec!(12.0)),  // 12
         TimeFrame::Quarter => pos_lit(dec!(4.0)), // 4
@@ -353,10 +360,14 @@ pub fn get_today_formatted() -> String {
 /// ```
 #[must_use]
 pub fn get_today_or_tomorrow_formatted() -> String {
-    // 18:30 is a valid wall-clock time, so the Err arm is unreachable.
+    // `NaiveTime::from_hms_opt` returns `None` only for `hour > 23`,
+    // `min > 59` or `sec > 59` (leap seconds aside). All three arguments are
+    // literals inside those ranges, so the `None` arm has no input that can
+    // select it, and `get_today_or_tomorrow_formatted` is infallible by
+    // signature so there is no cutoff to fall back to.
     let cutoff_time = match NaiveTime::from_hms_opt(18, 30, 0) {
         Some(t) => t,
-        None => unreachable!("18:30:00 is always a valid NaiveTime"),
+        None => unreachable!("18:30:00 is always a valid NaiveTime"), // scan-banned: allow -- literal arguments inside chrono's documented ranges
     };
     let now = Utc::now();
     // Get the date we should use based on current UTC time

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -104,20 +104,25 @@ pub fn constant_volatility(returns: &[Decimal]) -> Result<Positive, VolatilityEr
 ///
 /// # Errors
 ///
+/// Returns [`VolatilityError::NumericalFailure`] when `window_size`
+/// is zero: `slice::windows` has no meaning at that width and
+/// panics rather than yielding an empty iterator.
+///
 /// Propagates any `VolatilityError::NumericalFailure` raised by
 /// `constant_volatility` on an individual window.
 ///
-/// # Panics
-///
-/// The underlying `slice::windows(window_size)` call panics when
-/// `window_size == 0`. When `window_size > returns.len()` the
-/// function returns `Ok(vec![])` instead of an error, so callers
-/// that need a non-empty result must validate the inputs
-/// themselves.
+/// When `window_size > returns.len()` the function returns
+/// `Ok(vec![])` instead of an error, so callers that need a
+/// non-empty result must validate the inputs themselves.
 pub fn historical_volatility(
     returns: &[Decimal],
     window_size: usize,
 ) -> Result<Vec<Positive>, VolatilityError> {
+    if window_size == 0 {
+        return Err(VolatilityError::NumericalFailure {
+            reason: "historical_volatility: window_size must be non-zero".to_string(),
+        });
+    }
     returns
         .windows(window_size)
         .map(constant_volatility)
@@ -221,6 +226,11 @@ pub fn ewma_volatility(
 /// `VolatilityError::PositiveError` when the boundary `Positive`
 /// conversion fails. Black–Scholes errors on individual candidates
 /// are discarded by the parallel filter rather than propagated.
+///
+/// Returns `VolatilityError::NumericalFailure` when
+/// `100 * max_iterations` overflows `i64` (`max_iterations` at or near
+/// `i64::MAX` or `i64::MIN`), which used to abort a debug build with
+/// `attempt to multiply with overflow` and wrap silently in release.
 #[instrument(skip(options), fields(
     market_price = %market_price,
     strike = %options.strike_price,
@@ -232,7 +242,14 @@ pub fn implied_volatility(
     max_iterations: i64,
 ) -> Result<Positive, VolatilityError> {
     let base_option = options.clone();
-    let iterations = 100 * max_iterations;
+    let iterations =
+        max_iterations
+            .checked_mul(100)
+            .ok_or_else(|| VolatilityError::NumericalFailure {
+                reason: format!(
+                    "implied_volatility: grid size 100 * {max_iterations} overflows i64"
+                ),
+            })?;
     let result = (1..iterations)
         .into_par_iter()
         .map(|i| {
@@ -345,11 +362,12 @@ pub fn calculate_iv(
 ///   parameters with `omega` or `beta * v_prev` negative). This is
 ///   a real diagnostic now instead of being silently clamped to
 ///   `Positive::ZERO` as in earlier implementations.
-///
-/// # Panics
-///
-/// Panics on `returns[0]` when `returns` is empty. Callers must
-/// validate the input slice length before invoking.
+/// - Returns [`VolatilityError::NumericalFailure`] when `returns` is
+///   empty: the recursion has no seed variance to start from.
+/// - Returns [`VolatilityError::PositiveError`] if a running
+///   `checked_sqrt` ever rejects its operand. A variance is
+///   non-negative by construction here, so this arm is a guard
+///   rather than a reachable outcome.
 pub fn garch_volatility(
     returns: &[Decimal],
     omega: Decimal,
@@ -369,15 +387,21 @@ pub fn garch_volatility(
 
     // Seed the recursion with `r_0^2` via `d_mul` so a saturating
     // squaring cannot feed a silently capped value into the GARCH
-    // update below.
+    // update below. `first()` is what makes the seed total: indexing
+    // `returns[0]` aborted on an empty slice.
+    let first_return = returns
+        .first()
+        .ok_or_else(|| VolatilityError::NumericalFailure {
+            reason: "garch_volatility: returns slice is empty".to_string(),
+        })?;
     let seed = d_mul(
-        returns[0],
-        returns[0],
+        *first_return,
+        *first_return,
         "volatility::garch::initial_variance",
     )?;
     let mut variance = to_positive_variance(seed, "initial_variance")?;
-    let mut volatilities = vec![variance.sqrt()];
-    for &return_value in &returns[1..] {
+    let mut volatilities = vec![variance.checked_sqrt()?];
+    for &return_value in returns.iter().skip(1) {
         // GARCH(1, 1) variance recursion:
         // v' = ω + α · r² + β · v_prev.
         let return_sq = d_mul(return_value, return_value, "volatility::garch::return_sq")?;
@@ -386,7 +410,7 @@ pub fn garch_volatility(
         let persistent = d_add(omega, alpha_r2, "volatility::garch::omega_plus_alpha")?;
         let next_variance = d_add(persistent, beta_v, "volatility::garch::variance")?;
         variance = to_positive_variance(next_variance, "variance")?;
-        volatilities.push(variance.sqrt());
+        volatilities.push(variance.checked_sqrt()?);
     }
     Ok(volatilities)
 }
@@ -413,11 +437,17 @@ pub fn garch_volatility(
 /// representable as `f64`, or when the per-step `dw` sample cannot
 /// be converted back into `Decimal`.
 ///
+/// Returns [`VolatilityError::DecimalError`] when a step of the
+/// Euler discretisation `v' = v + κ(θ − v)dt + ξ√v dW` leaves the
+/// representable `Decimal` range. The raw operators this used to be
+/// written with aborted instead; there is no limit to substitute,
+/// because the variance is the state being simulated and a step that
+/// cannot be represented ends the path.
+///
 /// Variance is clamped to zero on each step
 /// (`v = v.max(Decimal::ZERO)`) and converted via
-/// `Positive::new_decimal(...).unwrap_or(Positive::ZERO)`, so
-/// negative variance is silently recovered and `PositiveError` is
-/// never surfaced.
+/// `Positive::new_decimal(...).unwrap_or(Positive::ZERO)`, so a
+/// negative intermediate is silently recovered.
 pub fn simulate_heston_volatility(
     kappa: Decimal,
     theta: Decimal,
@@ -428,7 +458,7 @@ pub fn simulate_heston_volatility(
 ) -> Result<Vec<Positive>, VolatilityError> {
     let mut v = v0.max(Decimal::ZERO);
     let mut v_pos = Positive::new_decimal(v).unwrap_or(Positive::ZERO);
-    let mut volatilities = vec![v_pos.sqrt()];
+    let mut volatilities = vec![v_pos.checked_sqrt()?];
     let dt_sqrt_f64 = dt
         .sqrt()
         .ok_or_else(|| VolatilityError::NumericalFailure {
@@ -442,11 +472,29 @@ pub fn simulate_heston_volatility(
         let dw_f64 = random::<f64>() * dt_sqrt_f64;
         let dw = finite_decimal(dw_f64)
             .ok_or_else(|| VolatilityError::non_finite("volatility::heston::dw", dw_f64))?;
-        let sqrt_v = v_pos.sqrt().to_dec();
-        v += kappa * (theta - v) * dt + xi * sqrt_v * dw;
+        let sqrt_v = v_pos.checked_sqrt()?.to_dec();
+        // Euler step of dv = κ(θ − v)dt + ξ√v dW, every factor checked:
+        // the raw operator form aborted with `Multiplication overflowed`
+        // on an extreme `dt` or an extreme initial variance.
+        let reversion = d_sub(theta, v, "volatility::heston::reversion")?;
+        let drift = d_mul(
+            d_mul(kappa, reversion, "volatility::heston::kappa_reversion")?,
+            dt,
+            "volatility::heston::drift",
+        )?;
+        let diffusion = d_mul(
+            d_mul(xi, sqrt_v, "volatility::heston::xi_sqrt_v")?,
+            dw,
+            "volatility::heston::diffusion",
+        )?;
+        v = d_add(
+            v,
+            d_add(drift, diffusion, "volatility::heston::dv")?,
+            "volatility::heston::variance",
+        )?;
         v = v.max(Decimal::ZERO); // Ensure variance doesn't become negative
         v_pos = Positive::new_decimal(v).unwrap_or(Positive::ZERO);
-        volatilities.push(v_pos.sqrt());
+        volatilities.push(v_pos.checked_sqrt()?);
     }
     Ok(volatilities)
 }
@@ -526,13 +574,16 @@ pub fn uncertain_volatility_bounds(
 ///
 /// Returns [`VolatilityError::PositiveError`] when the scaling factor
 /// multiplied by the base volatility cannot be represented as a
-/// `Positive` (e.g. overflow on an extreme timeframe annualisation).
+/// `Positive` — for example `Positive::MAX` annualised from
+/// `TimeFrame::Microsecond`, which used to abort with
+/// `Positive arithmetic overflow in mul`.
 #[inline]
 pub fn annualized_volatility(
     volatility: Positive,
     timeframe: TimeFrame,
 ) -> Result<Positive, VolatilityError> {
-    Ok(volatility * timeframe.periods_per_year().sqrt())
+    let scale_factor = timeframe.periods_per_year().checked_sqrt()?;
+    Ok(volatility.checked_mul(&scale_factor)?)
 }
 
 /// De-annualizes a volatility value to a specific timeframe.
@@ -565,15 +616,33 @@ pub fn annualized_volatility(
 ///
 /// # Errors
 ///
+/// Returns [`VolatilityError::InvalidTime`] when the timeframe reports
+/// zero periods per year — `TimeFrame::Custom(Positive::ZERO)` — since
+/// the square-root-of-time rule has no de-annualised value there. The
+/// guard and its message mirror the one [`adjust_volatility`] applies
+/// to its target timeframe, so the two entry points agree on where the
+/// domain ends.
+///
 /// Returns [`VolatilityError::PositiveError`] when the rescaling
-/// produces a value that violates the `Positive` invariant, typically
-/// due to division rounding on an extremely small timeframe.
+/// produces a value that violates the `Positive` invariant or
+/// overflows, typically due to division by an extremely small
+/// number of periods.
 #[inline]
 pub fn de_annualized_volatility(
     annual_volatility: Positive,
     timeframe: TimeFrame,
 ) -> Result<Positive, VolatilityError> {
-    Ok(annual_volatility / timeframe.periods_per_year().sqrt())
+    let periods = timeframe.periods_per_year();
+    if periods.is_zero() {
+        return Err(VolatilityError::InvalidTime {
+            time: periods,
+            reason: format!(
+                "Cannot de-annualize volatility to timeframe with zero periods per year: {timeframe:?}"
+            ),
+        });
+    }
+    let scale_factor = periods.checked_sqrt()?;
+    Ok(annual_volatility.checked_div(&scale_factor)?)
 }
 
 /// Adjusts volatility between different timeframes using the square root of time rule
@@ -600,9 +669,12 @@ pub fn de_annualized_volatility(
 ///
 /// # Errors
 ///
-/// Propagates any [`VolatilityError::PositiveError`] surfaced by the
-/// intermediate [`annualized_volatility`] or [`de_annualized_volatility`]
-/// calls when either rescaling breaches the `Positive` invariant.
+/// Returns [`VolatilityError::InvalidTime`] when `to_frame` reports zero
+/// periods per year, and [`VolatilityError::PositiveError`] when the
+/// period ratio or the rescaled volatility leaves the representable
+/// `Positive` range — for example `TimeFrame::Microsecond` into
+/// `TimeFrame::Custom(1e-27)`, which used to abort with
+/// `Positive arithmetic overflow in div`.
 pub fn adjust_volatility(
     volatility: Positive,
     from_frame: TimeFrame,
@@ -630,11 +702,13 @@ pub fn adjust_volatility(
     }
 
     // Scale factor is square root of (from_periods / to_periods). `Positive`
-    // already implements `sqrt()`, so skip the f64 round-trip and keep the
-    // computation in `Decimal` precision end-to-end.
-    let scale_factor = (from_periods / to_periods).sqrt();
+    // has a checked square root, so skip the f64 round-trip and keep the
+    // computation in `Decimal` precision end-to-end. Both steps are checked:
+    // the ratio overflows for a `Custom` target of 1e-27, and the operator
+    // form aborted there.
+    let scale_factor = from_periods.checked_div(&to_periods)?.checked_sqrt()?;
 
-    Ok(volatility * scale_factor)
+    Ok(volatility.checked_mul(&scale_factor)?)
 }
 
 /// Adjusts annualized volatility for use in random walk simulations with a specific dt.

--- a/src/volatility/utils.rs
+++ b/src/volatility/utils.rs
@@ -21,7 +21,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use positive::Positive;
 use rand::random;
 use rayon::prelude::*;
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::{Decimal, MathematicalOps, RoundingStrategy};
 use tracing::instrument;
 
 #[cfg(test)]
@@ -642,7 +642,11 @@ pub fn de_annualized_volatility(
         });
     }
     let scale_factor = periods.checked_sqrt()?;
-    Ok(annual_volatility.checked_div(&scale_factor)?)
+    // Explicit rounding rather than the dependency's default, matching the
+    // strategy `d_div` applies crate-wide, so a de-annualised volatility
+    // rounds the same way whichever path computes it.
+    Ok(annual_volatility
+        .checked_div_with_strategy(&scale_factor, RoundingStrategy::MidpointNearestEven)?)
 }
 
 /// Adjusts volatility between different timeframes using the square root of time rule
@@ -701,12 +705,20 @@ pub fn adjust_volatility(
         });
     }
 
-    // Scale factor is square root of (from_periods / to_periods). `Positive`
-    // has a checked square root, so skip the f64 round-trip and keep the
-    // computation in `Decimal` precision end-to-end. Both steps are checked:
-    // the ratio overflows for a `Custom` target of 1e-27, and the operator
-    // form aborted there.
-    let scale_factor = from_periods.checked_div(&to_periods)?.checked_sqrt()?;
+    // Scale factor is the square root of `from_periods / to_periods`, taken
+    // as `sqrt(from) / sqrt(to)` rather than `sqrt(from / to)`. The two are
+    // equal in exact arithmetic and not in this one: the ratio is rounded to
+    // 28 decimal places before the root can rescue it, so a `Year` source
+    // against a `Custom(Positive::MAX)` target rounds `1 / MAX` — about
+    // `1.26e-29` — to zero and the volatility silently collapses, even
+    // though the root of that ratio is around `1.1e-15` and perfectly
+    // representable. Rooting first keeps both operands far from the scale
+    // limit. The division that follows chooses `MidpointNearestEven`, the
+    // strategy `d_div` applies to every `Decimal` division in the crate.
+    let scale_factor = from_periods.checked_sqrt()?.checked_div_with_strategy(
+        &to_periods.checked_sqrt()?,
+        RoundingStrategy::MidpointNearestEven,
+    )?;
 
     Ok(volatility.checked_mul(&scale_factor)?)
 }
@@ -879,6 +891,27 @@ pub fn generate_ou_process(
 #[cfg(test)]
 mod tests_annualize_volatility {
     use super::*;
+
+    /// A representable scale factor must not collapse to zero on its way to
+    /// being computed. `Year` against `Custom(Positive::MAX)` divides one by
+    /// `Decimal::MAX`, which is about `1.26e-29` and rounds to zero at the
+    /// 28-place scale — but the square root of that ratio is around
+    /// `1.1e-15`, which is representable, so the answer exists and the
+    /// intermediate was the only thing that did not.
+    #[test]
+    fn test_adjust_volatility_survives_an_extreme_target_timeframe() {
+        let adjusted = adjust_volatility(
+            pos_or_panic!(0.2),
+            TimeFrame::Year,
+            TimeFrame::Custom(Positive::MAX),
+        )
+        .expect("the conversion is representable");
+
+        assert!(
+            adjusted > Positive::ZERO,
+            "a representable scale factor collapsed to zero: {adjusted}"
+        );
+    }
     use positive::assert_pos_relative_eq;
 
     #[test]

--- a/tests/property/mod.rs
+++ b/tests/property/mod.rs
@@ -13,3 +13,4 @@ mod pricing_panic_freedom_test;
 mod put_call_parity_test;
 mod quote_invariants_test;
 mod strategies_panic_freedom_test;
+mod volatility_panic_freedom_test;

--- a/tests/property/volatility_panic_freedom_test.rs
+++ b/tests/property/volatility_panic_freedom_test.rs
@@ -1,0 +1,271 @@
+//! Property-based tests for panic freedom across the volatility module.
+//!
+//! The library is embedded in long-running services, where a panic kills the
+//! worker thread and takes the in-flight request with it. Every failure must
+//! therefore come back as a `Result`, including for inputs that are extreme
+//! but structurally valid.
+//!
+//! Volatility fails along three axes, and all three are driven here. The
+//! numeric axis is the usual `Decimal` domain: returns at the smallest
+//! representable scale, at `Decimal::MAX` and `Decimal::MIN`, and the
+//! ordinary values between. The structural axis is the shape of the sample:
+//! an empty slice (the GARCH recursion has no seed), a single observation
+//! (the sample variance divides by `n - 1`), and a window wider than the
+//! sample or of width zero (`slice::windows` has no meaning at zero and
+//! panics rather than yielding nothing). The third axis is the timeframe:
+//! `TimeFrame::Custom` carries an arbitrary `Positive`, so the periods per
+//! year that every square-root-of-time rescaling divides by can be zero,
+//! `1e-27`, or `Positive::MAX`.
+//!
+//! The assertion is deliberately weak: whatever comes back, it must come
+//! back.
+
+use optionstratlib::utils::time::TimeFrame;
+use optionstratlib::volatility::{
+    adjust_volatility, annualized_volatility, calculate_iv, constant_volatility,
+    de_annualized_volatility, ewma_volatility, garch_volatility, generate_ou_process,
+    historical_volatility, implied_volatility, simulate_heston_volatility,
+    uncertain_volatility_bounds, volatility_for_dt,
+};
+use optionstratlib::{ExpirationDate, OptionStyle, OptionType, Options, Side};
+use positive::Positive;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+/// The smallest representable `Decimal`. As a number of periods per year it
+/// makes the annualisation ratio overflow; as a return it makes the squared
+/// deviation underflow to zero.
+const TINY: Decimal = Decimal::from_parts(1, 0, 0, false, 28);
+
+/// Returns that reach the arithmetic failures: the edges of the `Decimal`
+/// range, the smallest representable scale, and the ordinary values between.
+fn extreme_return() -> impl Strategy<Value = Decimal> {
+    prop_oneof![
+        Just(Decimal::ZERO),
+        Just(TINY),
+        Just(-TINY),
+        Just(dec!(0.01)),
+        Just(dec!(-0.02)),
+        Just(dec!(1)),
+        Just(dec!(1000000)),
+        Just(dec!(-1000000)),
+        Just(Decimal::MAX),
+        Just(Decimal::MIN),
+    ]
+}
+
+/// `Positive` values at the edges of the domain. `Positive` is `>= 0`, so
+/// `Positive::ZERO` is a legitimate divisor to hand to a rescaling.
+fn extreme_positive() -> impl Strategy<Value = Positive> {
+    prop_oneof![
+        Just(Positive::ZERO),
+        Just(Positive::ONE),
+        Just(Positive::HUNDRED),
+        Just(Positive::new_decimal(TINY).unwrap_or(Positive::ZERO)),
+        Just(Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO)),
+        Just(Positive::new_decimal(dec!(100000000000000)).unwrap_or(Positive::ZERO)),
+        Just(Positive::MAX),
+    ]
+}
+
+/// Every named timeframe plus the `Custom` ones whose periods per year are
+/// the extremes the square-root-of-time rule divides by.
+fn extreme_timeframe() -> impl Strategy<Value = TimeFrame> {
+    prop_oneof![
+        Just(TimeFrame::Microsecond),
+        Just(TimeFrame::Millisecond),
+        Just(TimeFrame::Second),
+        Just(TimeFrame::Minute),
+        Just(TimeFrame::Hour),
+        Just(TimeFrame::Day),
+        Just(TimeFrame::Week),
+        Just(TimeFrame::Month),
+        Just(TimeFrame::Quarter),
+        Just(TimeFrame::Year),
+        extreme_positive().prop_map(TimeFrame::Custom),
+    ]
+}
+
+/// The structural shapes a return sample can take, each paired with the
+/// numeric extreme the strategy draws.
+fn degenerate_returns() -> impl Strategy<Value = Vec<Decimal>> {
+    (extreme_return(), extreme_return(), 0usize..7).prop_map(|(a, b, shape)| match shape {
+        // Empty: the GARCH seed has no first element, the EWMA no initial
+        // variance, and the sample mean divides by zero.
+        0 => vec![],
+        // A single observation: the sample variance divides by `n - 1`.
+        1 => vec![a],
+        // Two observations, the minimum the sample variance accepts.
+        2 => vec![a, b],
+        // Flat: zero variance, zero standard deviation.
+        3 => vec![a; 4],
+        // Alternating extremes: the centred deviations span the whole range.
+        4 => vec![a, b, a, b],
+        // Ordinary returns with one extreme spliced in.
+        5 => vec![dec!(0.01), a, dec!(-0.02), b, dec!(0.015)],
+        // Longer sample, so the recursions run for several steps.
+        _ => vec![a, b, dec!(0.01), a, dec!(-0.01), b, dec!(0.02), a],
+    })
+}
+
+fn option_with(
+    strike: Positive,
+    underlying: Positive,
+    volatility: Positive,
+    days: Positive,
+    rate: Decimal,
+    style: OptionStyle,
+) -> Options {
+    Options::new(
+        OptionType::European,
+        Side::Long,
+        "PROBE".to_string(),
+        strike,
+        ExpirationDate::Days(days),
+        volatility,
+        Positive::ONE,
+        underlying,
+        rate,
+        style,
+        Positive::ZERO,
+        None,
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// The sample estimators return for every degenerate sample shape and
+    /// every extreme decay factor. `historical_volatility` is driven at
+    /// window zero, which `slice::windows` rejects by aborting, and at a
+    /// window wider than the sample.
+    #[test]
+    fn test_sample_estimators_never_panic(
+        returns in degenerate_returns(),
+        lambda in extreme_return(),
+        window in 0usize..6,
+    ) {
+        let _ = constant_volatility(&returns);
+        let _ = historical_volatility(&returns, window);
+        let _ = historical_volatility(&returns, usize::MAX);
+        let _ = ewma_volatility(&returns, lambda);
+        let _ = garch_volatility(&returns, lambda, lambda, lambda);
+    }
+
+    /// The GARCH recursion returns for every combination of extreme
+    /// parameters, including the ones that drive the variance out of the
+    /// representable range on the first step.
+    #[test]
+    fn test_garch_volatility_never_panics(
+        returns in degenerate_returns(),
+        omega in extreme_return(),
+        alpha in extreme_return(),
+        beta in extreme_return(),
+    ) {
+        let _ = garch_volatility(&returns, omega, alpha, beta);
+    }
+
+    /// The Heston Euler step returns for every extreme parameter set. Each
+    /// factor of `v + κ(θ − v)dt + ξ√v dW` can overflow on its own, so the
+    /// same draw is applied to all of them and to `dt` independently.
+    #[test]
+    fn test_simulate_heston_volatility_never_panics(
+        param in extreme_return(),
+        dt in extreme_return(),
+        steps in 0usize..6,
+    ) {
+        let _ = simulate_heston_volatility(param, param, param, param, dt, steps);
+        let _ = simulate_heston_volatility(param, dec!(0.04), dec!(0.3), dec!(0.04), dt, steps);
+    }
+
+    /// The Ornstein-Uhlenbeck path returns for every extreme parameter,
+    /// including a zero time step and a level at `Positive::MAX`.
+    #[test]
+    fn test_generate_ou_process_never_panics(
+        level in extreme_positive(),
+        dt in extreme_positive(),
+        steps in 0usize..6,
+    ) {
+        let _ = generate_ou_process(level, level, level, level, dt, steps);
+        let _ = generate_ou_process(
+            Positive::ONE,
+            Positive::ONE,
+            Positive::ONE,
+            Positive::ONE,
+            dt,
+            steps,
+        );
+    }
+
+    /// Every square-root-of-time rescaling returns for every timeframe pair,
+    /// including the `Custom` timeframes whose periods per year are zero
+    /// (the divisor of the de-annualisation) and `1e-27` (which makes the
+    /// period ratio overflow).
+    #[test]
+    fn test_timeframe_rescaling_never_panics(
+        volatility in extreme_positive(),
+        from_frame in extreme_timeframe(),
+        to_frame in extreme_timeframe(),
+    ) {
+        let _ = annualized_volatility(volatility, from_frame);
+        let _ = de_annualized_volatility(volatility, from_frame);
+        let _ = adjust_volatility(volatility, from_frame, to_frame);
+        let _ = volatility_for_dt(volatility, Positive::ONE, from_frame, to_frame);
+    }
+
+    /// The implied-volatility grid search returns for every extreme option
+    /// geometry and for the iteration counts at which the grid size
+    /// `100 * max_iterations` overflows `i64`.
+    #[test]
+    fn test_implied_volatility_never_panics(
+        strike in extreme_positive(),
+        underlying in extreme_positive(),
+        days in extreme_positive(),
+        market_price in extreme_positive(),
+    ) {
+        let mut option = option_with(
+            strike,
+            underlying,
+            Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO),
+            days,
+            dec!(0.05),
+            OptionStyle::Call,
+        );
+        let _ = implied_volatility(market_price, &mut option, 2);
+        for max_iterations in [i64::MIN, -1, 0, 1, i64::MAX] {
+            let _ = implied_volatility(market_price, &mut option, max_iterations);
+        }
+        let _ = calculate_iv(
+            market_price,
+            strike,
+            OptionStyle::Put,
+            underlying,
+            days,
+            "PROBE".to_string(),
+        );
+    }
+
+    /// The uncertain-volatility bounds return for every extreme option
+    /// geometry and every volatility band, including one whose ends are
+    /// `Positive::ZERO` and `Positive::MAX`.
+    #[test]
+    fn test_uncertain_volatility_bounds_never_panics(
+        strike in extreme_positive(),
+        underlying in extreme_positive(),
+        days in extreme_positive(),
+        min_volatility in extreme_positive(),
+        max_volatility in extreme_positive(),
+    ) {
+        let option = option_with(
+            strike,
+            underlying,
+            Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO),
+            days,
+            dec!(0.05),
+            OptionStyle::Call,
+        );
+        let _ = uncertain_volatility_bounds(&option, min_volatility, max_volatility);
+        let _ = uncertain_volatility_bounds(&option, Positive::ZERO, Positive::MAX);
+    }
+}

--- a/tests/property/volatility_panic_freedom_test.rs
+++ b/tests/property/volatility_panic_freedom_test.rs
@@ -269,3 +269,86 @@ proptest! {
         let _ = uncertain_volatility_bounds(&option, Positive::ZERO, Positive::MAX);
     }
 }
+
+/// The properties above assert only that nothing aborts, which a silent
+/// `Ok(0)` or the wrong variant satisfies just as well as the right answer.
+/// These pin the documented outcome of each error path so a regression to a
+/// quiet zero fails the suite instead of passing it.
+mod documented_error_paths {
+    use super::*;
+
+    #[test]
+    fn test_zero_window_is_rejected_and_an_oversized_one_is_empty() {
+        let returns = vec![dec!(0.01), dec!(-0.02), dec!(0.015)];
+        assert!(historical_volatility(&returns, 0).is_err());
+        // `slice::windows` yields nothing for a window wider than the sample,
+        // so the answer is an empty series rather than an error. Pinned
+        // because it is a contract, not an accident: the caller gets "no
+        // windows", not "no volatility".
+        assert_eq!(
+            historical_volatility(&returns, usize::MAX)
+                .expect("an oversized window is not an error")
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_an_empty_sample_has_no_variance_rather_than_an_error() {
+        let empty: Vec<Decimal> = Vec::new();
+        assert!(garch_volatility(&empty, dec!(0.1), dec!(0.1), dec!(0.8)).is_err());
+        assert!(ewma_volatility(&empty, dec!(0.94)).is_err());
+        // `constant_volatility` differs deliberately: fewer than two
+        // observations carry no sample variance, and zero is the documented
+        // answer rather than a failure. Pinned so it cannot drift into an
+        // error, or an error path drift into this.
+        assert_eq!(
+            constant_volatility(&empty).expect("a short sample is not an error"),
+            Positive::ZERO
+        );
+    }
+
+    #[test]
+    fn test_heston_reports_an_overflowing_step_instead_of_returning_zero() {
+        let result = simulate_heston_volatility(
+            Decimal::MAX,
+            Decimal::MAX,
+            Decimal::MAX,
+            Decimal::MAX,
+            Decimal::MAX,
+            4,
+        );
+        assert!(result.is_err(), "an overflowing Euler step must report");
+    }
+
+    /// The two directions that *divide* by the period count reject a zero
+    /// one; annualisation multiplies by it and answers zero.
+    ///
+    /// The asymmetry is the existing contract, not something this PR
+    /// introduced, and it is pinned here rather than quietly evened out: a
+    /// volatility annualised over zero periods a year comes back as zero
+    /// without an error, which is worth a caller's attention.
+    #[test]
+    fn test_zero_period_timeframes_reject_where_they_divide() {
+        let vol = Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO);
+        let zero = TimeFrame::Custom(Positive::ZERO);
+
+        assert!(de_annualized_volatility(vol, zero).is_err());
+        assert!(adjust_volatility(vol, TimeFrame::Year, zero).is_err());
+        assert_eq!(
+            annualized_volatility(vol, zero).expect("annualisation multiplies, it does not divide"),
+            Positive::ZERO
+        );
+    }
+
+    /// The other half of the rescaling case: a target that does not divide by
+    /// zero but sits at the far end of the range must come back with a real
+    /// scale factor rather than a silent zero.
+    #[test]
+    fn test_extreme_rescaling_returns_a_non_zero_factor() {
+        let vol = Positive::new_decimal(dec!(0.2)).unwrap_or(Positive::ZERO);
+        let adjusted = adjust_volatility(vol, TimeFrame::Year, TimeFrame::Custom(Positive::MAX))
+            .expect("the conversion is representable");
+        assert!(adjusted > Positive::ZERO, "the scale factor collapsed");
+    }
+}

--- a/tests/unit/model/decimal_ops_tests.rs
+++ b/tests/unit/model/decimal_ops_tests.rs
@@ -37,6 +37,6 @@ fn decimal_partial_eq_with_positive() {
 #[test]
 fn decimalstats_empty_vec_returns_zeroes() {
     let v: Vec<Decimal> = vec![];
-    assert_eq!(v.mean(), Decimal::ZERO);
-    assert_eq!(v.std_dev(), Decimal::ZERO);
+    assert_eq!(v.mean().unwrap(), Decimal::ZERO);
+    assert_eq!(v.std_dev().unwrap(), Decimal::ZERO);
 }


### PR DESCRIPTION
## Summary

The capstone of the panic-freedom programme. #442's task list is now closed:
nine sibling issues landed the module sweeps, and this PR does the four things
left — the `volatility` sweep, the `unreachable!` / `panic!` inventory, the
silent-zero conversions in `Options`, and the lint that stops any of it
regressing.

| #442 box | closed by |
|---|---|
| `src/pricing/` exotics | #445 (issue #444) |
| `src/curves/` + `src/surfaces/` | #452 (#446) |
| `src/strategies/` | #468 (#460), #480 (#463) |
| `src/simulation/`, `src/chains/` beyond `build_chain` | #458 (#456) |
| **`src/volatility/`** | **here** |
| **the 14 `unreachable!` / 5 `panic!`** | **here** |
| **`make scan-banned` extended to the math operators** | **here** |
| **`Options::intrinsic_value`'s silent zero** | **here** |
| Upstream `expiration_date` 0.3.0 | still open — belongs in that crate |

## 1. `src/volatility/`: 287 panics → 0

Probed with `catch_unwind` over 3305 cases across the `Decimal` extremes, the
same method the rest of the programme used. Eight functions aborted:

| function | input | panic |
|---|---|---|
| `adjust_volatility` | `Microsecond → Custom(1e-27)` | `Positive arithmetic overflow in div` (179 hits) |
| `simulate_heston_volatility` | `dt = Decimal::MAX` | `Multiplication overflowed` (53) |
| `garch_volatility` | `returns = []` | `index out of bounds: the len is 0 but the index is 0` (13) |
| `annualized_volatility` | `vol = MAX`, `Microsecond` | `Positive arithmetic overflow in mul` (12) |
| `historical_volatility` | `window_size = 0` | `window size must be non-zero` (10) |
| `de_annualized_volatility` | `Custom(Positive::ZERO)` | `Positive invariant broken in div` (9) |
| `volatility_for_dt` | delegates to the above | (9) |
| `implied_volatility` | `max_iterations = i64::MAX` | `attempt to multiply with overflow` (2) |

**No signature changed** — all eight already returned `Result`. The zero-periods
guard reuses `adjust_volatility`'s existing message shape so the two entry
points agree on where the domain ends.

`tests/property/volatility_panic_freedom_test.rs` is the sweep, and it bites:
reverting `utils.rs` to `main` fails five of its six properties. The two that
pass either way cover `generate_ou_process` and `uncertain_volatility_bounds`,
which were already clean.

## 2. Every `unreachable!` and `panic!`, disposed of individually

Each is now a typed error **or** carries a `// scan-banned: allow -- <reason>`
with the argument for why it cannot fire. A marker without a real argument is
worse than the panic, because it looks reviewed.

The `src/constants.rs` group is the interesting one: four are in `const` items,
where the `match` is compiler-evaluated, so a failing arm is `evaluation of
constant value failed` at **build** time — there is no run time at which the arm
exists. The other seven are `LazyLock` cells whose closure captures nothing and
whose only input is a `dec!()` literal. No `const` alternative exists:
`positive` keeps `from_decimal_const` crate-private, and a `Positive::ZERO`
stand-in would make every annualisation divide by zero.

## 3. Three silent zeros in `src/model/option.rs`, not one

The issue names `intrinsic_value`. There are three:
`Decimal::from_f64(payoff).unwrap_or_default()` and the same pattern for
`price` and `iv`. A non-finite `f64` became `0` with no error — silently wrong
rather than a panic, which this programme treats as the worse failure. All three
report now.

## 4. `make scan-banned` extended — and it found things

It guarded `.unwrap()` / `.expect()`. It now also rejects `panic!`,
`unreachable!`, `todo!`, `unimplemented!`, `.exp()`, `.ln()`, `.powd(` and
`.sqrt().unwrap()`.

The lint and the fixes it demands land together, deliberately: a lint alone is a
failing lint, and fixes alone leave nothing enforcing them.

Two findings worth naming:

- **Its comment filter skipped every line starting with `*`**, which swallowed
  the continuation lines of multi-line products — **five `.exp()` calls in
  `src/pricing/compound.rs` were invisible to it.** Fixed.
- The `f64` methods share three of those names and do not abort, so those call
  sites carry a marker saying so; grep cannot tell receiver types apart.

## 5. `make doc` now builds documentation

It was `cargo clippy -- -W missing-docs`, which builds no docs. It is now
`cargo doc --all-features --no-deps`.

This matters beyond the name. `create-doc` — the target `pre-push` actually
reaches, via `readme` — has no `--all-features`, so **a doc link behind
`plotly`, `static_export` or `async` was checked by nothing**, locally or in CI.
Demonstrated by injecting `[`this_symbol_does_not_exist`]` into
`src/visualization/plotly.rs` on `main`:

```
make create-doc                     exit 0    link never mentioned
cargo doc --all-features --no-deps  exit 101  3 occurrences
```

**The new gate starts green**, which is the point — a gate that starts red
teaches people to ignore it:

```
$ make doc            # on this branch
warning: public documentation for `new` links to private item `RNDStatistics::new`
warning: public documentation for `BreakEvenable` links to private item `lower_break_even`
exit 0
```

Those two warnings are pre-existing and named in `AGENTS.md` so nobody
re-investigates them.

`AGENTS.md` gains five facts, each with the command that demonstrates it and
nothing else — a reference, not a narrative:

1. what `make doc` did, and the feature-gated hole in `create-doc` above
2. `make public-api-check` builds rustdoc with `--all-features` but
   `cargo public-api` prints rustdoc's errors and exits 0 — `error:` lines
   appear under a green check
3. `cargo test --all-features` never exercises the default feature set;
   `make test` runs default, `plotly` and `static_export,plotly` separately
4. `cargo-semver-checks` compares against the **published** baseline, so a
   rename or a variant on an exhaustive public enum needs a minor bump on a 0.x
   crate — `make public-api-check` compares against the snapshot and never asks
5. `gh pr merge` reports a base-branch policy refusal on **stderr only**, so a
   caller redirecting stderr sees a silent no-op

## Gates

```
cargo test --all-features --workspace       4058 lib + 78 property + 423 + 210 doctests, 0 failed
LOGLEVEL=WARN cargo test  (default set)     4062 + 78 + 396 + 210, 0 failed
cargo fmt --all --check                     clean
cargo clippy --all-targets --all-features --workspace -- -D warnings   clean
cargo build --release                       no warnings
make doc                                    exit 0, the two known warnings
make scan-banned                            OK: no unwrap/expect, no panic/unreachable/todo/
                                            unimplemented, no unchecked exp/ln/powd/sqrt
make public-api-check                       OK
```

## Public API impact

**One breaking change, not none.** An earlier revision of this section said the
API was unchanged; it is not, and the snapshot carries the difference:

| before | after |
|---|---|
| `DecimalStats::mean(&self) -> Decimal` | `-> Result<Decimal, DecimalError>` |
| `DecimalStats::std_dev(&self) -> Decimal` | `-> Result<Decimal, DecimalError>` |

Both aborted on a sample they could not sum — `mean` through `iter().sum()`,
`std_dev` through `.powd(Decimal::TWO)` — and `vec![Decimal::MAX; 2]` reached
each. A trait method cannot report that without a return type that can carry
it.

**Migration.** Add `?` where the value feeds a fallible function, or
`.expect("…")` at a boundary that cannot propagate. An external implementor of
`DecimalStats` changes two signatures and returns `Ok(..)`.

**Versioning.** No further bump. 0.21.0 is already the breaking version for
this cycle, set in #473 for the `Surface::project_onto` rename, and it is
unreleased — the published baseline is still 0.20.0. `cargo semver-checks`
reads `0.20.0 -> 0.21.0 (major change)` and passes; a second bump inside one
unreleased cycle would say something untrue about what shipped.

## Stack

The capstone. Every other chain has merged: #459/#472, #466/#473, #462/#474,
#470/#475, #451/#477, #469/#478, #463/#480, #453/#481, #471/#482.

Closes #442

