### PR TITLE
Drop the cdylib crate type (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **The crate no longer builds a `cdylib`** (#496). `Cargo.toml` declared
+  `crate-type = ["cdylib", "rlib"]`, but the library exposes no C ABI: there is
+  not one `extern "C"`, `#[no_mangle]`, `#[unsafe(no_mangle)]` or
+  `#[export_name]` in `src/`, so the dynamic library it produced had no callable
+  entry point. It was build and release surface without a foreign-function
+  interface behind it.
+
+  The compatibility impact is nil for any consumer using the crate as a Rust
+  dependency: the `rlib` is unchanged and the public API snapshot does not move.
+  It is only observable to something loading `liboptionstratlib.dylib` /
+  `.so` / `.dll` by filename, which would have found no symbols to call. Nothing
+  in this repository consumed the artifact — not the `Makefile`, not the
+  workflows, not `Docker/`.
+
+  To reinstate a dynamic library, the crate needs an actual `extern "C"` surface
+  first; restoring the target alone would rebuild the same empty artifact.
+
 ## [0.21.1] - 2026-08-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ harness = false
 [lib]
 name = "optionstratlib"
 path = "src/lib.rs"
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [workspace]
 members = [


### PR DESCRIPTION
Closes #496

## What changed

`Cargo.toml` declared `crate-type = ["cdylib", "rlib"]`. It now declares
`["rlib"]`.

## Why it was safe

The library exposes **no C ABI**. Not one `extern "C"`, `#[no_mangle]`,
`#[unsafe(no_mangle)]` or `#[export_name]` anywhere in `src/`:

```
$ grep -rnE 'extern[[:space:]]+"C"|no_mangle|export_name' --include='*.rs' src/
$
```

So the dynamic library it produced had no callable entry point — build and
release surface with no foreign-function interface behind it.

## Verified, not assumed

**The artifact actually stops being produced**, on both surfaces:

```
$ cargo build --release && ls target/release/ | grep liboptionstratlib
liboptionstratlib.d
liboptionstratlib.rlib          # no .dylib

$ cargo build --release --all-features && ls target/release/ | grep liboptionstratlib
liboptionstratlib.d
liboptionstratlib.rlib
```

**Nothing consumed it by filename** — not the `Makefile`, not
`.github/workflows/`, not `Docker/`.

**It is not a semver event:**

```
$ cargo semver-checks --all-features
Checked 196 checks: 196 pass, 58 skip
Summary no semver update required
```

Removing a crate type that exported no symbols breaks no caller, and the
`public-api` snapshot does not move for the same reason.

## Acceptance criteria

- [x] `Cargo.toml` no longer declares `cdylib`
- [x] Default, all-feature and release builds pass without producing the
      dynamic library
- [x] No supported C ABI symbol or documented FFI consumer is removed — there
      were none
- [x] The compatibility impact is recorded

## One deviation from the issue, and why

The issue asks to record the removal "in the 0.22 migration guide and release
notes". **`doc/` is excluded from the repository** at `.git/info/exclude:22`, so
a PR cannot carry a file there — only `doc/generate_md_docs.sh` and
`doc/images/logo.png` are tracked, and they predate the exclusion. The
compatibility note therefore goes in `CHANGELOG.md`, which is tracked, and says
what a consumer would observe: nothing, unless it was loading
`liboptionstratlib.dylib` by filename and finding no symbols to call.

That exclusion blocks more than this issue — see the run report on #490, #491
and #497, whose deliverables are all files under `doc/`.

## Gates

```
cargo test --all-features --workspace     4065 + 83 + 423 + 210, 0 failed
LOGLEVEL=WARN cargo test  (default set)   4069 + 83 + 396 + 210, 0 failed
cargo fmt --all --check                   clean
cargo clippy --all-targets --all-features --workspace -- -D warnings   clean
cargo build --release                     warning-free
make doc                                  clean
make scan-banned                          OK
make public-api-check                     OK
cargo semver-checks --all-features        no update required
```

No version bump: the crate is at 0.21.1 and this cycle's bump belongs to the
release that ships it, not to this PR.