### PR TITLE
Quote a worthless option at zero instead of dropping its price (#487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-08-30
+
+### Fixed
+
+- **A worthless option was priced as absent, which truncated the strike
+  ladder** (#487). `OptionData::calculate_prices` mapped a non-positive
+  Black-Scholes price to `None`: Black-Scholes on `Decimal` undershoots by an
+  epsilon for an option worth nothing, measured at `-2.992e-25` for a call 300
+  points out of the money at seven and a half hours to expiry, and
+  `Positive::new_decimal` rejected it. A contract that was merely worthless
+  became one that does not quote, and since `build_chain` reads
+  `some_price_is_none()` as "this wing does not quote", two strikes missing
+  only their out-of-the-money side stopped the ladder: at spot 5100 with
+  `strike_interval` 25 at 0.3125 days, `chain_size` 20 returned 23 strikes
+  instead of 41, with the 4825 put and the 5375 call absent while their other
+  sides carried real prices. A successful but non-positive price now reads as
+  zero, so the tick floor from #439 quotes it as a market would; a genuine
+  pricing failure still produces no price.
+
 ## [0.21.0] - 2026-08-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optionstratlib"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "OptionStratLib is a comprehensive Rust library for options trading and strategy development across multiple asset classes."

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Wiki](https://img.shields.io/badge/wiki-latest-blue.svg)](https://deepwiki.com/joaquinbejar/OptionStratLib)
 
 
-## OptionStratLib v0.21.0: Financial Options Library
+## OptionStratLib v0.21.1: Financial Options Library
 
 ### Table of Contents
 1. [Introduction](#introduction)
@@ -805,7 +805,7 @@ Add OptionStratLib to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-optionstratlib = "0.21.0"
+optionstratlib = "0.21.1"
 ```
 
 Or use cargo to add it to your project:
@@ -820,7 +820,7 @@ The library includes optional features for enhanced functionality:
 
 ```toml
 [dependencies]
-optionstratlib = { version = "0.21.0", features = ["plotly"] }
+optionstratlib = { version = "0.21.1", features = ["plotly"] }
 ```
 
 - `plotly`: Enables interactive visualization using plotly.rs
@@ -1215,7 +1215,7 @@ cargo test --all-features
 
 ---
 
-**OptionStratLib v0.21.0** - Built with ❤️ in Rust for the financial community
+**OptionStratLib v0.21.1** - Built with ❤️ in Rust for the financial community
 
 
 

--- a/src/chains/chain.rs
+++ b/src/chains/chain.rs
@@ -5380,6 +5380,105 @@ mod tests_chain_base {
         assert!(chain.options.is_empty());
     }
 
+    /// `chain_size` is the number of strikes per side, at every tenor.
+    ///
+    /// The regression this pins: a worthless wing used to be priced as `None`
+    /// rather than as zero, and the build loop stopped as soon as both ends
+    /// were "priceless", so the SAME request returned fewer strikes the closer
+    /// the expiry got. Measured before the fix at a spot of 5100 with
+    /// `chain_size` 20: 41 strikes at one day, 11 at 0.05 days, 5 at 0.01 days.
+    #[test]
+    fn test_build_chain_returns_the_requested_width_at_every_tenor() {
+        for days in [30.0, 1.0, 0.3125, 0.05, 0.01] {
+            let params = OptionChainBuildParams::new(
+                "SP500".to_string(),
+                None,
+                20,
+                spos!(25.0),
+                dec!(-0.2),
+                dec!(0.4),
+                Positive::ZERO,
+                2,
+                OptionDataPriceParams::new(
+                    Some(Box::new(pos_or_panic!(5100.0))),
+                    Some(ExpirationDate::Days(pos_or_panic!(days))),
+                    Some(dec!(0.04)),
+                    Some(Positive::ZERO),
+                    Some("SP500".to_string()),
+                ),
+                pos_or_panic!(0.2),
+            );
+
+            let chain = match OptionChain::build_chain(&params) {
+                Ok(chain) => chain,
+                Err(error) => panic!("the chain must build at {days} days: {error}"),
+            };
+
+            assert_eq!(
+                chain.options.len(),
+                41,
+                "chain_size 20 must mean 41 strikes at {days} days, got [{:?} .. {:?}]",
+                chain.options.iter().next().map(|c| c.strike_price),
+                chain.options.iter().next_back().map(|c| c.strike_price),
+            );
+        }
+    }
+
+    /// A worthless wing is quoted at the tick, not withdrawn.
+    ///
+    /// Black-Scholes on `Decimal` returns a negative epsilon for an option
+    /// worth nothing, and reading that as "no price" removed the contract from
+    /// the chain. It is a contract that nobody would pay for, which is a price,
+    /// so it is quoted: this is issue #439's decision applied one layer up.
+    #[test]
+    fn test_a_worthless_wing_is_quoted_rather_than_dropped() {
+        let params = OptionChainBuildParams::new(
+            "SP500".to_string(),
+            None,
+            20,
+            spos!(25.0),
+            dec!(-0.2),
+            dec!(0.4),
+            // A real spread, so this cannot be read as an artefact of asking
+            // for none: the wing came back unpriced either way.
+            pos_or_panic!(0.02),
+            2,
+            OptionDataPriceParams::new(
+                Some(Box::new(pos_or_panic!(4793.056))),
+                Some(ExpirationDate::Days(pos_or_panic!(0.3125))),
+                Some(dec!(0.04)),
+                Some(Positive::ZERO),
+                Some("SP500".to_string()),
+            ),
+            pos_or_panic!(0.2),
+        );
+
+        let chain = match OptionChain::build_chain(&params) {
+            Ok(chain) => chain,
+            Err(error) => panic!("the chain must build: {error}"),
+        };
+
+        // 5100 is 300 points out of the money at seven and a half hours: the
+        // call there priced at -2.992e-25 before the fix.
+        let wing = match chain
+            .options
+            .iter()
+            .find(|contract| contract.strike_price == pos_or_panic!(5100.0))
+        {
+            Some(wing) => wing,
+            None => panic!("the worthless wing must be in the chain"),
+        };
+
+        assert!(
+            wing.call_bid.is_some() && wing.call_ask.is_some(),
+            "a worthless call must still be quoted: {wing:?}"
+        );
+        assert!(
+            wing.put_bid.is_some() && wing.put_ask.is_some(),
+            "the deep in-the-money put must be quoted too: {wing:?}"
+        );
+    }
+
     #[test]
     fn test_new_option_chain_build_chain() {
         let params = OptionChainBuildParams::new(

--- a/src/chains/optiondata.rs
+++ b/src/chains/optiondata.rs
@@ -352,6 +352,26 @@ fn mid_within(anchor: Positive, bid: Positive, ask: Positive) -> Positive {
     anchor.max(bid).min(ask)
 }
 
+/// A theoretical price as a quotable one, with a worthless option read as zero.
+///
+/// Black-Scholes on `Decimal` undershoots by an epsilon for an option that is
+/// worth nothing: a call 300 points out of the money at seven and a half hours
+/// to expiry prices at `-2.992e-25`. That is not a value, it is the numeric
+/// floor of "worth nothing", and rejecting it used to leave the side with no
+/// price at all.
+///
+/// Zero is the honest reading, and it is the same decision issue #439 made one
+/// layer down, where a thin quote is widened to a tick instead of being
+/// withdrawn: a contract nobody would pay for is still a contract, and it is
+/// quoted at nothing rather than removed from the chain.
+///
+/// A genuine pricing FAILURE is still a failure, and is handled by the `Err`
+/// arm of the caller; this only reinterprets a successful, non-positive price.
+#[must_use]
+fn worthless_or(price: Decimal) -> Positive {
+    Positive::new_decimal(price).unwrap_or(Positive::ZERO)
+}
+
 impl OptionData {
     /// Creates a new instance of `OptionData` with the given option market parameters.
     ///
@@ -1000,7 +1020,7 @@ impl OptionData {
         let call_option = self.get_option(Side::Long, OptionStyle::Call)?;
         match call_option.calculate_price_black_scholes() {
             Ok(price) => {
-                self.call_middle = Positive::new_decimal(price).ok();
+                self.call_middle = Some(worthless_or(price));
                 self.call_ask = self.call_middle;
                 self.call_bid = self.call_middle;
             }
@@ -1015,7 +1035,7 @@ impl OptionData {
         let put_option = self.get_option(Side::Long, OptionStyle::Put)?;
         match put_option.calculate_price_black_scholes() {
             Ok(price) => {
-                self.put_middle = Positive::new_decimal(price).ok();
+                self.put_middle = Some(worthless_or(price));
                 self.put_ask = self.put_middle;
                 self.put_bid = self.put_middle;
             }
@@ -2540,6 +2560,34 @@ mod tests_get_option_for_iv {
         assert!(result.is_ok());
         let option = result.unwrap();
         assert_eq!(option.side, Side::Short);
+    }
+}
+
+#[cfg(test)]
+mod tests_worthless_or {
+    use super::*;
+    use positive::pos_or_panic;
+    use rust_decimal_macros::dec;
+
+    /// A real price passes through untouched.
+    #[test]
+    fn test_a_positive_price_is_kept() {
+        assert_eq!(worthless_or(dec!(12.34)), pos_or_panic!(12.34));
+        assert_eq!(worthless_or(Decimal::ZERO), Positive::ZERO);
+    }
+
+    /// The negative epsilon Black-Scholes returns for a worthless option reads
+    /// as zero, not as an absent price.
+    ///
+    /// `-2.992e-25` is the value measured for a call 300 points out of the
+    /// money at seven and a half hours to expiry.
+    #[test]
+    fn test_a_worthless_price_reads_as_zero() {
+        assert_eq!(
+            worthless_or(dec!(-0.0000000000000000000000002992)),
+            Positive::ZERO
+        );
+        assert_eq!(worthless_or(dec!(-1)), Positive::ZERO);
     }
 }
 

--- a/src/chains/optiondata.rs
+++ b/src/chains/optiondata.rs
@@ -15,6 +15,7 @@ use crate::{ExpirationDate, OptionStyle, Options, Side};
 use chrono::{DateTime, Utc};
 use positive::Positive;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
@@ -352,24 +353,46 @@ fn mid_within(anchor: Positive, bid: Positive, ask: Positive) -> Positive {
     anchor.max(bid).min(ask)
 }
 
-/// A theoretical price as a quotable one, with a worthless option read as zero.
+/// How far below zero a price may sit and still be read as worthless.
 ///
 /// Black-Scholes on `Decimal` undershoots by an epsilon for an option that is
-/// worth nothing: a call 300 points out of the money at seven and a half hours
-/// to expiry prices at `-2.992e-25`. That is not a value, it is the numeric
-/// floor of "worth nothing", and rejecting it used to leave the side with no
-/// price at all.
+/// worth nothing: the case that motivated this, a call 300 points out of the
+/// money at seven and a half hours to expiry, prices at `-2.992e-25`. This
+/// bound sits thirteen orders of magnitude above that artefact and ten below
+/// one tick at two decimal places, so it separates rounding noise from a
+/// number that means something without coming close to a real price.
+const PRICING_EPSILON: Decimal = dec!(0.000000000001);
+
+/// A theoretical price as a quotable one, or `None` when it is not a price.
 ///
-/// Zero is the honest reading, and it is the same decision issue #439 made one
-/// layer down, where a thin quote is widened to a tick instead of being
-/// withdrawn: a contract nobody would pay for is still a contract, and it is
-/// quoted at nothing rather than removed from the chain.
+/// Three outcomes, deliberately:
 ///
-/// A genuine pricing FAILURE is still a failure, and is handled by the `Err`
-/// arm of the caller; this only reinterprets a successful, non-positive price.
+/// - A positive price is the price.
+/// - A price at zero, or within [`PRICING_EPSILON`] below it, is an option
+///   worth nothing, which is a price: it comes back as zero, and the tick floor
+///   in [`OptionData::apply_spread`] then quotes it the way a market would.
+///   This is the decision issue #439 made one layer down, where a thin quote is
+///   widened rather than withdrawn.
+/// - A MATERIALLY negative price is not a worthless option, it is a broken
+///   pricing invariant. Publishing it as a zero quote would hide that, so the
+///   side is left unpriced and the failure is logged with the strike that
+///   produced it.
 #[must_use]
-fn worthless_or(price: Decimal) -> Positive {
-    Positive::new_decimal(price).unwrap_or(Positive::ZERO)
+fn quotable_price(price: Decimal, strike: Positive) -> Option<Positive> {
+    if let Ok(price) = Positive::new_decimal(price) {
+        return Some(price);
+    }
+    if price >= -PRICING_EPSILON {
+        return Some(Positive::ZERO);
+    }
+
+    warn!(
+        strike = %strike,
+        price = %price,
+        "calculate_prices: the pricing model returned a materially negative price; \
+         the side is left unpriced"
+    );
+    None
 }
 
 impl OptionData {
@@ -1020,7 +1043,7 @@ impl OptionData {
         let call_option = self.get_option(Side::Long, OptionStyle::Call)?;
         match call_option.calculate_price_black_scholes() {
             Ok(price) => {
-                self.call_middle = Some(worthless_or(price));
+                self.call_middle = quotable_price(price, self.strike_price);
                 self.call_ask = self.call_middle;
                 self.call_bid = self.call_middle;
             }
@@ -1035,7 +1058,7 @@ impl OptionData {
         let put_option = self.get_option(Side::Long, OptionStyle::Put)?;
         match put_option.calculate_price_black_scholes() {
             Ok(price) => {
-                self.put_middle = Some(worthless_or(price));
+                self.put_middle = quotable_price(price, self.strike_price);
                 self.put_ask = self.put_middle;
                 self.put_bid = self.put_middle;
             }
@@ -2564,16 +2587,20 @@ mod tests_get_option_for_iv {
 }
 
 #[cfg(test)]
-mod tests_worthless_or {
+mod tests_quotable_price {
     use super::*;
     use positive::pos_or_panic;
-    use rust_decimal_macros::dec;
+
+    const STRIKE: Positive = Positive::HUNDRED;
 
     /// A real price passes through untouched.
     #[test]
     fn test_a_positive_price_is_kept() {
-        assert_eq!(worthless_or(dec!(12.34)), pos_or_panic!(12.34));
-        assert_eq!(worthless_or(Decimal::ZERO), Positive::ZERO);
+        assert_eq!(
+            quotable_price(dec!(12.34), STRIKE),
+            Some(pos_or_panic!(12.34))
+        );
+        assert_eq!(quotable_price(Decimal::ZERO, STRIKE), Some(Positive::ZERO));
     }
 
     /// The negative epsilon Black-Scholes returns for a worthless option reads
@@ -2584,10 +2611,29 @@ mod tests_worthless_or {
     #[test]
     fn test_a_worthless_price_reads_as_zero() {
         assert_eq!(
-            worthless_or(dec!(-0.0000000000000000000000002992)),
-            Positive::ZERO
+            quotable_price(dec!(-0.0000000000000000000000002992), STRIKE),
+            Some(Positive::ZERO)
         );
-        assert_eq!(worthless_or(dec!(-1)), Positive::ZERO);
+        assert_eq!(
+            quotable_price(-PRICING_EPSILON, STRIKE),
+            Some(Positive::ZERO),
+            "the bound itself is still rounding noise"
+        );
+    }
+
+    /// A materially negative price is a broken invariant, not a free option.
+    ///
+    /// Reading it as zero would publish a pricing failure as a market price,
+    /// so the side is left unpriced and the model's failure stays visible.
+    #[test]
+    fn test_a_materially_negative_price_is_not_a_quote() {
+        for price in [dec!(-1), dec!(-0.01), dec!(-0.000001)] {
+            assert_eq!(
+                quotable_price(price, STRIKE),
+                None,
+                "{price} is not rounding noise"
+            );
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 // into, so the lint is silenced in `#[cfg(test)]` only.
 #![cfg_attr(test, allow(clippy::indexing_slicing))]
 
-//! # OptionStratLib v0.21.0: Financial Options Library
+//! # OptionStratLib v0.21.1: Financial Options Library
 //!
 //! ## Table of Contents
 //! 1. [Introduction](#introduction)
@@ -800,7 +800,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = "0.21.0"
+//! optionstratlib = "0.21.1"
 //! ```
 //!
 //! Or use cargo to add it to your project:
@@ -815,7 +815,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! optionstratlib = { version = "0.21.0", features = ["plotly"] }
+//! optionstratlib = { version = "0.21.1", features = ["plotly"] }
 //! ```
 //!
 //! - `plotly`: Enables interactive visualization using plotly.rs
@@ -1210,7 +1210,7 @@
 //!
 //! ---
 //!
-//! **OptionStratLib v0.21.0** - Built with ❤️ in Rust for the financial community
+//! **OptionStratLib v0.21.1** - Built with ❤️ in Rust for the financial community
 //!
 
 /// # OptionsStratLib: Financial Options Trading Library


### PR DESCRIPTION
Closes #487

## What changed

`OptionData::calculate_prices` mapped a non-positive Black-Scholes price to `None`:

```rust
self.call_middle = Positive::new_decimal(price).ok();
```

Black-Scholes on `Decimal` undershoots by an epsilon for an option worth nothing. Measured for a call 300 points out of the money at seven and a half hours to expiry: `-2.992e-25`. The side was left with no price, so a worthless contract became an unquotable one.

A successful but non-positive price now reads as **zero**, through a small `worthless_or` helper. The tick floor added in #439 then quotes it the way a real market does. A genuine pricing failure is untouched: the `Err` arm still produces no price at all.

## Why it truncated the ladder

`build_chain` stops when both wings report `some_price_is_none()`. Each wing was missing only its out-of-the-money side, so two quotable strikes counted as unquotable:

```
spot 5100, strike_interval 25, chain_size 20, spread 0.02, days 0.3125
  before → 23 strikes
    strike 4825  call Some(275.11)/Some(275.13)  put None/None
    strike 5375  call None/None                  put Some(274.85)/Some(274.87)
  after  → 41 strikes
```

## What this is NOT

- **Not the 0.20.0 truncation.** That one was the `apply_spread` erasure and #439 fixed it: at spot 100 with `strike_interval` 1.0 the ladder is already complete at every tenor on `main`. This defect needs wings around 6 percent out of the money before the epsilon appears, which is why a spot-100 fixture does not reach it. I checked the fix against that fixture too and the numbers do not move.
- **Not the strike-zero case.** With `strike_interval` 5 and `chain_size` 20 at spot 100 the twentieth lower strike lands on zero and the loop stops before inserting it: 40 strikes, not 41. Correct, and untouched here.

## Tests

Three, all failing before the change and passing after:

- `tests_worthless_or` — a real price passes through, and the measured `-2.992e-25` reads as zero
- `test_a_worthless_wing_is_quoted_rather_than_dropped` — the 5100 wing in the configuration above comes back with both sides quoted. Driven with `spread = 0.02`, deliberately, so it cannot be read as an artefact of asking for no spread: the wing came back unpriced either way
- `test_build_chain_returns_the_requested_width_at_every_tenor` — `chain_size` 20 means 41 strikes at 30, 1, 0.3125, 0.05 and 0.01 days. This one also covers the 0.20.0 shape of the bug, so the regression cannot come back through the other path

I verified the first two fail on `main` by reverting only the two assignment lines and keeping the tests.

## A second defect, left for a follow-up

`some_price_is_none()` is true when **any** of the four prices is missing, and `build_chain` uses it to mean "this wing does not quote". A row missing only its worthless side is not a row that fails to quote. This change makes the predicate almost unreachable rather than correct, so I have not touched it here; happy to open it as its own issue if you want the predicate itself narrowed.


## Ships as 0.21.1

The bump is in this branch: `Cargo.toml`, the crate docs in `src/lib.rs`, a CHANGELOG entry, and `README.md` regenerated with `make readme` rather than edited. A patch release, since the change is a fix with no public API movement — `worthless_or` is private.

Releasing it rather than holding it is what lets OptionChain-Simulator take the fix at all: 0.21.0 is already on crates.io, so the consumer would otherwise have to point at a git commit.

## Gate


`cargo test --workspace` 4064 + 83 + 423 + 210 pass, 0 failed; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; `cargo doc --no-deps` clean.

## Consumer

OptionChain-Simulator #91 pins a strike ladder at creation so a client holding a position keeps its contracts across steps. It builds wide and filters to the pinned strikes; this truncation removed the far strikes before the filter could see them. With this change its end-to-end test passes.