### PR TITLE
release(0.21.0): fold the unreleased entries into the 0.21.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1078,7 +1078,14 @@ post-migration example layout.
 - `README.tpl` passthrough regenerates `README.md` with the updated
   module docs.
 
-[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.16.5...HEAD
+[Unreleased]: https://github.com/joaquinbejar/OptionStratLib/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.21.0
+[0.20.0]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.20.0
+[0.19.1]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.19.1
+[0.19.0]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.19.0
+[0.18.1]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.18.1
+[0.18.0]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.18.0
+[0.17.2]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.17.2
 [0.16.5]: https://github.com/joaquinbejar/OptionStratLib/releases/tag/v0.16.5
 
 ## [0.16.4] - 2026-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-30
+
 ### Fixed
 
 - **Seven entry points in `src/volatility/` aborted on inputs the type system


### PR DESCRIPTION
Cuts the `0.21.0` changelog section ahead of the tag and the crates.io publish.

`Cargo.toml`, the four version strings in the `lib.rs` doc header and `README.md`
are already at `0.21.0` — that bump landed with #473, which needed it to make the
`Surface::get_curve` → `project_onto` rename legal for `cargo-semver-checks`. What
was missing is the changelog heading: everything under `[Unreleased]` belongs to
this version.

Same shape as the `0.20.0` release commit (#438): the entries are folded under a
dated heading and `[Unreleased]` is left empty for the next cycle. No entry text
changed — this is a heading move, so the diff is two lines.

## What 0.21.0 contains

The panic-freedom programme, ten issues:

| issue | PR |
|---|---|
| #459 widened quotes came out locked | #472 |
| #466 duplicate abscissae had no defined rule | #473 |
| #462 arithmetic Asian lost all precision at short maturities | #474 |
| #470 the model layer the strategies run through | #475 |
| #451 bilinear interpolation near the upper boundary | #477 |
| #469 greek aggregation aborted on its own alpha sentinel | #478 |
| #463 break-even indexing in the multi-leg strategies | #480 |
| #453 Multiply merge was non-deterministic across runs | #481 |
| #471 infallible signatures that could still abort | #482 |
| #442 the sweep's capstone: volatility, the panicking macros, the lint | #483 |

Plus #476 and #479, two file-cleanup races found while running the above, and
#484.

Breaking for consumers: `Surface::get_curve` is renamed and retyped, twenty
public methods gained an error channel, `model::utils::mean_and_std` returns a
`Result`, and `PositionError` gained a variant. Each has its migration note in
the section.